### PR TITLE
Eval plugin: proper multilined results handling and command-name abbreviations

### DIFF
--- a/plugins/default/src/Ide/Plugin/Eval.hs
+++ b/plugins/default/src/Ide/Plugin/Eval.hs
@@ -292,7 +292,7 @@ evalGhciLikeCmd :: Text -> Text -> Ghc (Maybe Text)
 evalGhciLikeCmd cmd arg = do
   df <- getSessionDynFlags
   case lookup cmd ghciLikeCommands
-    <|> snd <$> find ((T.isPrefixOf cmd).fst) ghciLikeCommands of
+    <|> snd <$> find (T.isPrefixOf cmd . fst) ghciLikeCommands of
     Just hndler -> hndler df arg
     _           -> E.throw $ GhciLikeCmdNotImplemented cmd arg
 

--- a/plugins/default/src/Ide/Plugin/Eval.hs
+++ b/plugins/default/src/Ide/Plugin/Eval.hs
@@ -1,6 +1,12 @@
-{-# LANGUAGE DeriveAnyClass, DeriveGeneric, DuplicateRecordFields #-}
-{-# LANGUAGE LambdaCase, NamedFieldPuns, OverloadedStrings        #-}
-{-# LANGUAGE RecordWildCards, ScopedTypeVariables, TupleSections  #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TupleSections         #-}
 
 -- | A plugin inspired by the REPLoid feature of Dante[1] which allows
 --     to evaluate code in comment prompts and splice the results right below:

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE NamedFieldPuns, OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Eval
   ( tests

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -1,31 +1,21 @@
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns, OverloadedStrings, ScopedTypeVariables #-}
 
 module Eval
   ( tests
   )
 where
 
-import           Control.Applicative.Combinators
-                                                ( skipManyTill )
-import           Control.Monad.IO.Class         ( MonadIO(liftIO) )
-import qualified Data.Text.IO                  as T
+import           Control.Applicative.Combinators (skipManyTill)
+import           Control.Monad.IO.Class          (MonadIO (liftIO))
+import qualified Data.Text.IO                    as T
 import           Language.Haskell.LSP.Test
-import           Language.Haskell.LSP.Types     ( ApplyWorkspaceEditRequest
-                                                , CodeLens
-                                                  ( CodeLens
-                                                  , _command
-                                                  , _range
-                                                  )
-                                                , Command(_title)
-                                                , Position(..)
-                                                , Range(..)
-                                                )
+import           Language.Haskell.LSP.Types      (ApplyWorkspaceEditRequest, CodeLens (CodeLens, _command, _range),
+                                                  Command (_title),
+                                                  Position (..), Range (..))
 import           System.FilePath
 import           Test.Hls.Util
 import           Test.Tasty
-import           Test.Tasty.ExpectedFailure (expectFailBecause)
+import           Test.Tasty.ExpectedFailure      (expectFailBecause)
 import           Test.Tasty.HUnit
 
 tests :: TestTree
@@ -66,10 +56,10 @@ tests = testGroup
   , testCase "Evaluate incorrect expressions" $ goldenTest "T8.hs"
   , testCase "Applies file LANGUAGE extensions" $ goldenTest "T9.hs"
   , testCase "Evaluate a type with :kind!" $ goldenTest "T10.hs"
-  , testCase "Reports an error for an incorrect type with :kind!" 
+  , testCase "Reports an error for an incorrect type with :kind!"
     $ goldenTest "T11.hs"
   , testCase "Shows a kind with :kind" $ goldenTest "T12.hs"
-  , testCase "Reports an error for an incorrect type with :kind" 
+  , testCase "Reports an error for an incorrect type with :kind"
     $ goldenTest "T13.hs"
   , testCase "Returns a fully-instantiated type for :type"
     $ goldenTest "T14.hs"
@@ -86,6 +76,16 @@ tests = testGroup
   , expectFailBecause "known issue - see a note in P.R. #361"
   $ testCase ":type +d reflects the `default' declaration of the module"
   $ goldenTest "T20.hs"
+  , testCase ":type handles a multilined result properly"
+  $ goldenTest "T21.hs"
+  , testCase ":t behaves exactly the same as :type"
+  $ goldenTest "T22.hs"
+  , testCase ":type does \"dovetails\" for short identifiers"
+  $ goldenTest "T23.hs"
+  , testCase ":kind! treats a multilined result properly"
+  $ goldenTest "T24.hs"
+  , testCase ":kind treats a multilined result properly"
+  $ goldenTest "T25.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/testdata/eval/T21.hs
+++ b/test/testdata/eval/T21.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE ScopedTypeVariables, PolyKinds #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module T21 where
 import Data.Proxy (Proxy(..))
 import GHC.TypeNats (KnownNat)

--- a/test/testdata/eval/T21.hs
+++ b/test/testdata/eval/T21.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE ScopedTypeVariables, PolyKinds #-}
+module T21 where
+import Data.Proxy (Proxy(..))
+import GHC.TypeNats (KnownNat)
+import Type.Reflection (Typeable)
+
+fun :: forall k n a. (KnownNat k, KnownNat n, Typeable a)
+    => Proxy k -> Proxy n -> Proxy a -> ()
+fun _ _ _ = ()
+
+-- >>> :type fun

--- a/test/testdata/eval/T21.hs.expected
+++ b/test/testdata/eval/T21.hs.expected
@@ -1,4 +1,5 @@
-{-# LANGUAGE ScopedTypeVariables, PolyKinds #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module T21 where
 import Data.Proxy (Proxy(..))
 import GHC.TypeNats (KnownNat)

--- a/test/testdata/eval/T21.hs.expected
+++ b/test/testdata/eval/T21.hs.expected
@@ -1,0 +1,15 @@
+{-# LANGUAGE ScopedTypeVariables, PolyKinds #-}
+module T21 where
+import Data.Proxy (Proxy(..))
+import GHC.TypeNats (KnownNat)
+import Type.Reflection (Typeable)
+
+fun :: forall k n a. (KnownNat k, KnownNat n, Typeable a)
+    => Proxy k -> Proxy n -> Proxy a -> ()
+fun _ _ _ = ()
+
+-- >>> :type fun
+-- fun
+--   :: forall k1 (k2 :: Nat) (n :: Nat) (a :: k1).
+--      (KnownNat k2, KnownNat n, Typeable a) =>
+--      Proxy k2 -> Proxy n -> Proxy a -> ()

--- a/test/testdata/eval/T22.hs
+++ b/test/testdata/eval/T22.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PolyKinds, ScopedTypeVariables #-}
 module T22 where
 import Data.Proxy      (Proxy (..))
 import GHC.TypeNats    (KnownNat)

--- a/test/testdata/eval/T22.hs
+++ b/test/testdata/eval/T22.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE PolyKinds, ScopedTypeVariables #-}
+module T22 where
+import Data.Proxy      (Proxy (..))
+import GHC.TypeNats    (KnownNat)
+import Type.Reflection (Typeable)
+
+f :: Integer
+f = 32
+
+-- >>> :t f

--- a/test/testdata/eval/T22.hs.expected
+++ b/test/testdata/eval/T22.hs.expected
@@ -1,0 +1,11 @@
+{-# LANGUAGE PolyKinds, ScopedTypeVariables #-}
+module T22 where
+import Data.Proxy      (Proxy (..))
+import GHC.TypeNats    (KnownNat)
+import Type.Reflection (Typeable)
+
+f :: Integer
+f = 32
+
+-- >>> :t f
+-- f :: Integer

--- a/test/testdata/eval/T22.hs.expected
+++ b/test/testdata/eval/T22.hs.expected
@@ -1,4 +1,3 @@
-{-# LANGUAGE PolyKinds, ScopedTypeVariables #-}
 module T22 where
 import Data.Proxy      (Proxy (..))
 import GHC.TypeNats    (KnownNat)

--- a/test/testdata/eval/T23.hs
+++ b/test/testdata/eval/T23.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE PolyKinds, ScopedTypeVariables #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module T23 where
 import Data.Proxy      (Proxy (..))
 import GHC.TypeNats    (KnownNat)

--- a/test/testdata/eval/T23.hs
+++ b/test/testdata/eval/T23.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE PolyKinds, ScopedTypeVariables #-}
+module T23 where
+import Data.Proxy      (Proxy (..))
+import GHC.TypeNats    (KnownNat)
+import Type.Reflection (Typeable)
+
+f :: forall k n a. (KnownNat k, KnownNat n, Typeable a)
+  => Proxy k -> Proxy n -> Proxy a -> ()
+f _ _ _ = ()
+
+-- >>> :type f

--- a/test/testdata/eval/T23.hs.expected
+++ b/test/testdata/eval/T23.hs.expected
@@ -1,4 +1,5 @@
-{-# LANGUAGE PolyKinds, ScopedTypeVariables #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module T23 where
 import Data.Proxy      (Proxy (..))
 import GHC.TypeNats    (KnownNat)

--- a/test/testdata/eval/T23.hs.expected
+++ b/test/testdata/eval/T23.hs.expected
@@ -1,0 +1,14 @@
+{-# LANGUAGE PolyKinds, ScopedTypeVariables #-}
+module T23 where
+import Data.Proxy      (Proxy (..))
+import GHC.TypeNats    (KnownNat)
+import Type.Reflection (Typeable)
+
+f :: forall k n a. (KnownNat k, KnownNat n, Typeable a)
+  => Proxy k -> Proxy n -> Proxy a -> ()
+f _ _ _ = ()
+
+-- >>> :type f
+-- f :: forall k1 (k2 :: Nat) (n :: Nat) (a :: k1).
+--      (KnownNat k2, KnownNat n, Typeable a) =>
+--      Proxy k2 -> Proxy n -> Proxy a -> ()

--- a/test/testdata/eval/T24.hs
+++ b/test/testdata/eval/T24.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DataKinds, PolyKinds, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE UndecidableInstances                              #-}
+module T24 where
+import GHC.TypeNats (type (-))
+data Proxy a = Stop | Next (Proxy a)
+
+type family LongP n a where
+  LongP 0 a = a
+  LongP n a = Next (LongP (n - 1) a)
+
+-- >>> :kind! ((LongP 10 Stop) :: Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy Double)))))))))))))

