### PR TITLE
Implements `:type [+v/+d]` in Eval Plugin

### DIFF
--- a/src/Ide/Plugin/Eval.hs
+++ b/src/Ide/Plugin/Eval.hs
@@ -337,7 +337,7 @@ instance E.Exception GhciLikeCmdException
 parseGhciLikeCmd :: Text -> Maybe (Text, Text)
 parseGhciLikeCmd input = do
   (':', rest) <- T.uncons $ T.stripStart input
-  pure $ second T.stripEnd $ T.break isSpace rest
+  pure $ second T.strip $ T.break isSpace rest
 
 strictTry :: NFData b => IO b -> IO (Either String b)
 strictTry op = E.catch

--- a/src/Ide/Plugin/Eval.hs
+++ b/src/Ide/Plugin/Eval.hs
@@ -325,8 +325,13 @@ evalGhciLikeCmd cmd arg = do
     _ -> E.throw $ GhciLikeCmdNotImplemented cmd arg
 
 data GhciLikeCmdException = GhciLikeCmdNotImplemented Text Text
-  deriving (Show, Typeable)
+  deriving (Typeable)
 
+instance Show GhciLikeCmdException where
+  showsPrec _ (GhciLikeCmdNotImplemented cmd _arg) =
+    showString "unknown command '" .
+    showString (T.unpack cmd) . showChar '\''
+  
 instance E.Exception GhciLikeCmdException
 
 parseGhciLikeCmd :: Text -> Maybe (Text, Text)

--- a/src/Ide/Plugin/Eval.hs
+++ b/src/Ide/Plugin/Eval.hs
@@ -87,7 +87,6 @@ import           Control.DeepSeq                ( NFData
                                                 , deepseq
                                                 )
 import Outputable (Outputable(ppr), showSDoc)
-import Control.Applicative ((<|>))
 import Data.Char (isSpace)
 import Control.Arrow (Arrow(second))
 import GHC (Ghc)

--- a/src/Ide/Plugin/Eval.hs
+++ b/src/Ide/Plugin/Eval.hs
@@ -335,13 +335,17 @@ parseExprMode rawArg =
     ("+d", rest) -> (TM_Default, T.strip rest)
     _ -> (TM_Inst, rawArg)
 
-data GhciLikeCmdException = GhciLikeCmdNotImplemented Text Text
+data GhciLikeCmdException =
+    GhciLikeCmdNotImplemented
+      { ghciCmdName :: Text
+      , ghciCmdArg  :: Text
+      }
   deriving (Typeable)
 
 instance Show GhciLikeCmdException where
-  showsPrec _ (GhciLikeCmdNotImplemented cmd _arg) =
+  showsPrec _ GhciLikeCmdNotImplemented{..} =
     showString "unknown command '" .
-    showString (T.unpack cmd) . showChar '\''
+    showString (T.unpack ghciCmdName) . showChar '\''
   
 instance E.Exception GhciLikeCmdException
 

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -70,6 +70,12 @@ tests = testGroup
   , testCase "Shows a kind with :kind" $ goldenTest "T12.hs"
   , testCase "Reports an error for an incorrect type with :kind" 
     $ goldenTest "T13.hs"
+  , testCase "Returns a fully-instantiated type for :type"
+    $ goldenTest "T14.hs"
+  , testCase "Returns an uninstantiated type for :type +v, admitting multiple whitespaces around arguments"
+    $ goldenTest "T15.hs"
+  , testCase "Returns defaulted type for :type +v, admitting multiple whitespaces around arguments"
+    $ goldenTest "T16.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -78,6 +78,8 @@ tests = testGroup
     $ goldenTest "T16.hs"
   , testCase ":type reports an error when given with unknown +x option"
     $ goldenTest "T17.hs"
+  , testCase "Reports an error when given with unknown command"
+    $ goldenTest "T18.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -26,6 +26,7 @@ import           System.FilePath
 import           Test.Hls.Util
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 
 tests :: TestTree
 tests = testGroup
@@ -82,6 +83,9 @@ tests = testGroup
     $ goldenTest "T18.hs"
   , testCase "Returns defaulted type for :type +d reflecting the default declaration specified in the >>> prompt"
     $ goldenTest "T19.hs"
