### PR TITLE
Mention docs on hover feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,23 @@ This is *very* early stage software.
 
    ![Eval](https://i.imgur.com/bh992sT.gif)
 
- - Type information and documentation on hover. Note that currently, in order for docs to be displayed for dependencies, they must have been built with GHC's `-haddock` flag. This can be achieved in a number of ways, such as `cabal configure --ghc-options=-haddock`.
+- Type information and documentation on hover. Note that currently, in order for docs to be displayed for dependencies, they must have been built with GHC's `-haddock` flag:
+
+  - For cabal:
+      - Add to your global config file (e.g. `~/.cabal/config`):
+        ```
+        program-default-options
+          ghc-options: -haddock
+        ```
+      - Or, for a single project, run `cabal configure --ghc-options=-haddock`
+
+  - For stack, add to global `$STACK_ROOT\config.yaml`, or project's `stack.yaml`:
+    ```
+    ghc-options:
+      "$everything": -haddock
+    ```
+
+  This will cause compilation errors if a dependency contains invalid Haddock markup, though in a future version of GHC (hopefully 8.12), [these will be demoted to warnings](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2377).
 
  - Many more (TBD)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This is *very* early stage software.
 
    ![Eval](https://i.imgur.com/bh992sT.gif)
 
+ - Type information and documentation on hover. Note that currently, in order for docs to be displayed for dependencies, they must have been built with GHC's `-haddock` flag. This can be achieved in a number of ways, such as `cabal configure --ghc-options=-haddock`.
+
  - Many more (TBD)
 
 ## Installation


### PR DESCRIPTION
Thanks to @pepeiborra at #208, I discovered that it is actually currently possible to get docs for dependencies to show up in HLS. Based on a discussion about this on IRC a few days ago, I suspect this is not widely known. Indeed, AFAICT, the `-haddock` flag is completely undocumented.

I don't know if this is necessarily the best part of the README in which to mention the workaround for this, but I feel it ought to be in there somewhere.

I was also unsure whether it's worth explaining how to specify a GHC flag for dependencies of a project, and which method to mention for doing so. Personally, I've just decided to bite the bullet and go with:

```
program-default-options
  ghc-options: -haddock
```

in my global cabal config, but I'd guess that's not suitable for everyone.