### PR TITLE
Tactics support for using given constraints

### DIFF
--- a/plugins/tactics/hls-tactics-plugin.cabal
+++ b/plugins/tactics/hls-tactics-plugin.cabal
@@ -84,6 +84,7 @@ test-suite tests
   main-is: Main.hs
   other-modules:
     AutoTupleSpec
+    UnificationSpec
   hs-source-dirs:
       test
   ghc-options: -Wall -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N

--- a/plugins/tactics/src/Ide/Plugin/Tactic.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic.hs
@@ -265,6 +265,7 @@ judgementForHole state nfp range = do
                 $ getDefiningBindings binds rss)
               tcg
       hyps = hypothesisFromBindings rss binds
+          <> M.fromList (contextMethodHypothesis ctx)
   pure ( resulting_range
        , mkFirstJudgement
            hyps

--- a/plugins/tactics/src/Ide/Plugin/Tactic.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic.hs
@@ -265,10 +265,11 @@ judgementForHole state nfp range = do
                 $ getDefiningBindings binds rss)
               tcg
       hyps = hypothesisFromBindings rss binds
-          <> M.fromList (contextMethodHypothesis ctx)
+      ambient = M.fromList $ contextMethodHypothesis ctx
   pure ( resulting_range
        , mkFirstJudgement
            hyps
+           ambient
            (isRhsHole rss tcs)
            (maybe
               mempty

--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -29,7 +29,8 @@ import           Type hiding (Var)
 
 useOccName :: MonadState TacticState m => Judgement -> OccName -> m ()
 useOccName jdg name =
-  case M.lookup name $ jHypothesis jdg of
+  -- Only score points if this is in the local hypothesis
+  case M.lookup name $ jLocalHypothesis jdg of
     Just{}  -> modify $ withUsedVals $ S.insert name
     Nothing -> pure ()
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Context.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Context.hs
@@ -10,16 +10,38 @@ import Development.IDE.GHC.Compat
 import Ide.Plugin.Tactic.Types
 import OccName
 import TcRnTypes
+import Ide.Plugin.Tactic.GHC (tacticsThetaTy)
+import Ide.Plugin.Tactic.Machinery (methodHypothesis)
+import Data.Maybe (mapMaybe)
 
 
 mkContext :: [(OccName, CType)] -> TcGblEnv -> Context
-mkContext locals
-  = Context locals
-  . fmap splitId
-  . (getFunBindId =<<)
-  . fmap unLoc
-  . bagToList
-  . tcg_binds
+mkContext locals tcg = Context
+  { ctxDefiningFuncs = locals
+  , ctxModuleFuncs = fmap splitId
+                   . (getFunBindId =<<)
+                   . fmap unLoc
+                   . bagToList
+                   $ tcg_binds tcg
+  }
+
+
+contextMethodHypothesis :: Context -> [(OccName, CType)]
+contextMethodHypothesis
+  = join
+  . concatMap
+      ( mapMaybe methodHypothesis
+      . fmap unCType
+      . traceIdX "tacticsTheta"
+      . fmap CType
+      . tacticsThetaTy
+      . unCType
+      . traceIdX "method hypothesis"
+      -- TODO(sandy): unify the poly type with the defined type
+      . snd
+      )
+  -- TODO(sandy): use the defining funcs to find the poly type in module funcs
+  . ctxModuleFuncs
 
 
 splitId :: Id -> (OccName, CType)

--- a/plugins/tactics/src/Ide/Plugin/Tactic/GHC.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/GHC.hs
@@ -53,16 +53,25 @@ isFunction (tacticsSplitFunTy -> (_, _, [], _)) = False
 isFunction _ = True
 
 
+------------------------------------------------------------------------------
+-- | Split a function, also splitting out its quantified variables and theta
+-- context.
 tacticsSplitFunTy :: Type -> ([TyVar], ThetaType, [Type], Type)
 tacticsSplitFunTy t
   = let (vars, theta, t') = tcSplitSigmaTy t
         (args, res) = tcSplitFunTys t'
      in (vars, theta, args, res)
 
+
+------------------------------------------------------------------------------
+-- | Rip the theta context out of a regular type.
 tacticsThetaTy :: Type -> ThetaType
-tacticsThetaTy (tacticsSplitFunTy -> (_, theta, _, _)) = theta
+tacticsThetaTy (tcSplitSigmaTy -> (_, theta,  _)) = theta
 
 
+------------------------------------------------------------------------------
+-- | Instantiate all of the quantified type variables in a type with fresh
+-- skolems.
 freshTyvars :: MonadState TacticState m => Type -> m Type
 freshTyvars t = do
   let (tvs, _, _, _) = tacticsSplitFunTy t

--- a/plugins/tactics/src/Ide/Plugin/Tactic/GHC.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/GHC.hs
@@ -43,8 +43,15 @@ cloneTyVar t =
 ------------------------------------------------------------------------------
 -- | Is this a function type?
 isFunction :: Type -> Bool
-isFunction (tcSplitFunTys -> ((_:_), _)) = True
-isFunction _ = False
+isFunction (tacticsSplitFunTy -> (_, _, [], _)) = False
+isFunction _ = True
+
+
+tacticsSplitFunTy :: Type -> ([TyVar], ThetaType, [Type], Type)
+tacticsSplitFunTy t
+  = let (vars, theta, t') = tcSplitSigmaTy t
+        (args, res) = tcSplitFunTys t'
+     in (vars, theta, args, res)
 
 ------------------------------------------------------------------------------
 -- | Is this an algebraic type?

--- a/plugins/tactics/src/Ide/Plugin/Tactic/GHC.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/GHC.hs
@@ -6,7 +6,6 @@
 module Ide.Plugin.Tactic.GHC where
 
 import           Control.Monad.State
-import           Data.Map (Map)
 import qualified Data.Map as M
 import           Data.Maybe (isJust)
 import           Data.Traversable
@@ -59,6 +58,9 @@ tacticsSplitFunTy t
   = let (vars, theta, t') = tcSplitSigmaTy t
         (args, res) = tcSplitFunTys t'
      in (vars, theta, args, res)
+
+tacticsThetaTy :: Type -> ThetaType
+tacticsThetaTy (tacticsSplitFunTy -> (_, theta, _, _)) = theta
 
 
 freshTyvars :: MonadState TacticState m => Type -> m Type

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Judgements.hs
@@ -163,7 +163,10 @@ disallowing ns =
 
 
 jHypothesis :: Judgement' a -> Map OccName a
-jHypothesis = _jHypothesis
+jHypothesis = _jHypothesis <> _jAmbientHypothesis
+
+jLocalHypothesis :: Judgement' a -> Map OccName a
+jLocalHypothesis = _jHypothesis
 
 
 isPatVal :: Judgement' a -> OccName -> Bool
@@ -191,13 +194,15 @@ substJdg :: TCvSubst -> Judgement -> Judgement
 substJdg subst = fmap $ coerce . substTy subst . coerce
 
 mkFirstJudgement
-    :: M.Map OccName CType
+    :: M.Map OccName CType  -- ^ local hypothesis
+    -> M.Map OccName CType  -- ^ ambient hypothesis
     -> Bool  -- ^ are we in the top level rhs hole?
     -> M.Map OccName [[OccName]]  -- ^ existing pos vals
     -> Type
     -> Judgement' CType
-mkFirstJudgement hy top posvals goal = Judgement
+mkFirstJudgement hy ambient top posvals goal = Judgement
   { _jHypothesis        = hy
+  , _jAmbientHypothesis = ambient
   , _jDestructed        = mempty
   , _jPatternVals       = mempty
   , _jBlacklistDestruct = False

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Judgements.hs
@@ -162,9 +162,15 @@ disallowing ns =
   field @"_jHypothesis" %~ flip M.withoutKeys (S.fromList ns)
 
 
+------------------------------------------------------------------------------
+-- | The hypothesis, consisting of local terms and the ambient environment
+-- (includes and class methods.)
 jHypothesis :: Judgement' a -> Map OccName a
 jHypothesis = _jHypothesis <> _jAmbientHypothesis
 
+
+------------------------------------------------------------------------------
+-- | Just the local hypothesis.
 jLocalHypothesis :: Judgement' a -> Map OccName a
 jLocalHypothesis = _jHypothesis
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
@@ -142,9 +142,9 @@ scoreSolution
        )
 scoreSolution ext TacticState{..} holes
   = ( Penalize $ length holes
-    , Reward $ S.null $ ts_intro_vals S.\\ ts_used_vals
+    , Reward   $ S.null $ ts_intro_vals S.\\ ts_used_vals
     , Penalize $ S.size ts_intro_vals
-    , Reward $ S.size ts_used_vals
+    , Reward   $ S.size ts_used_vals
     , Penalize $ solutionSize ext
     )
 
@@ -196,7 +196,6 @@ methodHypothesis ty = do
   let methods = classMethods cls
       tvs     = classTyVars cls
       subst   = zipTvSubst tvs apps
-  traceMX "methods" $ unsafeRender methods
   pure $ methods <&> \method ->
     let (_, _, ty) = tcSplitSigmaTy $ idType method
     in (occName method,  CType $ substTy subst ty)

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
@@ -180,16 +180,13 @@ unify goal inst = do
 
 methodHypothesis :: PredType -> Maybe [(OccName, CType)]
 methodHypothesis ty = do
-  traceMX "pred ty " $ unsafeRender ty
   (tc, apps) <- splitTyConApp_maybe ty
-  traceMX "got a tycon" $ unsafeRender tc
   cls <- tyConClass_maybe tc
-  traceMX "got a cls" $ unsafeRender cls
   let methods = classMethods cls
-      tvs = classTyVars cls
-      subst = zipTvSubst tvs apps
-  -- TODO(sandy): strip out the theta type from the result
+      tvs     = classTyVars cls
+      subst   = zipTvSubst tvs apps
   traceMX "methods" $ unsafeRender methods
   pure $ methods <&> \method ->
-    (occName method,  CType $ substTy subst $ idType method)
+    let (_, _, ty) = tcSplitSigmaTy $ idType method
+    in (occName method,  CType $ substTy subst ty)
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
@@ -201,7 +201,10 @@ methodHypothesis ty = do
   let methods = classMethods cls
       tvs     = classTyVars cls
       subst   = zipTvSubst tvs apps
-  pure $ methods <&> \method ->
+  sc_methods <- fmap join
+              $ traverse (methodHypothesis . substTy subst)
+              $ classSCTheta cls
+  pure $ mappend sc_methods $ methods <&> \method ->
     let (_, _, ty) = tcSplitSigmaTy $ idType method
     in (occName method,  CType $ substTy subst ty)
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
@@ -170,3 +170,4 @@ unify goal inst = do
       modify (\s -> s { ts_unifier = unionTCvSubst subst (ts_unifier s) })
     Nothing -> throwError (UnificationError inst goal)
 
+

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Machinery.hs
@@ -208,3 +208,16 @@ methodHypothesis ty = do
     let (_, _, ty) = tcSplitSigmaTy $ idType method
     in (occName method,  CType $ substTy subst ty)
 
+
+------------------------------------------------------------------------------
+-- | Run the given tactic iff the current hole contains no univars. Skolems and
+-- already decided univars are OK though.
+requireConcreteHole :: TacticsM a -> TacticsM a
+requireConcreteHole m = do
+  jdg     <- goal
+  skolems <- gets $ S.fromList . ts_skolems
+  let vars = S.fromList $ tyCoVarsOfTypeWellScoped $ unCType $ jGoal jdg
+  case S.size $ vars S.\\ skolems of
+    0 -> m
+    _ -> throwError TooPolymorphic
+

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
@@ -14,6 +14,7 @@ module Ide.Plugin.Tactic.Tactics
   , runTactic
   ) where
 
+import           Control.Monad (when)
 import           Control.Monad.Except (throwError)
 import           Control.Monad.Reader.Class (MonadReader(ask))
 import           Control.Monad.State.Class
@@ -56,9 +57,8 @@ assume name = rule $ \jdg -> do
   case M.lookup name $ jHypothesis jdg of
     Just ty -> do
       unify ty $ jGoal jdg
-      case M.member name (jPatHypothesis jdg) of
-        True  -> setRecursionFrameData True
-        False -> pure ()
+      when (M.member name $ jPatHypothesis jdg) $
+        setRecursionFrameData True
       useOccName jdg name
       pure $ (tracePrim $ "assume " <> occNameString name, ) $ noLoc $ var' name
     Nothing -> throwError $ UndefinedHypothesis name

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
@@ -177,6 +177,7 @@ data TacticError
   | RecursionOnWrongParam OccName Int OccName
   | UnhelpfulDestruct OccName
   | UnhelpfulSplit OccName
+  | TooPolymorphic
   deriving stock (Eq)
 
 instance Show TacticError where
@@ -213,6 +214,8 @@ instance Show TacticError where
       "Destructing patval " <> show n <> " leads to no new types"
     show (UnhelpfulSplit n) =
       "Splitting constructor " <> show n <> " leads to no new goals"
+    show TooPolymorphic =
+      "The tactic isn't applicable because the goal is too polymorphic"
 
 
 ------------------------------------------------------------------------------

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
@@ -225,6 +225,10 @@ data Context = Context
   deriving stock (Eq, Ord)
 
 
+emptyContext :: Context
+emptyContext  = Context mempty mempty
+
+
 newtype Rose a = Rose (Tree a)
   deriving stock (Eq, Functor, Generic)
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
@@ -129,6 +129,9 @@ withIntroducedVals f =
 -- | The current bindings and goal for a hole to be filled by refinery.
 data Judgement' a = Judgement
   { _jHypothesis :: !(Map OccName a)
+  , _jAmbientHypothesis :: !(Map OccName a)
+    -- ^ Things in the hypothesis that were imported. Solutions don't get
+    -- points for using the ambient hypothesis.
   , _jDestructed :: !(Set OccName)
     -- ^ These should align with keys of _jHypothesis
   , _jPatternVals :: !(Set OccName)

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
@@ -22,23 +22,23 @@ module Ide.Plugin.Tactic.Types
   ) where
 
 import Control.Lens hiding (Context)
-import Data.Generics.Product (field)
 import Control.Monad.Reader
+import Control.Monad.State
+import Data.Coerce
 import Data.Function
+import Data.Generics.Product (field)
 import Data.Map (Map)
 import Data.Set (Set)
+import Data.Tree
 import Development.IDE.GHC.Compat hiding (Node)
 import Development.IDE.Types.Location
 import GHC.Generics
 import Ide.Plugin.Tactic.Debug
 import OccName
 import Refinery.Tactic
-import Type
-import Data.Tree
-import Data.Coerce
-import UniqSupply (takeUniqFromSupply, mkSplitUniqSupply, UniqSupply)
 import System.IO.Unsafe (unsafePerformIO)
-import Control.Monad.State
+import Type
+import UniqSupply (takeUniqFromSupply, mkSplitUniqSupply, UniqSupply)
 import Unique (Unique)
 
 
@@ -84,10 +84,14 @@ data TacticState = TacticState
 instance Show UniqSupply where
   show _ = "<uniqsupply>"
 
+
+------------------------------------------------------------------------------
+-- | A 'UniqSupply' to use in 'defaultTacticState'
 unsafeDefaultUniqueSupply :: UniqSupply
 unsafeDefaultUniqueSupply =
   unsafePerformIO $ mkSplitUniqSupply '🚒'
 {-# NOINLINE unsafeDefaultUniqueSupply #-}
+
 
 defaultTacticState :: TacticState
 defaultTacticState =
@@ -101,6 +105,8 @@ defaultTacticState =
     }
 
 
+------------------------------------------------------------------------------
+-- | Generate a new 'Unique'
 freshUnique :: MonadState TacticState m => m Unique
 freshUnique = do
   (uniq, supply) <- gets $ takeUniqFromSupply . ts_unique_gen
@@ -228,6 +234,8 @@ data Context = Context
   deriving stock (Eq, Ord)
 
 
+------------------------------------------------------------------------------
+-- | An empty context
 emptyContext :: Context
 emptyContext  = Context mempty mempty
 

--- a/plugins/tactics/test/AutoTupleSpec.hs
+++ b/plugins/tactics/test/AutoTupleSpec.hs
@@ -43,6 +43,7 @@ spec = describe "auto for tuple" $ do
             (Context [] [])
             (mkFirstJudgement
               (M.singleton (mkVarOcc "x") $ CType in_type)
+              mempty
               True
               mempty
               out_type)

--- a/plugins/tactics/test/UnificationSpec.hs
+++ b/plugins/tactics/test/UnificationSpec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module UnificationSpec where
+
+import           Control.Arrow
+import           Data.Bool (bool)
+import           Data.Functor ((<&>))
+import           Data.Traversable
+import           Data.Tuple (swap)
+import           Ide.Plugin.Tactic.Debug
+import           Ide.Plugin.Tactic.Machinery
+import           Ide.Plugin.Tactic.Types
+import           TcType (tcGetTyVar_maybe, substTy)
+import           Test.Hspec
+import           Test.QuickCheck
+import           Type (mkTyVarTy)
+import           TysPrim (alphaTyVars)
+import           TysWiredIn (mkBoxedTupleTy)
+import Data.Maybe (mapMaybe)
+
+
+instance Show Type where
+  show = unsafeRender
+
+
+spec :: Spec
+spec = describe "unification" $ do
+  it "should be able to unify univars with skolems on either side of the equality" $ do
+    property $ do
+      -- Pick some number of unification vars and skolem
+      n <- choose (1, 1)
+      let (skolems, take n -> univars) = splitAt n $ fmap mkTyVarTy alphaTyVars
+      -- Randomly pair them
+      skolem_uni_pairs <-
+        for (zip skolems univars) randomSwap
+      let (lhs, rhs)
+            = mkBoxedTupleTy *** mkBoxedTupleTy
+            $ unzip skolem_uni_pairs
+      pure $
+        counterexample (show skolems) $
+        counterexample (show lhs) $
+        counterexample (show rhs) $
+          case tryUnifyUnivarsButNotSkolems
+                 (mapMaybe tcGetTyVar_maybe skolems)
+                 (CType lhs)
+                 (CType rhs) of
+            Just subst ->
+              -- For each pair, running the unification over the univar should
+              -- result in the skolem
+              conjoin $ zip univars skolems <&> \(uni, skolem) ->
+                let substd = substTy subst uni
+                 in counterexample (show substd) $
+                    counterexample (show skolem) $
+                      CType substd === CType skolem
+            Nothing -> True === False
+
+
+randomSwap :: (a, a) -> Gen (a, a)
+randomSwap ab = do
+  which <- arbitrary
+  pure $ bool swap id which ab
+
+

--- a/plugins/tactics/test/UnificationSpec.hs
+++ b/plugins/tactics/test/UnificationSpec.hs
@@ -3,21 +3,21 @@
 
 module UnificationSpec where
 
-import           Control.Arrow
-import           Data.Bool (bool)
-import           Data.Functor ((<&>))
-import           Data.Traversable
-import           Data.Tuple (swap)
-import           Ide.Plugin.Tactic.Debug
-import           Ide.Plugin.Tactic.Machinery
-import           Ide.Plugin.Tactic.Types
-import           TcType (tcGetTyVar_maybe, substTy)
-import           Test.Hspec
-import           Test.QuickCheck
-import           Type (mkTyVarTy)
-import           TysPrim (alphaTyVars)
-import           TysWiredIn (mkBoxedTupleTy)
+import Control.Arrow
+import Data.Bool (bool)
+import Data.Functor ((<&>))
 import Data.Maybe (mapMaybe)
+import Data.Traversable
+import Data.Tuple (swap)
+import Ide.Plugin.Tactic.Debug
+import Ide.Plugin.Tactic.Machinery
+import Ide.Plugin.Tactic.Types
+import TcType (tcGetTyVar_maybe, substTy)
+import Test.Hspec
+import Test.QuickCheck
+import Type (mkTyVarTy)
+import TysPrim (alphaTyVars)
+import TysWiredIn (mkBoxedTupleTy)
 
 
 instance Show Type where

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -102,6 +102,9 @@ tests = testGroup
   , goldenTest "GoldenGADTAuto.hs"          7 13 Auto ""
   , goldenTest "GoldenSwapMany.hs"          2 12 Auto ""
   , goldenTest "GoldenBigTuple.hs"          4 12 Auto ""
+  , goldenTest "GoldenShow.hs"              2 10 Auto ""
+  , goldenTest "GoldenShowCompose.hs"       2 15 Auto ""
+  , goldenTest "GoldenShowMapChar.hs"       2 8  Auto ""
   ]
 
 

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -105,6 +105,7 @@ tests = testGroup
   , goldenTest "GoldenShow.hs"              2 10 Auto ""
   , goldenTest "GoldenShowCompose.hs"       2 15 Auto ""
   , goldenTest "GoldenShowMapChar.hs"       2 8  Auto ""
+  , goldenTest "GoldenSuperclass.hs"        7 8  Auto ""
   ]
 
 

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -106,6 +106,7 @@ tests = testGroup
   , goldenTest "GoldenShowCompose.hs"       2 15 Auto ""
   , goldenTest "GoldenShowMapChar.hs"       2 8  Auto ""
   , goldenTest "GoldenSuperclass.hs"        7 8  Auto ""
+  , goldenTest "GoldenApplicativeThen.hs"   2 11 Auto ""
   ]
 
 

--- a/test/testdata/tactic/GoldenApplicativeThen.hs
+++ b/test/testdata/tactic/GoldenApplicativeThen.hs
@@ -1,0 +1,2 @@
+useThen :: Applicative f => f Int -> f a -> f a
+useThen = _

--- a/test/testdata/tactic/GoldenApplicativeThen.hs.expected
+++ b/test/testdata/tactic/GoldenApplicativeThen.hs.expected
@@ -1,0 +1,2 @@
+useThen :: Applicative f => f Int -> f a -> f a
+useThen = (\ x x8 -> (*>) x x8)

--- a/test/testdata/tactic/GoldenShow.hs
+++ b/test/testdata/tactic/GoldenShow.hs
@@ -1,0 +1,2 @@
+showMe :: Show a => a -> String
+showMe = _

--- a/test/testdata/tactic/GoldenShow.hs.expected
+++ b/test/testdata/tactic/GoldenShow.hs.expected
@@ -1,0 +1,2 @@
+showMe :: Show a => a -> String
+showMe = show

--- a/test/testdata/tactic/GoldenShowCompose.hs
+++ b/test/testdata/tactic/GoldenShowCompose.hs
@@ -1,0 +1,2 @@
+showCompose :: Show a => (b -> a) -> b -> String
+showCompose = _

--- a/test/testdata/tactic/GoldenShowCompose.hs.expected
+++ b/test/testdata/tactic/GoldenShowCompose.hs.expected
@@ -1,0 +1,2 @@
+showCompose :: Show a => (b -> a) -> b -> String
+showCompose = (\ fba b -> show (fba b))

--- a/test/testdata/tactic/GoldenShowMapChar.hs
+++ b/test/testdata/tactic/GoldenShowMapChar.hs
@@ -1,0 +1,2 @@
+test :: Show a => a -> (String -> b) -> b
+test = _

--- a/test/testdata/tactic/GoldenShowMapChar.hs.expected
+++ b/test/testdata/tactic/GoldenShowMapChar.hs.expected
@@ -1,0 +1,2 @@
+test :: Show a => a -> (String -> b) -> b
+test = (\ a fl_cb -> fl_cb (show a))

--- a/test/testdata/tactic/GoldenSuperclass.hs
+++ b/test/testdata/tactic/GoldenSuperclass.hs
@@ -1,0 +1,8 @@
+class Super a where
+    super :: a
+
+class Super a => Sub a
+
+blah :: Sub a => a
+blah = _
+

--- a/test/testdata/tactic/GoldenSuperclass.hs.expected
+++ b/test/testdata/tactic/GoldenSuperclass.hs.expected
@@ -1,0 +1,8 @@
+class Super a where
+    super :: a
+
+class Super a => Sub a
+
+blah :: Sub a => a
+blah = super
+


### PR DESCRIPTION
This PR allows tactics to use methods from given constraints, meaning it can solve holes like this:

```haskell
showMe :: Show a => a -> String
showMe = _
```

It will not, however, discover instances. So this one *won't* solve:


```haskell
showMe :: Int -> String
showMe = _
```

There's quite a lot of finicky details going on in order to support this. The primary challenge is that our types are running after the typechecker has finished, meaning it's already solved the constraints and inlined their evidence. Our solution is to look up the written polymorphic type and unify it with the final, typechecked type. We can use the polymorphic type to find the theta context, and instantiate every class method in the theta.

In addition, this PR fixes a subtle bug in our unification code, which could cause skolems to unify in some circumstances.

Furthermore, it adds a tie-breaker to the scoring metric to prefer shorter programs.