### PR TITLE
Fix CI failures on GHC 8.10.2

### DIFF
--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -26,6 +26,7 @@ extra-deps:
 - implicit-hie-cradle-0.2.0.1
 - implicit-hie-0.1.1.0
 - hie-bios-0.7.1
+- data-tree-print-0.1.0.2
 
 flags:
   haskell-language-server:


### PR DESCRIPTION
We got

```
    data-tree-print needed, but the
                    stack configuration
                    has no specified
                    version  (latest
                    matching version
                    is 0.1.0.2)
```

in #475 - try fixing that.
