### PR TITLE
Upate Emacs setup notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,12 +504,18 @@ Install HLS along with the following emacs packages:
 
 Make sure to follow the instructions in the README of each of these packages.
 
-Install [use-package](https://github.com/jwiegley/use-package), and add the following to your .emacs
+The default `lsp-haskell-server-path` is set to `haskell-language-server-wrapper`. In 
+case you would like your editor to use a specific version of the `hls` server, then this
+variable can be updated.
+
+Install [use-package](https://github.com/jwiegley/use-package), and add the following to your .emacs 
+when you want to customize this variable.
+
 ``` emacs-lisp
 (use-package lsp-haskell
  :ensure t
  :config
- (setq lsp-haskell-process-path-hie "haskell-language-server-wrapper")
+     (setq lsp-haskell-server-path "haskell-language-server-8.10.2")
  ;; Comment/uncomment this line to see interactions between lsp client/server.
  ;;(setq lsp-log-io t)
 )

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Make sure to follow the instructions in the README of each of these packages.
 
 The default `lsp-haskell-server-path` is set to `haskell-language-server-wrapper`. In 
 case you would like your editor to use a specific version of the `hls` server, then this
-variable can be updated. For more information on other configurations can be found at 
+variable can be updated. Information on other configurations can be found at 
 [lsp-haskell](https://github.com/emacs-lsp/lsp-haskell)
 
 ### Using haskell-language-server with [doom-emacs](https://github.com/hlissner/doom-emacs/tree/develop/modules/lang/haskell#module-flags)

--- a/README.md
+++ b/README.md
@@ -506,20 +506,8 @@ Make sure to follow the instructions in the README of each of these packages.
 
 The default `lsp-haskell-server-path` is set to `haskell-language-server-wrapper`. In 
 case you would like your editor to use a specific version of the `hls` server, then this
-variable can be updated.
-
-Install [use-package](https://github.com/jwiegley/use-package), and add the following to your .emacs 
-when you want to customize this variable.
-
-``` emacs-lisp
-(use-package lsp-haskell
- :ensure t
- :config
-     (setq lsp-haskell-server-path "haskell-language-server-8.10.2")
- ;; Comment/uncomment this line to see interactions between lsp client/server.
- ;;(setq lsp-log-io t)
-)
-```
+variable can be updated. For more information on other configurations can be found at 
+[lsp-haskell](https://github.com/emacs-lsp/lsp-haskell)
 
 ### Using haskell-language-server with [doom-emacs](https://github.com/hlissner/doom-emacs/tree/develop/modules/lang/haskell#module-flags)
 


### PR DESCRIPTION
Update the Emacs set up notes to reflect that latest changes in lsp-haskell. The latest version of lsp-haskell sets the default server to `haskell-language-server-wrapper`. The old variable `lsp-haskell-process-path-hie` is deprecated.