### PR TITLE
Drop dependency on shake for install.hs

### DIFF
--- a/cabal-hls-install
+++ b/cabal-hls-install
@@ -1,2 +1,2 @@
 #!/bin/sh
-cabal v2-run ./install.hs --project-file install/shake.project $@
+cabal v2-run ./install.hs --project-file install/shake.project -- $@

--- a/cabal-hls-install.cmd
+++ b/cabal-hls-install.cmd
@@ -1,1 +1,1 @@
-@cabal v2-run .\install.hs --project-file=install\shake.project %*
+@cabal v2-run .\install.hs --project-file=install\shake.project -- %*

--- a/install/hls-install.cabal
+++ b/install/hls-install.cabal
@@ -24,7 +24,6 @@ library
                      , process
                      , filepath
                      , optparse-applicative
-                     , extra
                      , text
   default-extensions: LambdaCase
                     , TupleSections

--- a/install/hls-install.cabal
+++ b/install/hls-install.cabal
@@ -18,10 +18,12 @@ library
                      , Print
                      , Env
                      , Help
+                     , Utils
   build-depends:       base >= 4.9 && < 5
-                     , shake >= 0.16.4 && < 0.19
                      , directory
+                     , process
                      , filepath
+                     , optparse-applicative
                      , extra
                      , text
   default-extensions: LambdaCase

--- a/install/src/Env.hs
+++ b/install/src/Env.hs
@@ -21,7 +21,6 @@ import           Data.List                                ( sort
                                                           , nubBy
                                                           )
 import           Data.Ord                                 ( comparing )
-import           Control.Monad.Extra                      ( mapMaybeM )
 
 import qualified Data.Text                     as T
 

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -1,7 +1,6 @@
 -- |Module for Help messages and traget descriptions
 module Help where
 
-import           Development.Shake
 import           Data.List                                ( intercalate )
 
 import           Env
@@ -19,23 +18,23 @@ buildCommand :: TargetDescription -> String
 buildCommand | isRunFromCabal = cabalCommand
              | otherwise = stackCommand
 
-printUsage :: Action ()
+printUsage :: IO ()
 printUsage = do
-  printLine ""
-  printLine "Usage:"
-  printLineIndented (stackCommand templateTarget)
-  printLineIndented "or"
-  printLineIndented (cabalCommand templateTarget)
+  putStrLn ""
+  putStrLn "Usage:"
+  putStrLnIndented (stackCommand templateTarget)
+  putStrLnIndented "or"
+  putStrLnIndented (cabalCommand templateTarget)
 
 -- | short help message is printed by default
-shortHelpMessage :: Action ()
+shortHelpMessage :: IO ()
 shortHelpMessage = do
   hlsVersions <- getHlsVersions
   printUsage
-  printLine ""
-  printLine "Targets:"
-  mapM_ (printLineIndented . showHelpItem (spaces hlsVersions)) (targets hlsVersions)
-  printLine ""
+  putStrLn ""
+  putStrLn "Targets:"
+  mapM_ (putStrLnIndented . showHelpItem (spaces hlsVersions)) (targets hlsVersions)
+  putStrLn ""
  where
   spaces hlsVersions = space (targets hlsVersions)
   targets hlsVersions =
@@ -60,16 +59,16 @@ getDefaultBuildSystemVersions BuildableVersions {..}
   | isRunFromCabal = cabalVersions
   | otherwise      = error $ "unknown build system: " ++ buildSystem
 
-helpMessage :: BuildableVersions -> Action ()
+helpMessage :: BuildableVersions -> IO ()
 helpMessage versions@BuildableVersions {..} = do
   printUsage
-  printLine ""
-  printLine "Targets:"
-  mapM_ (printLineIndented . showHelpItem spaces) targets
-  printLine ""
-  printLine "Options:"
-  mapM_ (printLineIndented . showHelpItem spaces) options
-  printLine ""
+  putStrLn ""
+  putStrLn "Targets:"
+  mapM_ (putStrLnIndented . showHelpItem spaces) targets
+  putStrLn ""
+  putStrLn "Options:"
+  mapM_ (putStrLnIndented . showHelpItem spaces) options
+  putStrLn ""
  where
   spaces = space targets
   -- All targets the shake file supports

