### PR TITLE
Copy working stack-8.6.5.yaml to stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ ghc-options:
 extra-deps:
 - aeson-1.5.2.0
 - ansi-terminal-0.10.3
-- base-compat-0.11.0
+- base-compat-0.10.5
 - github: bubba/brittany
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 - butcher-1.3.3.1
@@ -42,14 +42,18 @@ extra-deps:
 - optparse-applicative-0.15.1.0
 - ormolu-0.1.2.0
 - parser-combinators-1.2.1
+- primitive-0.7.1.0
 - regex-base-0.94.0.0
 - regex-pcre-builtin-0.95.1.1.8.43
 - regex-tdfa-1.3.1.0
 - retrie-0.1.1.1
 - semialign-1.1
+# - github: wz1000/shake
+#   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - stylish-haskell-0.11.0.3
 - tasty-rerun-1.1.17
 - temporary-1.2.1.1
+- these-1.1.1.1
 - type-equality-1
 - topograph-1
 


### PR DESCRIPTION
* The actual `stack.yaml` didnt work for me (i was testing it trying to reproduce #327):

```
PS D:\dev\ws\haskell\hls> stack build

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for HsYAML-aeson-0.2.0.0:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to haskell-language-server-0.3.0.0 -> HsYAML-aeson-0.2.0.0

Dependency cycle detected in packages:
    [aeson,these,aeson,ghcide]

In the dependencies for aeson-pretty-0.8.8:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to ghcide-0.2.0 -> aeson-pretty-0.8.8

In the dependencies for brittany-0.12.1.1:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to haskell-language-server-0.3.0.0 -> brittany-0.12.1.1

In the dependencies for floskell-0.10.4:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to haskell-language-server-0.3.0.0 -> floskell-0.10.4

In the dependencies for fourmolu-0.1.0.0:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to haskell-language-server-0.3.0.0 -> fourmolu-0.1.0.0

In the dependencies for haskell-language-server-0.3.0.0(+pedantic):
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed since haskell-language-server is a build target.

In the dependencies for haskell-lsp-0.22.0.0:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to ghcide-0.2.0 -> haskell-lsp-0.22.0.0

In the dependencies for haskell-lsp-types-0.22.0.0:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to ghcide-0.2.0 -> haskell-lsp-types-0.22.0.0

In the dependencies for hie-bios-0.6.1:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to ghcide-0.2.0 -> hie-bios-0.6.1

In the dependencies for lsp-test-0.11.0.4:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to ghcide-0.2.0 -> lsp-test-0.11.0.4

In the dependencies for stylish-haskell-0.11.0.3:
    aeson dependency cycle detected: aeson, these, aeson, ghcide
needed due to haskell-language-server-0.3.0.0 -> stylish-haskell-0.11.0.3
In the dependencies for these-1.0.1:
    aeson dependency cycle detected: aeson, these, aeson, ghcide

In the dependencies for yaml-0.11.2.0:

Some different approaches to resolving this:

Plan construction failed.
```

`stack-8.6.5.yaml` does work