+  , ignoreTestBecause "Expected failure - known issue (see a note in #361)"
+  $ testCase ":type +d reflects the `default' declaration of the module"
+  $ goldenTest "T20.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -25,8 +25,8 @@ import           Language.Haskell.LSP.Types     ( ApplyWorkspaceEditRequest
 import           System.FilePath
 import           Test.Hls.Util
 import           Test.Tasty
+import           Test.Tasty.ExpectedFailure (expectFailBecause)
 import           Test.Tasty.HUnit
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 
 tests :: TestTree
 tests = testGroup
@@ -83,7 +83,7 @@ tests = testGroup
     $ goldenTest "T18.hs"
   , testCase "Returns defaulted type for :type +d reflecting the default declaration specified in the >>> prompt"
     $ goldenTest "T19.hs"
-  , ignoreTestBecause "Expected failure - known issue (see a note in #361)"
+  , expectFailBecause "known issue - see a note in P.R. #361"
   $ testCase ":type +d reflects the `default' declaration of the module"
   $ goldenTest "T20.hs"
   ]

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -74,7 +74,7 @@ tests = testGroup
     $ goldenTest "T14.hs"
   , testCase "Returns an uninstantiated type for :type +v, admitting multiple whitespaces around arguments"
     $ goldenTest "T15.hs"
-  , testCase "Returns defaulted type for :type +v, admitting multiple whitespaces around arguments"
+  , testCase "Returns defaulted type for :type +d, admitting multiple whitespaces around arguments"
     $ goldenTest "T16.hs"
   , testCase ":type reports an error when given with unknown +x option"
     $ goldenTest "T17.hs"

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -76,6 +76,8 @@ tests = testGroup
     $ goldenTest "T15.hs"
   , testCase "Returns defaulted type for :type +v, admitting multiple whitespaces around arguments"
     $ goldenTest "T16.hs"
+  , testCase ":type reports an error when given with unknown +x option"
+    $ goldenTest "T17.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -80,6 +80,8 @@ tests = testGroup
     $ goldenTest "T17.hs"
   , testCase "Reports an error when given with unknown command"
     $ goldenTest "T18.hs"
+  , testCase "Returns defaulted type for :type +d reflecting the default declaration specified in the >>> prompt"
+    $ goldenTest "T19.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/testdata/eval/T14.hs
+++ b/test/testdata/eval/T14.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE TypeApplications #-}
+module T14 where
+
+foo :: Show a => a -> String
+foo = show
+
+-- >>> :type foo @Int

--- a/test/testdata/eval/T14.hs.expected
+++ b/test/testdata/eval/T14.hs.expected
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeApplications #-}
+module T14 where
+
+foo :: Show a => a -> String
+foo = show
+
+-- >>> :type foo @Int
+-- foo @Int :: Int -> String

--- a/test/testdata/eval/T15.hs
+++ b/test/testdata/eval/T15.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE TypeApplications #-}
+module T15 where
+
+foo :: Show a => a -> String
+foo = show
+
+-- >>> :type  +v  foo @Int

--- a/test/testdata/eval/T15.hs.expected
+++ b/test/testdata/eval/T15.hs.expected
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeApplications #-}
+module T15 where
+
+foo :: Show a => a -> String
+foo = show
+
+-- >>> :type  +v  foo @Int
+-- foo @Int :: Show Int => Int -> String

--- a/test/testdata/eval/T16.hs
+++ b/test/testdata/eval/T16.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 module T16 where
-
-foo :: Show a => a -> String
-foo = show
 
 -- >>> :type  +d   40+ 2 

--- a/test/testdata/eval/T16.hs
+++ b/test/testdata/eval/T16.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE TypeApplications #-}
+module T16 where
+
+foo :: Show a => a -> String
+foo = show
+
+-- >>> :type  +d   40+ 2 

--- a/test/testdata/eval/T16.hs.expected
+++ b/test/testdata/eval/T16.hs.expected
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeApplications #-}
+module T16 where
+
+foo :: Show a => a -> String
+foo = show
+
+-- >>> :type  +d   40+ 2 
+-- 40+ 2 :: Integer

