### PR TITLE
Rename the configuration section from languageServerHaskell => haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Then issue `:CocConfig` and add the following to your Coc config file.
       "haskell"
     ],
     "initializationOptions": {
-      "languageServerHaskell": {
+      "haskell": {
       }
     }
   }

--- a/src/Ide/Plugin/Config.hs
+++ b/src/Ide/Plugin/Config.hs
@@ -70,7 +70,7 @@ instance Default Config where
 -- TODO: Add API for plugins to expose their own LSP config options
 instance A.FromJSON Config where
   parseJSON = A.withObject "Config" $ \v -> do
-    s <- v .: "languageServerHaskell"
+    s <- v .: "haskell"
     flip (A.withObject "Config.settings") s $ \o -> Config
       <$> o .:? "hlintOn"                     .!= hlintOn def
       <*> o .:? "diagnosticsOnChange"         .!= diagnosticsOnChange def
@@ -81,17 +81,17 @@ instance A.FromJSON Config where
       <*> o .:? "formatOnImportOn"            .!= formatOnImportOn def
       <*> o .:? "formattingProvider"          .!= formattingProvider def
 
--- 2017-10-09 23:22:00.710515298 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"languageServerHaskell":{"maxNumberOfProblems":100,"hlintOn":true}}}}
+-- 2017-10-09 23:22:00.710515298 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"haskell":{"maxNumberOfProblems":100,"hlintOn":true}}}}
 -- 2017-10-09 23:22:00.710667381 [ThreadId 15] - reactor:got didChangeConfiguration notification:
 -- NotificationMessage
 --   {_jsonrpc = "2.0"
 --   , _method = WorkspaceDidChangeConfiguration
 --   , _params = DidChangeConfigurationParams
---                 {_settings = Object (fromList [("languageServerHaskell",Object (fromList [("hlintOn",Bool True)
---                                                                                          ,("maxNumberOfProblems",Number 100.0)]))])}}
+--                 {_settings = Object (fromList [("haskell",Object (fromList [("hlintOn",Bool True)
+--                                                                            ,("maxNumberOfProblems",Number 100.0)]))])}}
 
 instance A.ToJSON Config where
-  toJSON (Config h diag m d l c f fp) = object [ "languageServerHaskell" .= r ]
+  toJSON (Config h diag m d l c f fp) = object [ "haskell" .= r ]
     where
       r = object [ "hlintOn"                     .= h
                  , "diagnosticsOnChange"         .= diag

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -311,7 +311,7 @@ tests = testGroup "completions" [
     --     doc <- openDoc "Completion.hs" "haskell"
     --     _   <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
-    --     let config = object [ "languageServerHaskell" .= (object ["completionSnippetsOn" .= False])]
+    --     let config = object [ "haskell" .= (object ["completionSnippetsOn" .= False])]
 
     --     sendNotification WorkspaceDidChangeConfiguration
     --                     (DidChangeConfigurationParams config)

--- a/test/functional/Format.hs
+++ b/test/functional/Format.hs
@@ -115,7 +115,7 @@ ormoluTests :: TestTree
 ormoluTests = testGroup "ormolu" [
     goldenVsStringDiff "formats correctly" goldenGitDiff ("test/testdata/Format.ormolu." ++ ormoluGoldenSuffix ++ ".hs") $ runSession hieCommand fullCaps "test/testdata" $ do
         let formatLspConfig provider =
-                object [ "languageServerHaskell" .= object ["formattingProvider" .= (provider :: Value)] ]
+                object [ "haskell" .= object ["formattingProvider" .= (provider :: Value)] ]
         sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))
         doc <- openDoc "Format.hs" "haskell"
         formatDoc doc (FormattingOptions 2 True)
@@ -129,7 +129,7 @@ ormoluTests = testGroup "ormolu" [
 
 
 formatLspConfig :: Value -> Value
-formatLspConfig provider = object [ "languageServerHaskell" .= object ["formattingProvider" .= (provider :: Value)] ]
+formatLspConfig provider = object [ "haskell" .= object ["formattingProvider" .= (provider :: Value)] ]
 
 formatConfig :: Value -> SessionConfig
 formatConfig provider = defaultConfig { lspConfig = Just (formatLspConfig provider) }


### PR DESCRIPTION
This matches up with how other language servers name their configuration section (see https://marketplace.visualstudio.com/items?itemName=rust-lang.rust), and the new VS Code extension has already done this rename.
Unfortunately we forgot to also change it in haskell-language-server. This is a bit of a growing pain and will break people's configs, but thankfully the only configuration option that seems to have any effect in hls at the moment is the formatter. We need to follow this up with the equivalent change in haskell-ide-engine too.

