### PR TITLE
Shell nix further steps

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,10 @@
+# This shell.nix file is designed for use with cabal build
+# It aims to leverage the nix cache in as much as possible
+# It does not aim to replace Cabal/Stack with Nix
+
+# Before making changes, ensure that the Nix expression works
+# for all the GHC versions supported by the project (8.6.x - 8.10.x)
+
 { sources ? import nix/sources.nix,
   nixpkgs ? import sources.nixpkgs {},
   compiler ? "default"
@@ -8,10 +15,21 @@ let haskellPackagesForProject = if compiler == "default"
     then haskellPackages.ghcWithPackages
     else haskell.packages.${compiler}.ghcWithPackages;
 
-    # these packages fail to build with ghc8101
-    extraPackages = p: if compiler == "ghc8101"
-      then []
-      else [p.haskell-lsp p.lsp-test];
+    extraPackages = p: with p;
+    if compiler == "ghc8101" then 
+          [conduit-extra
+           conduit-parse
+           hie-bios
+           yaml
+          ]
+        else if compiler == "ghc865" then [] else
+         # compiler = ghc88
+          [ haskell-lsp 
+            lsp-test
+            brittany
+            ormolu
+            stylish-haskell
+           ];
 
    compilerWithPackages = haskellPackagesForProject(p:
         with p;
@@ -21,8 +39,6 @@ let haskellPackagesForProject = if compiler == "default"
           base16-bytestring
           blaze-builder
           blaze-markup
-          conduit-extra
-          conduit-parse
           cryptohash-sha1
           data-default
           data-default-class
@@ -34,14 +50,19 @@ let haskellPackagesForProject = if compiler == "default"
           floskell
           fuzzy
           generic-deriving
+          ghc-check
           gitrev
           Glob
+          haddock-library
           happy
           haskell-src-exts
           hslogger
           hspec
+          HsYAML-aeson
           lens
+          megaparsec
           network
+          opentelemetry
           optparse-simple
           QuickCheck
           parsers
@@ -55,16 +76,19 @@ let haskellPackagesForProject = if compiler == "default"
           safe-exceptions
           shake
           sorted-list
+          strict
           tasty
+          tasty-ant-xml
+          tasty-expected-failure
           tasty-golden
           tasty-hunit
           tasty-rerun
           temporary
           text
           typed-process
+          unix-compat
           unordered-containers
           xml
-          yaml
           zlib
          ] ++ extraPackages p);
 in

--- a/shell.nix
+++ b/shell.nix
@@ -8,30 +8,65 @@ let haskellPackagesForProject = if compiler == "default"
     then haskellPackages.ghcWithPackages
     else haskell.packages.${compiler}.ghcWithPackages;
 
+    # these packages fail to build with ghc8101
+    extraPackages = p: if compiler == "ghc8101"
+      then []
+      else [p.haskell-lsp p.lsp-test];
+
    compilerWithPackages = haskellPackagesForProject(p:
         with p;
         [ aeson
+          alex
           async
+          base16-bytestring
+          blaze-builder
+          blaze-markup
+          conduit-extra
+          conduit-parse
+          cryptohash-sha1
+          data-default
+          data-default-class
+          data-default-instances-containers
+          data-default-instances-dlist
+          data-default-instances-old-locale
+          Diff
           extra
+          floskell
+          fuzzy
+          generic-deriving
           gitrev
-          haskell-lsp
+          Glob
+          happy
+          haskell-src-exts
+          hslogger
+          hspec
           lens
           network
           optparse-simple
-          prettyprinter
           QuickCheck
+          parsers
+          parser-combinators
+          prettyprinter
+          prettyprinter-ansi-terminal
+          primes
+          psqueues
           regex-tdfa
           rope-utf16-splay
           safe-exceptions
           shake
+          sorted-list
           tasty
           tasty-golden
           tasty-hunit
           tasty-rerun
           temporary
           text
+          typed-process
           unordered-containers
-         ]);
+          xml
+          yaml
+          zlib
+         ] ++ extraPackages p);
 in
 stdenv.mkDerivation {
   name = "haskell-language-server";

--- a/shell.nix
+++ b/shell.nix
@@ -10,8 +10,9 @@
  }:
 with nixpkgs;
 
-let haskellPackagesForProject = p:
-        if compiler == "default" || compiler == "ghc883"
+let defaultCompiler = "ghc" + lib.replaceStrings ["."] [""] haskellPackages.ghc.version;
+    haskellPackagesForProject = p:
+        if compiler == "default" || compiler == defaultCompiler
             then haskellPackages.ghcWithPackages p
             # for all other compilers there is no Nix cache so dont bother building deps with NIx
             else haskell.packages.${compiler}.ghcWithPackages [];


### PR DESCRIPTION
I've done a bit more work on this, fixing compatibility with all supported ghc versions and adding some comments on the rationale behind the approach.

```
pepeiborra@devvm370 ~/s/ide (shell-nix)> nix-shell -run "cabal build --dry-run"
Resolving dependencies...
Build profile: -w ghc-8.8.3 -O1
In order, the following would be built (use -v for more details):
 - ghcide-0.2.0 (exe:ghcide-test-preprocessor) (first run)
 - lsp-test-0.11.0.2 (lib) (requires build)
 - streaming-commons-0.2.1.2 (lib) (requires download & build)
 - conduit-extra-1.3.5 (lib) (requires build)
 - hie-bios-0.6.1 (lib) (requires build)
 - ghcide-0.2.0 (lib) (first run)
 - haskell-language-server-0.2.2.0 (lib) (first run)
 - haskell-language-server-0.2.2.0 (exe:haskell-language-server-wrapper) (first run)
 - haskell-language-server-0.2.2.0 (exe:haskell-language-server) (first run)
 - haskell-language-server-0.2.2.0 (test:wrapper-test) (first run)
 - haskell-language-server-0.2.2.0 (test:func-test) (first run)
```