### PR TITLE
hls-plugin-api: version bump

### DIFF
--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hls-plugin-api
-version:       0.4.0.0
+version:       0.4.0.1
 synopsis:      Haskell Language Server API for plugin communication
 description:   Please see README.md
 license:       Apache-2.0


### PR DESCRIPTION
The version on Hackage currently doesn't build. This prevents the current master from being built in Nixpkgs. @alanz, please upload the 0.4.0.1 tarball to Hackage.
```diff
--- Version on Hackage
+++ Master version
@@ -39,7 +39,7 @@

 commandAddSignature :: CommandFunction WorkspaceEdit
 commandAddSignature lf ide params
-    = executeAddSignatureCommand lf ide (ExecuteCommandParams "typesignature.add" (Just (List [toJSON params])) Nothing)
+    = commandHandler lf ide (ExecuteCommandParams "typesignature.add" (Just (List [toJSON params])) Nothing)

 -- ---------------------------------------------------------------------
```