### PR TITLE
Use cabal-plan from Hackage

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,12 +2,6 @@ packages:
          ./
          ghcide
 
--- See https://github.com/haskell-hvr/cabal-plan/pull/55
-source-repository-package
-    type: git
-    location: https://github.com/peti/cabal-plan
-    tag: 894b76c0b6bf8f7d2f881431df1f13959a8fce87
-
 tests: true
 documentation: true
 
@@ -18,4 +12,4 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-06-18T17:03:29Z
+index-state: 2020-07-01T21:29:04Z


### PR DESCRIPTION
The patched version just relaxed some upper bounds. Those changes have since been upstreamed.

This is necessary for #161, since cabal-plan 0.7 also relaxes the upper bound on Aeson.