### PR TITLE
Remove hspec-expectations

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -243,7 +243,6 @@ test-suite func-test
                       , haskell-language-server
                       , haskell-lsp
                       , haskell-lsp-types
-                      , hspec-expectations
                       , lens
                       , lsp-test >= 0.11.0.3
                       , tasty

--- a/test/functional/Command.hs
+++ b/test/functional/Command.hs
@@ -12,7 +12,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
-import Test.Hspec.Expectations
 
 
 --TODO : Response Message no longer has 4 inputs
@@ -24,8 +23,8 @@ tests = testGroup "commands" [
             let List cmds = res ^. LSP.capabilities . executeCommandProvider . _Just . commands
                 f x = (T.length (T.takeWhile isNumber x) >= 1) && (T.count ":" x >= 2)
             liftIO $ do
-                cmds `shouldSatisfy` all f
-                cmds `shouldNotSatisfy` null
+                all f cmds @? "All prefixed"
+                not (null cmds) @? "Commands aren't empty"
     , ignoreTestBecause "Broken: Plugin package doesn't exist" $
       testCase "get de-prefixed" $
         runSession hieCommand fullCaps "test/testdata/" $ do
@@ -34,5 +33,5 @@ tests = testGroup "commands" [
                 (ExecuteCommandParams "1234:package:add" (Just (List [])) Nothing) :: Session ExecuteCommandResponse
             let ResponseError _ msg _ = err
             -- We expect an error message about the dud arguments, but should pickup "add" and "package"
-            liftIO $ msg `shouldSatisfy` T.isInfixOf "while parsing args for add in plugin package"
+            liftIO $ (msg `T.isInfixOf` "while parsing args for add in plugin package") @? "Has error message"
     ]

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -13,7 +13,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 --TODO: Fix tests, some structural changed hav been made
 
@@ -29,17 +28,17 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 5 9)
 --         let item = head $ filter ((== "putStrLn") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "putStrLn"
---             item ^. kind `shouldBe` Just CiFunction
---             item ^. detail `shouldBe` Just "Prelude"
+--             item ^. label @?= "putStrLn"
+--             item ^. kind @?= Just CiFunction
+--             item ^. detail @?= Just "Prelude"
 --         resolvedRes <- request CompletionItemResolve item
 --         let Just (resolved :: CompletionItem) = resolvedRes ^. result
 --         liftIO $ do
---             resolved ^. label `shouldBe` "putStrLn"
---             resolved ^. kind `shouldBe` Just CiFunction
---             resolved ^. detail `shouldBe` Just "String -> IO ()\nPrelude"
---             resolved ^. insertTextFormat `shouldBe` Just Snippet
---             resolved ^. insertText `shouldBe` Just "putStrLn ${1:String}"
+--             resolved ^. label @?= "putStrLn"
+--             resolved ^. kind @?= Just CiFunction
+--             resolved ^. detail @?= Just "String -> IO ()\nPrelude"
+--             resolved ^. insertTextFormat @?= Just Snippet
+--             resolved ^. insertText @?= Just "putStrLn ${1:String}"
 
 --     , testCase "completes imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -51,9 +50,9 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 1 22)
 --         let item = head $ filter ((== "Maybe") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "Maybe"
---             item ^. detail `shouldBe` Just "Data.Maybe"
---             item ^. kind `shouldBe` Just CiModule
+--             item ^. label @?= "Maybe"
+--             item ^. detail @?= Just "Data.Maybe"
+--             item ^. kind @?= Just CiModule
 
 --     , testCase "completes qualified imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -65,9 +64,9 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 1 19)
 --         let item = head $ filter ((== "Data.List") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "Data.List"
---             item ^. detail `shouldBe` Just "Data.List"
---             item ^. kind `shouldBe` Just CiModule
+--             item ^. label @?= "Data.List"
+--             item ^. detail @?= Just "Data.List"
+--             item ^. kind @?= Just CiModule
 
 --     , testCase "completes language extensions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -79,8 +78,8 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 0 24)
 --         let item = head $ filter ((== "OverloadedStrings") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "OverloadedStrings"
---             item ^. kind `shouldBe` Just CiKeyword
+--             item ^. label @?= "OverloadedStrings"
+--             item ^. kind @?= Just CiKeyword
 
 --     , testCase "completes pragmas" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -92,10 +91,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 0 4)
 --         let item = head $ filter ((== "LANGUAGE") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "LANGUAGE"
---             item ^. kind `shouldBe` Just CiKeyword
---             item ^. insertTextFormat `shouldBe` Just Snippet
---             item ^. insertText `shouldBe` Just "LANGUAGE ${1:extension} #-}"
+--             item ^. label @?= "LANGUAGE"
+--             item ^. kind @?= Just CiKeyword
+--             item ^. insertTextFormat @?= Just Snippet
+--             item ^. insertText @?= Just "LANGUAGE ${1:extension} #-}"
 
 --     , testCase "completes pragmas no close" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -107,10 +106,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 0 4)
 --         let item = head $ filter ((== "LANGUAGE") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "LANGUAGE"
---             item ^. kind `shouldBe` Just CiKeyword
---             item ^. insertTextFormat `shouldBe` Just Snippet
---             item ^. insertText `shouldBe` Just "LANGUAGE ${1:extension}"
+--             item ^. label @?= "LANGUAGE"
+--             item ^. kind @?= Just CiKeyword
+--             item ^. insertTextFormat @?= Just Snippet
+--             item ^. insertText @?= Just "LANGUAGE ${1:extension}"
 
 --     , testCase "completes options pragma" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -122,10 +121,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 0 4)
 --         let item = head $ filter ((== "OPTIONS_GHC") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "OPTIONS_GHC"
---             item ^. kind `shouldBe` Just CiKeyword
---             item ^. insertTextFormat `shouldBe` Just Snippet
---             item ^. insertText `shouldBe` Just "OPTIONS_GHC -${1:option} #-}"
+--             item ^. label @?= "OPTIONS_GHC"
+--             item ^. kind @?= Just CiKeyword
+--             item ^. insertTextFormat @?= Just Snippet
+--             item ^. insertText @?= Just "OPTIONS_GHC -${1:option} #-}"
 
 --   -- -----------------------------------
 
@@ -140,10 +139,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 0 24)
 --         let item = head $ filter ((== "Wno-redundant-constraints") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "Wno-redundant-constraints"
---             item ^. kind `shouldBe` Just CiKeyword
---             item ^. insertTextFormat `shouldBe` Nothing
---             item ^. insertText `shouldBe` Nothing
+--             item ^. label @?= "Wno-redundant-constraints"
+--             item ^. kind @?= Just CiKeyword
+--             item ^. insertTextFormat @?= Nothing
+--             item ^. insertText @?= Nothing
 
 --   -- -----------------------------------
 
@@ -164,10 +163,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 5 4)
 --         let item = head $ filter (\c -> c^.label == "accessor") compls
 --         liftIO $ do
---             item ^. label `shouldBe` "accessor"
---             item ^. kind `shouldBe` Just CiFunction
---             item ^. detail `shouldBe` Just "Two -> Int\nDupRecFields"
---             item ^. insertText `shouldBe` Just "accessor ${1:Two}"
+--             item ^. label @?= "accessor"
+--             item ^. kind @?= Just CiFunction
+--             item ^. detail @?= Just "Two -> Int\nDupRecFields"
+--             item ^. insertText @?= Just "accessor ${1:Two}"
 
 --     , testCase "have implicit foralls on basic polymorphic types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -179,7 +178,7 @@ tests = testGroup "completions" [
 --         resolvedRes <- request CompletionItemResolve item
 --         let Just (resolved :: CompletionItem) = resolvedRes ^. result
 --         liftIO $
---             resolved ^. detail `shouldBe` Just "a -> a\nPrelude"
+--             resolved ^. detail @?= Just "a -> a\nPrelude"
 
 --     , testCase "have implicit foralls with multiple type variables" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -191,7 +190,7 @@ tests = testGroup "completions" [
 --         resolvedRes <- request CompletionItemResolve item
 --         let Just (resolved :: CompletionItem) = resolvedRes ^. result
 --         liftIO $
---             resolved ^. detail `shouldBe` Just "(a -> b -> c) -> b -> a -> c\nPrelude"
+--             resolved ^. detail @?= Just "(a -> b -> c) -> b -> a -> c\nPrelude"
 
        contextTests
 --     , snippetTests
@@ -209,8 +208,8 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 5 14)
 --         let item = head $ filter ((== "Nothing") . (^. label)) compls
 --         liftIO $ do
---             item ^. insertTextFormat `shouldBe` Just Snippet
---             item ^. insertText `shouldBe` Just "Nothing"
+--             item ^. insertTextFormat @?= Just Snippet
+--             item ^. insertText @?= Just "Nothing"
 
 --     , testCase "work for polymorphic types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -224,10 +223,10 @@ tests = testGroup "completions" [
 --         resolvedRes <- request CompletionItemResolve item
 --         let Just (resolved :: CompletionItem) = resolvedRes ^. result
 --         liftIO $ do
---             resolved ^. label `shouldBe` "foldl"
---             resolved ^. kind `shouldBe` Just CiFunction
---             resolved ^. insertTextFormat `shouldBe` Just Snippet
---             resolved ^. insertText `shouldBe` Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
+--             resolved ^. label @?= "foldl"
+--             resolved ^. kind @?= Just CiFunction
+--             resolved ^. insertTextFormat @?= Just Snippet
+--             resolved ^. insertText @?= Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
 
 --     , testCase "work for complex types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -241,10 +240,10 @@ tests = testGroup "completions" [
 --         resolvedRes <- request CompletionItemResolve item
 --         let Just (resolved :: CompletionItem) = resolvedRes ^. result
 --         liftIO $ do
---             resolved ^. label `shouldBe` "mapM"
---             resolved ^. kind `shouldBe` Just CiFunction
---             resolved ^. insertTextFormat `shouldBe` Just Snippet
---             resolved ^. insertText `shouldBe` Just "mapM ${1:a -> m b} ${2:t a}"
+--             resolved ^. label @?= "mapM"
+--             resolved ^. kind @?= Just CiFunction
+--             resolved ^. insertTextFormat @?= Just Snippet
+--             resolved ^. insertText @?= Just "mapM ${1:a -> m b} ${2:t a}"
 
 --     , testCase "work for infix functions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -256,10 +255,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 5 18)
 --         let item = head $ filter ((== "filter") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "filter"
---             item ^. kind `shouldBe` Just CiFunction
---             item ^. insertTextFormat `shouldBe` Just Snippet
---             item ^. insertText `shouldBe` Just "filter`"
+--             item ^. label @?= "filter"
+--             item ^. kind @?= Just CiFunction
+--             item ^. insertTextFormat @?= Just Snippet
+--             item ^. insertText @?= Just "filter`"
 
 --     , testCase "work for infix functions in backticks" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -271,10 +270,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 5 18)
 --         let item = head $ filter ((== "filter") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "filter"
---             item ^. kind `shouldBe` Just CiFunction
---             item ^. insertTextFormat `shouldBe` Just Snippet
---             item ^. insertText `shouldBe` Just "filter"
+--             item ^. label @?= "filter"
+--             item ^. kind @?= Just CiFunction
+--             item ^. insertTextFormat @?= Just Snippet
+--             item ^. insertText @?= Just "filter"
 
 --     , testCase "work for qualified infix functions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -286,10 +285,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 5 29)
 --         let item = head $ filter ((== "intersperse") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "intersperse"
---             item ^. kind `shouldBe` Just CiFunction
---             item ^. insertTextFormat `shouldBe` Just Snippet
---             item ^. insertText `shouldBe` Just "intersperse`"
+--             item ^. label @?= "intersperse"
+--             item ^. kind @?= Just CiFunction
+--             item ^. insertTextFormat @?= Just Snippet
+--             item ^. insertText @?= Just "intersperse`"
 
 --     , testCase "work for qualified infix functions in backticks" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
@@ -301,10 +300,10 @@ tests = testGroup "completions" [
 --         compls <- getCompletions doc (Position 5 29)
 --         let item = head $ filter ((== "intersperse") . (^. label)) compls
 --         liftIO $ do
---             item ^. label `shouldBe` "intersperse"
---             item ^. kind `shouldBe` Just CiFunction
---             item ^. insertTextFormat `shouldBe` Just Snippet
---             item ^. insertText `shouldBe` Just "intersperse"
+--             item ^. label @?= "intersperse"
+--             item ^. kind @?= Just CiFunction
+--             item ^. insertTextFormat @?= Just Snippet
+--             item ^. insertText @?= Just "intersperse"
 
     -- -- TODO : Fix compile issue in the test "Variable not in scope: object"
     -- , testCase "respects lsp configuration" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
@@ -332,18 +331,18 @@ tests = testGroup "completions" [
     --         compls <- getCompletions doc (Position 5 11)
     --         let item = head $ filter ((== "foldl") . (^. label)) compls
     --         liftIO $ do
-    --             item ^. label `shouldBe` "foldl"
-    --             item ^. kind `shouldBe` Just CiFunction
-    --             item ^. insertTextFormat `shouldBe` Just PlainText
-    --             item ^. insertText `shouldBe` Nothing
+    --             item ^. label @?= "foldl"
+    --             item ^. kind @?= Just CiFunction
+    --             item ^. insertTextFormat @?= Just PlainText
+    --             item ^. insertText @?= Nothing
 
     --         resolvedRes <- request CompletionItemResolve item
     --         let Just (resolved :: CompletionItem) = resolvedRes ^. result
     --         liftIO $ do
-    --             resolved ^. label `shouldBe` "foldl"
-    --             resolved ^. kind `shouldBe` Just CiFunction
-    --             resolved ^. insertTextFormat `shouldBe` Just PlainText
-    --             resolved ^. insertText `shouldBe` Nothing
+    --             resolved ^. label @?= "foldl"
+    --             resolved ^. kind @?= Just CiFunction
+    --             resolved ^. insertTextFormat @?= Just PlainText
+    --             resolved ^. insertText @?= Nothing
 
     --     noSnippetsCaps =
     --         (  textDocument
@@ -391,6 +390,6 @@ contextTests = testGroup "contexts" [
     ]
     where
         compls `shouldContainCompl` x  =
-            filter ((== x) . (^. label)) compls `shouldNotSatisfy` null
+            null (filter ((== x) . (^. label)) compls) @? "Should contain completion"
         compls `shouldNotContainCompl` x =
-            filter ((== x) . (^. label)) compls `shouldSatisfy` null
+            null (filter ((== x) . (^. label)) compls) @? "Should not contain completion"

--- a/test/functional/Deferred.hs
+++ b/test/functional/Deferred.hs
@@ -16,7 +16,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 
 tests :: TestTree
@@ -30,16 +29,16 @@ tests = testGroup "deferred responses" [
 
     --   skipMany anyNotification
     --   hoverRsp <- message :: Session HoverResponse
-    --   liftIO $ hoverRsp ^? result . _Just . _Just . contents `shouldBe` Nothing
-    --   liftIO $ hoverRsp ^. LSP.id `shouldBe` responseId id1
+    --   liftIO $ hoverRsp ^? result . _Just . _Just . contents @?= Nothing
+    --   liftIO $ hoverRsp ^. LSP.id @?= responseId id1
 
     --   id2 <- sendRequest TextDocumentDocumentSymbol (DocumentSymbolParams doc Nothing)
     --   symbolsRsp <- skipManyTill anyNotification message :: Session DocumentSymbolsResponse
-    --   liftIO $ symbolsRsp ^. LSP.id `shouldBe` responseId id2
+    --   liftIO $ symbolsRsp ^. LSP.id @?= responseId id2
 
     --   id3 <- sendRequest TextDocumentHover (TextDocumentPositionParams doc (Position 4 2) Nothing)
     --   hoverRsp2 <- skipManyTill anyNotification message :: Session HoverResponse
-    --   liftIO $ hoverRsp2 ^. LSP.id `shouldBe` responseId id3
+    --   liftIO $ hoverRsp2 ^. LSP.id @?= responseId id3
 
     --   let contents2 = hoverRsp2 ^? result . _Just . _Just . contents
     --   liftIO $ contents2 `shouldNotSatisfy` null
@@ -48,7 +47,7 @@ tests = testGroup "deferred responses" [
     --   let highlightParams = TextDocumentPositionParams doc (Position 7 0) Nothing
     --   highlightRsp <- request TextDocumentDocumentHighlight highlightParams
     --   let (Just (List locations)) = highlightRsp ^. result
-    --   liftIO $ locations `shouldBe` [ DocumentHighlight
+    --   liftIO $ locations @?= [ DocumentHighlight
     --                  { _range = Range
     --                    { _start = Position {_line = 7, _character = 0}
     --                    , _end   = Position {_line = 7, _character = 2}
@@ -95,7 +94,7 @@ tests = testGroup "deferred responses" [
      testCase "instantly respond to failed modules with no cache" $ runSession hieCommand fullCaps "test/testdata" $ do
         doc <- openDoc "FuncTestFail.hs" "haskell"
         defs <- getDefinitions doc (Position 1 11)
-        liftIO $ defs `shouldBe` []
+        liftIO $ defs @?= []
 
     -- TODO: the benefits of caching parsed modules is doubted.
     -- TODO: add issue link
@@ -103,7 +102,7 @@ tests = testGroup "deferred responses" [
     --   runSession hieCommand fullCaps "test/testdata" $ do
     --     doc <- openDoc "FuncTestFail.hs" "haskell"
     --     (Left (sym:_)) <- getDocumentSymbols doc
-    --     liftIO $ sym ^. name `shouldBe` "main"
+    --     liftIO $ sym ^. name @?= "main"
 
     -- TODO does not compile
     -- , testCase "returns hints as diagnostics" $ runSession hieCommand fullCaps "test/testdata" $ do
@@ -113,7 +112,7 @@ tests = testGroup "deferred responses" [
     --     let testUri = filePathToUri $ cwd </> "test/testdata/FuncTest.hs"
 
     --     diags <- skipManyTill loggingNotification publishDiagnosticsNotification
-    --     liftIO $ diags ^? params `shouldBe` (Just $ PublishDiagnosticsParams
+    --     liftIO $ diags ^? params @?= (Just $ PublishDiagnosticsParams
     --                 { _uri         = testUri
     --                 , _diagnostics = List
     --                     [ Diagnostic
@@ -130,12 +129,12 @@ tests = testGroup "deferred responses" [
         --     args = List [Object args']
         --
         -- executeRsp <- request WorkspaceExecuteCommand (ExecuteCommandParams "hare:demote" (Just args) Nothing)
-        -- liftIO $ executeRsp ^. result `shouldBe` Just (Object H.empty)
+        -- liftIO $ executeRsp ^. result @?= Just (Object H.empty)
 
         -- editReq <- message :: Session ApplyWorkspaceEditRequest
         -- let expectedTextEdits = List [TextEdit (Range (Position 6 0) (Position 7 6)) "  where\n    bb = 5"]
         --     expectedTextDocEdits = List [TextDocumentEdit (VersionedTextDocumentIdentifier testUri (Just 0)) expectedTextEdits]
-        -- liftIO $ editReq ^. params . edit `shouldBe` WorkspaceEdit
+        -- liftIO $ editReq ^. params . edit @?= WorkspaceEdit
         --       Nothing
         --       (Just expectedTextDocEdits)
     -- , multiServerTests
@@ -165,7 +164,7 @@ multiMainTests = testGroup "multiple main modules" [
             diagsRspGhc    <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification
             let (List diags) = diagsRspGhc ^. params . diagnostics
 
-            liftIO $ length diags `shouldBe` 2
+            liftIO $ length diags @?= 2
 
             _doc2 <- openDoc "HaReRename.hs" "haskell"
             _diagsRspHlint2 <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification
@@ -173,5 +172,5 @@ multiMainTests = testGroup "multiple main modules" [
             diagsRsp2 <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification
             let (List diags2) = diagsRsp2 ^. params . diagnostics
 
-            liftIO $ show diags2 `shouldBe` "[]"
+            liftIO $ show diags2 @?= "[]"
     ]

--- a/test/functional/Definition.hs
+++ b/test/functional/Definition.hs
@@ -10,7 +10,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 tests :: TestTree
 tests = testGroup "definitions" [
@@ -20,7 +19,7 @@ tests = testGroup "definitions" [
         doc <- openDoc "References.hs" "haskell"
         defs <- getDefinitions doc (Position 7 8)
         let expRange = Range (Position 4 0) (Position 4 3)
-        liftIO $ defs `shouldBe` [Location (doc ^. uri) expRange]
+        liftIO $ defs @?= [Location (doc ^. uri) expRange]
 
   -- -----------------------------------
 
@@ -30,7 +29,7 @@ tests = testGroup "definitions" [
         defs <- getDefinitions doc (Position 2 8)
         liftIO $ do
             fp <- canonicalizePath "test/testdata/definition/Bar.hs"
-            defs `shouldBe` [Location (filePathToUri fp) zeroRange]
+            defs @?= [Location (filePathToUri fp) zeroRange]
 
   , ignoreTestBecause "Broken: file:///Users/jwindsor/src/haskell-language-server/test/testdata/Bar.hs" $
     testCase "goto's exported modules" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
@@ -38,7 +37,7 @@ tests = testGroup "definitions" [
         defs <- getDefinitions doc (Position 0 15)
         liftIO $ do
             fp <- canonicalizePath "test/testdata/definition/Bar.hs"
-            defs `shouldBe` [Location (filePathToUri fp) zeroRange]
+            defs @?= [Location (filePathToUri fp) zeroRange]
 
   , ignoreTestBecause "Broken: file:///Users/jwindsor/src/haskell-language-server/test/testdata/Bar.hs" $
     testCase "goto's imported modules that are loaded" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
@@ -47,7 +46,7 @@ tests = testGroup "definitions" [
         defs <- getDefinitions doc (Position 2 8)
         liftIO $ do
             fp <- canonicalizePath "test/testdata/definition/Bar.hs"
-            defs `shouldBe` [Location (filePathToUri fp) zeroRange]
+            defs @?= [Location (filePathToUri fp) zeroRange]
 
   , ignoreTestBecause "Broken: file:///Users/jwindsor/src/haskell-language-server/test/testdata/Bar.hs" $
     testCase "goto's imported modules that are loaded, and then closed" $
@@ -60,7 +59,7 @@ tests = testGroup "definitions" [
             liftIO $ putStrLn "D"
             liftIO $ do
                 fp <- canonicalizePath "test/testdata/definition/Bar.hs"
-                defs `shouldBe` [Location (filePathToUri fp) zeroRange]
+                defs @?= [Location (filePathToUri fp) zeroRange]
             liftIO $ putStrLn "E" -- AZ
 
             noDiagnostics

--- a/test/functional/Diagnostic.hs
+++ b/test/functional/Diagnostic.hs
@@ -17,7 +17,6 @@ import           Test.Hls.Util
 import           Test.Tasty
 import           Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import           Test.Tasty.HUnit
-import           Test.Hspec.Expectations
 
 -- ---------------------------------------------------------------------
 
@@ -41,26 +40,26 @@ triggerTests = testGroup "diagnostics triggers" [
             diags@(reduceDiag:_) <- waitForDiagnostics
 
             liftIO $ do
-                length diags `shouldBe` 2
-                reduceDiag ^. LSP.range `shouldBe` Range (Position 1 0) (Position 1 12)
-                reduceDiag ^. LSP.severity `shouldBe` Just DsInfo
-                reduceDiag ^. LSP.code `shouldBe` Just (StringValue "Eta reduce")
-                reduceDiag ^. LSP.source `shouldBe` Just "hlint"
+                length diags @?= 2
+                reduceDiag ^. LSP.range @?= Range (Position 1 0) (Position 1 12)
+                reduceDiag ^. LSP.severity @?= Just DsInfo
+                reduceDiag ^. LSP.code @?= Just (StringValue "Eta reduce")
+                reduceDiag ^. LSP.source @?= Just "hlint"
 
             diags2a <- waitForDiagnostics
 
-            liftIO $ length diags2a `shouldBe` 2
+            liftIO $ length diags2a @?= 2
 
             sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
 
             diags3@(d:_) <- waitForDiagnosticsSource "eg2"
 
             liftIO $ do
-                length diags3 `shouldBe` 1
-                d ^. LSP.range `shouldBe` Range (Position 0 0) (Position 1 0)
-                d ^. LSP.severity `shouldBe` Nothing
-                d ^. LSP.code `shouldBe` Nothing
-                d ^. LSP.message `shouldBe` T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave"
+                length diags3 @?= 1
+                d ^. LSP.range @?= Range (Position 0 0) (Position 1 0)
+                d ^. LSP.severity @?= Nothing
+                d ^. LSP.code @?= Nothing
+                d ^. LSP.message @?= T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave"
     ]
 
 errorTests :: TestTree
@@ -69,7 +68,7 @@ errorTests = testGroup  "typed hole errors" [
         runSession hieCommand fullCaps "test/testdata" $ do
             _ <- openDoc "TypedHoles.hs" "haskell"
             [diag] <- waitForDiagnosticsSource "bios"
-            liftIO $ diag ^. LSP.severity `shouldBe` Just DsWarning
+            liftIO $ diag ^. LSP.severity @?= Just DsWarning
     ]
 
 warningTests :: TestTree
@@ -78,7 +77,7 @@ warningTests = testGroup  "Warnings are warnings" [
         runSession hieCommand fullCaps "test/testdata/wErrorTest" $ do
             _ <- openDoc "src/WError.hs" "haskell"
             [diag] <- waitForDiagnosticsSource "bios"
-            liftIO $ diag ^. LSP.severity `shouldBe` Just DsWarning
+            liftIO $ diag ^. LSP.severity @?= Just DsWarning
     ]
 
 saveTests :: TestTree
@@ -91,7 +90,7 @@ saveTests = testGroup  "only diagnostics on save" [
             diags <- waitForDiagnostics
 
             liftIO $ do
-                length diags `shouldBe` 0
+                length diags @?= 0
 
             let te = TextEdit (Range (Position 0 0) (Position 0 13)) ""
             _ <- applyEdit doc te
@@ -100,5 +99,5 @@ saveTests = testGroup  "only diagnostics on save" [
             sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
             diags2 <- waitForDiagnostics
             liftIO $
-                length diags2 `shouldBe` 1
+                length diags2 @?= 1
     ]

--- a/test/functional/Format.hs
+++ b/test/functional/Format.hs
@@ -113,6 +113,8 @@ stylishHaskellTests = testGroup "stylish-haskell" [
       BS.fromStrict . T.encodeUtf8 <$> documentContents doc
   ]
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,10,0,0) || !defined(AGPL)
+#else
 brittanyTests :: TestTree
 brittanyTests = testGroup "brittany" [
     goldenVsStringDiff "formats a document with LF endings" goldenGitDiff "test/testdata/BrittanyLF.formatted_document.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
@@ -141,6 +143,7 @@ brittanyTests = testGroup "brittany" [
         formatRange doc (FormattingOptions 4 True) range
         BS.fromStrict . T.encodeUtf8 <$> documentContents doc
     ]
+#endif
 
 ormoluTests :: TestTree
 ormoluTests = testGroup "ormolu" [
@@ -160,9 +163,12 @@ ormoluTests = testGroup "ormolu" [
 formatLspConfig :: Value -> Value
 formatLspConfig provider = object [ "haskell" .= object ["formattingProvider" .= (provider :: Value)] ]
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,10,0,0) || !defined(AGPL)
+#else
 -- | The same as 'formatLspConfig' but using the legacy section name
 formatLspConfigOld :: Value -> Value
 formatLspConfigOld provider = object [ "languageServerHaskell" .= object ["formattingProvider" .= (provider :: Value)] ]
+#endif
 
 formatConfig :: Value -> SessionConfig
 formatConfig provider = defaultConfig { lspConfig = Just (formatLspConfig provider) }

--- a/test/functional/FunctionalBadProject.hs
+++ b/test/functional/FunctionalBadProject.hs
@@ -11,7 +11,6 @@ module FunctionalBadProject (tests) where
 -- import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 -- ---------------------------------------------------------------------
 -- TODO: Currently this can not succeed, since such an error is thrown in "runActionWithContext" which
@@ -20,7 +19,7 @@ import Test.Hspec.Expectations
 --
 tests :: TestTree
 tests = testGroup "behaviour on malformed projects" [
-    testCase "no test executed" $ True `shouldBe` True
+    testCase "no test executed" $ True @?= True
     ]
 
     -- testCase "deals with cabal file with unsatisfiable dependency" $
@@ -29,14 +28,14 @@ tests = testGroup "behaviour on malformed projects" [
     --         _doc <- openDoc "Foo.hs" "haskell"
 
     --         diags@(d:_) <- waitForDiagnosticsSource "bios"
-    --         -- liftIO $ show diags `shouldBe` ""
+    --         -- liftIO $ show diags @?= ""
     --         -- liftIO $ putStrLn $ show diags
     --         -- liftIO $ putStrLn "a"
     --         liftIO $ do
-    --             length diags `shouldBe` 1
-    --             d ^. range `shouldBe` Range (Position 0 0) (Position 1 0)
-    --             d ^. severity `shouldBe` (Just DsError)
-    --             d ^. code `shouldBe` Nothing
-    --             d ^. source `shouldBe` Just "bios"
-    --             d ^. message `shouldBe`
+    --             length diags @?= 1
+    --             d ^. range @?= Range (Position 0 0) (Position 1 0)
+    --             d ^. severity @?= (Just DsError)
+    --             d ^. code @?= Nothing
+    --             d ^. source @?= Just "bios"
+    --             d ^. message @?=
     --                 (T.pack "readCreateProcess: stack \"build\" \"--only-configure\" \".\" (exit 1): failed\n")

--- a/test/functional/FunctionalLiquid.hs
+++ b/test/functional/FunctionalLiquid.hs
@@ -15,7 +15,6 @@ import           Test.Hls.Util
 import           Test.Tasty
 import           Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import           Test.Tasty.HUnit
-import           Test.Hspec.Expectations
 
 -- ---------------------------------------------------------------------
 
@@ -28,26 +27,26 @@ tests = testGroup "liquid haskell diagnostics" [
             diags@(reduceDiag:_) <- waitForDiagnostics
 
             liftIO $ do
-                length diags `shouldBe` 2
-                reduceDiag ^. range `shouldBe` Range (Position 5 18) (Position 5 22)
-                reduceDiag ^. severity `shouldBe` Just DsHint
-                reduceDiag ^. code `shouldBe` Just (StringValue "Use negate")
-                reduceDiag ^. source `shouldBe` Just "hlint"
+                length diags @?= 2
+                reduceDiag ^. range @?= Range (Position 5 18) (Position 5 22)
+                reduceDiag ^. severity @?= Just DsHint
+                reduceDiag ^. code @?= Just (StringValue "Use negate")
+                reduceDiag ^. source @?= Just "hlint"
 
             diags2hlint <- waitForDiagnostics
 
-            liftIO $ length diags2hlint `shouldBe` 2
+            liftIO $ length diags2hlint @?= 2
 
             sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
 
             diags3@(d:_) <- waitForDiagnosticsSource "eg2"
 
             liftIO $ do
-                length diags3 `shouldBe` 1
-                d ^. LSP.range `shouldBe` Range (Position 0 0) (Position 1 0)
-                d ^. LSP.severity `shouldBe` Nothing
-                d ^. LSP.code `shouldBe` Nothing
-                d ^. LSP.message `shouldBe` T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave"
+                length diags3 @?= 1
+                d ^. LSP.range @?= Range (Position 0 0) (Position 1 0)
+                d ^. LSP.severity @?= Nothing
+                d ^. LSP.code @?= Nothing
+                d ^. LSP.message @?= T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave"
 
     -- ---------------------------------
 
@@ -58,14 +57,14 @@ tests = testGroup "liquid haskell diagnostics" [
 
             diags@(reduceDiag:_) <- waitForDiagnostics
 
-            -- liftIO $ show diags `shouldBe` ""
+            -- liftIO $ show diags @?= ""
 
             liftIO $ do
-                length diags `shouldBe` 2
-                reduceDiag ^. range `shouldBe` Range (Position 5 18) (Position 5 22)
-                reduceDiag ^. severity `shouldBe` Just DsHint
-                reduceDiag ^. code `shouldBe` Just (StringValue "Use negate")
-                reduceDiag ^. source `shouldBe` Just "hlint"
+                length diags @?= 2
+                reduceDiag ^. range @?= Range (Position 5 18) (Position 5 22)
+                reduceDiag ^. severity @?= Just DsHint
+                reduceDiag ^. code @?= Just (StringValue "Use negate")
+                reduceDiag ^. source @?= Just "hlint"
 
             -- Enable liquid haskell plugin and disable hlint
             let config = def { liquidOn  = True, hlintOn = False }
@@ -77,25 +76,27 @@ tests = testGroup "liquid haskell diagnostics" [
             -- TODO: whether hlint is really disbabled?
             -- TODO: @fendor, document or remove
             -- diags2hlint <- waitForDiagnostics
-            -- -- liftIO $ show diags2hlint `shouldBe` ""
+            -- -- liftIO $ show diags2hlint @?= ""
 
             -- -- We turned hlint diagnostics off
-            -- liftIO $ length diags2hlint `shouldBe` 0
+            -- liftIO $ length diags2hlint @?= 0
             -- diags2liquid <- waitForDiagnostics
-            -- liftIO $ length diags2liquid `shouldBe` 0
-            -- liftIO $ show diags2liquid `shouldBe` ""
+            -- liftIO $ length diags2liquid @?= 0
+            -- liftIO $ show diags2liquid @?= ""
             diags3@(d:_) <- waitForDiagnosticsSource "liquid"
-            -- liftIO $ show diags3 `shouldBe` ""
+            -- liftIO $ show diags3 @?= ""
             liftIO $ do
-                length diags3 `shouldBe` 1
-                d ^. range `shouldBe` Range (Position 8 0) (Position 8 11)
-                d ^. severity `shouldBe` Just DsError
-                d ^. code `shouldBe` Nothing
-                d ^. source `shouldBe` Just "liquid"
-                d ^. message `shouldSatisfy` T.isPrefixOf ("Error: Liquid Type Mismatch\n" <>
-                                                "  Inferred type\n" <>
-                                                "    VV : {v : GHC.Types.Int | v == 7}\n" <>
-                                                " \n" <>
-                                                "  not a subtype of Required type\n" <>
-                                                "    VV : {VV : GHC.Types.Int | VV mod 2 == 0}\n ")
+                length diags3 @?= 1
+                d ^. range @?= Range (Position 8 0) (Position 8 11)
+                d ^. severity @?= Just DsError
+                d ^. code @?= Nothing
+                d ^. source @?= Just "liquid"
+                (d ^. message) `T.isPrefixOf`
+                    ("Error: Liquid Type Mismatch\n" <>
+                     "  Inferred type\n" <>
+                     "    VV : {v : GHC.Types.Int | v == 7}\n" <>
+                     " \n" <>
+                     "  not a subtype of Required type\n" <>
+                     "    VV : {VV : GHC.Types.Int | VV mod 2 == 0}\n ")
+                    @? "Contains error message"
     ]

--- a/test/functional/Highlight.hs
+++ b/test/functional/Highlight.hs
@@ -9,7 +9,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 tests :: TestTree
 tests = testGroup "highlight" [
@@ -23,7 +22,7 @@ tests = testGroup "highlight" [
                     , DocumentHighlight (mkRange 4 22 4 25) (Just HkRead)
                     , DocumentHighlight (mkRange 3 6 3 9) (Just HkRead)
                     , DocumentHighlight (mkRange 1 0 1 3) (Just HkRead)]
-            mapM_ (\x -> highlights `shouldContain` [x]) hls
+            mapM_ (\x -> x `elem` highlights @? "Contains highlight") hls
     ]
     where
         mkRange sl sc el ec = Range (Position sl sc) (Position el ec)

--- a/test/functional/Progress.hs
+++ b/test/functional/Progress.hs
@@ -16,7 +16,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 tests :: TestTree
 tests = testGroup "window/workDoneProgress" [
@@ -29,25 +28,25 @@ tests = testGroup "window/workDoneProgress" [
 
             createRequest <- message :: Session WorkDoneProgressCreateRequest
             liftIO $ do
-                    createRequest ^. L.params `shouldBe` WorkDoneProgressCreateParams (ProgressNumericToken 0)
+                    createRequest ^. L.params @?= WorkDoneProgressCreateParams (ProgressNumericToken 0)
 
             startNotification <- message :: Session WorkDoneProgressBeginNotification
             liftIO $ do
                     -- Expect a stack cradle, since the given `hie.yaml` is expected
                     -- to contain a multi-stack cradle.
-                    startNotification ^. L.params . L.value . L.title `shouldBe` "Initializing Stack project"
-                    startNotification ^. L.params . L.token `shouldBe` (ProgressNumericToken 0)
+                    startNotification ^. L.params . L.value . L.title @?= "Initializing Stack project"
+                    startNotification ^. L.params . L.token @?= (ProgressNumericToken 0)
 
             reportNotification <- message :: Session WorkDoneProgressReportNotification
             liftIO $ do
-                    reportNotification ^. L.params . L.value . L.message `shouldBe` Just "Main"
-                    reportNotification ^. L.params . L.token `shouldBe` (ProgressNumericToken 0)
+                    reportNotification ^. L.params . L.value . L.message @?= Just "Main"
+                    reportNotification ^. L.params . L.token @?= (ProgressNumericToken 0)
 
             -- may produce diagnostics
             skipMany publishDiagnosticsNotification
 
             doneNotification <- message :: Session WorkDoneProgressEndNotification
-            liftIO $ doneNotification ^. L.params . L.token `shouldBe` (ProgressNumericToken 0)
+            liftIO $ doneNotification ^. L.params . L.token @?= (ProgressNumericToken 0)
 
             -- Initial hlint notifications
             _ <- publishDiagnosticsNotification
@@ -57,20 +56,20 @@ tests = testGroup "window/workDoneProgress" [
 
             createRequest' <- skipManyTill loggingNotification (message :: Session WorkDoneProgressCreateRequest)
             liftIO $ do
-                    createRequest' ^. L.params `shouldBe` WorkDoneProgressCreateParams (ProgressNumericToken 1)
+                    createRequest' ^. L.params @?= WorkDoneProgressCreateParams (ProgressNumericToken 1)
 
             startNotification' <- message :: Session WorkDoneProgressBeginNotification
             liftIO $ do
-                    startNotification' ^. L.params . L.value . L.title `shouldBe` "loading"
-                    startNotification' ^. L.params . L.token `shouldBe` (ProgressNumericToken 1)
+                    startNotification' ^. L.params . L.value . L.title @?= "loading"
+                    startNotification' ^. L.params . L.token @?= (ProgressNumericToken 1)
 
             reportNotification' <- message :: Session WorkDoneProgressReportNotification
             liftIO $ do
-                    reportNotification' ^. L.params . L.value . L.message `shouldBe` Just "Main"
-                    reportNotification' ^. L.params . L.token `shouldBe` (ProgressNumericToken 1)
+                    reportNotification' ^. L.params . L.value . L.message @?= Just "Main"
+                    reportNotification' ^. L.params . L.token @?= (ProgressNumericToken 1)
 
             doneNotification' <- message :: Session WorkDoneProgressEndNotification
-            liftIO $ doneNotification' ^. L.params . L.token `shouldBe` (ProgressNumericToken 1)
+            liftIO $ doneNotification' ^. L.params . L.token @?= (ProgressNumericToken 1)
 
             -- Initial hlint notifications
             _ <- publishDiagnosticsNotification

--- a/test/functional/Reference.hs
+++ b/test/functional/Reference.hs
@@ -2,6 +2,7 @@ module Reference (tests) where
 
 import Control.Lens
 import Control.Monad.IO.Class
+import Data.List
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Lens
@@ -9,7 +10,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 tests :: TestTree
 tests = testGroup "references" [
@@ -17,14 +17,14 @@ tests = testGroup "references" [
         doc <- openDoc "References.hs" "haskell"
         let pos = Position 2 7 -- foo = bar <--
         refs <- getReferences doc pos True
-        liftIO $ refs `shouldContain` map (Location (doc ^. uri)) [
+        liftIO $ map (Location (doc ^. uri)) [
                 mkRange 4 0 4 3
             , mkRange 8 11 8 14
             , mkRange 7 7 7 10
             , mkRange 4 14 4 17
             , mkRange 4 0 4 3
             , mkRange 2 6 2 9
-            ]
+            ] `isInfixOf` refs @? "Contains references"
     -- TODO: Respect withDeclaration parameter
     -- ignoreTestBecause "Broken" $ testCase "works without definitions" $ runSession hieCommand fullCaps "test/testdata" $ do
     --   doc <- openDoc "References.hs" "haskell"

--- a/test/functional/Rename.hs
+++ b/test/functional/Rename.hs
@@ -7,11 +7,10 @@ module Rename (tests) where
 -- import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 tests :: TestTree
 tests = testGroup "rename" [
-  testCase "works" $ True `shouldBe` True
+  testCase "works" $ True @?= True
   --  pendingWith "removed because of HaRe"
   -- runSession hieCommand fullCaps "test/testdata" $ do
   --   doc <- openDoc "Rename.hs" "haskell"

--- a/test/functional/Symbol.hs
+++ b/test/functional/Symbol.hs
@@ -2,6 +2,7 @@
 module Symbol (tests) where
 
 import Control.Monad.IO.Class
+import Data.List
 import Language.Haskell.LSP.Test as Test
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
@@ -9,7 +10,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 tests :: TestTree
 tests = testGroup "document symbols" [
@@ -27,7 +27,7 @@ v310Tests = testGroup "3.10 hierarchical document symbols" [
             a = DocumentSymbol "A" (Just "") SkConstructor Nothing aR aSR (Just mempty)
             b = DocumentSymbol "B" (Just "") SkConstructor Nothing bR bSR (Just mempty)
 
-        liftIO $ symbs `shouldContain` [myData]
+        liftIO $ myData `elem` symbs @? "Contains symbol"
 
     ,ignoreTestBecause "Broken" $ testCase "provides nested where functions" $ runSession hieCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Symbols.hs" "haskell"
@@ -38,7 +38,7 @@ v310Tests = testGroup "3.10 hierarchical document symbols" [
             dog = DocumentSymbol "dog" (Just "") SkVariable Nothing dogR dogSR (Just mempty)
             cat = DocumentSymbol "cat" (Just "") SkVariable Nothing catR catSR (Just mempty)
 
-        liftIO $ symbs `shouldContain` [foo]
+        liftIO $ foo `elem` symbs @? "Contains symbol"
 
     , ignoreTestBecause "Broken" $ testCase "provides pattern synonyms" $ runSession hieCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Symbols.hs" "haskell"
@@ -47,7 +47,7 @@ v310Tests = testGroup "3.10 hierarchical document symbols" [
         let testPattern = DocumentSymbol "TestPattern"
                 (Just "") SkFunction Nothing testPatternR testPatternSR (Just mempty)
 
-        liftIO $ symbs `shouldContain` [testPattern]
+        liftIO $ testPattern `elem` symbs @? "Contains symbol"
     ]
 
 -- TODO: Test module, imports
@@ -62,7 +62,7 @@ pre310Tests = testGroup "pre 3.10 symbol information" [
             a = SymbolInformation "A" SkConstructor Nothing (Location testUri aR) (Just "MyData")
             b = SymbolInformation "B" SkConstructor Nothing (Location testUri bR) (Just "MyData")
 
-        liftIO $ symbs `shouldContain` [myData, a, b]
+        liftIO $ [myData, a, b] `isInfixOf` symbs @? "Contains symbols"
 
     ,ignoreTestBecause "Broken" $ testCase "provides nested where functions" $ runSession hieCommand oldCaps "test/testdata" $ do
         doc@(TextDocumentIdentifier testUri) <- openDoc "Symbols.hs" "haskell"
@@ -74,7 +74,7 @@ pre310Tests = testGroup "pre 3.10 symbol information" [
             cat = SymbolInformation "cat" SkVariable Nothing (Location testUri catR) (Just "bar")
 
         -- Order is important!
-        liftIO $ symbs `shouldContain` [foo, bar, dog, cat]
+        liftIO $ [foo, bar, dog, cat] `isInfixOf` symbs @? "Contains symbols"
     ]
 
 oldCaps :: ClientCapabilities

--- a/test/functional/TypeDefinition.hs
+++ b/test/functional/TypeDefinition.hs
@@ -8,7 +8,6 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-import Test.Hspec.Expectations
 
 tests :: TestTree
 tests = testGroup "type definitions" [
@@ -19,10 +18,9 @@ tests = testGroup "type definitions" [
             defs <- getTypeDefinitions doc (toPos (11, 23))
             liftIO $ do
                 fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
-                defs
-                    `shouldBe` [ Location (filePathToUri fp)
-                                        (Range (toPos (8, 1)) (toPos (8, 29)))
-                            ]
+                defs @?= [ Location (filePathToUri fp)
+                                    (Range (toPos (8, 1)) (toPos (8, 29)))
+                         ]
     , ignoreTestBecause "Broken" $ testCase "finds local definition of newtype variable"
         $ runSession hieCommand fullCaps "test/testdata/gototest"
         $ do
@@ -30,10 +28,9 @@ tests = testGroup "type definitions" [
             defs <- getTypeDefinitions doc (toPos (16, 21))
             liftIO $ do
                 fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
-                defs
-                    `shouldBe` [ Location (filePathToUri fp)
-                                        (Range (toPos (13, 1)) (toPos (13, 30)))
-                            ]
+                defs @?= [ Location (filePathToUri fp)
+                                    (Range (toPos (13, 1)) (toPos (13, 30)))
+                         ]
     , ignoreTestBecause "Broken" $ testCase "finds local definition of sum type variable"
         $ runSession hieCommand fullCaps "test/testdata/gototest"
         $ do
@@ -41,10 +38,9 @@ tests = testGroup "type definitions" [
             defs <- getTypeDefinitions doc (toPos (21, 13))
             liftIO $ do
                 fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
-                defs
-                    `shouldBe` [ Location (filePathToUri fp)
-                                        (Range (toPos (18, 1)) (toPos (18, 26)))
-                            ]
+                defs @?= [ Location (filePathToUri fp)
+                                    (Range (toPos (18, 1)) (toPos (18, 26)))
+                         ]
     , ignoreTestBecause "Broken" $ testCase "finds local definition of sum type contructor"
             $ runSession hieCommand fullCaps "test/testdata/gototest"
             $ do
@@ -53,15 +49,15 @@ tests = testGroup "type definitions" [
                 liftIO $ do
                     fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
                     defs
-                        `shouldBe` [ Location (filePathToUri fp)
-                                            (Range (toPos (18, 1)) (toPos (18, 26)))
-                                ]
+                        @?= [ Location (filePathToUri fp)
+                                       (Range (toPos (18, 1)) (toPos (18, 26)))
+                            ]
     , ignoreTestBecause "Broken" $ testCase "can not find non-local definition of type def"
         $ runSession hieCommand fullCaps "test/testdata/gototest"
         $ do
             doc  <- openDoc "src/Lib.hs" "haskell"
             defs <- getTypeDefinitions doc (toPos (30, 17))
-            liftIO $ defs `shouldBe` []
+            liftIO $ defs @?= []
 
     , ignoreTestBecause "Broken" $ testCase "find local definition of type def"
         $ runSession hieCommand fullCaps "test/testdata/gototest"
@@ -70,10 +66,9 @@ tests = testGroup "type definitions" [
             defs <- getTypeDefinitions doc (toPos (35, 16))
             liftIO $ do
                 fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
-                defs
-                    `shouldBe` [ Location (filePathToUri fp)
-                                        (Range (toPos (18, 1)) (toPos (18, 26)))
-                            ]
+                defs @?= [ Location (filePathToUri fp)
+                                    (Range (toPos (18, 1)) (toPos (18, 26)))
+                         ]
 
     {--  TODO Implement
      , ignoreTestBecause "Broken" $ testCase "find type-definition of type def in component"
@@ -87,7 +82,7 @@ tests = testGroup "type definitions" [
              liftIO $ do
                fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
                defs
-                 `shouldBe` [ Location (filePathToUri fp)
+                 @?= [ Location (filePathToUri fp)
                                        (Range (toPos (8, 1)) (toPos (8, 29)))
                             ]
     --}
@@ -98,10 +93,9 @@ tests = testGroup "type definitions" [
             defs <- getTypeDefinitions doc (toPos (40, 19))
             liftIO $ do
                 fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
-                defs
-                    `shouldBe` [ Location (filePathToUri fp)
-                                        (Range (toPos (37, 1)) (toPos (37, 31)))
-                            ]
+                defs @?= [ Location (filePathToUri fp)
+                                    (Range (toPos (37, 1)) (toPos (37, 31)))
+                         ]
     ]
 
 --NOTE: copied from Haskell.Ide.Engine.ArtifactMap


### PR DESCRIPTION
Use @? and @?= instead, since they give easier to read error messages. The `shouldX` functions all just end up dumping the Show instance of a HSpecFailure or what have you which is hard to read. It also doesn't look like hspec-expectations is that actively maintained anymore