### PR TITLE
Add a Nix CI job + a Hoogle option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,32 @@ jobs:
           key: cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - ~/.cabal
+  nix:
+    working_directory: ~/build
+    environment:
+        - NIXPKGS_ALLOW_BROKEN: 1
+    docker:
+        - image: nixorg/nix:circleci
+    steps:
+      - checkout
+      - run:
+          name: Sync submodules
+          command: git submodule sync --recursive
+      - run:
+          name: Update submodules
+          command: git submodule update --recursive --init
+      - restore-cache:
+          keys:
+            - cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+      - run:
+          name: Build
+          command: nix-shell -j4 --run "cabal new-update && cabal new-build -j1 --enable-tests"
+          no_output_timeout: 30m
+      - save_cache:
+          key: cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - ~/.cabal
+
 
 
 workflows:
@@ -170,3 +196,4 @@ workflows:
       - ghc-8.10.1
       # - ghc-nightly
       - cabal
+      - nix

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "b8c367a7bd05e3a514c2b057c09223c74804a21b",
-        "sha256": "0y17zxhwdw0afml2bwkmhvkymd9fv242hksl3l3xz82gmlg1zks4",
+        "rev": "2c4e0f37a6d5d33666b550a1b85daf46b37f1b25",
+        "sha256": "0hqr6ci0rgg1fyfg7w2182vgbi0cq472p2j8r7mcmkbpdwwi6i69",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/b8c367a7bd05e3a514c2b057c09223c74804a21b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/2c4e0f37a6d5d33666b550a1b85daf46b37f1b25.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,17 @@
 # while reducing Nix maintenance costs.
 # It does **not** aim to replace Cabal/Stack with Nix
 
+# Maintaining this file:
+#
+# - Dealing with broken nix-shell
+#
+#     1. Bump the nixpkgs version using `niv update nixpkgs`
+#     2. Comment out any remaining failing packages
+#
+# - Dealing with broken cabal build inside nix-shell:
+#
+#    If my understanding of cabal new-build is correct this should never happen,
+#    assuming that cabal new-build does succeed outside nix-shell
 
 { sources ? import nix/sources.nix,
   nixpkgs ? import sources.nixpkgs {},
@@ -47,7 +58,7 @@ let defaultCompiler = "ghc" + lib.replaceStrings ["."] [""] haskellPackages.ghc.
           data-default-instances-old-locale
           extra
           floskell
-          fourmolu
+        #   fourmolu
           fuzzy
           generic-deriving
           ghc-check
@@ -99,9 +110,10 @@ in
 stdenv.mkDerivation {
   name = "haskell-language-server";
   buildInputs = [
+    git
     gmp
-    zlib
     ncurses
+    zlib
 
     haskellPackages.cabal-install
     haskellPackages.hlint

--- a/src/Ide/Plugin/Example.hs
+++ b/src/Ide/Plugin/Example.hs
@@ -37,6 +37,7 @@ import Ide.Plugin
 import Ide.Types
 import Language.Haskell.LSP.Types
 import Text.Regex.TDFA.Text()
+import Development.IDE.GHC.Compat (ParsedModule(ParsedModule))
 
 -- ---------------------------------------------------------------------
 
@@ -106,7 +107,9 @@ mkDiag file diagSource sev loc msg = (file, D.ShowDiag,)
 
 -- | Generate code actions.
 codeAction :: CodeActionProvider
-codeAction _lf _state _pid (TextDocumentIdentifier uri) _range CodeActionContext{_diagnostics=List _xs} = do
+codeAction _lf state _pid (TextDocumentIdentifier uri) _range CodeActionContext{_diagnostics=List _xs} = do
+    let Just nfp = uriToNormalizedFilePath $ toNormalizedUri uri
+    Just (ParsedModule{},_) <- runIdeAction "example" (shakeExtras state) $ useWithStaleFast GetParsedModule nfp
     let
       title = "Add TODO Item 1"
       tedit = [TextEdit (Range (Position 2 0) (Position 2 0))


### PR DESCRIPTION
Fixes #294 - although I could not repro the problem in the issue, I found that nix-shell was failing due to fourmulu. 

The CI job should ensure that this doesn't break silently again, and I added instructions on what to do when it breaks.

The example ParsedModule commit is unrelated - let me know if you prefer me to send it in a separate PR