### PR TITLE
Use patched version of hie-bios in stack config

### DIFF
--- a/src/Ide/Cradle.hs
+++ b/src/Ide/Cradle.hs
@@ -467,6 +467,7 @@ cabalHelperCradle file = do
                                       $ CradleSuccess
                                         ComponentOptions
                                           { componentOptions = [file, fixImportDirs cwd "-i."]
+                                          , componentRoot = cwd
                                           , componentDependencies = []
                                           }
                                 }
@@ -551,8 +552,9 @@ cabalHelperAction proj env package root fp = do
         return
           $ CradleSuccess
             ComponentOptions { componentOptions = ghcOptions
-                              , componentDependencies = []
-                              }
+                             , componentRoot = root
+                             , componentDependencies = []
+                             }
       Left err   -> return
         $ CradleFail
         $ CradleError

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -26,7 +26,9 @@ extra-deps:
 - haskell-lsp-0.21.0.0
 - haskell-lsp-types-0.21.0.0
 - haskell-src-exts-1.21.1
-- hie-bios-0.4.0
+# - hie-bios-0.4.0
+- github: fendor/hie-bios
+  commit: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -20,7 +20,9 @@ extra-deps:
 - haddock-library-1.8.0
 - haskell-lsp-0.21.0.0
 - haskell-lsp-types-0.21.0.0
-- hie-bios-0.4.0
+# - hie-bios-0.4.0
+- github: fendor/hie-bios
+  commit: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
 - indexed-profunctors-0.1
 - lsp-test-0.10.2.0
 - monad-dijkstra-0.1.1.2

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -20,7 +20,9 @@ extra-deps:
 - haskell-lsp-0.21.0.0
 - haskell-lsp-types-0.21.0.0
 - haskell-src-exts-1.21.1
-- hie-bios-0.4.0
+# - hie-bios-0.4.0
+- github: fendor/hie-bios
+  commit: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -20,7 +20,9 @@ extra-deps:
 - haskell-lsp-0.21.0.0
 - haskell-lsp-types-0.21.0.0
 - haskell-src-exts-1.21.1
-- hie-bios-0.4.0
+# - hie-bios-0.4.0
+- github: fendor/hie-bios
+  commit: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,7 +20,9 @@ extra-deps:
 - haddock-library-1.8.0
 - haskell-lsp-0.21.0.0
 - haskell-lsp-types-0.21.0.0
-- hie-bios-0.4.0
+# - hie-bios-0.4.0
+- github: fendor/hie-bios
+  commit: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
 - indexed-profunctors-0.1
 - lsp-test-0.10.2.0
 - monad-dijkstra-0.1.1.2


### PR DESCRIPTION
* It needs a ghcide version compatible with the hie-bios patch:  https://github.com/alanz/ghcide/pull/1