### PR TITLE
Remove dependency on Cabal

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -62,7 +62,6 @@ library
     , aeson
     , binary
     , bytestring
-    , Cabal
     , cabal-helper >= 1.1
     , containers
     , data-default

--- a/src/Ide/Version.hs
+++ b/src/Ide/Version.hs
@@ -7,8 +7,6 @@ module Ide.Version where
 
 import           Data.Maybe
 import           Development.GitRev              (gitCommitCount)
-import           Distribution.System             (buildArch)
-import           Distribution.Text               (display)
 import           Options.Applicative.Simple      (simpleVersion)
 import           Ide.Cradle                      (execProjectGhc)
 import qualified HIE.Bios.Types as Bios
@@ -26,7 +24,7 @@ hlsVersion =
       -- See https://github.com/commercialhaskell/stack/issues/792
     , [" (" ++ commitCount ++ " commits)" | commitCount /= ("1"::String) &&
                                             commitCount /= ("UNKNOWN" :: String)]
-    , [" ", display buildArch]
+    , [" ", arch]
     , [" ", hlsGhcDisplayVersion]
     ]
 


### PR DESCRIPTION
Cabal as a dependency is a pretty hefty price to pay for simply getting the build architecture, which already seems to be in System.Info. Probably just accidentally copied over from when HIE used Cabal for dealing with .cabal files