### PR TITLE
Include testdata hie.yaml cradles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,5 @@ shake.yaml.lock
 stack*.yaml.lock
 shake.yaml.lock
 
-# ignore hie.yaml's for testdata
-test/testdata/**/hie.yaml
-
 # metadata files on macOS
 .DS_Store


### PR DESCRIPTION
My tests were mysteriously failing on CI but not locally. Turns out the cradle is necessary for getting tests to run. 

This also correlates with how the `context` functional tests are timing out (no hie.yaml checked in) but `eval` works just fine (has a hie.yaml).