### PR TITLE
Fix stack build for ghc-8.8.3 failing on some machines

### DIFF
--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.5
+resolver: lts-16.11
 
 packages:
 - .


### PR DESCRIPTION
Bump the lts version to resolve an issue with these-1.1.1

these-1.1.1 fails to build on some machine due to a bug in gcc. This
was worked around in these-1.1.1.1