--- a/test/testdata/eval/T16.hs.expected
+++ b/test/testdata/eval/T16.hs.expected
@@ -1,8 +1,4 @@
-{-# LANGUAGE TypeApplications #-}
 module T16 where
-
-foo :: Show a => a -> String
-foo = show
 
 -- >>> :type  +d   40+ 2 
 -- 40+ 2 :: Integer

--- a/test/testdata/eval/T17.hs
+++ b/test/testdata/eval/T17.hs
@@ -1,0 +1,3 @@
+module T17 where
+
+-- >>> :type  +no 42

--- a/test/testdata/eval/T17.hs.expected
+++ b/test/testdata/eval/T17.hs.expected
@@ -1,0 +1,4 @@
+module T17 where
+
+-- >>> :type  +no 42
+-- parse error on input ‘+’

--- a/test/testdata/eval/T18.hs
+++ b/test/testdata/eval/T18.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
+module T18 where
+
+-- >>> :noooop foo bar

--- a/test/testdata/eval/T18.hs.expected
+++ b/test/testdata/eval/T18.hs.expected
@@ -1,0 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+module T18 where
+
+-- >>> :noooop foo bar
+-- unknown command 'noooop'

--- a/test/testdata/eval/T19.hs
+++ b/test/testdata/eval/T19.hs
@@ -1,0 +1,6 @@
+module T19 where
+import Data.Word (Word)
+type W = Word
+
+-- >>> default (Word)
+-- >>> :type  +d   40+ 2 

--- a/test/testdata/eval/T19.hs.expected
+++ b/test/testdata/eval/T19.hs.expected
@@ -1,0 +1,7 @@
+module T19 where
+import Data.Word (Word)
+type W = Word
+
+-- >>> default (Word)
+-- >>> :type  +d   40+ 2 
+-- 40+ 2 :: Word

--- a/test/testdata/eval/T20.hs
+++ b/test/testdata/eval/T20.hs
@@ -1,0 +1,6 @@
+module T20 where
+import Data.Word (Word)
+
+default (Word)
+
+-- >>> :type  +d   40+ 2 

--- a/test/testdata/eval/T20.hs.expected
+++ b/test/testdata/eval/T20.hs.expected
@@ -1,0 +1,7 @@
+module T20 where
+import Data.Word (Word)
+
+default (Word)
+
+-- >>> :type  +d   40+ 2 
+-- 40+ 2 :: Word


### PR DESCRIPTION
This implements `:type` command ala GHCi.
It also restructures the handling of GHCi-Like command and adds an exception for unknown command.

## Examples

```haskell
{-# LANGUAGE TypeApplications #-}
foo :: Show a => a -> String
foo = show

-- >>> :type foo @Int
-- foo @Int :: Int -> String

-- >>> :type +v foo @Int
-- foo @Int :: Show Int => Int -> String

-- >>> :type 40 + 2
-- 40 + 2 :: forall a. Num a => a

-- >>> :type +d 40 + 2
-- 40 + 2 :: Integer

-- >>> default (Word)
-- >>> :type +d 40 + 2
-- 40 + 2 :: Word

-- >>> :type +nope 12
-- parse error on input ‘+’

-- >>> :nooope 42
-- unknown command 'nooope'
```

## Known limitations

Currently, `:type +d` ignores `default` declarations specified in the module, though it can handle `default`s declared in the same `>>>` prompt group.

I once tried to obtain the module's defaulting declarations by applying `tcg_default` to the `tm_internals_` of `TypecheckedModule` obtained by `use_ TypeCheck` and `mappend` it to the HscEnv using `modifySession`, but this doesn't change the situation.
Is there any ideas to resolve this, or we can just let `+d` ignore the module's default pragma?

For example, consider the following:

```haskell
default (Int)
-- >>> :type +d 42
```

It is expected to say that `42 :: Int`. But with the current implementation, it answers `Integer`,ignoring the module's `default` declaration:

```haskell
default (Int)
-- >>> :type +d 42
-- 42 :: Integer
```

On the other hand, if we specify `default` inside the `>>>` prompt, it works as expected:

```haskell
-- >>> default (Int)
-- >>> :type +d 42
-- 42 :: Int
```
