### PR TITLE
fix missing component(hls-tests) in hie.yaml samples (added func-test)

### DIFF
--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -8,8 +8,8 @@
 cradle:
   cabal:
 
-    - path: "./test"
-      component: "haskell-language-server:hls-tests"
+    - path: "./test/functional/"
+      component: "haskell-language-server:func-test"
 
     - path: "./test/utils/"
       component: "haskell-language-server:hls-test-utils"

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -11,8 +11,12 @@
 #          ```
 cradle:
   stack:
-    - path: "./test"
-      component: "haskell-language-server:hls-tests"
+    - path: "./test/functional/"
+      component: "haskell-language-server:func-test"
+
+    # This target does not currently work (stack 2.1.3)
+    # - path: "./test/utils"
+    #   component: "haskell-language-server:lib:hls-test-utils"
 
     - path: "./exe/Main.hs"
       component: "haskell-language-server:exe:haskell-language-server"


### PR DESCRIPTION
I removed missing `hls-tests` component and added `func-test`.
I also added `hls-test-utils` component, but it does not work (stack 2.1.3), so I left it commented.