### PR TITLE
Coc config file requires a {} nesting everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Follow Coc's [installation instructions](https://github.com/neoclide/coc.nvim).
 Then issue `:CocConfig` and add the following to your Coc config file.
 
 ```json
+{
 "languageserver": {
   "haskell": {
     "command": "haskell-language-server-wrapper",
@@ -403,6 +404,7 @@ Then issue `:CocConfig` and add the following to your Coc config file.
       }
     }
   }
+}
 }
 ```
 


### PR DESCRIPTION
Coc site [1] now shows an example config with a top level `{}` that includes everything. Without it, `Coc` complains about syntax error in the config file, and the language server will not be loaded. 

```json
{
  "languageserver": {
    "go": {
      "command": "gopls",
      "rootPatterns": ["go.mod"],
      "trace.server": "verbose",
      "filetypes": ["go"]
    }
  }
}
```
[1] https://github.com/neoclide/coc.nvim