### PR TITLE
Bump stylish-haskell to 0.12.2.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,6 +20,6 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-10-02T22:25:53Z
+index-state: 2020-10-08T12:51:21Z
 
 allow-newer: data-tree-print:base

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -147,7 +147,7 @@ executable haskell-language-server
     , retrie                   >=0.1.1.0
     , safe-exceptions
     , shake                    >=0.17.5
-    , stylish-haskell          ^>=0.11
+    , stylish-haskell          ^>=0.12
     , temporary
     , text
     , syb

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -23,7 +23,7 @@ extra-deps:
 - ormolu-0.1.3.0
 - refinery-0.2.0.0
 - retrie-0.1.1.1
-- stylish-haskell-0.11.0.3
+- stylish-haskell-0.12.2.0
 - semigroups-0.18.5
 - temporary-1.2.1.1
 - implicit-hie-cradle-0.2.0.1

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -21,7 +21,7 @@ extra-deps:
 - opentelemetry-0.4.2
 - refinery-0.2.0.0
 - retrie-0.1.1.1
-- stylish-haskell-0.11.0.3
+- stylish-haskell-0.12.2.0
 - semigroups-0.18.5
 - temporary-1.2.1.1
 - implicit-hie-cradle-0.2.0.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -54,7 +54,7 @@ extra-deps:
 - semialign-1.1
 # - github: wz1000/shake
 #   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
-- stylish-haskell-0.11.0.3
+- stylish-haskell-0.12.2.0
 - tasty-rerun-1.1.17
 - temporary-1.2.1.1
 - these-1.1.1.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -53,7 +53,7 @@ extra-deps:
 - semialign-1.1
 # - github: wz1000/shake
 #   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
-- stylish-haskell-0.11.0.3
+- stylish-haskell-0.12.2.0
 - tasty-rerun-1.1.17
 - temporary-1.2.1.1
 - these-1.1.1.1

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -43,7 +43,7 @@ extra-deps:
 - semigroups-0.18.5
 # - github: wz1000/shake
 #   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
-- stylish-haskell-0.11.0.3
+- stylish-haskell-0.12.2.0
 - temporary-1.2.1.1
 - these-1.1.1.1
 - implicit-hie-cradle-0.2.0.1

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -35,7 +35,7 @@ extra-deps:
 - semigroups-0.18.5
 # - github: wz1000/shake
 #   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
-- stylish-haskell-0.11.0.3
+- stylish-haskell-0.12.2.0
 - temporary-1.2.1.1
 - implicit-hie-cradle-0.2.0.1
 - implicit-hie-0.1.1.0

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -35,6 +35,7 @@ extra-deps:
 - semigroups-0.18.5
 # - github: wz1000/shake
 #   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
+- stylish-haskell-0.12.2.0
 - temporary-1.2.1.1
 - ghc-exactprint-0.6.3.2
 - implicit-hie-cradle-0.2.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,7 +53,7 @@ extra-deps:
 - semialign-1.1
 # - github: wz1000/shake
 #   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
-- stylish-haskell-0.11.0.3
+- stylish-haskell-0.12.2.0
 - tasty-rerun-1.1.17
 - temporary-1.2.1.1
 - these-1.1.1.1


### PR DESCRIPTION
`stylish-haskell-0.12` uses `ghc-lib-parser` instead of `haskell-src-exts`, so it should be more reliable.

Surprisingly, this update did not require any changes in the code.

CC @jaspervdj.