### PR TITLE
Accept the legacy "languageServerHaskell" config name

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,4 +14,4 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-07-16T17:24:10Z
+index-state: 2020-07-27T12:40:45Z

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -245,7 +245,7 @@ test-suite func-test
                       , haskell-lsp-types
                       , hspec-expectations
                       , lens
-                      , lsp-test >= 0.10.0.3
+                      , lsp-test >= 0.11.0.3
                       , tasty
                       , tasty-ant-xml >= 1.1.6
                       , tasty-expected-failure

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -215,7 +215,7 @@ common hls-test-utils
                      , hslogger
                      , hspec
                      , hspec-core
-                     , lsp-test
+                     , lsp-test >= 0.11.0.3
                      , stm
                      , tasty-hunit
                      , temporary
@@ -245,7 +245,7 @@ test-suite func-test
                       , haskell-lsp-types
                       , hspec-expectations
                       , lens
-                      , lsp-test >= 0.10.0.0
+                      , lsp-test >= 0.10.0.3
                       , tasty
                       , tasty-ant-xml >= 1.1.6
                       , tasty-expected-failure

--- a/src/Ide/Plugin/Config.hs
+++ b/src/Ide/Plugin/Config.hs
@@ -10,6 +10,7 @@ module Ide.Plugin.Config
     , Config(..)
     ) where
 
+import           Control.Applicative
 import qualified Data.Aeson                    as A
 import           Data.Aeson              hiding ( Error )
 import           Data.Default
@@ -70,7 +71,9 @@ instance Default Config where
 -- TODO: Add API for plugins to expose their own LSP config options
 instance A.FromJSON Config where
   parseJSON = A.withObject "Config" $ \v -> do
-    s <- v .: "haskell"
+    -- Officially, we use "haskell" as the section name but for
+    -- backwards compatibility we also accept "languageServerHaskell"
+    s <- v .: "haskell" <|> v .: "languageServerHaskell"
     flip (A.withObject "Config.settings") s $ \o -> Config
       <$> o .:? "hlintOn"                     .!= hlintOn def
       <*> o .:? "diagnosticsOnChange"         .!= diagnosticsOnChange def

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -15,7 +15,7 @@ extra-deps:
 - floskell-0.10.3
 - ghc-exactprint-0.6.3
 - lens-4.19.1
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.3
 - monad-dijkstra-0.1.1.2
 - optics-core-0.3
 - ormolu-0.1.2.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -39,7 +39,7 @@ extra-deps:
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:1
 - lens-4.18
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.3
 - microlens-th-0.4.2.3@rev:1
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -31,7 +31,7 @@ extra-deps:
 - HsYAML-aeson-0.2.0.0@rev:1
 - indexed-profunctors-0.1
 - lens-4.18
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.3
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
 - optics-core-0.2

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -31,7 +31,7 @@ extra-deps:
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:1
 - ilist-0.3.1.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.3
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
 - ormolu-0.1.2.0

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -22,7 +22,7 @@ extra-deps:
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - ilist-0.3.1.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.3
 - monad-dijkstra-0.1.1.2
 - semigroups-0.18.5
 # - github: wz1000/shake

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -24,7 +24,7 @@ extra-deps:
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - ilist-0.3.1.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.3
 - monad-dijkstra-0.1.1.2
 - semigroups-0.18.5
 # - github: wz1000/shake

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,7 +31,7 @@ extra-deps:
 - HsYAML-aeson-0.2.0.0@rev:1
 - indexed-profunctors-0.1
 - lens-4.18
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.3
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
 - optics-core-0.2

--- a/test/testdata/BrittanyCRLF.formatted_document.hs
+++ b/test/testdata/BrittanyCRLF.formatted_document.hs
@@ -1,4 +1,4 @@
 foo :: Int -> String -> IO ()
 foo x y = do
-  print x
-  return 42
+    print x
+    return 42

--- a/test/testdata/BrittanyCRLF.formatted_range.hs
+++ b/test/testdata/BrittanyCRLF.formatted_range.hs
@@ -1,4 +1,4 @@
-foo :: Int -> String -> IO ()
+foo ::   Int   -> String-> IO ()
 foo x y = do
-  print x
-  return 42
+    print x
+    return 42

--- a/test/testdata/BrittanyLF.formatted_document.hs
+++ b/test/testdata/BrittanyLF.formatted_document.hs
@@ -1,4 +1,4 @@
 foo :: Int -> String -> IO ()
 foo x y = do
-  print x
-  return 42
+    print x
+    return 42

--- a/test/testdata/BrittanyLF.formatted_range.hs
+++ b/test/testdata/BrittanyLF.formatted_range.hs
@@ -1,4 +1,4 @@
-foo :: Int -> String -> IO ()
+foo ::   Int   -> String-> IO ()
 foo x y = do
-  print x
-  return 42
+    print x
+    return 42

--- a/test/testdata/Format.brittany.formatted.hs
+++ b/test/testdata/Format.brittany.formatted.hs
@@ -1,0 +1,11 @@
+module Format where
+foo :: Int -> Int
+foo 3 = 2
+foo x = x
+bar :: String -> IO String
+bar s = do
+  x <- return "hello"
+  return "asdf"
+
+data Baz = Baz { a :: Int, b :: String }
+

--- a/test/testdata/Format.brittany_post_floskell.formatted.hs
+++ b/test/testdata/Format.brittany_post_floskell.formatted.hs
@@ -1,0 +1,13 @@
+module Format where
+
+foo :: Int -> Int
+foo 3 = 2
+foo x = x
+
+bar :: String -> IO String
+bar s = do
+  x <- return "hello"
+  return "asdf"
+
+data Baz = Baz { a :: Int, b :: String }
+

--- a/test/testdata/Format.floskell.formatted.hs
+++ b/test/testdata/Format.floskell.formatted.hs
@@ -1,0 +1,13 @@
+module Format where
+
+foo :: Int -> Int
+foo 3 = 2
+foo x = x
+
+bar :: String -> IO String
+bar s = do
+  x <- return "hello"
+  return "asdf"
+
+data Baz = Baz { a :: Int, b :: String }
+

--- a/test/wrapper/Main.hs
+++ b/test/wrapper/Main.hs
@@ -23,10 +23,9 @@ projectGhcVersionTests = testGroup "--project-ghc-version"
   ]
 
 testDir :: FilePath -> String -> Assertion
-testDir dir expectedVer = do
-  wrapper <- findExe "haskell-language-server-wrapper"
+testDir dir expectedVer =
   withCurrentDirectoryInTmp dir $ do
-    actualVer <- trim <$> readProcess wrapper ["--project-ghc-version"] ""
+    actualVer <- trim <$> readProcess "haskell-language-server-wrapper" ["--project-ghc-version"] ""
     actualVer @?= expectedVer
 
 trim :: String -> String


### PR DESCRIPTION
This also requires a bump to lsp-test to fix a test, and drops the
trick that the wrapper tests used to find the wrapper executable since
it was just confusing