### PR TITLE
wrapper: cd to --cwd earlier

### DIFF
--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -47,6 +47,8 @@ main = do
 
 launchHaskellLanguageServer :: LspArguments -> IO ()
 launchHaskellLanguageServer LspArguments{..} = do
+  whenJust argsCwd setCurrentDirectory
+
   d <- getCurrentDirectory
 
   -- Get the cabal directory from the cradle
@@ -54,8 +56,6 @@ launchHaskellLanguageServer LspArguments{..} = do
   setCurrentDirectory $ cradleRootDir cradle
 
   when argsProjectGhcVersion $ getRuntimeGhcVersion' cradle >>= putStrLn >> exitSuccess
-
-  whenJust argsCwd setCurrentDirectory
 
   progName <- getProgName
   hPutStrLn stderr $ "Run entered for haskell-language-server-wrapper(" ++ progName ++ ") "


### PR DESCRIPTION
Currently, if `haskell-language-server-wrapper` is called with `--cwd`, a cradle will first be loaded and _then_ the change of working directory will happen. This commit reorders this such that if `--cwd` is supplied, the very first action is to change directory. This means a cradle will be found with `--cwd`, rather than the directory that `haskell-language-server-wrapper` was called in.