### PR TITLE
Use shell.nix from Haskell-IDE-Engine

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+with (import <nixpkgs> {});
+stdenv.mkDerivation {
+  name = "haskell-language-server";
+  buildInputs = [
+    gmp
+    zlib
+    ncurses
+
+    haskellPackages.cabal-install
+  ];
+  src = null;
+  shellHook = ''
+    export LD_LIBRARY_PATH=${gmp}/lib:${zlib}/lib:${ncurses}/lib
+    export PATH=$PATH:$HOME/.local/bin
+  '';
+}


### PR DESCRIPTION
My personal workflow is to use this shell to have `binutils-unwrapped` and similar in scope.
