### PR TITLE
Replace wrong occurrences of "engine" by "server"

### DIFF
--- a/install/hls-install.cabal
+++ b/install/hls-install.cabal
@@ -1,6 +1,6 @@
 name:                hls-install
 version:             0.8.0.0
-synopsis:            Install the haskell-language-engine
+synopsis:            Install the haskell-language-server
 license:             BSD3
 author:              Many, TBD when we release
 maintainer:          samuel.pilz@posteo.net

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -114,7 +114,7 @@ stackBuildFailMsg =
     $  "Building failed, "
     ++ "Try running `stack clean` and restart the build\n"
     ++ "If this does not work, open an issue at \n"
-    ++ "\thttps://github.com/haskell/haskell-language-engine"
+    ++ "\thttps://github.com/haskell/haskell-language-server"
 
 getVerbosityArg :: Verbosity -> String
 getVerbosityArg v = "--verbosity=" ++ stackVerbosity


### PR DESCRIPTION
This PR corrects two occurrences of `haskell-language-engine` by `haskell-language-server`. This corrects a URL that was directing to a non-existing repository.