### PR TITLE
[WIP]: Nix env support for the wrapper

### DIFF
--- a/src/Ide/Version.hs
+++ b/src/Ide/Version.hs
@@ -54,6 +54,7 @@ findProgramVersions :: IO ProgramsOfInterest
 findProgramVersions = ProgramsOfInterest
   <$> findVersionOf "cabal"
   <*> findVersionOf "stack"
+  <*> findVersionOf "nix"
   <*> findVersionOf "ghc"
 
 -- | Find the version of the given program.


### PR DESCRIPTION
WIP to solving #493 

IDEs are currently required to provide their own custom Nix env loading mechanism and wrapper for the `haskell-language-server-wrapper`.

Nix env load from first and second look seems pretty trivial to do.

What essentially needs to be done - is:
a) `--nix <args>` option to load Nix env and then load `--lsp <args>`
b) `--nix <args> <all_other_keys>` option to load Nix env with args and there `language-server-wrapper  <all_other_keys>`.

Since `wrapper` exe is properly decoupled (does `callProcess` for main HLS exe) - so when `--nix` wrapper runs itselt inside Nix env: `nix-shell . --command '<path_to>/haskell-language-server-wrapper <args>'` as always.