### PR TITLE
Improve missing brittany format provider error message (#269)

### DIFF
--- a/hls-plugin-api/src/Ide/Plugin/Formatter.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Formatter.hs
@@ -62,7 +62,19 @@ doFormatting lf providers ideState ft uri params = do
                   provider lf ideState ft contents fp params
               Nothing -> return $ Left $ responseError $ T.pack $ "Formatter plugin: could not get file contents for " ++ show uri
           Nothing -> return $ Left $ responseError $ T.pack $ "Formatter plugin: uriToFilePath failed for: " ++ show uri
-      Nothing -> return $ Left $ responseError $ T.pack $ "Formatter plugin: no formatter found for:[" ++ T.unpack mf ++ "]"
+      Nothing -> return $ Left $ responseError $ mconcat
+        [ "Formatter plugin: no formatter found for:["
+        , mf
+        , "]"
+        , if mf == "brittany"
+          then T.unlines
+            [ "\nThe haskell-language-server must be compiled with the agpl flag to provide Brittany."
+            , "Stack users add 'agpl: true' in the flags section of the 'stack.yaml' file."
+            , "The 'haskell-language-server.cabal' file already has this flag enabled by default."
+            , "For more information see: https://github.com/haskell/haskell-language-server/issues/269"
+            ]
+          else ""
+        ]
 
 -- ---------------------------------------------------------------------
 
@@ -73,7 +85,6 @@ noneProvider _ _ _ _ _ _ = return $ Right (List [])
 
 responseError :: T.Text -> ResponseError
 responseError txt = ResponseError InvalidParams txt Nothing
-
 -- ---------------------------------------------------------------------
 
 extractRange :: Range -> T.Text -> T.Text

--- a/hls-plugin-api/src/Ide/Plugin/Formatter.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Formatter.hs
@@ -85,6 +85,7 @@ noneProvider _ _ _ _ _ _ = return $ Right (List [])
 
 responseError :: T.Text -> ResponseError
 responseError txt = ResponseError InvalidParams txt Nothing
+
 -- ---------------------------------------------------------------------
 
 extractRange :: Range -> T.Text -> T.Text


### PR DESCRIPTION
I have tested this error message with cabal. By setting `haskell-language-server/haskell-language-server.cabal`:

```
flag agpl
  description: Enable AGPL dependencies
  default:     True
  manual:      True
```

to 

```
flag agpl
  description: Enable AGPL dependencies
  default:     False
  manual:      True
```

using `cabal build exe:haskell-language-server`

And after setting my editor to use `cabal exec which haskell-language-server` and the Brittany formatter. I can see the error message show up correctly.

I thought about adding a test to `haskell-language-server/test/functional/Format.hs` for when `AGPL` is false, but wasn't sure if it would ever be run. Do CI tests with this flag on or off?

Please let me know if style should be changed or if the error message is too verbose.
