### PR TITLE
Use implicit-hie

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,8 +9,13 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/mpickering/hie-bios.git
-    tag: 501cc337691cc9da45ff12db46d8b3af9a2a0eda 
+    location: https://github.com/Avi-D-coder/hie-bios.git
+    tag: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+
+source-repository-package
+    type: git
+    location: https://github.com/Avi-D-coder/implicit-hie.git
+    tag: e033a562a8b18878d354b91977dbcd33604ad554
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -15,7 +15,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/implicit-hie.git
-    tag: e033a562a8b18878d354b91977dbcd33604ad554
+    tag: 2de791efafb25e020061f9cb808dda0bfb3755ae
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -10,7 +10,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/hie-bios.git
-    tag: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+    tag: 63e6e56ecfd726829f0b3fdc626de3796feaa05a
 
 source-repository-package
     type: git

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -28,9 +28,9 @@ extra-deps:
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
 - github: Avi-D-coder/hie-bios
-  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+  commit: 6d95e0343a35b44f6aa7600af46b0c3d48ffd3da
 - github: Avi-D-coder/implicit-hie
-  commit: e033a562a8b18878d354b91977dbcd33604ad554
+  commit: a71069c2baf6fb0a3fd3298ad59bd7d79afebe49
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -27,8 +27,10 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
-- github: mpickering/hie-bios
-  commit: 501cc337691cc9da45ff12db46d8b3af9a2a0eda
+- github: Avi-D-coder/hie-bios
+  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+- github: Avi-D-coder/implicit-hie
+  commit: e033a562a8b18878d354b91977dbcd33604ad554
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -23,8 +23,10 @@ extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 # - hie-bios-0.4.0
-- github: mpickering/hie-bios
-  commit: f0abff9c855ea7e6624617df669825f3f62f723b
+- github: Avi-D-coder/hie-bios
+  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+- github: Avi-D-coder/implicit-hie
+  commit: e033a562a8b18878d354b91977dbcd33604ad554
 - indexed-profunctors-0.1
 - lsp-test-0.10.3.0
 - monad-dijkstra-0.1.1.2

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -24,9 +24,9 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 # - hie-bios-0.4.0
 - github: Avi-D-coder/hie-bios
-  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+  commit: 6d95e0343a35b44f6aa7600af46b0c3d48ffd3da
 - github: Avi-D-coder/implicit-hie
-  commit: e033a562a8b18878d354b91977dbcd33604ad554
+  commit: a71069c2baf6fb0a3fd3298ad59bd7d79afebe49
 - indexed-profunctors-0.1
 - lsp-test-0.10.3.0
 - monad-dijkstra-0.1.1.2

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -23,9 +23,9 @@ extra-deps:
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
 - github: Avi-D-coder/hie-bios
-  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+  commit: 6d95e0343a35b44f6aa7600af46b0c3d48ffd3da
 - github: Avi-D-coder/implicit-hie
-  commit: e033a562a8b18878d354b91977dbcd33604ad554
+  commit: a71069c2baf6fb0a3fd3298ad59bd7d79afebe49
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -22,8 +22,10 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
-- github: mpickering/hie-bios
-  commit: 501cc337691cc9da45ff12db46d8b3af9a2a0eda 
+- github: Avi-D-coder/hie-bios
+  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+- github: Avi-D-coder/implicit-hie
+  commit: e033a562a8b18878d354b91977dbcd33604ad554
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -23,9 +23,9 @@ extra-deps:
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
 - github: Avi-D-coder/hie-bios
-  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+  commit: 6d95e0343a35b44f6aa7600af46b0c3d48ffd3da
 - github: Avi-D-coder/implicit-hie
-  commit: e033a562a8b18878d354b91977dbcd33604ad554
+  commit: a71069c2baf6fb0a3fd3298ad59bd7d79afebe49
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -22,8 +22,10 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
-- github: mpickering/hie-bios
-  commit: 501cc337691cc9da45ff12db46d8b3af9a2a0eda
+- github: Avi-D-coder/hie-bios
+  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+- github: Avi-D-coder/implicit-hie
+  commit: e033a562a8b18878d354b91977dbcd33604ad554
 - hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,19 +1,18 @@
-resolver: lts-14.22
+resolver: lts-15.10
 
 packages:
 - .
 - ./ghcide/
 
 extra-deps:
-- ansi-terminal-0.10.2
-- base-compat-0.11.0
+- apply-refact-0.7.0.0
+- bytestring-trie-0.2.5.0
 # - cabal-helper-1.0.0.0
 - github: DanielG/cabal-helper
   commit: 5b85a4b9e1c6463c94ffa595893ad02c9a3d2ec3
-- cabal-plan-0.6.2.0
 - clock-0.7.2
+- constrained-dynamic-0.1.0.0
 - floskell-0.10.2
-- fuzzy-0.1.0.0
 # - ghcide-0.1.0
 - ghc-check-0.1.0.3
 - ghc-lib-parser-8.10.1.20200412
@@ -21,28 +20,24 @@ extra-deps:
 - haddock-library-1.8.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
+- haskell-src-exts-1.21.1
 # - hie-bios-0.4.0
 - github: Avi-D-coder/hie-bios
-  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+  commit: 6d95e0343a35b44f6aa7600af46b0c3d48ffd3da
 - github: Avi-D-coder/implicit-hie
-  commit: e033a562a8b18878d354b91977dbcd33604ad554
-- indexed-profunctors-0.1
+  commit: a71069c2baf6fb0a3fd3298ad59bd7d79afebe49
+- hlint-2.2.8
+- hoogle-5.0.17.11
+- hsimport-0.11.0
+- ilist-0.3.1.0
 - lsp-test-0.10.3.0
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.3.0
-- optics-core-0.2
-- optparse-applicative-0.15.1.0
+- opentelemetry-0.3.2
 - ormolu-0.0.5.0
-- parser-combinators-1.2.1
-- regex-base-0.94.0.0
-- regex-pcre-builtin-0.95.1.1.8.43
-- regex-tdfa-1.3.1.0
-- semialign-1.1
+- semigroups-0.18.5
 - github: wz1000/shake
   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
-- tasty-rerun-1.1.17
 - temporary-1.2.1.1
-- topograph-1
 
 flags:
   haskell-language-server:

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,8 +22,10 @@ extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 # - hie-bios-0.4.0
-- github: mpickering/hie-bios
-  commit: 501cc337691cc9da45ff12db46d8b3af9a2a0eda
+- github: Avi-D-coder/hie-bios
+  commit: b67ebfdabe3d6801aca8f64ee8fe21fac77f24da
+- github: Avi-D-coder/implicit-hie
+  commit: e033a562a8b18878d354b91977dbcd33604ad554
 - indexed-profunctors-0.1
 - lsp-test-0.10.3.0
 - monad-dijkstra-0.1.1.2


### PR DESCRIPTION
Related to https://github.com/mpickering/hie-bios/pull/178.
Alternative to #68
Resolves #38, until stack and cabal `show-build-info`.

See https://github.com/mpickering/hie-bios/pull/178 for bugs and progress.