### PR TITLE
Remove a redundant caching step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,6 @@ defaults: &defaults
         path: test-logs
 
     - save_cache:
-        key: stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
-        paths: *cache_paths
-
-    - save_cache:
         key: stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
         paths: *cache_paths
 


### PR DESCRIPTION
AFAIK, CircleCI's cache system treats a restore key as a prefix of a real cache key, not the exact cache key.
If the prefix(restore key) matches with many cache keys, the recent most cache will be restored.
In our setting, we have two different key schemes for saving cache
1. `stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}`
2. `stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}`

However, 1. is a prefix of 2., so every prefix (restore key) that matches with 1. also matches with 2., and 2. is created later in the CI script so it's the one that will always be restored.

Ref: https://circleci.com/docs/2.0/configuration-reference/#restore_cache
(see the `Note:` part)