### PR TITLE
Add GitHub Actions CI for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ defaults:
 on:
   release:
     types: [created]
+
 jobs:
 
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,8 @@ jobs:
       env:
         HLS_TEST_EXE: hls
         HLS_WRAPPER_TEST_EXE: hls-wrapper
+      # run the tests without parallelism, otherwise tasty will attempt to run
+      # all functional test cases simultaneously which causes way too many hls
+      # instances to be spun up for the poor github actions runner to handle
       run: cabal test --test-options=-j1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
+    - run: cabal update
 
     - name: Shorten binary names
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.2'
+        enable-stack: true
 
     - name: Cache Cabal
       uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,5 +56,5 @@ jobs:
     - name: Test
       env:
         HLS_TEST_EXE: hls
-      run: cabal test
+      run: cabal test --test-options=-j1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
         path: ~/.cabal/
         key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+          ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ matrix.ghc }}-build-
+          ${{ runner.os }}-${{ matrix.ghc }}
 
     - run: cabal update
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
 
     - run: cabal update
 
+    # Need this to work around filepath length limits in Windows
     - name: Shorten binary names
       shell: bash
       run: |
@@ -58,5 +59,6 @@ jobs:
     - name: Test
       env:
         HLS_TEST_EXE: hls
+        HLS_WRAPPER_TEST_EXE: hls-wrapper
       run: cabal test --test-options=-j1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,5 +54,7 @@ jobs:
     - name: Build
       run: cabal build
     - name: Test
+      env:
+        HLS_TEST_EXE: hls
       run: cabal test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,58 @@
