### PR TITLE
Add lower bound to tasty-ant-xml

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -224,7 +224,7 @@ test-suite func-test
                       , lens
                       , lsp-test >= 0.10.0.0
                       , tasty
-                      , tasty-ant-xml
+                      , tasty-ant-xml >= 1.1.6
                       , tasty-expected-failure
                       , tasty-hunit
                       , tasty-rerun


### PR DESCRIPTION
* The pr adding tast-ant-xml was built succesfullt [with cabal in ci](https://circleci.com/gh/haskell/haskell-language-server/379?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
  * It used:
```
 - tasty-1.2.3 (lib) (requires download & build)
 - tasty-rerun-1.1.17 (lib) (requires download & build)
 - tasty-hunit-0.10.0.2 (lib) (requires download & build)
 - tasty-expected-failure-0.11.1.2 (lib) (requires download & build)
 - tasty-ant-xml-1.1.6 (lib) (requires download & build)
```
* The next commit (mine! ✋ ) changed the hackage index from 2020-05-13T21:21:45Z to 2020-05-17T20:25:21Z and triggered the build error picking;

```
 - tasty-1.3.1 (lib) (requires download & build)
 - tasty-rerun-1.1.17 (lib) (requires download & build)
 - tasty-hunit-0.10.0.2 (lib) (requires download & build)
 - tasty-expected-failure-0.11.1.2 (lib) (requires download & build)
 - tasty-ant-xml-1.0.0.5 (lib) (requires download & build)
```

Not sure what is going on but adding a lower bound force cabal to pick the good version. Tested locally for ghc-8.6.4, ghc-8.6.5, ghc-8.8.3 y ghc-8.10.1 