### PR TITLE
Return nothing if tool is not on the PATH

### DIFF
--- a/src/Ide/Version.hs
+++ b/src/Ide/Version.hs
@@ -13,6 +13,7 @@ import qualified Paths_haskell_language_server as Meta
 import           System.Info
 import           Data.Version
 import           Data.Maybe (listToMaybe)
+import           System.Directory
 import           System.Process
 import           System.Exit
 import           Text.ParserCombinators.ReadP
@@ -60,10 +61,12 @@ findProgramVersions = ProgramsOfInterest
 -- If the invocation has a non-zero exit-code, we return 'Nothing'
 findVersionOf :: FilePath -> IO (Maybe Version)
 findVersionOf tool =
-  readProcessWithExitCode tool ["--numeric-version"] "" >>= \case
-    (ExitSuccess, sout, _) -> pure $ consumeParser myVersionParser sout
-    _ -> pure $ Nothing
-
+  findExecutable tool >>= \case
+    Nothing -> pure Nothing
+    Just path ->
+      readProcessWithExitCode path ["--numeric-version"] "" >>= \case
+        (ExitSuccess, sout, _) -> pure $ consumeParser myVersionParser sout
+        _ -> pure $ Nothing
   where
     myVersionParser = do
       skipSpaces


### PR DESCRIPTION
As discovered by https://github.com/haskell/haskell-language-server/pull/306#issuecomment-671829315, I forgot to actually check that a tool is on the path!
Therefore, currently HLS breaks for everyone who built it from source since the commit 0b12fcb4a2cddffdf0a5e25c799a6a5c5cb8b490 and has not every tool installed.
