### PR TITLE
Create specific project file for ghc-8.10.

### DIFF
--- a/cabal.project-8.10.1
+++ b/cabal.project-8.10.1
@@ -18,7 +18,7 @@ source-repository-package
     tag: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 
 tests: true
-documentation: true
+documentation: false
 
 package haskell-language-server
   test-show-details: direct
@@ -28,3 +28,5 @@ package ghcide
 write-ghc-environment-files: never
 
 index-state: 2020-05-05T17:33:00Z
+
+allow-newer: cabal-plan:base,floskell:base,floskell:ghc-prim,tasty-rerun:base


### PR DESCRIPTION
* It let us isolate temporary config tweaks in its own config file like `allow-newer` and turning off docs
* The install.hs script will pick it auto
* But you have to remember use it wen building using directly cabal