--- a/install/src/HlsInstall.hs
+++ b/install/src/HlsInstall.hs
@@ -1,8 +1,10 @@
 module HlsInstall where
 
-import           Development.Shake
+import           Options.Applicative
 import           Control.Monad
 import           System.Environment                       ( unsetEnv )
+import           System.Process
+import           System.Environment
 
 import           BuildSystem
 import           Stack
@@ -24,78 +26,76 @@ defaultMain = do
   stackVersions <- getHlsVersions
 
   let versions = if isRunFromStack then stackVersions else cabalVersions
-
   let toolsVersions = BuildableVersions stackVersions cabalVersions
-
   let latestVersion = last versions
 
-  shakeArgs shakeOptions { shakeFiles = "_build" } $ do
+  let showOptions :: String -> IO ()
+      showOptions verb = do
+        putStrLn $ "Options:"
+        putStrLn $ "    Verbosity level: " ++ verb
+  -- general purpose targets
+  let submodules = updateSubmodules
+  let shortHelp = shortHelpMessage
+  let help = helpMessage toolsVersions
 
-    shakeOptionsRules <- getShakeOptionsRules
+  let checkInstalledTool verb = if isRunFromStack then checkStack [verb] else checkCabal_ [verb]
 
-    let verbosityArg = if isRunFromStack then Stack.getVerbosityArg else Cabal.getVerbosityArg
+  let buildData verb = do
+        showOptions verb
+        submodules
+        checkInstalledTool verb
+        if isRunFromStack then stackBuildData [verb] else cabalBuildData [verb]
 
-    let args = [verbosityArg (shakeVerbosity shakeOptionsRules)]
-
-    phony "show-options" $ do
-      putNormal $ "Options:"
-      putNormal $ "    Verbosity level: " ++ show (shakeVerbosity shakeOptionsRules)
-
-    want ["short-help"]
-    -- general purpose targets
-    phony "submodules"  updateSubmodules
-    phony "short-help"  shortHelpMessage
-    phony "help"        (helpMessage toolsVersions)
-
-    phony "check" (if isRunFromStack then checkStack args else checkCabal_ args)
-
-    phony "data" $ do
-      need ["show-options"]
-      need ["submodules"]
-      need ["check"]
-      if isRunFromStack then stackBuildData args else cabalBuildData args
-
-    forM_
-      versions
-      (\version -> phony ("hls-" ++ version) $ do
-        need ["show-options"]
-        need ["submodules"]
-        need ["check"]
+  let installVersion verb version = do
+        showOptions verb
+        submodules
+        checkInstalledTool verb
         if isRunFromStack then
-          stackInstallHlsWithErrMsg (Just version) args
+          stackInstallHlsWithErrMsg (Just version) [verb]
         else
-          cabalInstallHls version args
-      )
+          cabalInstallHls version [verb]
 
-    unless (null versions) $ do
-      phony "latest" (need ["hls-" ++ latestVersion])
-      phony "hls"  (need ["data", "latest"])
+  let installLatest verb = installVersion verb latestVersion
+  let installLatestAndData verb = buildData verb >> installLatest verb
 
-    -- stack specific targets
-    -- Default `stack.yaml` uses ghc-8.8.2 and we can't build hls in windows
-    -- TODO: Enable for windows when it uses ghc-8.8.3
-    when (isRunFromStack && not isWindowsSystem) $
-      phony "dev" $ do
-        need ["show-options"]
-        stackInstallHlsWithErrMsg Nothing args
+  let installNightly verb = do
+        showOptions verb
+        stackInstallHlsWithErrMsg Nothing [verb]
 
