### PR TITLE
Bump ormolu to 0.1.3.0

### DIFF
--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -20,6 +20,7 @@ extra-deps:
 - HsYAML-aeson-0.2.0.0@rev:2
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
+- ormolu-0.1.3.0
 - refinery-0.2.0.0
 - retrie-0.1.1.1
 - stylish-haskell-0.11.0.3

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -1,5 +1,4 @@
-resolver: nightly-2020-08-08
-compiler: ghc-8.10.2
+resolver: nightly-2020-10-03
 
 packages:
 - .
@@ -15,13 +14,10 @@ extra-deps:
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 - Cabal-3.0.2.0
 - clock-0.7.2
-- data-tree-print-0.1.0.2
 - floskell-0.10.4
 - fourmolu-0.2.0.0
-- HsYAML-aeson-0.2.0.0@rev:2
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
-- ormolu-0.1.3.0
 - refinery-0.2.0.0
 - retrie-0.1.1.1
 - stylish-haskell-0.11.0.3

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -21,6 +21,7 @@ extra-deps:
 - HsYAML-aeson-0.2.0.0@rev:2
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
+- ormolu-0.1.3.0
 - refinery-0.2.0.0
 - retrie-0.1.1.1
 - stylish-haskell-0.11.0.3

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -43,7 +43,7 @@ extra-deps:
 - opentelemetry-0.4.2
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
-- ormolu-0.1.2.0
+- ormolu-0.1.3.0
 - parser-combinators-1.2.1
 - primitive-0.7.1.0
 - refinery-0.2.0.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -42,7 +42,7 @@ extra-deps:
 - opentelemetry-0.4.2
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
-- ormolu-0.1.2.0
+- ormolu-0.1.3.0
 - parser-combinators-1.2.1
 - primitive-0.7.1.0
 - refinery-0.2.0.0

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -37,7 +37,7 @@ extra-deps:
 - lsp-test-0.11.0.5
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
-- ormolu-0.1.2.0
+- ormolu-0.1.3.0
 - refinery-0.2.0.0
 - retrie-0.1.1.1
 - semigroups-0.18.5

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -29,6 +29,7 @@ extra-deps:
 - ilist-0.3.1.0
 - lsp-test-0.11.0.5
 - monad-dijkstra-0.1.1.2
+- ormolu-0.1.3.0
 - refinery-0.2.0.0
 - retrie-0.1.1.1
 - semigroups-0.18.5

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,5 +1,4 @@
-resolver: lts-16.5
-compiler: ghc-8.8.4
+resolver: lts-16.16
 
 packages:
 - .
@@ -26,17 +25,14 @@ extra-deps:
 - haskell-src-exts-1.21.1
 - hie-bios-0.7.1
 - hlint-2.2.8
-- HsYAML-aeson-0.2.0.0@rev:2
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - ilist-0.3.1.0
 - lsp-test-0.11.0.5
 - monad-dijkstra-0.1.1.2
-- ormolu-0.1.3.0
 - refinery-0.2.0.0
 - retrie-0.1.1.1
 - semigroups-0.18.5
-- stylish-haskell-0.11.0.3
 # - github: wz1000/shake
 #   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - temporary-1.2.1.1

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -32,6 +32,7 @@ extra-deps:
 - ilist-0.3.1.0
 - lsp-test-0.11.0.5
 - monad-dijkstra-0.1.1.2
+- ormolu-0.1.3.0
 - refinery-0.2.0.0
 - retrie-0.1.1.1
 - semigroups-0.18.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,7 +42,7 @@ extra-deps:
 - opentelemetry-0.4.2
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
-- ormolu-0.1.2.0
+- ormolu-0.1.3.0
 - parser-combinators-1.2.1
 - primitive-0.7.1.0
 - refinery-0.2.0.0


### PR DESCRIPTION
I just pinned it with extra-deps in all cases.

Alternatively `0.1.3.0` appears in `nightly-2020-09-22` and should appear in `lts-16.16` in a few days. So I could instead bump ghc `8.8.3` and up to use the updated resolvers (and I guess remove other extra deps that no longer need to be pinned)?

