### PR TITLE
Add support for ghc-8.10.2

### DIFF
--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-06-29
+resolver: nightly-2020-08-08
 
 packages:
 - .
@@ -12,24 +12,16 @@ extra-deps:
 - github: bubba/brittany
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 - Cabal-3.0.2.0
-- hie-bios-0.6.1
-- cabal-plan-0.7.0.0
 - clock-0.7.2
 - data-tree-print-0.1.0.2
 - floskell-0.10.4
 - fourmolu-0.1.0.0@rev:1
-- ghc-exactprint-0.6.3
 - HsYAML-aeson-0.2.0.0@rev:2
-- lens-4.19.1
-- lsp-test-0.11.0.4
 - monad-dijkstra-0.1.1.2
-- optics-core-0.3
-- ormolu-0.1.2.0
 - retrie-0.1.1.1
 - stylish-haskell-0.11.0.3
 - semigroups-0.18.5
 - temporary-1.2.1.1
-- these-1.1
 
 flags:
   haskell-language-server:

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -1,0 +1,39 @@
+resolver: nightly-2020-08-08
+compiler: ghc-8.10.2
+
+packages:
+- .
+- ./ghcide/
+
+ghc-options:
+  "$everything": -haddock
+
+extra-deps:
+- aeson-1.5.2.0
+- github: bubba/brittany
+  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- Cabal-3.0.2.0
+- clock-0.7.2
+- data-tree-print-0.1.0.2
+- floskell-0.10.4
+- fourmolu-0.1.0.0@rev:1
+- HsYAML-aeson-0.2.0.0@rev:2
+- monad-dijkstra-0.1.1.2
+- retrie-0.1.1.1
+- stylish-haskell-0.11.0.3
+- semigroups-0.18.5
+- temporary-1.2.1.1
+
+flags:
+  haskell-language-server:
+    pedantic: true
+  retrie:
+    BuildExecutable: false
+
+# for data-tree-print's bounds on base (>=4.8 && <4.14); using base-4.14.0.0.
+allow-newer: true
+
+nix:
+  packages: [ icu libcxx zlib ]
+
+concurrent-tests: false


### PR DESCRIPTION
* Although it seems 8.10.3 will be released soon
* I've updated the stack-8.10.1.yaml resolver before using it as base for stack-8.10.2.yaml
* Tested locally with cabal
* Fixes #298