### PR TITLE
Use -haddock for cabal and stack

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,8 @@
-packages: 
+packages:
          ./
          ghcide
 
 tests: true
-
-program-options
-  ghc-options: -haddock
 
 package *
   ghc-options: -haddock

--- a/cabal.project
+++ b/cabal.project
@@ -1,9 +1,14 @@
-packages:
+packages: 
          ./
          ghcide
 
 tests: true
-documentation: true
+
+program-options
+  ghc-options: -haddock
+
+package *
+  ghc-options: -haddock
 
 package haskell-language-server
   test-show-details: direct

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -4,6 +4,9 @@ packages:
 - .
 - ./ghcide/
 
+ ghc-options:
+  "$everything": -haddock
+
 extra-deps:
 - Cabal-3.0.2.0
 - hie-bios-0.6.1

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 - ./ghcide/
 
- ghc-options:
+ghc-options:
   "$everything": -haddock
 
 extra-deps:

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -4,6 +4,9 @@ packages:
 - .
 - ./ghcide/
 
+ ghc-options:
+  "$everything": -haddock
+
 extra-deps:
 - aeson-1.4.3.0
 - brittany-0.12.1.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 - ./ghcide/
 
- ghc-options:
+ghc-options:
   "$everything": -haddock
 
 extra-deps:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -4,6 +4,9 @@ packages:
 - .
 - ./ghcide/
 
+ ghc-options:
+  "$everything": -haddock
+
 extra-deps:
 - ansi-terminal-0.10.2
 - base-compat-0.11.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 - ./ghcide/
 
- ghc-options:
+ghc-options:
   "$everything": -haddock
 
 extra-deps:

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -4,6 +4,9 @@ packages:
 - .
 - ./ghcide/
 
+ ghc-options:
+  "$everything": -haddock
+
 extra-deps:
 - apply-refact-0.7.0.0
 - brittany-0.12.1.1

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 - ./ghcide/
 
- ghc-options:
+ghc-options:
   "$everything": -haddock
 
 extra-deps:

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -4,6 +4,9 @@ packages:
 - .
 - ./ghcide/
 
+ ghc-options:
+  "$everything": -haddock
+
 extra-deps:
 - apply-refact-0.7.0.0
 - bytestring-trie-0.2.5.0

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 - ./ghcide/
 
- ghc-options:
+ghc-options:
   "$everything": -haddock
 
 extra-deps:

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -5,7 +5,7 @@ packages:
 - .
 - ./ghcide/
 
- ghc-options:
+ghc-options:
   "$everything": -haddock
 
 extra-deps:

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -5,6 +5,9 @@ packages:
 - .
 - ./ghcide/
 
+ ghc-options:
+  "$everything": -haddock
+
 extra-deps:
 - apply-refact-0.7.0.0
 - bytestring-trie-0.2.5.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,9 @@ packages:
 - .
 - ./ghcide/
 
+ ghc-options:
+  "$everything": -haddock
+
 extra-deps:
 - ansi-terminal-0.10.2
 - base-compat-0.11.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 - .
 - ./ghcide/
 
- ghc-options:
+ghc-options:
   "$everything": -haddock
 
 extra-deps:

--- a/test/functional/Deferred.hs
+++ b/test/functional/Deferred.hs
@@ -159,7 +159,6 @@ multiMainTests :: TestTree
 multiMainTests = testGroup "multiple main modules" [
     ignoreTestBecause "Broken: Unexpected ConduitParser.empty" $
     testCase "Can load one file at a time, when more than one Main module exists"
-        -- $ runSession hieCommand fullCaps "test/testdata" $ do
         $ runSession hieCommand fullCaps "test/testdata" $ do
             _doc <- openDoc "ApplyRefact2.hs" "haskell"
             _diagsRspHlint <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification

--- a/test/functional/TypeDefinition.hs
+++ b/test/functional/TypeDefinition.hs
@@ -75,21 +75,22 @@ tests = testGroup "type definitions" [
                                         (Range (toPos (18, 1)) (toPos (18, 26)))
                             ]
 
-    -- TODO Implement
-    -- , ignoreTestBecause "Broken" $ testCase "find type-definition of type def in component"
-    --     $ pendingWith "Finding symbols cross module is currently not supported"
-        -- $ runSession hieCommand fullCaps "test/testdata/gototest"
-        -- $ do
-        --     doc      <- openDoc "src/Lib2.hs" "haskell"
-        --     otherDoc <- openDoc "src/Lib.hs" "haskell"
-        --     closeDoc otherDoc
-        --     defs <- getTypeDefinitions doc (toPos (13, 20))
-        --     liftIO $ do
-        --       fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
-        --       defs
-        --         `shouldBe` [ Location (filePathToUri fp)
-        --                               (Range (toPos (8, 1)) (toPos (8, 29)))
-        --                    ]
+    {--  TODO Implement
+     , ignoreTestBecause "Broken" $ testCase "find type-definition of type def in component"
+         $ pendingWith "Finding symbols cross module is currently not supported"
+         $ runSession hieCommand fullCaps "test/testdata/gototest"
+         $ do
+             doc      <- openDoc "src/Lib2.hs" "haskell"
+             otherDoc <- openDoc "src/Lib.hs" "haskell"
+             closeDoc otherDoc
+             defs <- getTypeDefinitions doc (toPos (13, 20))
+             liftIO $ do
+               fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
+               defs
+                 `shouldBe` [ Location (filePathToUri fp)
+                                       (Range (toPos (8, 1)) (toPos (8, 29)))
+                            ]
+    --}
     , ignoreTestBecause "Broken" $ testCase "find definition of parameterized data type"
         $ runSession hieCommand fullCaps "test/testdata/gototest"
         $ do


### PR DESCRIPTION
* After make sure with dont need `documentation: true` for sure
* This is related with #208 and #209, where i learned that hls/ghcide is using the docs included in ~~hie~~`.hi` files when you pass `-haddock` to ghc and no the docs generated by the haddock tool (with `documentation: true`)
  * See the mentioned issue/pr for more context