--- a/test/testdata/eval/T24.hs
+++ b/test/testdata/eval/T24.hs
@@ -1,5 +1,8 @@
-{-# LANGUAGE DataKinds, PolyKinds, TypeFamilies, TypeOperators #-}
-{-# LANGUAGE UndecidableInstances                              #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 module T24 where
 import GHC.TypeNats (type (-))
 data Proxy a = Stop | Next (Proxy a)

--- a/test/testdata/eval/T24.hs.expected
+++ b/test/testdata/eval/T24.hs.expected
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds, PolyKinds, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE UndecidableInstances                              #-}
+module T24 where
+import GHC.TypeNats (type (-))
+data Proxy a = Stop | Next (Proxy a)
+
+type family LongP n a where
+  LongP 0 a = a
+  LongP n a = Next (LongP (n - 1) a)
+
+-- >>> :kind! ((LongP 10 Stop) :: Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy Double)))))))))))))
+-- ((LongP 10 Stop) :: Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy Double))))))))))))) :: Proxy
+--                                                                                                                                        (Proxy
+--                                                                                                                                           (Proxy
+--                                                                                                                                              (Proxy
+--                                                                                                                                                 (Proxy
+--                                                                                                                                                    (Proxy
+--                                                                                                                                                       (Proxy
+--                                                                                                                                                          (Proxy
+--                                                                                                                                                             (Proxy
+--                                                                                                                                                                (Proxy
+--                                                                                                                                                                   (Proxy
+--                                                                                                                                                                      (Proxy
+--                                                                                                                                                                         (Proxy
+--                                                                                                                                                                            Double))))))))))))
+-- = 'Next
+--     ('Next
+--        ('Next
+--           ('Next ('Next ('Next ('Next ('Next ('Next ('Next 'Stop)))))))))

