### PR TITLE
Tactic plugin: Excludes Dictionary arguments in GADTs in Destruct Tactic

### DIFF
--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -25,6 +25,9 @@ cradle:
             - path: "./plugins/default/src"
               component: "haskell-language-server:exe:haskell-language-server"
 
+            - path: "./plugins/tactics/src"
+              component: "haskell-language-server:exe:haskell-language-server"
+
             - path: "./exe/Wrapper.hs"
               component: "haskell-language-server:exe:haskell-language-server-wrapper"
 

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -21,6 +21,8 @@ cradle:
 
             - path: "./plugins/default/src"
               component: "haskell-language-server:exe:haskell-language-server"
+            - path: "./plugins/tactics/src"
+              component: "haskell-language-server:exe:haskell-language-server"
 
             - path: "./exe/Arguments.hs"
               component: "haskell-language-server:exe:haskell-language-server"

--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -85,7 +85,7 @@ buildDataCon
     -> [Type]             -- ^ Type arguments for the data con
     -> RuleM (LHsExpr GhcPs)
 buildDataCon jdg dc apps = do
-  let args = dataConInstArgTys dc apps
+  let args = dataConInstOrigArgTys dc apps
   sgs <- traverse (newSubgoal . flip withNewGoal jdg . CType) args
   pure
     . noLoc

--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -38,7 +38,7 @@ destructMatches f f2 t jdg = do
       case dcs of
         [] -> throwError $ GoalMismatch "destruct" g
         _ -> for dcs $ \dc -> do
-          let args = dataConInstOrigArgTys dc apps
+          let args = dataConInstOrigArgTys' dc apps
           names <- mkManyGoodNames hy args
 
           let pat :: Pat GhcPs
@@ -51,9 +51,19 @@ destructMatches f f2 t jdg = do
           pure $ match [pat] $ unLoc sg
 
 
+-- | Essentially same as 'dataConInstOrigArgTys' in GHC,
+--   but we need some tweaks in GHC >= 8.8.
+--   Since old 'dataConInstArgTys' seems working with >= 8.8,
+--   we just filter out non-class types in the result.
+dataConInstOrigArgTys' :: DataCon -> [Type] -> [Type]
+dataConInstOrigArgTys' con ty =
+    let tys0 = dataConInstArgTys con ty
+    in filter (maybe True (not . isClassTyCon) . tyConAppTyCon_maybe) tys0
+
 ------------------------------------------------------------------------------
 -- | Combinator for performing case splitting, and running sub-rules on the
 -- resulting matches.
+
 destruct' :: (DataCon -> Judgement -> Rule) -> OccName -> Judgement -> Rule
 destruct' f term jdg = do
   let hy = jHypothesis jdg
@@ -85,7 +95,7 @@ buildDataCon
     -> [Type]             -- ^ Type arguments for the data con
     -> RuleM (LHsExpr GhcPs)
 buildDataCon jdg dc apps = do
-  let args = dataConInstOrigArgTys dc apps
+  let args = dataConInstOrigArgTys' dc apps
   sgs <- traverse (newSubgoal . flip withNewGoal jdg . CType) args
   pure
     . noLoc

--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -38,7 +38,7 @@ destructMatches f f2 t jdg = do
       case dcs of
         [] -> throwError $ GoalMismatch "destruct" g
         _ -> for dcs $ \dc -> do
-          let args = dataConInstArgTys dc apps
+          let args = dataConInstOrigArgTys dc apps
           names <- mkManyGoodNames hy args
 
           let pat :: Pat GhcPs

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -14,6 +14,7 @@ extra-deps:
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 - Cabal-3.0.2.0
 - clock-0.7.2
+- data-tree-print-0.1.0.2
 - floskell-0.10.4
 - fourmolu-0.2.0.0
 - monad-dijkstra-0.1.1.2

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -94,6 +94,7 @@ tests = testGroup
   , goldenTest "GoldenNote.hs"              2 8  Auto ""
   , goldenTest "GoldenPureList.hs"          2 12 Auto ""
   , goldenTest "GoldenGADTDestruct.hs"      7 17 Destruct "gadt"
