### PR TITLE
Bump bounds of hie-bios to 0.7.0

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -81,7 +81,7 @@ library
     , gitrev
     , hashable
     , haskell-lsp == 0.22.*
-    , hie-bios ^>= 0.6.1
+    , hie-bios >= 0.6.1 && < 0.8
     , hslogger
     , lens
     , ormolu ^>= 0.1.2


### PR DESCRIPTION
```
16:18 <maralorn> Should I expect any trouble when building current ghcide (hls-3 branch to be precise) with hie-bios 0.7.0?
16:19 <maralorn> Apparently it does compile without issues.
16:21 <fendor> maralorn, no, the breaking change is in the config type, which neither hls nor ghcide explicltly use
16:21 <fendor> so, everything should just work fine for both these projects
```
I tested. This builds with newest hie-bios for me.