### PR TITLE
Add support for ghc-8.8.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,4 +12,4 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-07-13T21:29:04Z
+index-state: 2020-07-16T17:24:10Z

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.3
+resolver: lts-16.5
 
 packages:
 - .
@@ -14,11 +14,6 @@ extra-deps:
 - extra-1.7.3
 - floskell-0.10.3
 # - ghcide-0.1.0
-- ghc-check-0.5.0.1
-- ghc-lib-parser-8.10.1.20200523
-- ghc-lib-parser-ex-8.10.0.4
-- haskell-lsp-0.22.0.0
-- haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
 - hie-bios-0.6.1
 - hlint-2.2.8
@@ -27,12 +22,9 @@ extra-deps:
 - ilist-0.3.1.0
 - lsp-test-0.11.0.2
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
-- ormolu-0.1.2.0
 - semigroups-0.18.5
 # - github: wz1000/shake
 #   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
-- stylish-haskell-0.11.0.0
 - temporary-1.2.1.1
 
 flags:

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,0 +1,40 @@
+resolver: lts-16.5
+compiler: ghc-8.8.4
+
+packages:
+- .
+- ./ghcide/
+
+extra-deps:
+- apply-refact-0.7.0.0
+- bytestring-trie-0.2.5.0
+- cabal-helper-1.1.0.0
+- cabal-plan-0.6.2.0
+- clock-0.7.2
+- constrained-dynamic-0.1.0.0
+- extra-1.7.3
+- floskell-0.10.3
+# - ghcide-0.1.0
+- haskell-src-exts-1.21.1
+- hie-bios-0.6.1
+- hlint-2.2.8
+- hoogle-5.0.17.11
+- hsimport-0.11.0
+- ilist-0.3.1.0
+- lsp-test-0.11.0.2
+- monad-dijkstra-0.1.1.2
+- semigroups-0.18.5
+# - github: wz1000/shake
+#   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
+- temporary-1.2.1.1
+
+flags:
+  haskell-language-server:
+    pedantic: true
+
+# allow-newer: true
+
+nix:
+  packages: [ icu libcxx zlib ]
+
+concurrent-tests: false


### PR DESCRIPTION
* Updating hackage index to get last version of ghc-exactprint, compatible with ghc-8.8.4
* Adding a `stack-8.8.4.yaml` using the last `ghc-8.8.3` resolver but informing explicitly `compiler: ghc-8.8.4`

I am getting errors compiling floskell in windows, but it is reproduced with other ghc versions. I get to compile downloading floskell locally and adding it as subpackage in `cabal.project`. 
To report upstream 🤷‍♂️ : https://github.com/ennocramer/floskell/issues/50
