### PR TITLE
Get building with ghc-8.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
   cabal:
     working_directory: ~/build
     docker:
-      - image: haskell:8.10.1
+      - image: haskell:8.8.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
   cabal:
     working_directory: ~/build
     docker:
-      - image: haskell:8.8.1
+      - image: haskell:8.10.1
     steps:
       - checkout
       - run:

--- a/cabal.project
+++ b/cabal.project
@@ -5,12 +5,12 @@ packages:
 source-repository-package
     type: git
     location: https://github.com/DanielG/cabal-helper.git
-    tag: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+    tag: 5b85a4b9e1c6463c94ffa595893ad02c9a3d2ec3
 
 source-repository-package
     type: git
-    location: https://github.com/fendor/hie-bios.git
-    tag: 89d28817716a1c8df7e191f3a43c4504bc6379eb
+    location: https://github.com/mpickering/hie-bios.git
+    tag: f0abff9c855ea7e6624617df669825f3f62f723b
 
 source-repository-package
     type: git
@@ -29,3 +29,5 @@ package ghcide
 write-ghc-environment-files: never
 
 index-state: 2020-05-05T17:33:00Z
+
+allow-newer: cabal-plan:base,floskell:base,floskell:ghc-prim,tasty-rerun:base

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -10,7 +10,7 @@ extra-deps:
 - bytestring-trie-0.2.5.0
 # - cabal-helper-1.0.0.0
 - github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+  commit: 5b85a4b9e1c6463c94ffa595893ad02c9a3d2ec3
 - cabal-plan-0.5.0.0
 - constrained-dynamic-0.1.0.0
 # - ghcide-0.1.0
@@ -27,8 +27,8 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
-- github: fendor/hie-bios
-  commit: 89d28817716a1c8df7e191f3a43c4504bc6379eb
+- github: mpickering/hie-bios
+  commit: f0abff9c855ea7e6624617df669825f3f62f723b
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - base-compat-0.11.0
 # - cabal-helper-1.0.0.0
 - github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+  commit: 5b85a4b9e1c6463c94ffa595893ad02c9a3d2ec3
 - cabal-plan-0.6.2.0
 - clock-0.7.2
 - floskell-0.10.2
@@ -23,8 +23,8 @@ extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 # - hie-bios-0.4.0
-- github: fendor/hie-bios
-  commit: 89d28817716a1c8df7e191f3a43c4504bc6379eb
+- github: mpickering/hie-bios
+  commit: f0abff9c855ea7e6624617df669825f3f62f723b
 - indexed-profunctors-0.1
 - lsp-test-0.10.3.0
 - monad-dijkstra-0.1.1.2

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - bytestring-trie-0.2.5.0
 # - cabal-helper-1.0.0.0
 - github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+  commit: 5b85a4b9e1c6463c94ffa595893ad02c9a3d2ec3
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2
@@ -22,8 +22,8 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
-- github: fendor/hie-bios
-  commit: 89d28817716a1c8df7e191f3a43c4504bc6379eb
+- github: mpickering/hie-bios
+  commit: f0abff9c855ea7e6624617df669825f3f62f723b
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - bytestring-trie-0.2.5.0
 # - cabal-helper-1.0.0.0
 - github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+  commit: 5b85a4b9e1c6463c94ffa595893ad02c9a3d2ec3
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2
@@ -22,8 +22,8 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
-- github: fendor/hie-bios
-  commit: 89d28817716a1c8df7e191f3a43c4504bc6379eb
+- github: mpickering/hie-bios
+  commit: f0abff9c855ea7e6624617df669825f3f62f723b
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - base-compat-0.11.0
 # - cabal-helper-1.0.0.0
 - github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+  commit: 5b85a4b9e1c6463c94ffa595893ad02c9a3d2ec3
 - cabal-plan-0.6.2.0
 - clock-0.7.2
 - floskell-0.10.2
@@ -22,8 +22,8 @@ extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 # - hie-bios-0.4.0
-- github: fendor/hie-bios
-  commit: 89d28817716a1c8df7e191f3a43c4504bc6379eb
+- github: mpickering/hie-bios
+  commit: f0abff9c855ea7e6624617df669825f3f62f723b
 - indexed-profunctors-0.1
 - lsp-test-0.10.3.0
 - monad-dijkstra-0.1.1.2


### PR DESCRIPTION
@alanz @fendor I think we can create a new release of haskell-lsp with updated bounds before merging this, to avoid extra submodules?
Also the mpickering hie-bios fork should have the changes from the fendor fork now