### PR TITLE
[#87] Fix completion via ghcide's `getCompletionsLSP`

### DIFF
--- a/src/Ide/Plugin.hs
+++ b/src/Ide/Plugin.hs
@@ -512,7 +512,7 @@ makeCompletions sps lf ideState params@(CompletionParams (TextDocumentIdentifier
       case mprefix of
           Nothing -> return $ Right $ Completions $ List []
           Just _prefix -> do
-            mhs <- mapM (\(_,p) -> p ideState params) sps
+            mhs <- mapM (\(_,p) -> p lf ideState params) sps
             case rights mhs of
                 [] -> return $ Left $ responseError $ T.pack $ show $ lefts mhs
                 hs -> return $ Right $ combine hs

--- a/src/Ide/Plugin/Example.hs
+++ b/src/Ide/Plugin/Example.hs
@@ -210,7 +210,7 @@ symbols _lf _ide (DocumentSymbolParams _doc _mt)
 -- ---------------------------------------------------------------------
 
 completion :: CompletionProvider
-completion _ide (CompletionParams _doc _pos _mctxt _mt)
+completion _lf _ide (CompletionParams _doc _pos _mctxt _mt)
     = pure $ Right $ Completions $ List [r]
     where
         r = CompletionItem label kind tags detail documentation deprecated preselect

--- a/src/Ide/Plugin/Example2.hs
+++ b/src/Ide/Plugin/Example2.hs
@@ -207,7 +207,7 @@ symbols _lf _ide (DocumentSymbolParams _doc _mt)
 -- ---------------------------------------------------------------------
 
 completion :: CompletionProvider
-completion _ide (CompletionParams _doc _pos _mctxt _mt)
+completion _lf _ide (CompletionParams _doc _pos _mctxt _mt)
     = pure $ Right $ Completions $ List [r]
     where
         r = CompletionItem label kind tags detail documentation deprecated preselect

--- a/src/Ide/Plugin/GhcIde.hs
+++ b/src/Ide/Plugin/GhcIde.hs
@@ -10,6 +10,7 @@ import Development.IDE.Core.Service
 import Development.IDE.LSP.HoverDefinition
 import Development.IDE.LSP.Outline
 import Development.IDE.Plugin.CodeAction
+import Development.IDE.Plugin.Completions
 import Development.IDE.Types.Logger
 import Ide.Plugin
 import Ide.Types
@@ -29,7 +30,7 @@ descriptor plId = PluginDescriptor
   , pluginHoverProvider      = Just hover'
   , pluginSymbolsProvider    = Just symbolsProvider
   , pluginFormattingProvider = Nothing
-  , pluginCompletionProvider = Nothing
+  , pluginCompletionProvider = Just getCompletionsLSP
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Ide/Types.hs
+++ b/src/Ide/Types.hs
@@ -99,6 +99,12 @@ type CodeActionProvider = LSP.LspFuncs Config
                         -> CodeActionContext
                         -> IO (Either ResponseError (List CAResult))
 
+type CompletionProvider = LSP.LspFuncs Config
+                        -> IdeState
+                        -> CompletionParams
+                        -> IO (Either ResponseError CompletionResponseResult)
+
+
 
 type CodeLensProvider = LSP.LspFuncs Config
                       -> IdeState
@@ -143,10 +149,6 @@ type ExecuteCommandProvider = IdeState
                             -> IO (Either ResponseError Value, Maybe (ServerMethod, ApplyWorkspaceEditParams))
 
 newtype WithSnippets = WithSnippets Bool
-
-type CompletionProvider = IdeState
-                        -> CompletionParams
-                        -> IO (Either ResponseError CompletionResponseResult)
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
fixes #71 and #87

This fix requires the **ghcide**'s `Development.IDE.Plugin.Completions` module to expose `getCompletionsLSP`