+name: Testing
+
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['8.10.2', '8.10.1', '8.8.4', '8.8.3', '8.8.2', '8.6.5', '8.6.4']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            ghc: '8.10.2' # broken due to https://gitlab.haskell.org/ghc/ghc/-/issues/18550
+          - os: windows-latest
+            ghc: '8.8.4' # also fails due to segfault :(
+          - os: windows-latest
+            ghc: '8.8.3' # fails due to segfault
+          - os: windows-latest
+            ghc: '8.8.2' # fails due to error with Cabal
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: '3.2'
+
+    - name: Cache Cabal
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal/
+        key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+
+    - name: Shorten binary names
+      shell: bash
+      run: |
+        sed -i.bak -e 's/haskell-language-server/hls/g' \
+                   -e 's/haskell_language_server/hls/g' \
+                   haskell-language-server.cabal
+        sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
+                   src/**/*.hs exe/*.hs
+
+    - name: Build
+      run: cabal build
+    - name: Test
+      run: cabal test
+

--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,11 @@ source-repository-package
   location: https://github.com/bubba/brittany.git
   tag: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 
+source-repository-package
+  type: git
+  location: https://github.com/bubba/hie-bios.git
+  tag: cec139a1c3da1632d9a59271acc70156413017e7
+
 tests: true
 
 package *

--- a/test/functional/Command.hs
+++ b/test/functional/Command.hs
@@ -18,7 +18,7 @@ import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 tests :: TestTree
 tests = testGroup "commands" [
     testCase "are prefixed" $
-        runSession hieCommand fullCaps "test/testdata/" $ do
+        runSession hlsCommand fullCaps "test/testdata/" $ do
             ResponseMessage _ _ (Right res) <- initializeResponse
             let List cmds = res ^. LSP.capabilities . executeCommandProvider . _Just . commands
                 f x = (T.length (T.takeWhile isNumber x) >= 1) && (T.count ":" x >= 2)
@@ -27,7 +27,7 @@ tests = testGroup "commands" [
                 not (null cmds) @? "Commands aren't empty"
     , ignoreTestBecause "Broken: Plugin package doesn't exist" $
       testCase "get de-prefixed" $
-        runSession hieCommand fullCaps "test/testdata/" $ do
+        runSession hlsCommand fullCaps "test/testdata/" $ do
             ResponseMessage _ _ (Left err) <- request
                 WorkspaceExecuteCommand
                 (ExecuteCommandParams "1234:package:add" (Just (List [])) Nothing) :: Session ExecuteCommandResponse

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -18,7 +18,7 @@ import Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "completions" [
---     testCase "works" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     testCase "works" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -40,7 +40,7 @@ tests = testGroup "completions" [
 --             resolved ^. insertTextFormat @?= Just Snippet
 --             resolved ^. insertText @?= Just "putStrLn ${1:String}"
 
---     , testCase "completes imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "completes imports" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -54,7 +54,7 @@ tests = testGroup "completions" [
 --             item ^. detail @?= Just "Data.Maybe"
 --             item ^. kind @?= Just CiModule
 
---     , testCase "completes qualified imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "completes qualified imports" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -68,7 +68,7 @@ tests = testGroup "completions" [
 --             item ^. detail @?= Just "Data.List"
 --             item ^. kind @?= Just CiModule
 
---     , testCase "completes language extensions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "completes language extensions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -81,7 +81,7 @@ tests = testGroup "completions" [
 --             item ^. label @?= "OverloadedStrings"
 --             item ^. kind @?= Just CiKeyword
 
---     , testCase "completes pragmas" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "completes pragmas" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -96,7 +96,7 @@ tests = testGroup "completions" [
 --             item ^. insertTextFormat @?= Just Snippet
 --             item ^. insertText @?= Just "LANGUAGE ${1:extension} #-}"
 
---     , testCase "completes pragmas no close" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "completes pragmas no close" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -111,7 +111,7 @@ tests = testGroup "completions" [
 --             item ^. insertTextFormat @?= Just Snippet
 --             item ^. insertText @?= Just "LANGUAGE ${1:extension}"
 
---     , testCase "completes options pragma" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "completes options pragma" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -128,7 +128,7 @@ tests = testGroup "completions" [
 
 --   -- -----------------------------------
 
---     , testCase "completes ghc options pragma values" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "completes ghc options pragma values" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
@@ -146,14 +146,14 @@ tests = testGroup "completions" [
 
 --   -- -----------------------------------
 
---     , testCase "completes with no prefix" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "completes with no prefix" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 --         compls <- getCompletions doc (Position 5 7)
 --         liftIO $ filter ((== "!!") . (^. label)) compls `shouldNotSatisfy` null
 
 --     -- See https://github.com/haskell/haskell-ide-engine/issues/903
---     , testCase "strips compiler generated stuff from completions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "strips compiler generated stuff from completions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "DupRecFields.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -168,7 +168,7 @@ tests = testGroup "completions" [
 --             item ^. detail @?= Just "Two -> Int\nDupRecFields"
 --             item ^. insertText @?= Just "accessor ${1:Two}"
 
---     , testCase "have implicit foralls on basic polymorphic types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "have implicit foralls on basic polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 --         let te = TextEdit (Range (Position 5 7) (Position 5 9)) "id"
@@ -180,7 +180,7 @@ tests = testGroup "completions" [
 --         liftIO $
 --             resolved ^. detail @?= Just "a -> a\nPrelude"
 
---     , testCase "have implicit foralls with multiple type variables" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "have implicit foralls with multiple type variables" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 --         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "flip"
@@ -198,7 +198,7 @@ tests = testGroup "completions" [
 
 -- snippetTests :: TestTree
 -- snippetTests = testGroup "snippets" [
---     testCase "work for argumentless constructors" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     testCase "work for argumentless constructors" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -211,7 +211,7 @@ tests = testGroup "completions" [
 --             item ^. insertTextFormat @?= Just Snippet
 --             item ^. insertText @?= Just "Nothing"
 
---     , testCase "work for polymorphic types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "work for polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -228,7 +228,7 @@ tests = testGroup "completions" [
 --             resolved ^. insertTextFormat @?= Just Snippet
 --             resolved ^. insertText @?= Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
 
---     , testCase "work for complex types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "work for complex types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -245,7 +245,7 @@ tests = testGroup "completions" [
 --             resolved ^. insertTextFormat @?= Just Snippet
 --             resolved ^. insertText @?= Just "mapM ${1:a -> m b} ${2:t a}"
 
---     , testCase "work for infix functions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "work for infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -260,7 +260,7 @@ tests = testGroup "completions" [
 --             item ^. insertTextFormat @?= Just Snippet
 --             item ^. insertText @?= Just "filter`"
 
---     , testCase "work for infix functions in backticks" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -275,7 +275,7 @@ tests = testGroup "completions" [
 --             item ^. insertTextFormat @?= Just Snippet
 --             item ^. insertText @?= Just "filter"
 
---     , testCase "work for qualified infix functions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -290,7 +290,7 @@ tests = testGroup "completions" [
 --             item ^. insertTextFormat @?= Just Snippet
 --             item ^. insertText @?= Just "intersperse`"
 
---     , testCase "work for qualified infix functions in backticks" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+--     , testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
 --         doc <- openDoc "Completion.hs" "haskell"
 --         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -306,7 +306,7 @@ tests = testGroup "completions" [
 --             item ^. insertText @?= Just "intersperse"
 
     -- -- TODO : Fix compile issue in the test "Variable not in scope: object"
-    -- , testCase "respects lsp configuration" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+    -- , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
     --     doc <- openDoc "Completion.hs" "haskell"
     --     _   <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -317,7 +317,7 @@ tests = testGroup "completions" [
 
     --     checkNoSnippets doc
 
-    -- , testCase "respects client capabilities" $ runSession hieCommand noSnippetsCaps "test/testdata/completion" $ do
+    -- , testCase "respects client capabilities" $ runSession hlsCommand noSnippetsCaps "test/testdata/completion" $ do
     --     doc <- openDoc "Completion.hs" "haskell"
     --     _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
@@ -359,7 +359,7 @@ tests = testGroup "completions" [
 contextTests :: TestTree
 contextTests = testGroup "contexts" [
     ignoreTestBecause "Broken: Timed out waiting to receive a message from the server" $
-    testCase "only provides type suggestions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+    testCase "only provides type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Context.hs" "haskell"
       _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
       compls <- getCompletions doc (Position 2 17)
@@ -368,7 +368,7 @@ contextTests = testGroup "contexts" [
         compls `shouldNotContainCompl` "interact"
 
     , ignoreTestBecause "Broken: Timed out waiting to receive a message from the server" $
-      testCase "only provides type suggestions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+      testCase "only provides type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Context.hs" "haskell"
       _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
       compls <- getCompletions doc (Position 3 9)
@@ -377,7 +377,7 @@ contextTests = testGroup "contexts" [
         compls `shouldNotContainCompl` "Applicative"
 
     -- This currently fails if , testCase takes too long to typecheck the module
-    -- , testCase "completes qualified type suggestions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+    -- , testCase "completes qualified type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
     --     doc <- openDoc "Context.hs" "haskell"
     --     _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
     --     let te = TextEdit (Range (Position 2 17) (Position 2 17)) " -> Conc."

--- a/test/functional/Deferred.hs
+++ b/test/functional/Deferred.hs
@@ -22,7 +22,7 @@ tests :: TestTree
 tests = testGroup "deferred responses" [
 
     --TODO: DOes not compile
-    -- testCase "do not affect hover requests" $ runSession hieCommand fullCaps "test/testdata" $ do
+    -- testCase "do not affect hover requests" $ runSession hlsCommand fullCaps "test/testdata" $ do
     --   doc <- openDoc "FuncTest.hs" "haskell"
 
     --   id1 <- sendRequest TextDocumentHover (TextDocumentPositionParams doc (Position 4 2) Nothing)
@@ -91,7 +91,7 @@ tests = testGroup "deferred responses" [
     --                  }
     --                ]
 
-     testCase "instantly respond to failed modules with no cache" $ runSession hieCommand fullCaps "test/testdata" $ do
+     testCase "instantly respond to failed modules with no cache" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "FuncTestFail.hs" "haskell"
         defs <- getDefinitions doc (Position 1 11)
         liftIO $ defs @?= []
@@ -99,13 +99,13 @@ tests = testGroup "deferred responses" [
     -- TODO: the benefits of caching parsed modules is doubted.
     -- TODO: add issue link
     -- , testCase "respond to untypecheckable modules with parsed module cache" $
-    --   runSession hieCommand fullCaps "test/testdata" $ do
+    --   runSession hlsCommand fullCaps "test/testdata" $ do
     --     doc <- openDoc "FuncTestFail.hs" "haskell"
     --     (Left (sym:_)) <- getDocumentSymbols doc
     --     liftIO $ sym ^. name @?= "main"
 
     -- TODO does not compile
-    -- , testCase "returns hints as diagnostics" $ runSession hieCommand fullCaps "test/testdata" $ do
+    -- , testCase "returns hints as diagnostics" $ runSession hlsCommand fullCaps "test/testdata" $ do
     --     _ <- openDoc "FuncTest.hs" "haskell"
 
     --     cwd <- liftIO getCurrentDirectory
@@ -145,7 +145,7 @@ tests = testGroup "deferred responses" [
 -- multiServerTests :: TestTree
 -- multiServerTests = testGroup "multi-server setup" [
 --     testCase "doesn't have clashing commands on two servers" $ do
---         let getCommands = runSession hieCommand fullCaps "test/testdata" $ do
+--         let getCommands = runSession hlsCommand fullCaps "test/testdata" $ do
 --                 rsp <- initializeResponse
 --                 let uuids = rsp ^? result . _Just . capabilities . executeCommandProvider . _Just . commands
 --                 return $ fromJust uuids
@@ -158,7 +158,7 @@ multiMainTests :: TestTree
 multiMainTests = testGroup "multiple main modules" [
     ignoreTestBecause "Broken: Unexpected ConduitParser.empty" $
     testCase "Can load one file at a time, when more than one Main module exists"
-        $ runSession hieCommand fullCaps "test/testdata" $ do
+        $ runSession hlsCommand fullCaps "test/testdata" $ do
             _doc <- openDoc "ApplyRefact2.hs" "haskell"
             _diagsRspHlint <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification
             diagsRspGhc    <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification

--- a/test/functional/Definition.hs
+++ b/test/functional/Definition.hs
@@ -15,7 +15,7 @@ tests :: TestTree
 tests = testGroup "definitions" [
 
     ignoreTestBecause "Broken: file:///Users/jwindsor/src/haskell-language-server/test/testdata/References.hs" $
-       testCase "goto's symbols" $ runSession hieCommand fullCaps "test/testdata" $ do
+       testCase "goto's symbols" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "References.hs" "haskell"
         defs <- getDefinitions doc (Position 7 8)
         let expRange = Range (Position 4 0) (Position 4 3)
@@ -24,7 +24,7 @@ tests = testGroup "definitions" [
   -- -----------------------------------
 
   , ignoreTestBecause "Broken: file:///Users/jwindsor/src/haskell-language-server/test/testdata/Bar.hs" $
-    testCase "goto's imported modules" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
+    testCase "goto's imported modules" $ runSession hlsCommand fullCaps "test/testdata/definition" $ do
         doc <- openDoc "Foo.hs" "haskell"
         defs <- getDefinitions doc (Position 2 8)
         liftIO $ do
@@ -32,7 +32,7 @@ tests = testGroup "definitions" [
             defs @?= [Location (filePathToUri fp) zeroRange]
 
   , ignoreTestBecause "Broken: file:///Users/jwindsor/src/haskell-language-server/test/testdata/Bar.hs" $
-    testCase "goto's exported modules" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
+    testCase "goto's exported modules" $ runSession hlsCommand fullCaps "test/testdata/definition" $ do
         doc <- openDoc "Foo.hs" "haskell"
         defs <- getDefinitions doc (Position 0 15)
         liftIO $ do
@@ -40,7 +40,7 @@ tests = testGroup "definitions" [
             defs @?= [Location (filePathToUri fp) zeroRange]
 
   , ignoreTestBecause "Broken: file:///Users/jwindsor/src/haskell-language-server/test/testdata/Bar.hs" $
-    testCase "goto's imported modules that are loaded" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
+    testCase "goto's imported modules that are loaded" $ runSession hlsCommand fullCaps "test/testdata/definition" $ do
         doc <- openDoc "Foo.hs" "haskell"
         _ <- openDoc "Bar.hs" "haskell"
         defs <- getDefinitions doc (Position 2 8)
@@ -50,7 +50,7 @@ tests = testGroup "definitions" [
 
   , ignoreTestBecause "Broken: file:///Users/jwindsor/src/haskell-language-server/test/testdata/Bar.hs" $
     testCase "goto's imported modules that are loaded, and then closed" $
-        runSession hieCommand fullCaps "test/testdata/definition" $ do
+        runSession hlsCommand fullCaps "test/testdata/definition" $ do
             doc <- openDoc "Foo.hs" "haskell"
             otherDoc <- openDoc "Bar.hs" "haskell"
             closeDoc otherDoc

--- a/test/functional/Diagnostic.hs
+++ b/test/functional/Diagnostic.hs
@@ -33,7 +33,7 @@ triggerTests :: TestTree
 triggerTests = testGroup "diagnostics triggers" [
     ignoreTestBecause "Broken" $
     ignoreTestBecause "Broken" $ testCase "runs diagnostics on save" $
-        runSession hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+        runSession hlsCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
             logm "starting DiagnosticSpec.runs diagnostic on save"
             doc <- openDoc "ApplyRefact2.hs" "haskell"
 
@@ -65,7 +65,7 @@ triggerTests = testGroup "diagnostics triggers" [
 errorTests :: TestTree
 errorTests = testGroup  "typed hole errors" [
     ignoreTestBecause "Broken" $ testCase "is deferred" $
-        runSession hieCommand fullCaps "test/testdata" $ do
+        runSession hlsCommand fullCaps "test/testdata" $ do
             _ <- openDoc "TypedHoles.hs" "haskell"
             [diag] <- waitForDiagnosticsSource "bios"
             liftIO $ diag ^. LSP.severity @?= Just DsWarning
@@ -74,7 +74,7 @@ errorTests = testGroup  "typed hole errors" [
 warningTests :: TestTree
 warningTests = testGroup  "Warnings are warnings" [
     ignoreTestBecause "Broken" $ testCase "Overrides -Werror" $
-        runSession hieCommand fullCaps "test/testdata/wErrorTest" $ do
+        runSession hlsCommand fullCaps "test/testdata/wErrorTest" $ do
             _ <- openDoc "src/WError.hs" "haskell"
             [diag] <- waitForDiagnosticsSource "bios"
             liftIO $ diag ^. LSP.severity @?= Just DsWarning
@@ -83,7 +83,7 @@ warningTests = testGroup  "Warnings are warnings" [
 saveTests :: TestTree
 saveTests = testGroup  "only diagnostics on save" [
     ignoreTestBecause "Broken" $ testCase "Respects diagnosticsOnChange setting" $
-        runSession hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+        runSession hlsCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
             let config = Data.Default.def { diagnosticsOnChange = False } :: Config
             sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
             doc <- openDoc "Hover.hs" "haskell"

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -24,27 +24,27 @@ tests :: TestTree
 tests = testGroup
   "eval"
   [ testCase "Produces Evaluate code lenses" $ do
-    runSession hieCommand fullCaps evalPath $ do
+    runSession hlsCommand fullCaps evalPath $ do
       doc    <- openDoc "T1.hs" "haskell"
       lenses <- getCodeLenses doc
       liftIO $ map (fmap _title . _command) lenses @?= [Just "Evaluate..."]
   , testCase "Produces Refresh code lenses" $ do
-    runSession hieCommand fullCaps evalPath $ do
+    runSession hlsCommand fullCaps evalPath $ do
       doc    <- openDoc "T2.hs" "haskell"
       lenses <- getCodeLenses doc
       liftIO $ map (fmap _title . _command) lenses @?= [Just "Refresh..."]
   , testCase "Code lenses have ranges" $ do
-    runSession hieCommand fullCaps evalPath $ do
+    runSession hlsCommand fullCaps evalPath $ do
       doc    <- openDoc "T1.hs" "haskell"
       lenses <- getCodeLenses doc
       liftIO $ map _range lenses @?= [Range (Position 4 0) (Position 4 15)]
   , testCase "Multi-line expressions have a multi-line range" $ do
-    runSession hieCommand fullCaps evalPath $ do
+    runSession hlsCommand fullCaps evalPath $ do
       doc    <- openDoc "T3.hs" "haskell"
       lenses <- getCodeLenses doc
       liftIO $ map _range lenses @?= [Range (Position 3 0) (Position 4 15)]
   , testCase "Executed expressions range covers only the expression" $ do
-    runSession hieCommand fullCaps evalPath $ do
+    runSession hlsCommand fullCaps evalPath $ do
       doc    <- openDoc "T2.hs" "haskell"
       lenses <- getCodeLenses doc
       liftIO $ map _range lenses @?= [Range (Position 4 0) (Position 4 15)]
@@ -93,7 +93,7 @@ tests = testGroup
   ]
 
 goldenTest :: FilePath -> IO ()
-goldenTest input = runSession hieCommand fullCaps evalPath $ do
+goldenTest input = runSession hlsCommand fullCaps evalPath $ do
   doc                              <- openDoc input "haskell"
   [CodeLens { _command = Just c }] <- getCodeLenses doc
   executeCommand c

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -95,7 +95,6 @@ tests = testGroup
 
 goldenTest :: FilePath -> IO ()
 goldenTest input = do
-  getEnv "LANG" >>= print
   setEnv "LANG" "en_US.UTF-8"
   runSession hlsCommand fullCaps evalPath $ do
     doc                              <- openDoc input "haskell"

--- a/test/functional/Eval.hs
+++ b/test/functional/Eval.hs
@@ -20,6 +20,7 @@ import           Test.Hls.Util
 import           Test.Tasty
 import           Test.Tasty.ExpectedFailure      (expectFailBecause)
 import           Test.Tasty.HUnit
+import System.IO
 
 tests :: TestTree
 tests = testGroup
@@ -95,7 +96,7 @@ tests = testGroup
 
 goldenTest :: FilePath -> IO ()
 goldenTest input = do
-  setEnv "LANG" "en_US.UTF-8"
+  print localeEncoding
   runSession hlsCommand fullCaps evalPath $ do
     doc                              <- openDoc input "haskell"
     [CodeLens { _command = Just c }] <- getCodeLenses doc

--- a/test/functional/Format.hs
+++ b/test/functional/Format.hs
@@ -18,11 +18,11 @@ import qualified Data.Text.IO as T
 
 tests :: TestTree
 tests = testGroup "format document" [
-    goldenVsStringDiff "works" goldenGitDiff "test/testdata/Format.formatted_document.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+    goldenVsStringDiff "works" goldenGitDiff "test/testdata/Format.formatted_document.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Format.hs" "haskell"
         formatDoc doc (FormattingOptions 2 True)
         BS.fromStrict . T.encodeUtf8 <$> documentContents doc
-    , goldenVsStringDiff "works with custom tab size" goldenGitDiff "test/testdata/Format.formatted_document_with_tabsize.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , goldenVsStringDiff "works with custom tab size" goldenGitDiff "test/testdata/Format.formatted_document_with_tabsize.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Format.hs" "haskell"
         formatDoc doc (FormattingOptions 5 True)
         BS.fromStrict . T.encodeUtf8 <$> documentContents doc
@@ -38,11 +38,11 @@ tests = testGroup "format document" [
 
 rangeTests :: TestTree
 rangeTests = testGroup "format range" [
-    goldenVsStringDiff "works" goldenGitDiff "test/testdata/Format.formatted_range.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+    goldenVsStringDiff "works" goldenGitDiff "test/testdata/Format.formatted_range.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Format.hs" "haskell"
         formatRange doc (FormattingOptions 2 True) (Range (Position 5 0) (Position 7 10))
         BS.fromStrict . T.encodeUtf8 <$> documentContents doc
-    , goldenVsStringDiff "works with custom tab size" goldenGitDiff "test/testdata/Format.formatted_range_with_tabsize.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , goldenVsStringDiff "works with custom tab size" goldenGitDiff "test/testdata/Format.formatted_range_with_tabsize.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Format.hs" "haskell"
         formatRange doc (FormattingOptions 5 True) (Range (Position 8 0) (Position 11 19))
         BS.fromStrict . T.encodeUtf8 <$> documentContents doc
@@ -50,7 +50,7 @@ rangeTests = testGroup "format range" [
 
 providerTests :: TestTree
 providerTests = testGroup "formatting provider" [
-    testCase "respects none" $ runSessionWithConfig (formatConfig "none") hieCommand fullCaps "test/testdata" $ do
+    testCase "respects none" $ runSessionWithConfig (formatConfig "none") hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Format.hs" "haskell"
         orig <- documentContents doc
 
@@ -61,7 +61,7 @@ providerTests = testGroup "formatting provider" [
         documentContents doc >>= liftIO . (@?= orig)
 
 #if AGPL
-    , testCase "can change on the fly" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , testCase "can change on the fly" $ runSession hlsCommand fullCaps "test/testdata" $ do
         formattedBrittany <- liftIO $ T.readFile "test/testdata/Format.brittany.formatted.hs"
         formattedFloskell <- liftIO $ T.readFile "test/testdata/Format.floskell.formatted.hs"
         formattedBrittanyPostFloskell <- liftIO $ T.readFile "test/testdata/Format.brittany_post_floskell.formatted.hs"
@@ -79,7 +79,7 @@ providerTests = testGroup "formatting provider" [
         sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "brittany"))
         formatDoc doc (FormattingOptions 2 True)
         documentContents doc >>= liftIO . (@?= formattedBrittanyPostFloskell)
-    , testCase "supports both new and old configuration sections" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , testCase "supports both new and old configuration sections" $ runSession hlsCommand fullCaps "test/testdata" $ do
        formattedBrittany <- liftIO $ T.readFile "test/testdata/Format.brittany.formatted.hs"
        formattedFloskell <- liftIO $ T.readFile "test/testdata/Format.floskell.formatted.hs"
 
@@ -97,12 +97,12 @@ providerTests = testGroup "formatting provider" [
 
 stylishHaskellTests :: TestTree
 stylishHaskellTests = testGroup "stylish-haskell" [
-  goldenVsStringDiff "formats a document" goldenGitDiff "test/testdata/StylishHaksell.formatted_document.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+  goldenVsStringDiff "formats a document" goldenGitDiff "test/testdata/StylishHaksell.formatted_document.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "stylish-haskell"))
       doc <- openDoc "StylishHaskell.hs" "haskell"
       formatDoc doc (FormattingOptions 2 True)
       BS.fromStrict . T.encodeUtf8 <$> documentContents doc
-  , goldenVsStringDiff "formats a range" goldenGitDiff "test/testdata/StylishHaksell.formatted_range.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+  , goldenVsStringDiff "formats a range" goldenGitDiff "test/testdata/StylishHaksell.formatted_range.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "stylish-haskell"))
       doc <- openDoc "StylishHaskell.hs" "haskell"
       formatRange doc (FormattingOptions 2 True) (Range (Position 0 0) (Position 2 21))
@@ -112,26 +112,26 @@ stylishHaskellTests = testGroup "stylish-haskell" [
 #if AGPL
 brittanyTests :: TestTree
 brittanyTests = testGroup "brittany" [
-    goldenVsStringDiff "formats a document with LF endings" goldenGitDiff "test/testdata/BrittanyLF.formatted_document.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+    goldenVsStringDiff "formats a document with LF endings" goldenGitDiff "test/testdata/BrittanyLF.formatted_document.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
         sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "brittany"))
         doc <- openDoc "BrittanyLF.hs" "haskell"
         formatDoc doc (FormattingOptions 4 True)
         BS.fromStrict . T.encodeUtf8 <$> documentContents doc
 
-    , goldenVsStringDiff "formats a document with CRLF endings" goldenGitDiff "test/testdata/BrittanyCRLF.formatted_document.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , goldenVsStringDiff "formats a document with CRLF endings" goldenGitDiff "test/testdata/BrittanyCRLF.formatted_document.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
         sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "brittany"))
         doc <- openDoc "BrittanyCRLF.hs" "haskell"
         formatDoc doc (FormattingOptions 4 True)
         BS.fromStrict . T.encodeUtf8 <$> documentContents doc
 
-    , goldenVsStringDiff "formats a range with LF endings" goldenGitDiff "test/testdata/BrittanyLF.formatted_range.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , goldenVsStringDiff "formats a range with LF endings" goldenGitDiff "test/testdata/BrittanyLF.formatted_range.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
         sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "brittany"))
         doc <- openDoc "BrittanyLF.hs" "haskell"
         let range = Range (Position 1 0) (Position 2 22)
         formatRange doc (FormattingOptions 4 True) range
         BS.fromStrict . T.encodeUtf8 <$> documentContents doc
 
-    , goldenVsStringDiff "formats a range with CRLF endings" goldenGitDiff "test/testdata/BrittanyCRLF.formatted_range.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , goldenVsStringDiff "formats a range with CRLF endings" goldenGitDiff "test/testdata/BrittanyCRLF.formatted_range.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
         sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "brittany"))
         doc <- openDoc "BrittanyCRLF.hs" "haskell"
         let range = Range (Position 1 0) (Position 2 22)
@@ -142,12 +142,12 @@ brittanyTests = testGroup "brittany" [
 
 ormoluTests :: TestTree
 ormoluTests = testGroup "ormolu"
-  [ goldenVsStringDiff "formats correctly" goldenGitDiff "test/testdata/Format.ormolu.formatted.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+  [ goldenVsStringDiff "formats correctly" goldenGitDiff "test/testdata/Format.ormolu.formatted.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))
       doc <- openDoc "Format.hs" "haskell"
       formatDoc doc (FormattingOptions 2 True)
       BS.fromStrict . T.encodeUtf8 <$> documentContents doc
-  , goldenVsStringDiff "formats imports correctly" goldenGitDiff "test/testdata/Format2.ormolu.formatted.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+  , goldenVsStringDiff "formats imports correctly" goldenGitDiff "test/testdata/Format2.ormolu.formatted.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))
       doc <- openDoc "Format2.hs" "haskell"
       formatDoc doc (FormattingOptions 2 True)
@@ -156,12 +156,12 @@ ormoluTests = testGroup "ormolu"
 
 fourmoluTests :: TestTree
 fourmoluTests = testGroup "fourmolu"
-  [ goldenVsStringDiff "formats correctly" goldenGitDiff "test/testdata/Format.fourmolu.formatted.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+  [ goldenVsStringDiff "formats correctly" goldenGitDiff "test/testdata/Format.fourmolu.formatted.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "fourmolu"))
       doc <- openDoc "Format.hs" "haskell"
       formatDoc doc (FormattingOptions 4 True)
       BS.fromStrict . T.encodeUtf8 <$> documentContents doc
-  , goldenVsStringDiff "formats imports correctly" goldenGitDiff "test/testdata/Format2.fourmolu.formatted.hs" $ runSession hieCommand fullCaps "test/testdata" $ do
+  , goldenVsStringDiff "formats imports correctly" goldenGitDiff "test/testdata/Format2.fourmolu.formatted.hs" $ runSession hlsCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "fourmolu"))
       doc <- openDoc "Format2.hs" "haskell"
       formatDoc doc (FormattingOptions 4 True)

--- a/test/functional/FunctionalBadProject.hs
+++ b/test/functional/FunctionalBadProject.hs
@@ -23,8 +23,8 @@ tests = testGroup "behaviour on malformed projects" [
     ]
 
     -- testCase "deals with cabal file with unsatisfiable dependency" $
-    --     runSession hieCommandExamplePlugin codeActionSupportCaps "test/testdata/badProjects/cabal" $ do
-    --     -- runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+    --     runSession hlsCommandExamplePlugin codeActionSupportCaps "test/testdata/badProjects/cabal" $ do
+    --     -- runSessionWithConfig logConfig hlsCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
     --         _doc <- openDoc "Foo.hs" "haskell"
 
     --         diags@(d:_) <- waitForDiagnosticsSource "bios"

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -44,7 +44,7 @@ tests = testGroup "code actions" [
 
 hlintTests :: TestTree
 hlintTests = testGroup "hlint suggestions" [
-    ignoreTestBecause "Broken" $ testCase "provides 3.8 code actions" $ runSession hieCommand fullCaps "test/testdata" $ do
+    ignoreTestBecause "Broken" $ testCase "provides 3.8 code actions" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "ApplyRefact2.hs" "haskell"
         diags@(reduceDiag:_) <- waitForDiagnostics
 
@@ -67,7 +67,7 @@ hlintTests = testGroup "hlint suggestions" [
 
         noDiagnostics
 
-    , ignoreTestBecause "Broken" $ testCase "falls back to pre 3.8 code actions" $ runSession hieCommand noLiteralCaps "test/testdata" $ do
+    , ignoreTestBecause "Broken" $ testCase "falls back to pre 3.8 code actions" $ runSession hlsCommand noLiteralCaps "test/testdata" $ do
         doc <- openDoc "ApplyRefact2.hs" "haskell"
 
         _ <- waitForDiagnostics
@@ -84,7 +84,7 @@ hlintTests = testGroup "hlint suggestions" [
 
         noDiagnostics
 
-    , ignoreTestBecause "Broken" $ testCase "runs diagnostics on save" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , ignoreTestBecause "Broken" $ testCase "runs diagnostics on save" $ runSession hlsCommand fullCaps "test/testdata" $ do
         let config = def { diagnosticsOnChange = False }
         sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
 
@@ -114,7 +114,7 @@ hlintTests = testGroup "hlint suggestions" [
 
 renameTests :: TestTree
 renameTests = testGroup "rename suggestions" [
-    ignoreTestBecause "Broken" $ testCase "works" $ runSession hieCommand noLiteralCaps "test/testdata" $ do
+    ignoreTestBecause "Broken" $ testCase "works" $ runSession hlsCommand noLiteralCaps "test/testdata" $ do
         doc <- openDoc "CodeActionRename.hs" "haskell"
 
         _ <- waitForDiagnosticsSource "bios"
@@ -126,7 +126,7 @@ renameTests = testGroup "rename suggestions" [
         liftIO $ x @?= "main = putStrLn \"hello\""
 
     , ignoreTestBecause "Broken" $ testCase "doesn't give both documentChanges and changes"
-        $ runSession hieCommand noLiteralCaps "test/testdata" $ do
+        $ runSession hlsCommand noLiteralCaps "test/testdata" $ do
             doc <- openDoc "CodeActionRename.hs" "haskell"
 
             _ <- waitForDiagnosticsSource "bios"
@@ -146,7 +146,7 @@ renameTests = testGroup "rename suggestions" [
 
 importTests :: TestTree
 importTests = testGroup "import suggestions" [
-    ignoreTestBecause "Broken" $ testCase "works with 3.8 code action kinds" $ runSession hieCommand fullCaps "test/testdata" $ do
+    ignoreTestBecause "Broken" $ testCase "works with 3.8 code action kinds" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "CodeActionImport.hs" "haskell"
         -- No Formatting:
         let config = def { formattingProvider = "none" }
@@ -181,7 +181,7 @@ packageTests :: TestTree
 packageTests = testGroup "add package suggestions" [
     ignoreTestBecause "Broken" $ testCase "adds to .cabal files" $ do
         flushStackEnvironment
-        runSession hieCommand fullCaps "test/testdata/addPackageTest/cabal-exe" $ do
+        runSession hlsCommand fullCaps "test/testdata/addPackageTest/cabal-exe" $ do
             doc <- openDoc "AddPackage.hs" "haskell"
 
             -- ignore the first empty hlint diagnostic publish
@@ -209,7 +209,7 @@ packageTests = testGroup "add package suggestions" [
                 any (\l -> "text -any" `T.isSuffixOf` l || "text : {} -any" `T.isSuffixOf` l) (T.lines contents) @? "Contains text package"
 
     , ignoreTestBecause "Broken" $ testCase "adds to hpack package.yaml files" $
-        runSession hieCommand fullCaps "test/testdata/addPackageTest/hpack-exe" $ do
+        runSession hlsCommand fullCaps "test/testdata/addPackageTest/hpack-exe" $ do
             doc <- openDoc "app/Asdf.hs" "haskell"
 
             -- ignore the first empty hlint diagnostic publish
@@ -242,7 +242,7 @@ packageTests = testGroup "add package suggestions" [
 redundantImportTests :: TestTree
 redundantImportTests = testGroup "redundant import code actions" [
     ignoreTestBecause "Broken" $ testCase "remove solitary redundant imports" $
-        runSession hieCommand fullCaps "test/testdata/redundantImportTest/" $ do
+        runSession hlsCommand fullCaps "test/testdata/redundantImportTest/" $ do
             doc <- openDoc "src/CodeActionRedundant.hs" "haskell"
 
             -- ignore the first empty hlint diagnostic publish
@@ -272,7 +272,7 @@ redundantImportTests = testGroup "redundant import code actions" [
             contents <- documentContents doc
             liftIO $ contents @?= "module CodeActionRedundant where\nmain :: IO ()\nmain = putStrLn \"hello\""
 
-    , ignoreTestBecause "Broken" $ testCase "doesn't touch other imports" $ runSession hieCommand noLiteralCaps "test/testdata/redundantImportTest/" $ do
+    , ignoreTestBecause "Broken" $ testCase "doesn't touch other imports" $ runSession hlsCommand noLiteralCaps "test/testdata/redundantImportTest/" $ do
         doc <- openDoc "src/MultipleImports.hs" "haskell"
         _   <- count 2 waitForDiagnostics
         [CACommand cmd, _] <- getAllCodeActions doc
@@ -289,7 +289,7 @@ redundantImportTests = testGroup "redundant import code actions" [
 typedHoleTests :: TestTree
 typedHoleTests = testGroup "typed hole code actions" [
     ignoreTestBecause "Broken" $ testCase "works" $
-        runSession hieCommand fullCaps "test/testdata" $ do
+        runSession hlsCommand fullCaps "test/testdata" $ do
             doc <- openDoc "TypedHoles.hs" "haskell"
             _ <- waitForDiagnosticsSource "bios"
             cas <- map (\(CACodeAction x)-> x) <$> getAllCodeActions doc
@@ -331,7 +331,7 @@ typedHoleTests = testGroup "typed hole code actions" [
                     ]
 
       , ignoreTestBecause "Broken" $ testCase "shows more suggestions" $
-            runSession hieCommand fullCaps "test/testdata" $ do
+            runSession hlsCommand fullCaps "test/testdata" $ do
                 doc <- openDoc "TypedHoles2.hs" "haskell"
                 _ <- waitForDiagnosticsSource "bios"
                 cas <- map fromAction <$> getAllCodeActions doc
@@ -387,7 +387,7 @@ typedHoleTests = testGroup "typed hole code actions" [
 signatureTests :: TestTree
 signatureTests = testGroup "missing top level signature code actions" [
     ignoreTestBecause "Broken" $ testCase "Adds top level signature" $
-      runSession hieCommand fullCaps "test/testdata/" $ do
+      runSession hlsCommand fullCaps "test/testdata/" $ do
         doc <- openDoc "TopLevelSignature.hs" "haskell"
 
         _ <- waitForDiagnosticsSource "bios"
@@ -413,7 +413,7 @@ signatureTests = testGroup "missing top level signature code actions" [
 missingPragmaTests :: TestTree
 missingPragmaTests = testGroup "missing pragma warning code actions" [
     ignoreTestBecause "Broken" $ testCase "Adds TypeSynonymInstances pragma" $
-        runSession hieCommand fullCaps "test/testdata/addPragmas" $ do
+        runSession hlsCommand fullCaps "test/testdata/addPragmas" $ do
             doc <- openDoc "NeedsPragmas.hs" "haskell"
 
             _ <- waitForDiagnosticsSource "bios"
@@ -450,7 +450,7 @@ missingPragmaTests = testGroup "missing pragma warning code actions" [
 unusedTermTests :: TestTree
 unusedTermTests = testGroup "unused term code actions" [
     -- ignoreTestBecause "Broken" $ testCase "Prefixes with '_'" $ pendingWith "removed because of HaRe"
-    --     runSession hieCommand fullCaps "test/testdata/" $ do
+    --     runSession hlsCommand fullCaps "test/testdata/" $ do
     --       doc <- openDoc "UnusedTerm.hs" "haskell"
     --
     --       _ <- waitForDiagnosticsSource "bios"
@@ -474,7 +474,7 @@ unusedTermTests = testGroup "unused term code actions" [
 
     -- See https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#textDocument_codeAction
     -- `CodeActionContext`
-    ignoreTestBecause "Broken" $ testCase "respect 'only' parameter" $ runSession hieCommand fullCaps "test/testdata" $ do
+    ignoreTestBecause "Broken" $ testCase "respect 'only' parameter" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc   <- openDoc "CodeActionOnly.hs" "haskell"
         _     <- count 2 waitForDiagnostics -- need to wait for both hlint and ghcmod
         diags <- getCurrentDiagnostics doc

--- a/test/functional/FunctionalLiquid.hs
+++ b/test/functional/FunctionalLiquid.hs
@@ -21,7 +21,7 @@ import           Test.Tasty.HUnit
 tests :: TestTree
 tests = testGroup "liquid haskell diagnostics" [
     ignoreTestBecause "Broken" $ testCase "runs diagnostics on save, no liquid" $
-        runSession hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+        runSession hlsCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
             doc <- openDoc "liquid/Evens.hs" "haskell"
 
             diags@(reduceDiag:_) <- waitForDiagnostics
@@ -51,8 +51,8 @@ tests = testGroup "liquid haskell diagnostics" [
     -- ---------------------------------
 
     , ignoreTestBecause "Broken" $ testCase "runs diagnostics on save, with liquid haskell" $
-        runSession hieCommand codeActionSupportCaps "test/testdata" $ do
-        -- runSessionWithConfig logConfig hieCommand codeActionSupportCaps "test/testdata" $ do
+        runSession hlsCommand codeActionSupportCaps "test/testdata" $ do
+        -- runSessionWithConfig logConfig hlsCommand codeActionSupportCaps "test/testdata" $ do
             doc <- openDoc "liquid/Evens.hs" "haskell"
 
             diags@(reduceDiag:_) <- waitForDiagnostics

--- a/test/functional/HieBios.hs
+++ b/test/functional/HieBios.hs
@@ -16,14 +16,14 @@ tests :: TestTree
 tests = testGroup "hie-bios" [
     ignoreTestBecause "Broken" $ testCase "loads modules inside main-is" $ do
         writeFile (hieBiosErrorPath </> "hie.yaml") ""
-        runSession hieCommand fullCaps "test/testdata/hieBiosMainIs" $ do
+        runSession hlsCommand fullCaps "test/testdata/hieBiosMainIs" $ do
             _ <- openDoc "Main.hs" "haskell"
             _ <- count 2 waitForDiagnostics
             return ()
 
     , ignoreTestBecause "Broken" $ testCase "reports errors in hie.yaml" $ do
         writeFile (hieBiosErrorPath </> "hie.yaml") ""
-        runSession hieCommand fullCaps hieBiosErrorPath $ do
+        runSession hlsCommand fullCaps hieBiosErrorPath $ do
             _ <- openDoc "Foo.hs" "haskell"
             _ <- skipManyTill loggingNotification (satisfy isMessage)
             return ()

--- a/test/functional/Highlight.hs
+++ b/test/functional/Highlight.hs
@@ -12,7 +12,7 @@ import Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "highlight" [
-    ignoreTestBecause "Broken" $ testCase "works" $ runSession hieCommand fullCaps "test/testdata" $ do
+    ignoreTestBecause "Broken" $ testCase "works" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Highlight.hs" "haskell"
         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
         highlights <- getHighlights doc (Position 2 2)

--- a/test/functional/ModuleName.hs
+++ b/test/functional/ModuleName.hs
@@ -26,7 +26,7 @@ import           Language.Haskell.LSP.Types     ( ApplyWorkspaceEditRequest
 import           System.FilePath                ( (<.>)
                                                 , (</>)
                                                 )
-import           Test.Hls.Util                  ( hieCommand )
+import           Test.Hls.Util                  ( hlsCommand )
 import           Test.Tasty                     ( TestTree
                                                 , testGroup
                                                 )
@@ -42,7 +42,7 @@ tests = testGroup
   ]
 
 goldenTest :: FilePath -> IO ()
-goldenTest input = runSession hieCommand fullCaps testdataPath $ do
+goldenTest input = runSession hlsCommand fullCaps testdataPath $ do
   doc                              <- openDoc input "haskell"
   -- getCodeLenses doc >>= liftIO . print . length
   [CodeLens { _command = Just c }] <- getCodeLenses doc

--- a/test/functional/Progress.hs
+++ b/test/functional/Progress.hs
@@ -21,7 +21,7 @@ tests :: TestTree
 tests = testGroup "window/workDoneProgress" [
     ignoreTestBecause "Broken" $ testCase "sends indefinite progress notifications" $
     -- Testing that ghc-mod sends progress notifications
-        runSession hieCommand progressCaps "test/testdata" $ do
+        runSession hlsCommand progressCaps "test/testdata" $ do
             doc <- openDoc "ApplyRefact2.hs" "haskell"
 
             skipMany loggingNotification
@@ -77,7 +77,7 @@ tests = testGroup "window/workDoneProgress" [
 
     , ignoreTestBecause "Broken" $ testCase "sends indefinite progress notifications with liquid" $
         -- Testing that Liquid Haskell sends progress notifications
-        runSession hieCommand progressCaps "test/testdata" $ do
+        runSession hlsCommand progressCaps "test/testdata" $ do
         doc <- openDoc "liquid/Evens.hs" "haskell"
 
         skipMany loggingNotification

--- a/test/functional/Reference.hs
+++ b/test/functional/Reference.hs
@@ -13,7 +13,7 @@ import Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "references" [
-    ignoreTestBecause "Broken" $ testCase "works with definitions" $ runSession hieCommand fullCaps "test/testdata" $ do
+    ignoreTestBecause "Broken" $ testCase "works with definitions" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "References.hs" "haskell"
         let pos = Position 2 7 -- foo = bar <--
         refs <- getReferences doc pos True
@@ -26,7 +26,7 @@ tests = testGroup "references" [
             , mkRange 2 6 2 9
             ] `isInfixOf` refs @? "Contains references"
     -- TODO: Respect withDeclaration parameter
-    -- ignoreTestBecause "Broken" $ testCase "works without definitions" $ runSession hieCommand fullCaps "test/testdata" $ do
+    -- ignoreTestBecause "Broken" $ testCase "works without definitions" $ runSession hlsCommand fullCaps "test/testdata" $ do
     --   doc <- openDoc "References.hs" "haskell"
     --   let pos = Position 2 7 -- foo = bar <--
     --   refs <- getReferences doc pos False

--- a/test/functional/Rename.hs
+++ b/test/functional/Rename.hs
@@ -12,7 +12,7 @@ tests :: TestTree
 tests = testGroup "rename" [
   testCase "works" $ True @?= True
   --  pendingWith "removed because of HaRe"
-  -- runSession hieCommand fullCaps "test/testdata" $ do
+  -- runSession hlsCommand fullCaps "test/testdata" $ do
   --   doc <- openDoc "Rename.hs" "haskell"
   --   rename doc (Position 3 1) "baz" -- foo :: Int -> Int
   --   documentContents doc >>= liftIO . flip shouldBe expected

--- a/test/functional/Symbol.hs
+++ b/test/functional/Symbol.hs
@@ -19,7 +19,7 @@ tests = testGroup "document symbols" [
 
 v310Tests :: TestTree
 v310Tests = testGroup "3.10 hierarchical document symbols" [
-    ignoreTestBecause "Broken" $ testCase "provides nested data types and constructors" $ runSession hieCommand fullCaps "test/testdata" $ do
+    ignoreTestBecause "Broken" $ testCase "provides nested data types and constructors" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Symbols.hs" "haskell"
         Left symbs <- getDocumentSymbols doc
 
@@ -29,7 +29,7 @@ v310Tests = testGroup "3.10 hierarchical document symbols" [
 
         liftIO $ myData `elem` symbs @? "Contains symbol"
 
-    ,ignoreTestBecause "Broken" $ testCase "provides nested where functions" $ runSession hieCommand fullCaps "test/testdata" $ do
+    ,ignoreTestBecause "Broken" $ testCase "provides nested where functions" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Symbols.hs" "haskell"
         Left symbs <- getDocumentSymbols doc
 
@@ -40,7 +40,7 @@ v310Tests = testGroup "3.10 hierarchical document symbols" [
 
         liftIO $ foo `elem` symbs @? "Contains symbol"
 
-    , ignoreTestBecause "Broken" $ testCase "provides pattern synonyms" $ runSession hieCommand fullCaps "test/testdata" $ do
+    , ignoreTestBecause "Broken" $ testCase "provides pattern synonyms" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Symbols.hs" "haskell"
         Left symbs <- getDocumentSymbols doc
 
@@ -54,7 +54,7 @@ v310Tests = testGroup "3.10 hierarchical document symbols" [
 
 pre310Tests :: TestTree
 pre310Tests = testGroup "pre 3.10 symbol information" [
-    ignoreTestBecause "Broken" $ testCase "provides nested data types and constructors" $ runSession hieCommand oldCaps "test/testdata" $ do
+    ignoreTestBecause "Broken" $ testCase "provides nested data types and constructors" $ runSession hlsCommand oldCaps "test/testdata" $ do
         doc@(TextDocumentIdentifier testUri) <- openDoc "Symbols.hs" "haskell"
         Right symbs <- getDocumentSymbols doc
 
@@ -64,7 +64,7 @@ pre310Tests = testGroup "pre 3.10 symbol information" [
 
         liftIO $ [myData, a, b] `isInfixOf` symbs @? "Contains symbols"
 
-    ,ignoreTestBecause "Broken" $ testCase "provides nested where functions" $ runSession hieCommand oldCaps "test/testdata" $ do
+    ,ignoreTestBecause "Broken" $ testCase "provides nested where functions" $ runSession hlsCommand oldCaps "test/testdata" $ do
         doc@(TextDocumentIdentifier testUri) <- openDoc "Symbols.hs" "haskell"
         Right symbs <- getDocumentSymbols doc
 

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -113,7 +113,7 @@ mkTest
     -> TestTree
 mkTest name fp line col ts =
   testCase name $ do
-  runSession hieCommand fullCaps tacticPath $ do
+  runSession hlsCommand fullCaps tacticPath $ do
     doc <- openDoc fp "haskell"
     actions <- getCodeActions doc $ pointRange line col
     let titles = mapMaybe codeActionTitle actions
@@ -127,7 +127,7 @@ mkTest name fp line col ts =
 goldenTest :: FilePath -> Int -> Int -> TacticCommand -> Text -> TestTree
 goldenTest input line col tc occ =
   testCase (input <> " (golden)") $ do
-    runSession hieCommand fullCaps tacticPath $ do
+    runSession hlsCommand fullCaps tacticPath $ do
       doc <- openDoc input "haskell"
       actions <- getCodeActions doc $ pointRange line col
       Just (CACodeAction (CodeAction {_command = Just c}))

--- a/test/functional/TypeDefinition.hs
+++ b/test/functional/TypeDefinition.hs
@@ -12,7 +12,7 @@ import Test.Tasty.HUnit
 tests :: TestTree
 tests = testGroup "type definitions" [
     ignoreTestBecause "Broken" $ testCase "finds local definition of record variable"
-        $ runSession hieCommand fullCaps "test/testdata/gototest"
+        $ runSession hlsCommand fullCaps "test/testdata/gototest"
         $ do
             doc  <- openDoc "src/Lib.hs" "haskell"
             defs <- getTypeDefinitions doc (toPos (11, 23))
@@ -22,7 +22,7 @@ tests = testGroup "type definitions" [
                                     (Range (toPos (8, 1)) (toPos (8, 29)))
                          ]
     , ignoreTestBecause "Broken" $ testCase "finds local definition of newtype variable"
-        $ runSession hieCommand fullCaps "test/testdata/gototest"
+        $ runSession hlsCommand fullCaps "test/testdata/gototest"
         $ do
             doc  <- openDoc "src/Lib.hs" "haskell"
             defs <- getTypeDefinitions doc (toPos (16, 21))
@@ -32,7 +32,7 @@ tests = testGroup "type definitions" [
                                     (Range (toPos (13, 1)) (toPos (13, 30)))
                          ]
     , ignoreTestBecause "Broken" $ testCase "finds local definition of sum type variable"
-        $ runSession hieCommand fullCaps "test/testdata/gototest"
+        $ runSession hlsCommand fullCaps "test/testdata/gototest"
         $ do
             doc  <- openDoc "src/Lib.hs" "haskell"
             defs <- getTypeDefinitions doc (toPos (21, 13))
@@ -42,7 +42,7 @@ tests = testGroup "type definitions" [
                                     (Range (toPos (18, 1)) (toPos (18, 26)))
                          ]
     , ignoreTestBecause "Broken" $ testCase "finds local definition of sum type contructor"
-            $ runSession hieCommand fullCaps "test/testdata/gototest"
+            $ runSession hlsCommand fullCaps "test/testdata/gototest"
             $ do
                 doc  <- openDoc "src/Lib.hs" "haskell"
                 defs <- getTypeDefinitions doc (toPos (24, 7))
@@ -53,14 +53,14 @@ tests = testGroup "type definitions" [
                                        (Range (toPos (18, 1)) (toPos (18, 26)))
                             ]
     , ignoreTestBecause "Broken" $ testCase "can not find non-local definition of type def"
-        $ runSession hieCommand fullCaps "test/testdata/gototest"
+        $ runSession hlsCommand fullCaps "test/testdata/gototest"
         $ do
             doc  <- openDoc "src/Lib.hs" "haskell"
             defs <- getTypeDefinitions doc (toPos (30, 17))
             liftIO $ defs @?= []
 
     , ignoreTestBecause "Broken" $ testCase "find local definition of type def"
-        $ runSession hieCommand fullCaps "test/testdata/gototest"
+        $ runSession hlsCommand fullCaps "test/testdata/gototest"
         $ do
             doc      <- openDoc "src/Lib.hs" "haskell"
             defs <- getTypeDefinitions doc (toPos (35, 16))
@@ -73,7 +73,7 @@ tests = testGroup "type definitions" [
     {--  TODO Implement
      , ignoreTestBecause "Broken" $ testCase "find type-definition of type def in component"
          $ pendingWith "Finding symbols cross module is currently not supported"
-         $ runSession hieCommand fullCaps "test/testdata/gototest"
+         $ runSession hlsCommand fullCaps "test/testdata/gototest"
          $ do
              doc      <- openDoc "src/Lib2.hs" "haskell"
              otherDoc <- openDoc "src/Lib.hs" "haskell"
@@ -87,7 +87,7 @@ tests = testGroup "type definitions" [
                             ]
     --}
     , ignoreTestBecause "Broken" $ testCase "find definition of parameterized data type"
-        $ runSession hieCommand fullCaps "test/testdata/gototest"
+        $ runSession hlsCommand fullCaps "test/testdata/gototest"
         $ do
             doc  <- openDoc "src/Lib.hs" "haskell"
             defs <- getTypeDefinitions doc (toPos (40, 19))

--- a/test/utils/Test/Hls/Util.hs
+++ b/test/utils/Test/Hls/Util.hs
@@ -6,9 +6,9 @@ module Test.Hls.Util
     , flushStackEnvironment
     , getHspecFormattedConfig
     , ghcVersion, GhcVersion(..)
-    , hieCommand
-    , hieCommandExamplePlugin
-    , hieCommandVomit
+    , hlsCommand
+    , hlsCommandExamplePlugin
+    , hlsCommandVomit
     , logConfig
     , logFilePath
     , noLogConfig
@@ -31,6 +31,7 @@ import           System.Environment
 import           System.FilePath
 import qualified System.Log.Logger as L
 import           System.IO.Temp
+import           System.IO.Unsafe
 import           Test.Hspec.Runner
 import           Test.Hspec.Core.Formatters
 import           Text.Blaze.Renderer.String (renderMarkup)
@@ -110,24 +111,23 @@ ghcVersion = GHC84
 #endif
 
 logFilePath :: String
-logFilePath = "hie-" ++ show ghcVersion ++ ".log"
+logFilePath = "hls-" ++ show ghcVersion ++ ".log"
 
 -- | The command to execute the version of hie for the current compiler.
 --
 -- Both @stack test@ and @cabal new-test@ setup the environment so @hie@ is
 -- on PATH. Cabal seems to respond to @build-tool-depends@ specifically while
 -- stack just puts all project executables on PATH.
-hieCommand :: String
--- hieCommand = "hie --lsp --bios-verbose -d -l test-logs/" ++ logFilePath
--- hieCommand = "haskell-language-server --lsp"
--- hieCommand = "haskell-language-server --lsp --test --shake-profiling=test-logs/" ++ logFilePath
-hieCommand = "haskell-language-server --lsp -d -l test-logs/" ++ logFilePath
+hlsCommand :: String
+hlsCommand = unsafePerformIO $ do
+  testExe <- fromMaybe "haskell-language-server" <$> lookupEnv "HLS_TEST_EXE"
+  pure $ testExe ++ " --lsp -d -l test-logs/" ++ logFilePath
 
-hieCommandVomit :: String
-hieCommandVomit = hieCommand ++ " --vomit"
+hlsCommandVomit :: String
+hlsCommandVomit = hlsCommand ++ " --vomit"
 
-hieCommandExamplePlugin :: String
-hieCommandExamplePlugin = hieCommand ++ " --example"
+hlsCommandExamplePlugin :: String
+hlsCommandExamplePlugin = hlsCommand ++ " --example"
 
 -- ---------------------------------------------------------------------
 

--- a/test/wrapper/Main.hs
+++ b/test/wrapper/Main.hs
@@ -1,9 +1,11 @@
-import Data.List
 import Data.Char
+import Data.List
+import Data.Maybe
 import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.HUnit
 import System.Process
+import System.Environment
 
 main :: IO ()
 main = do
@@ -25,7 +27,9 @@ projectGhcVersionTests = testGroup "--project-ghc-version"
 testDir :: FilePath -> String -> Assertion
 testDir dir expectedVer =
   withCurrentDirectoryInTmp dir $ do
-    actualVer <- trim <$> readProcess "haskell-language-server-wrapper" ["--project-ghc-version"] ""
+    testExe <- fromMaybe "haskell-language-server-wrapper"
+      <$> lookupEnv "HLS_WRAPPER_TEST_EXE"
+    actualVer <- trim <$> readProcess testExe ["--project-ghc-version"] ""
     actualVer @?= expectedVer
 
 trim :: String -> String


### PR DESCRIPTION
Following the discussion in #6 , it looks like we should probably move away from CircleCI at some point. This adds GitHub Actions CI workflows, reusing the infrastructure we already have for the static binaries. It should run the tests on linux, macOS and windows now. 