### PR TITLE
Convert private lib in common stanza

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -205,6 +205,9 @@ executable haskell-language-server-wrapper
     , process
   default-language:    Haskell2010
 
+-- This common stanza simulates a previous private lib
+-- We removed it due to issues with stack when loading the project using a stack based hie.yaml
+-- See https://github.com/haskell/haskell-language-server/issues/114
 common hls-test-utils
   import: agpl
   hs-source-dirs:      test/utils

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -205,8 +205,36 @@ executable haskell-language-server-wrapper
     , process
   default-language:    Haskell2010
 
+common hls-test-utils
+  import: agpl
+  hs-source-dirs:      test/utils
+  other-modules:       Test.Hls.Util
+  build-depends:       base
+                     , haskell-language-server
+                     , haskell-lsp
+                     , hie-bios
+                     , aeson
+                     , blaze-markup
+                     , containers
+                     , data-default
+                     , directory
+                     , filepath
+                     , hslogger
+                     , hspec
+                     , hspec-core
+                     , lsp-test
+                     , stm
+                     , tasty-hunit
+                     , text
+                     , unordered-containers
+                     , yaml
+  ghc-options:         -Wall -Wredundant-constraints
+  if flag(pedantic)
+     ghc-options:      -Werror
+  default-language:    Haskell2010
+
 test-suite func-test
-  import:               agpl
+  import:               agpl, hls-test-utils
   type:                 exitcode-stdio-1.0
   default-language:     Haskell2010
   build-tool-depends:   haskell-language-server:haskell-language-server
@@ -219,7 +247,6 @@ test-suite func-test
                       , haskell-language-server
                       , haskell-lsp
                       , haskell-lsp-types
-                      , hls-test-utils
                       , hspec-expectations
                       , lens
                       , lsp-test >= 0.10.0.0
@@ -253,31 +280,3 @@ test-suite func-test
                         -threaded -rtsopts -with-rtsopts=-N
   if flag(pedantic)
      ghc-options: -Werror -Wredundant-constraints
-
-library hls-test-utils
-  import: agpl
-  hs-source-dirs:      test/utils
-  exposed-modules:     Test.Hls.Util
-  build-depends:       base
-                     , haskell-language-server
-                     , haskell-lsp
-                     , hie-bios
-                     , aeson
-                     , blaze-markup
-                     , containers
-                     , data-default
-                     , directory
-                     , filepath
-                     , hslogger
-                     , hspec
-                     , hspec-core
-                     , lsp-test
-                     , stm
-                     , tasty-hunit
-                     , text
-                     , unordered-containers
-                     , yaml
-  ghc-options:         -Wall -Wredundant-constraints
-  if flag(pedantic)
-     ghc-options:      -Werror
-  default-language:    Haskell2010

--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -7,7 +7,7 @@ cradle:
     - path: "./test/functional/"
       component: "haskell-language-server:func-test"
 
-    - path: "./test/util/"
+    - path: "./test/utils/"
       component: "haskell-language-server:func-test"
 
     - path: "./exe/Main.hs"

--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -7,8 +7,8 @@ cradle:
     - path: "./test/functional/"
       component: "haskell-language-server:func-test"
 
-    - path: "./test/utils/"
-      component: "haskell-language-server:hls-test-utils"
+    - path: "./test/util/"
+      component: "haskell-language-server:func-test"
 
     - path: "./exe/Main.hs"
       component: "haskell-language-server:exe:haskell-language-server"

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -6,9 +6,8 @@ cradle:
     - path: "./test/functional/"
       component: "haskell-language-server:func-test"
 
-    # This target does not currently work (stack 2.1.3)
-    # - path: "./test/utils"
-    #   component: "haskell-language-server:lib:hls-test-utils"
+    - path: "./test/utils/"
+      component: "haskell-language-server:func-test"
 
     - path: "./exe/Main.hs"
       component: "haskell-language-server:exe:haskell-language-server"


### PR DESCRIPTION
* To workaround the issues involving the stack based cradle: #114 and #121 
* I've not changed the build info of the previous private lib, in the hope we will restore it
* I've tested it locally:
  * You can open `Test.Hls.Util` after building the project with test enabled `stack build --test --no-run.tests`
  * When opening exe/Main.hs after deleting `.stack-work`, it hits https://github.com/mpickering/ghcide/issues/50 but it seems it does not need a `stack build`(it starts the initial ghc session)

![imagen](https://user-images.githubusercontent.com/54035/82985708-d0ac2280-9ff4-11ea-898b-016e1bb9691b.png)