--- a/test/testdata/eval/T24.hs.expected
+++ b/test/testdata/eval/T24.hs.expected
@@ -1,5 +1,8 @@
-{-# LANGUAGE DataKinds, PolyKinds, TypeFamilies, TypeOperators #-}
-{-# LANGUAGE UndecidableInstances                              #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 module T24 where
 import GHC.TypeNats (type (-))
 data Proxy a = Stop | Next (Proxy a)

--- a/test/testdata/eval/T25.hs
+++ b/test/testdata/eval/T25.hs
@@ -1,5 +1,8 @@
-{-# LANGUAGE DataKinds, PolyKinds, TypeFamilies, TypeOperators #-}
-{-# LANGUAGE UndecidableInstances                              #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 module T25 where
 import GHC.TypeNats (type (-))
 data Proxy a = Stop | Next (Proxy a)

--- a/test/testdata/eval/T25.hs
+++ b/test/testdata/eval/T25.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DataKinds, PolyKinds, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE UndecidableInstances                              #-}
+module T25 where
+import GHC.TypeNats (type (-))
+data Proxy a = Stop | Next (Proxy a)
+
+type family LongP n a where
+  LongP 0 a = a
+  LongP n a = Next (LongP (n - 1) a)
+
+-- >>> :kind (Stop :: Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy Double)))))))))))))

