### PR TITLE
Adds `:kind` and `:kind!` commands to Eval Plugin

### DIFF
--- a/src/Ide/Plugin/Eval.hs
+++ b/src/Ide/Plugin/Eval.hs
@@ -258,7 +258,7 @@ done, we want to switch back to GhcSessionDeps:
               $ T.unlines 
               $ map ("-- " <>)
               $ (input <> " :: " <> T.pack (showSDoc df $ ppr kind))
-              : [ " = " <> T.pack (showSDoc df $ ppr ty) | reduce]
+              : [ "= " <> T.pack (showSDoc df $ ppr ty) | reduce]
           | isStmt df stmt = do
             -- set up a custom interactive print function
             liftIO $ writeFile temp ""

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -67,6 +67,9 @@ tests = testGroup
   , testCase "Evaluate a type with :kind!" $ goldenTest "T10.hs"
   , testCase "Reports an error for an incorrect type with :kind!" 
     $ goldenTest "T11.hs"
+  , testCase "Shows a kind with :kind" $ goldenTest "T12.hs"
+  , testCase "Reports an error for an incorrect type with :kind" 
+    $ goldenTest "T13.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -64,6 +64,9 @@ tests = testGroup
   , testCase "Refresh a multiline evaluation" $ goldenTest "T7.hs"
   , testCase "Evaluate incorrect expressions" $ goldenTest "T8.hs"
   , testCase "Applies file LANGUAGE extensions" $ goldenTest "T9.hs"
+  , testCase "Evaluate a type with :kind!" $ goldenTest "T10.hs"
+  , testCase "Reports an error for an incorrect type with :kind!" 
+    $ goldenTest "T11.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/testdata/eval/T10.hs
+++ b/test/testdata/eval/T10.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module T10 where
+import GHC.TypeNats ( type (+) )
+
+type Dummy = 1 + 1
+
+-- >>> type N = 1
+-- >>> type M = 40
+-- >>> :kind! N + M + 1
+-- N + M + 1 :: Nat
+--  = 42

--- a/test/testdata/eval/T10.hs
+++ b/test/testdata/eval/T10.hs
@@ -7,5 +7,3 @@ type Dummy = 1 + 1
 -- >>> type N = 1
 -- >>> type M = 40
 -- >>> :kind! N + M + 1
--- N + M + 1 :: Nat
---  = 42

--- a/test/testdata/eval/T10.hs.expected
+++ b/test/testdata/eval/T10.hs.expected
@@ -1,0 +1,11 @@
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module T10 where
+import GHC.TypeNats ( type (+) )
+
+type Dummy = 1 + 1
+
+-- >>> type N = 1
+-- >>> type M = 40
+-- >>> :kind! N + M + 1
+-- N + M + 1 :: Nat
+--  = 42

--- a/test/testdata/eval/T10.hs.expected
+++ b/test/testdata/eval/T10.hs.expected
@@ -8,4 +8,4 @@ type Dummy = 1 + 1
 -- >>> type M = 40
 -- >>> :kind! N + M + 1
 -- N + M + 1 :: Nat
---  = 42
+-- = 42

--- a/test/testdata/eval/T11.hs
+++ b/test/testdata/eval/T11.hs
@@ -1,0 +1,3 @@
+module T11 where
+
+-- >>> :kind! a

--- a/test/testdata/eval/T11.hs.expected
+++ b/test/testdata/eval/T11.hs.expected
@@ -1,0 +1,4 @@
+module T11 where
+
+-- >>> :kind! a
+-- Not in scope: type variable ‘a’

--- a/test/testdata/eval/T12.hs
+++ b/test/testdata/eval/T12.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module T12 where
+import GHC.TypeNats ( type (+) )
+
+type Dummy = 1 + 1
+
+-- >>> type N = 1
+-- >>> type M = 40
+-- >>> :kind N + M + 1

--- a/test/testdata/eval/T12.hs.expected
+++ b/test/testdata/eval/T12.hs.expected
@@ -1,0 +1,10 @@
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module T12 where
+import GHC.TypeNats ( type (+) )
+
+type Dummy = 1 + 1
+
+-- >>> type N = 1
+-- >>> type M = 40
+-- >>> :kind N + M + 1
+-- N + M + 1 :: Nat

--- a/test/testdata/eval/T13.hs
+++ b/test/testdata/eval/T13.hs
@@ -1,0 +1,3 @@
+module T13 where
+
+-- >>> :kind a

--- a/test/testdata/eval/T13.hs.expected
+++ b/test/testdata/eval/T13.hs.expected
@@ -1,0 +1,4 @@
+module T13 where
+
+-- >>> :kind a
+-- Not in scope: type variable ‘a’

--- a/test/testdata/eval/T9.hs
+++ b/test/testdata/eval/T9.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 module T9 where
-import Data.Proxy
+import Data.Proxy (Proxy(..))
+
+type P = Proxy
 
 -- >>> Proxy :: Proxy 3

--- a/test/testdata/eval/T9.hs.expected
+++ b/test/testdata/eval/T9.hs.expected
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 module T9 where
-import Data.Proxy
+import Data.Proxy (Proxy(..))
+
+type P = Proxy
 
 -- >>> Proxy :: Proxy 3
 -- Proxy


### PR DESCRIPTION
This pull request implements `:kind` and `:kind!` commands ala GHCi to Eval plugin.
The former displays the kind of a given type and the latter also displays the normalised form of a given type.

## Examples

```haskell
-- >>> type N = 1
-- >>> type M = 40
-- >>> :kind N + M + 1
```

evaluates to:

```haskell
-- >>> type N = 1
-- >>> type M = 40
-- >>> :kind N + M + 1
-- N + M + 1 :: Nat
```

And

```haskell
-- >>> type N = 1
-- >>> type M = 40
-- >>> :kind! N + M + 1
```

evaluates to:

```haskell
-- >>> type N = 1
-- >>> type M = 40
-- >>> :kind! N + M + 1
-- N + M + 1 :: Nat
-- = 42
```