-    -- cabal specific targets
-    when isRunFromCabal $ do
-      -- It throws an error if there is no ghc in $PATH
-      checkInstalledGhcs ghcPaths
-      phony "ghcs" $ showInstalledGhcs ghcPaths
+  -- cabal specific targets
+  let ghcs = do
+        -- It throws an error if there is no ghc in $PATH
+        checkInstalledGhcs ghcPaths
+        showInstalledGhcs ghcPaths
 
-    -- macos specific targets
-    phony "icu-macos-fix" $ do
-      need ["show-options"]
-      need ["icu-macos-fix-install"]
-      need ["icu-macos-fix-build"]
+  let icuMacosFixInstall = callProcess "brew" ["install", "icu4c"]
+  let icuMacosFixBuild verb =  mapM_ (flip buildIcuMacosFix [verb]) versions
 
-    phony "icu-macos-fix-install" (command_ [] "brew" ["install", "icu4c"])
-    phony "icu-macos-fix-build" $ mapM_ (flip buildIcuMacosFix $ args) versions
+  -- macos specific targets
+  let icuMacosFix verb = do
+        showOptions verb
+        icuMacosFixBuild verb
+        icuMacosFixInstall
 
+  args <- getArgs
+  case args of
+    [] -> shortHelp
+    _ -> do
+      Options {..} <- execParser (info (optionParser versions) mempty)
+      let verb = getVerbosity verbosity
+      case cmd of
+        IcuMacosFix -> icuMacosFix verb
+        ShowInstalledGhcs -> ghcs
+        InstallNightly -> installNightly verb
+        InstallLatest -> installLatest verb
+        InstallLatestWithData -> installLatestAndData verb
+        InstallVersion version -> installVersion verb verb
+        BuildData -> buildData verb
+        CheckInstalledTools -> checkInstalledTool verb
+        ShortHelp -> shortHelp
+        AllHelp -> help
 
-buildIcuMacosFix :: VersionNumber -> [String] -> Action ()
+buildIcuMacosFix :: VersionNumber -> [String] -> IO ()
 buildIcuMacosFix version args = execStackWithGhc_
   version $
   [ "build"
@@ -105,7 +105,79 @@ buildIcuMacosFix version args = execStackWithGhc_
   ] ++ args
 
 -- | update the submodules that the project is in the state as required by the `stack.yaml` files
-updateSubmodules :: Action ()
+updateSubmodules :: IO ()
 updateSubmodules = do
-  command_ [] "git" ["submodule", "sync"]
-  command_ [] "git" ["submodule", "update", "--init"]
+  callProcess "git" ["submodule", "sync"]
+  callProcess "git" ["submodule", "update", "--init"]
+
+data Cmd
+  = IcuMacosFix
+  | ShowInstalledGhcs
+  | InstallNightly
+  | InstallLatest
+  | InstallLatestWithData
+  | InstallVersion String
+  | BuildData
+  | CheckInstalledTools
+  | ShortHelp
+  | AllHelp
+  deriving (Show, Eq, Read)
+
+data Verbosity
+  = Silent
+  | Normal
+  | Verbose
+  | Debug
+  deriving (Show, Eq, Read)
+
+data Options = Options
+  { verbosity :: Verbosity
+  , cmd :: Cmd
+  }
+
+optionParser :: [String] -> Parser Options
+optionParser versions = Options
+  <$> verbosityParser
+  <*> cmdParser
+  where
+    verbosityParser :: Parser Verbosity
+    verbosityParser =
+        option (maybeReader parseVerbosity) (long "verbosity" <> short 'v' <> value Normal)
+
+    parseVerbosity "silent" = Just Silent
+    parseVerbosity "normal" = Just Normal
+    parseVerbosity "verbose" = Just Verbose
+    parseVerbosity "debug" = Just Debug
+    parseVerbosity _ = Nothing
+
+    cmdParser :: Parser Cmd
+    cmdParser = subparser
+      (  command "icu-macos-fix" (info (pure IcuMacosFix) mempty)
+      <> command "ghcs" (info (pure ShowInstalledGhcs) mempty)
+      <> command "dev" (info (pure InstallNightly) mempty)
+      <> command "latest" (info (pure InstallLatest) mempty)
+      <> command "hls" (info (pure InstallLatestWithData) mempty)
+      <> mconcat
+          (map (\v -> command ("hls-" ++ v) (info (pure $ InstallVersion v) mempty)) versions)
+      <> command "data" (info (pure BuildData) mempty)
+      <> command "check" (info (pure CheckInstalledTools) mempty)
+      <> command "short-help" (info (pure ShortHelp) mempty)
+      <> command "help" (info (pure AllHelp) mempty)
+      )
+
+
+getVerbosity :: Verbosity -> String
+getVerbosity verb
+  | isRunFromStack = "--verbosity=" ++ stackVerbosity verb
+  | otherwise = "-v" ++ cabalVerbosity verb
+  where
+    cabalVerbosity = \case
+      Silent -> "0"
+      Normal -> "1"
+      Verbose -> "2"
+      Debug -> "3"
+    stackVerbosity = \case
+      Silent -> "silent"
+      Normal -> "info"
+      Verbose -> "warn"
+      Debug -> "debug"

