### PR TITLE
Restrict editor config to Haskell file, to avoid affecting Makefiles or other tab-based formats

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,10 +3,13 @@
 
 root = true
 
+[Makefile]
+indent_style = tab
+
 [*]
 end_of_line = LF
 
-[*]
+[*.{hs,lhs}]
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,5 @@ trim_trailing_whitespace = true
 [*.{hs,lhs}]
 indent_style = space
 indent_size = 4
-trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ indent_style = tab
 
 [*]
 end_of_line = LF
+trim_trailing_whitespace = true
 
 [*.{hs,lhs}]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,4 @@ insert_final_newline = true
 [*.{hs,lhs}]
 indent_style = space
 indent_size = 4
-insert_final_newline = true
 max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,6 @@
 
 root = true
 
-[Makefile]
-indent_style = tab
-
 [*]
 end_of_line = LF
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ indent_style = tab
 [*]
 end_of_line = LF
 trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.{hs,lhs}]
 indent_style = space


### PR DESCRIPTION
indent_style = space 
makes it impossible to write Makefiles