### PR TITLE
Create plugin for wrapping the handlers from ghcide

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,13 +148,21 @@ jobs:
             - cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Update
-          command: cabal update
+          command: cabal new-update
       - run:
           name: Configure
-          command: cabal configure --enable-tests
+          command: cabal new-configure --enable-tests
+      - run:
+          name: Build dependencies
+          command: cabal new-build -j1 --dependencies-only # need j1, else ghc-lib-parser triggers OOM
+          no_output_timeout: 30m
+      - save_cache:
+          key: cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - ~/.cabal
       - run:
           name: Build
-          command: cabal build -j1 # need j1, else ghc-lib-parser triggers OOM
+          command: cabal new-build -j1 # need j1, else ghc-lib-parser triggers OOM
           no_output_timeout: 30m
       - save_cache:
           key: cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,5 @@
 #     rm -rf path_to_submodule
 [submodule "ghcide"]
 	path = ghcide
-	url = https://github.com/digital-asset/ghcide.git
-	# url = https://github.com/alanz/ghcide.git
+	# url = https://github.com/digital-asset/ghcide.git
+	url = https://github.com/alanz/ghcide.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,5 @@
 #     rm -rf path_to_submodule
 [submodule "ghcide"]
 	path = ghcide
-	# url = https://github.com/digital-asset/ghcide.git
-	url = https://github.com/alanz/ghcide.git
+	url = https://github.com/digital-asset/ghcide.git
+	# url = https://github.com/alanz/ghcide.git

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -58,14 +58,19 @@ import System.Log.Logger as L
 import System.Time.Extra
 
 -- ---------------------------------------------------------------------
-
+-- ghcide partialhandlers
 import Development.IDE.Plugin.CodeAction  as CodeAction
 import Development.IDE.Plugin.Completions as Completions
+import Development.IDE.LSP.HoverDefinition as HoverDefinition
+
+ -- haskell-language-server plugins
 import Ide.Plugin.Example                 as Example
 import Ide.Plugin.Example2                as Example2
+import Ide.Plugin.GhcIde                  as GhcIde
 import Ide.Plugin.Floskell                as Floskell
 import Ide.Plugin.Ormolu                  as Ormolu
 import Ide.Plugin.Pragmas                 as Pragmas
+
 
 -- ---------------------------------------------------------------------
 
@@ -90,7 +95,8 @@ idePlugins pid includeExamples
       -- , hsimportDescriptor    "hsimport"
       -- , liquidDescriptor      "liquid"
       -- , packageDescriptor     "package"
-        Pragmas.descriptor  "pragmas"
+        GhcIde.descriptor  "ghc"
+      , Pragmas.descriptor  "pragmas"
       , Floskell.descriptor "floskell"
       -- , genericDescriptor     "generic"
       -- , ghcmodDescriptor      "ghcmod"
@@ -145,6 +151,7 @@ main = do
         -- (ps, commandIds) = idePlugins pid argsExamplePlugin
         (ps, commandIds) = idePlugins pid True
         plugins = Completions.plugin <> CodeAction.plugin <>
+                  Plugin mempty HoverDefinition.setHandlersDefinition <>
                   ps
         options = def { LSP.executeCommandCommands = Just commandIds
                       , LSP.completionTriggerCharacters = Just "."

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -34,6 +34,7 @@ library
       Ide.Plugin.Config
       Ide.Plugin.Example
       Ide.Plugin.Example2
+      Ide.Plugin.GhcIde
       Ide.Plugin.Ormolu
       Ide.Plugin.Pragmas
       Ide.Plugin.Floskell

--- a/src/Ide/Plugin.hs
+++ b/src/Ide/Plugin.hs
@@ -40,6 +40,7 @@ import           Ide.Plugin.Config
 import           Ide.Plugin.Formatter
 import           Ide.Types
 import qualified Language.Haskell.LSP.Core as LSP
+import qualified Language.Haskell.LSP.Messages as LSP
 import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
 import qualified Language.Haskell.LSP.Types              as J

--- a/src/Ide/Plugin.hs
+++ b/src/Ide/Plugin.hs
@@ -40,7 +40,6 @@ import           Ide.Plugin.Config
 import           Ide.Plugin.Formatter
 import           Ide.Types
 import qualified Language.Haskell.LSP.Core as LSP
-import qualified Language.Haskell.LSP.Messages as LSP
 import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
 import qualified Language.Haskell.LSP.Types              as J

--- a/src/Ide/Plugin/GhcIde.hs
+++ b/src/Ide/Plugin/GhcIde.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Ide.Plugin.GhcIde
+  (
+    descriptor
+  ) where
+
+import Development.IDE.Types.Logger
+import Ide.Types
+import Development.IDE.LSP.HoverDefinition
+import Development.IDE.Core.Shake
+
+-- ---------------------------------------------------------------------
+
+descriptor :: PluginId -> PluginDescriptor
+descriptor plId = PluginDescriptor
+  { pluginId = plId
+  , pluginRules = mempty
+  , pluginCommands = []
+  , pluginCodeActionProvider = Nothing
+  , pluginCodeLensProvider   = Nothing
+  , pluginDiagnosticProvider = Nothing
+  , pluginHoverProvider      = Just hover'
+  , pluginSymbolsProvider    = Nothing
+  , pluginFormattingProvider = Nothing
+  , pluginCompletionProvider = Nothing
+  }
+
+-- ---------------------------------------------------------------------
+
+hover' :: HoverProvider
+hover' ideState params = do
+    logInfo (ideLogger ideState) "GhcIde.hover entered (ideLogger)" -- AZ
+    hover ideState params
+
+-- ---------------------------------------------------------------------


### PR DESCRIPTION
The way PartialHandlers are chained in ghcide means earlier ones get masked by
ones added later in the chain.

Create GhcIde plugin so the underlying hover handler can be combined with other
configured hover handlers at the haskell-language-server combined handler.

Requires https://github.com/digital-asset/ghcide/pull/490