--- a/test/testdata/eval/T25.hs.expected
+++ b/test/testdata/eval/T25.hs.expected
@@ -1,5 +1,8 @@
-{-# LANGUAGE DataKinds, PolyKinds, TypeFamilies, TypeOperators #-}
-{-# LANGUAGE UndecidableInstances                              #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 module T25 where
 import GHC.TypeNats (type (-))
 data Proxy a = Stop | Next (Proxy a)

--- a/test/testdata/eval/T25.hs.expected
+++ b/test/testdata/eval/T25.hs.expected
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds, PolyKinds, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE UndecidableInstances                              #-}
+module T25 where
+import GHC.TypeNats (type (-))
+data Proxy a = Stop | Next (Proxy a)
+
+type family LongP n a where
+  LongP 0 a = a
+  LongP n a = Next (LongP (n - 1) a)
+
+-- >>> :kind (Stop :: Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy Double)))))))))))))
+-- (Stop :: Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy (Proxy Double))))))))))))) :: Proxy
+--                                                                                                                             (Proxy
+--                                                                                                                                (Proxy
+--                                                                                                                                   (Proxy
+--                                                                                                                                      (Proxy
+--                                                                                                                                         (Proxy
+--                                                                                                                                            (Proxy
+--                                                                                                                                               (Proxy
+--                                                                                                                                                  (Proxy
+--                                                                                                                                                     (Proxy
+--                                                                                                                                                        (Proxy
+--                                                                                                                                                           (Proxy
+--                                                                                                                                                              (Proxy
+--                                                                                                                                                                 Double))))))))))))


### PR DESCRIPTION
This pull-request consists of two changes to Eval plugin:

1. Bugfix: a proper treatment of multilined results.

   Previously, GHCi-like commands in Eval plugin doesn't treat multilined results properly.

   For example, with the current Eval plugin we get:

   ```haskell
   f :: forall k n a. (KnownNat k, KnownNat n, Typeable a)
     => Proxy k -> Proxy n -> Proxy a -> ()
   f _ _ _ = ()

   -- >>> :type f
   -- f :: forall k1 (k2 :: Nat) (n :: Nat) (a :: k1).
   (KnownNat k2, KnownNat n, Typeable a) =>
   Proxy k2 -> Proxy n -> Proxy a -> ()
   ```

   Apparlently, the last two lines must be prefixed with `--`.
   This pull request addresses this issue and now it seems that the plugin returns the same result as GHCi:

   ```haskell
   -- >>> :type f
   -- f :: forall k1 (k2 :: Nat) (n :: Nat) (a :: k1).
   --      (KnownNat k2, KnownNat n, Typeable a) =>
   --      Proxy k2 -> Proxy n -> Proxy a -> ()
   ```

   It tries to use `Outputable.SDoc` to generate the same alignment as the GHCi.

2. New feature: abbreviation for GHCi commands.

   Eval plugin now lookups GHCi-like commands first by exact match, then fallbacks to the first element in the dictionary with the given prefix.
   Since there are just three commands currently, I just used lists to implement command dictionary; perhaps we should use some kind of trie in a future?