### PR TITLE
Include Brittany in binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,8 @@ jobs:
         echo '::set-env name=LINUX_CABAL_ARGS::--enable-executable-static --ghc-options=-split-sections'
 
     - name: Build Server
-      # Try building it twice in case of flakey builds on Windows
       run: |
-        cabal build exe:hls -O2 $LINUX_CABAL_ARGS || \
-        cabal build exe:hls -O2 $LINUX_CABAL_ARGS -j1
+        cabal build exe:hls -O2 -fagpl $LINUX_CABAL_ARGS
 
     - name: Compress Server Binary
       id: compress_server_binary
@@ -95,7 +93,7 @@ jobs:
 
     - name: Build Wrapper
       if: matrix.ghc == '8.10.1'
-      run: cabal build exe:hls-wrapper -O2 $LINUX_CABAL_ARGS
+      run: cabal build exe:hls-wrapper -O2 -fagpl $LINUX_CABAL_ARGS
 
     - name: Compress Wrapper Binary
       if: matrix.ghc == '8.10.1'

--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,13 @@ packages:
          ./
          ghcide
 
+source-repository-package
+    type: git
+    location: https://github.com/infinity0/brittany.git
+    tag: 0807fc9b30eb9758dffdb87d2a9a9fa6a17a62b1
+
+allow-newer: data-tree-print:base
+
 tests: true
 
 package *

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -108,9 +108,7 @@ idePlugins includeExamples = pluginDescToIdePlugins allPlugins
       , StylishHaskell.descriptor "stylish-haskell"
       , Retrie.descriptor "retrie"
 #if AGPL
-#if !MIN_VERSION_ghc(8,10,1)
       , Brittany.descriptor    "brittany"
-#endif
 #endif
       , Eval.descriptor "eval"
       ]

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -101,11 +101,10 @@ library
   else
     build-depends:     unix
   if flag(agpl)
-    if impl(ghc < 8.10)
-      build-depends:
-        brittany
-      exposed-modules:
-        Ide.Plugin.Brittany
+    build-depends:
+      brittany
+    exposed-modules:
+      Ide.Plugin.Brittany
 
   ghc-options:
          -Wall


### PR DESCRIPTION
Unforutnately, this also invovles vendoring Brittany with a fork that
allows it to build on ghc-8.10.1. This is only vendored on the
cabal.project file though, not the stack.yamls