### PR TITLE
install: create hls hardlinks instead of copies except on Windows

### DIFF
--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -5,6 +5,7 @@ import           Development.Shake
 import           Development.Shake.FilePath
 import           Control.Monad
 import           System.Directory                         ( copyFile )
+import           System.Info                              ( os )
 
 import           Version
 import           Print
@@ -74,9 +75,11 @@ cabalInstallHls versionNumber args = do
   let minorVerExe = "haskell-language-server-" ++ versionNumber <.> exe
       majorVerExe = "haskell-language-server-" ++ dropExtension versionNumber <.> exe
 
-  liftIO $ do
-    copyFile (localBin </> "haskell-language-server" <.> exe) (localBin </> minorVerExe)
-    copyFile (localBin </> "haskell-language-server" <.> exe) (localBin </> majorVerExe)
+  let copyCmd old new = if os == "mingw32"
+                        then liftIO $ copyFile old new
+                        else command [] "ln" ["-f", old, new]
+  copyCmd (localBin </> "haskell-language-server" <.> exe) (localBin </> minorVerExe)
+  copyCmd (localBin </> "haskell-language-server" <.> exe) (localBin </> majorVerExe)
 
   printLine $   "Copied executables "
              ++ ("haskell-language-server-wrapper" <.> exe) ++ ", "
@@ -141,4 +144,3 @@ getVerbosityArg v = "-v" ++ cabalVerbosity
           Chatty ->     "2"
 #endif
           Diagnostic -> "3"
-

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -6,6 +6,7 @@ import           Development.Shake.FilePath
 import           Control.Monad
 import           System.Directory                         ( copyFile )
 -- import           System.FilePath                          ( (</>) )
+import           System.Info                              ( os )
 import           Version
 import           Print
 
@@ -32,11 +33,13 @@ stackInstallHls mbVersionNumber args = do
 
   localBinDir <- getLocalBin args
   let hls = "haskell-language-server" <.> exe
-  liftIO $ do
-    copyFile (localBinDir </> hls)
-             (localBinDir </> "haskell-language-server-" ++ versionNumber <.> exe)
-    copyFile (localBinDir </> hls)
-             (localBinDir </> "haskell-language-server-" ++ dropExtension versionNumber <.> exe)
+      copyCmd old new = if os == "mingw32"
+                        then liftIO $ copyFile old new
+                        else command [] "ln" ["-f", old, new]
+  copyCmd (localBinDir </> hls)
+           (localBinDir </> "haskell-language-server-" ++ versionNumber <.> exe)
+  copyCmd (localBinDir </> hls)
+           (localBinDir </> "haskell-language-server-" ++ dropExtension versionNumber <.> exe)
 
 getGhcVersionOfCfgFile :: String -> [String] -> Action VersionNumber
 getGhcVersionOfCfgFile stackFile args = do


### PR DESCRIPTION
This saves quite a bit of diskspace for linux, by using hardlinks to avoid having 3 copies of the main executable on disk.
I guess it should also work for MacOS (that would be `"darwin"`?).

I built this locally and it tested it for a Stack install.