### PR TITLE
Use infix notation for destructing and splitting infix data cons

### DIFF
--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -153,10 +153,10 @@ buildDataCon jdg dc apps = do
                   $ CType arg
                   ) $ zip args [0..]
   pure
-    .  (rose (show dc) $ pure tr,)
+    . (rose (show dc) $ pure tr,)
     . noLoc
     $ case isTupleDataCon dc of
-      True -> tuple $ fmap unLoc sgs
+      True  -> tuple $ fmap unLoc sgs
       False -> foldl' (@@) (bvar' dcon_name) $ fmap unLoc sgs
 
 

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -100,6 +100,7 @@ tests = testGroup
   , goldenTest "GoldenFmapTree.hs"          4 11 Auto ""
   , goldenTest "GoldenGADTDestruct.hs"      7 17 Destruct "gadt"
   , goldenTest "GoldenGADTAuto.hs"          7 13 Auto ""
+  , goldenTest "GoldenSwapMany.hs"          2 12 Auto ""
   ]
 
 

--- a/test/testdata/tactic/GoldenFoldr.hs.expected
+++ b/test/testdata/tactic/GoldenFoldr.hs.expected
@@ -2,4 +2,4 @@ foldr2 :: (a -> b -> b) -> b -> [a] -> b
 foldr2 = (\ f_b b l_a
    -> case l_a of
         [] -> b
-        ((:) a l_a4) -> f_b a (foldr2 f_b b l_a4))
+        (a : l_a4) -> f_b a (foldr2 f_b b l_a4))

--- a/test/testdata/tactic/GoldenListFmap.hs.expected
+++ b/test/testdata/tactic/GoldenListFmap.hs.expected
@@ -2,4 +2,4 @@ fmapList :: (a -> b) -> [a] -> [b]
 fmapList = (\ fab l_a
    -> case l_a of
         [] -> []
-        ((:) a l_a3) -> (:) (fab a) (fmapList fab l_a3))
+        (a : l_a3) -> fab a : fmapList fab l_a3)

--- a/test/testdata/tactic/GoldenPureList.hs.expected
+++ b/test/testdata/tactic/GoldenPureList.hs.expected
@@ -1,2 +1,2 @@
 pureList :: a -> [a]
-pureList = (\ a -> (:) a [])
+pureList = (\ a -> a : [])

--- a/test/testdata/tactic/GoldenSwap.hs.expected
+++ b/test/testdata/tactic/GoldenSwap.hs.expected
@@ -1,2 +1,2 @@
 swap :: (a, b) -> (b, a)
-swap = (\ p_ab -> case p_ab of { ((,) a b) -> (,) b a })
+swap = (\ p_ab -> case p_ab of { (a, b) -> (b, a) })

--- a/test/testdata/tactic/GoldenSwapMany.hs
+++ b/test/testdata/tactic/GoldenSwapMany.hs
@@ -1,0 +1,2 @@
+swapMany :: (a, b, c, d, e) -> (e, d, c, b, a)
+swapMany = _

--- a/test/testdata/tactic/GoldenSwapMany.hs.expected
+++ b/test/testdata/tactic/GoldenSwapMany.hs.expected
@@ -1,0 +1,2 @@
+swapMany :: (a, b, c, d, e) -> (e, d, c, b, a)
+swapMany = (\ pabcde -> case pabcde of { (a, b, c, d, e) -> (e, d, c, b, a) })


### PR DESCRIPTION
The tactics plugin is a bit stupid when working with infix-defined datacons, both in expressions and patterns. For example it will produce `(,) a b` and `(:) a as` rather than the more natural `(a, b)` and `a : as`. This PR makes it do the right thing.

The solution is to inspect the data con when building an expression or pattern. Unfortunately tuples are extra special in GHC, so this introduces a special case for tuples, and another for everyday infix things (like list).

There's a bit of annoying fiddling in order to build the infix pattern. The logic is in `infixifyPatIfNecessary`, which is the only thing I'm not super comfortable with in the diff.

Fixes #468 