--- a/install/src/Print.hs
+++ b/install/src/Print.hs
@@ -1,26 +1,21 @@
 module Print where
 
-import           Development.Shake
 import           Control.Monad.IO.Class
 import           Data.List                                ( dropWhileEnd
                                                           )
 import           Data.Char                                ( isSpace )
 
--- | lift putStrLn to MonadIO
-printLine :: MonadIO m => String -> m ()
-printLine = liftIO . putStrLn
-
 -- | print a line prepended with 4 spaces
-printLineIndented :: MonadIO m => String -> m ()
-printLineIndented = printLine . ("    " ++)
+putStrLnIndented :: String -> IO ()
+putStrLnIndented = putStrLn . ("    " ++)
 
 embedInStars :: String -> String
 embedInStars str =
   let starsLine = "\n" <> replicate 80 '*' <> "\n"
   in  starsLine <> str <> starsLine
 
-printInStars :: MonadIO m => String -> m ()
-printInStars = liftIO . putStrLn . embedInStars
+printInStars :: String -> IO ()
+printInStars = putStrLn . embedInStars
 
 
 -- | Trim whitespace of both ends of a string
@@ -28,8 +23,8 @@ trim :: String -> String
 trim = dropWhileEnd isSpace . dropWhile isSpace
 
 -- | Trim the whitespace of the stdout of a command
-trimmedStdout :: Stdout String -> String
-trimmedStdout (Stdout s) = trim s
+trimmedStdout :: String -> String
+trimmedStdout s = trim s
 
 type TargetDescription = (String, String)
 

--- a/install/src/Utils.hs
+++ b/install/src/Utils.hs
@@ -1,0 +1,7 @@
+module Utils where 
+
+import System.Info.Extra
+
+-- | The extension of executables, @\"exe\"@ on Windows and @\"\"@ otherwise.
+exe :: String
+exe = if isWindows then "exe" else ""

--- a/install/src/Utils.hs
+++ b/install/src/Utils.hs
@@ -1,7 +1,21 @@
-module Utils where 
+{-# LANGUAGE CPP #-}
+module Utils where
 
-import System.Info.Extra
+import System.Info
 
 -- | The extension of executables, @\"exe\"@ on Windows and @\"\"@ otherwise.
 exe :: String
 exe = if isWindows then "exe" else ""
+
+isWindows :: Bool
+#if defined(mingw32_HOST_OS)
+isWindows = True
+#else
+isWindows = False
+#endif
+
+-- | A version of 'mapMaybe' that works with a monadic predicate.
+mapMaybeM :: Monad m => (a -> m (Maybe b)) -> [a] -> m [b]
+{-# INLINE mapMaybeM #-}
+mapMaybeM op = foldr f (pure [])
+    where f x xs = do x <- op x; case x of Nothing -> xs; Just x -> do xs <- xs; pure $ x:xs


### PR DESCRIPTION
As discussed with @jneira, we dont need `shake` to build this project. It makes the installation script more complex and increases first build-time.

There can be a number of improvements build on top of it.