### PR TITLE
Add missing tactic subpackage in default stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - .
 - ./ghcide/
 - ./hls-plugin-api
+- ./plugins/tactics
 
 ghc-options:
   "$everything": -haddock


### PR DESCRIPTION
* It is not being built in ci (cause it is identical to `stack-8.6.5.yaml`) :thinking: 