### PR TITLE
Add subcradle for Setup.hs

### DIFF
--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -6,6 +6,14 @@ cradle:
     - path: "./test/testdata/"
       config: { cradle: { none:  } }
 
+    - path: ./Setup.hs
+      config:
+        cradle:
+          direct:
+            arguments:
+              - "-package Cabal"
+              - "-package base"
+
     - path: "./"
       config:
         cradle:

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -6,6 +6,14 @@ cradle:
     - path: "./test/testdata/"
       config: { cradle: { none:  } }
 
+    - path: ./Setup.hs
+      config:
+        cradle:
+          direct:
+            arguments:
+              - "-package Cabal"
+              - "-package base"
+
     - path: "./"
       config:
         cradle:


### PR DESCRIPTION
* Leverage multicradle adding the workaround described here by @fendor: https://github.com/haskell/haskell-ide-engine/issues/1650#issuecomment-650192055
* I think it could be used as example for using hi.yaml in other projects