### PR TITLE
Separate ghcide tests and disable them for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,16 @@ defaults: &defaults
           - ~/build/ghcide/.stack-work
 
     - run:
-        name: Test
+        name: Test ghcide
         # Tests MUST run with -j1, since multiple ghc-mod sessions are not allowed
-        command: stack -j 1 --stack-yaml=${STACK_FILE} test --dump-logs
+        # command: stack -j 1 --stack-yaml=${STACK_FILE} test ghcide --dump-logs
+        command: echo "ghcide tests disabled until they got fixed, see https://github.com/mpickering/ghcide/issues/25"
+        no_output_timeout: 120m
+
+    - run:
+        name: Test haskell-language-server
+        # Tests MUST run with -j1, since multiple ghc-mod sessions are not allowed
+        command: stack -j 1 --stack-yaml=${STACK_FILE} test haskell-language-server --dump-logs
         no_output_timeout: 120m
 
     - store_test_results:


### PR DESCRIPTION
* CI always red is not good, we have to check that them at least builds
* I think separate tests could be useful in its own