### PR TITLE
Simplify coc.nvim instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,22 +386,8 @@ Then issue `:CocConfig` and add the following to your Coc config file.
   "haskell": {
     "command": "haskell-language-server-wrapper",
     "args": ["--lsp"],
-    "rootPatterns": [
-      "hie.yaml",
-      "*.cabal",
-      "stack.yaml",
-      "cabal.project",
-      "package.yaml"
-    ],
-    "filetypes": [
-      "hs",
-      "lhs",
-      "haskell"
-    ],
-    "initializationOptions": {
-      "haskell": {
-      }
-    }
+    "rootPatterns": ["*.cabal", "stack.yaml", "cabal.project", "package.yaml", "hie.yaml"],
+    "filetypes": ["haskell", "lhaskell"]
   }
 }
 ```


### PR DESCRIPTION
This also corrects filetypes supported, as `lhaskell` is the correct filetype for literate haskell in vim-land, and file extensions (`hs`, `lhs`) don't matter as coc understands vim filetypes, not file extensions.