+  , goldenTest "GoldenGADTAuto.hs"          7 13 Auto ""
   ]
 
 

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -93,6 +93,7 @@ tests = testGroup
   , goldenTest "GoldenEitherHomomorphic.hs" 2 15 Auto ""
   , goldenTest "GoldenNote.hs"              2 8  Auto ""
   , goldenTest "GoldenPureList.hs"          2 12 Auto ""
+  , goldenTest "GoldenGADTDestruct.hs"      7 17 Destruct "gadt"
   ]
 
 

--- a/test/testdata/tactic/GoldenGADTAuto.hs
+++ b/test/testdata/tactic/GoldenGADTAuto.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE GADTs #-}
+module GoldenGADTAuto where
+data CtxGADT a where
+  MkCtxGADT :: (Show a, Eq a) => a -> CtxGADT a
+
+ctxGADT :: CtxGADT ()
+ctxGADT = _auto

--- a/test/testdata/tactic/GoldenGADTAuto.hs.expected
+++ b/test/testdata/tactic/GoldenGADTAuto.hs.expected
@@ -1,0 +1,7 @@
+{-# LANGUAGE GADTs #-}
+module GoldenGADTAuto where
+data CtxGADT a where
+  MkCtxGADT :: (Show a, Eq a) => a -> CtxGADT a
+
+ctxGADT :: CtxGADT ()
+ctxGADT = (MkCtxGADT ())

--- a/test/testdata/tactic/GoldenGADTDestruct.hs
+++ b/test/testdata/tactic/GoldenGADTDestruct.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE GADTs #-}
+module GoldenGADTDestruct where
+data CtxGADT where
+  MkCtxGADT :: (Show a, Eq a) => a -> CtxGADT
+
+ctxGADT :: CtxGADT -> String
+ctxGADT gadt = _decons

--- a/test/testdata/tactic/GoldenGADTDestruct.hs.expected
+++ b/test/testdata/tactic/GoldenGADTDestruct.hs.expected
@@ -1,0 +1,7 @@
+{-# LANGUAGE GADTs #-}
+module GoldenGADTDestruct where
+data CtxGADT where
+  MkCtxGADT :: (Show a, Eq a) => a -> CtxGADT
+
+ctxGADT :: CtxGADT -> String
+ctxGADT gadt = (case gadt of { (MkCtxGADT a) -> _ })


### PR DESCRIPTION
Consider the following:

```hs
{-# LANGUAGE GADTs #-}
module GoldenGADTDestruct where
data CtxGADT where
  MkCtxGADT :: (Show a, Eq a) => a -> CtxGADT

ctxGADT :: CtxGADT -> String
ctxGADT gadt = _decons
```

If we select `case split on gadt` at `_decons`, the Tactic Plugin in HEAD introduces instance dictionary in data constructor:

```hs
{-# LANGUAGE GADTs #-}
module T4 where
data CtxGADT where
  MkCtxGADT :: (Show a, Eq a) => a -> CtxGADT

ctxGADT :: CtxGADT -> Bool
ctxGADT gadt = (case gadt of { (MkCtxGADT sa ea a) -> _ })
```

As it stands, generated pattern includes dictionary argumetns, which must not (cannot) appear in the source language.
This behaviour is due to the call to the `dataConInstArgTys`, which also includes dictionary argument.
This pull-request changes to use `dataConInstOrigArgTys`, which excludes dictionaries and adds a golden test for destructing GADTs, and the above case-splitting generates the expected result:

```hs
ctxGADT :: CtxGADT -> Bool
ctxGADT gadt = (case gadt of { (MkCtxGADT a) -> _ })
```

One concern: I also change the use of `dataConInstArgTys` in `buildDataCon` to `dataConInstOrigArgTys`. This should also correct the expression constructed by Homo or Auto tactic, but the generated expressions don't take type-level constraints into account. Any thoughts?