### PR TITLE
Update extra-deps to use latest fork version of shake

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,8 +14,8 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/mpickering/shake
-    tag: 4d56fe9f09bd3bd63ead541c571c756995da490a
+    location: https://github.com/wz1000/shake
+    tag: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 
 tests: true
 documentation: false

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -43,8 +43,8 @@ extra-deps:
 - regex-tdfa-1.3.1.0
 - rope-utf16-splay-0.3.1.0
 # - shake-0.18.5
-- github: mpickering/shake
-  commit: 4d56fe9f09bd3bd63ead541c571c756995da490a
+- github: wz1000/shake
+  commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - syz-0.2.0.0
 - tasty-rerun-1.1.17
 - temporary-1.2.1.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -36,8 +36,8 @@ extra-deps:
 - regex-base-0.94.0.0
 - regex-pcre-builtin-0.95.1.1.8.43
 - regex-tdfa-1.3.1.0
-- github: mpickering/shake
-  commit: 4d56fe9f09bd3bd63ead541c571c756995da490a
+- github: wz1000/shake
+  commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - semialign-1.1
 - tasty-rerun-1.1.17
 - temporary-1.2.1.1

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -33,8 +33,8 @@ extra-deps:
 - opentelemetry-0.3.2
 - ormolu-0.0.5.0
 - semigroups-0.18.5
-- github: mpickering/shake
-  commit: 4d56fe9f09bd3bd63ead541c571c756995da490a
+- github: wz1000/shake
+  commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - temporary-1.2.1.1
 
 flags:

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -33,8 +33,8 @@ extra-deps:
 - opentelemetry-0.3.2
 - ormolu-0.0.5.0
 - semigroups-0.18.5
-- github: mpickering/shake
-  commit: 4d56fe9f09bd3bd63ead541c571c756995da490a
+- github: wz1000/shake
+  commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - temporary-1.2.1.1
 
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,6 +36,8 @@ extra-deps:
 - regex-pcre-builtin-0.95.1.1.8.43
 - regex-tdfa-1.3.1.0
 - semialign-1.1
+- github: wz1000/shake
+  commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - tasty-rerun-1.1.17
 - temporary-1.2.1.1
 - topograph-1


### PR DESCRIPTION
Since afaict, the current shake ref has been removed by force-pushing.