### PR TITLE
Add numeric-version option for wrapper and server

### DIFF
--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -26,8 +26,21 @@ main :: IO ()
 main = do
   -- WARNING: If you write to stdout before runLanguageServer
   --          then the language server will not work
-  Arguments{..} <- getArguments "haskell-language-server-wrapper"
+  args <- getArguments "haskell-language-server-wrapper"
 
+  hlsVer <- haskellLanguageServerVersion
+  case args of
+      VersionMode PrintVersion ->
+          putStrLn hlsVer
+
+      VersionMode PrintNumericVersion ->
+          putStrLn haskellLanguageServerNumericVersion
+
+      LspMode lspArgs ->
+          launchHaskellLanguageServer lspArgs
+
+launchHaskellLanguageServer :: LspArguments -> IO ()
+launchHaskellLanguageServer LspArguments{..} = do
   d <- getCurrentDirectory
 
   -- Get the cabal directory from the cradle
@@ -35,7 +48,6 @@ main = do
   setCurrentDirectory $ cradleRootDir cradle
 
   when argsProjectGhcVersion $ getRuntimeGhcVersion' cradle >>= putStrLn >> exitSuccess
-  when argsVersion $ haskellLanguageServerVersion >>= putStrLn >> exitSuccess
 
   whenJust argsCwd setCurrentDirectory
 


### PR DESCRIPTION
closes #238 

Also correctly shuts down the language server if `--version` was given.

Minor rework of argument parser.

This might cause breakage, since combinations such as `haskell-language-server --version --lsp` used to be valid but are not anymore. Not sure if and how important that is, though. I think we can change it if it is important, but we might lose the stronger types or increase the complexity of the arguments parser.