### PR TITLE
Wait for diagnostics in tactics tests

### DIFF
--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -122,6 +122,7 @@ mkTest name fp line col ts =
   testCase name $ do
   runSession hlsCommand fullCaps tacticPath $ do
     doc <- openDoc fp "haskell"
+    _ <- waitForDiagnostics
     actions <- getCodeActions doc $ pointRange line col
     let titles = mapMaybe codeActionTitle actions
     for_ ts $ \(f, tc, var) -> do
@@ -136,6 +137,7 @@ goldenTest input line col tc occ =
   testCase (input <> " (golden)") $ do
     runSession hlsCommand fullCaps tacticPath $ do
       doc <- openDoc input "haskell"
+      _ <- waitForDiagnostics
       actions <- getCodeActions doc $ pointRange line col
       Just (CACodeAction (CodeAction {_command = Just c}))
         <- pure $ find ((== Just (tacticTitle tc occ)) . codeActionTitle) actions


### PR DESCRIPTION
This appears to be the fix for the flaky tactics fixes, and should unblock #521 and #166. Thanks to @jneira for all of his hard work in tracking it down.