### PR TITLE
Use patched version of hie-bios to load ghcide modules

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,6 +7,12 @@ source-repository-package
     location: https://github.com/DanielG/cabal-helper.git
     tag: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
 
+source-repository-package
+    type: git
+    location: https://github.com/fendor/hie-bios.git
+    tag: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
+
+
 tests: true
 documentation: false
 -- documentation: true

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -53,11 +53,11 @@ import DynFlags                                 (gopt_set, gopt_unset,
                                                  updOptLevel)
 import DynFlags                                 (PackageFlag(..), PackageArg(..))
 import GHC hiding                               (def)
-import           GHC.Check                      (runTimeVersion, compileTimeVersionFromLibdir)
+import GHC.Check                                (runTimeVersion, compileTimeVersionFromLibdir)
 -- import GhcMonad
-import           HIE.Bios.Cradle
+import HIE.Bios.Cradle
 import HIE.Bios.Environment                     (addCmdOpts)
-import           HIE.Bios.Types
+import HIE.Bios.Types
 import HscTypes                                 (HscEnv(..), ic_dflags)
 import qualified Language.Haskell.LSP.Core as LSP
 import Ide.Logger
@@ -497,9 +497,9 @@ memoIO op = do
             Just res -> return (mp, res)
 
 setOptions :: GhcMonad m => ComponentOptions -> DynFlags -> m (DynFlags, [Target])
-setOptions (ComponentOptions theOpts _) dflags = do
+setOptions (ComponentOptions theOpts compRoot _) dflags = do
     cacheDir <- liftIO $ getCacheDir theOpts
-    (dflags', targets) <- addCmdOpts theOpts dflags
+    (dflags', targets) <- addCmdOpts compRoot theOpts dflags
     let dflags'' =
           -- disabled, generated directly by ghcide instead
           flip gopt_unset Opt_WriteInterface $


### PR DESCRIPTION
* With the actual version of hie-bios, loading modules from the ghcide submodule failed, see https://github.com/mpickering/hie-bios/pull/166#issuecomment-613091664
* We can either wait to an hie-bios release [with the patch included](https://github.com/mpickering/hie-bios/pull/166) and remove the git dependency or merge this as is 