### PR TITLE
add hie.yaml to coc configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Then issue `:CocConfig` and add the following to your Coc config file.
     "command": "haskell-language-server-wrapper",
     "args": ["--lsp"],
     "rootPatterns": [
+      "hie.yaml",
       "*.cabal",
       "stack.yaml",
       "cabal.project",


### PR DESCRIPTION
`hie.yaml` should be at the top since root is decided by `hie.yaml` as a first priority.