### PR TITLE
Discover skolems in the hypothesis, not just goal

### DIFF
--- a/plugins/tactics/src/Ide/Plugin/Tactic/Auto.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Auto.hs
@@ -1,12 +1,13 @@
 module Ide.Plugin.Tactic.Auto where
 
+import Control.Monad.State (gets)
 import Ide.Plugin.Tactic.Context
 import Ide.Plugin.Tactic.Judgements
 import Ide.Plugin.Tactic.KnownStrategies
+import Ide.Plugin.Tactic.Machinery (tracing)
 import Ide.Plugin.Tactic.Tactics
 import Ide.Plugin.Tactic.Types
 import Refinery.Tactic
-import Ide.Plugin.Tactic.Machinery (tracing)
 
 
 ------------------------------------------------------------------------------
@@ -14,9 +15,11 @@ import Ide.Plugin.Tactic.Machinery (tracing)
 auto :: TacticsM ()
 auto = do
   jdg <- goal
+  skolems <- gets ts_skolems
   current <- getCurrentDefinitions
   traceMX "goal" jdg
   traceMX "ctx" current
+  traceMX "skolems" skolems
   commit knownStrategies
     . tracing "auto"
     . localTactic (auto' 4)

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -153,7 +153,7 @@ goldenTest input line col tc occ =
       actions <- getCodeActions doc $ pointRange line col
       Just (CACodeAction (CodeAction {_command = Just c}))
         <- pure $ find ((== Just (tacticTitle tc occ)) . codeActionTitle) actions
-      resp <- executeCommandWithResp c
+      executeCommand c
       _resp :: ApplyWorkspaceEditRequest <- skipManyTill anyMessage message
       edited <- documentContents doc
       let expected_name = tacticPath </> input <.> "expected"

--- a/test/testdata/tactic/GoldenFish.hs
+++ b/test/testdata/tactic/GoldenFish.hs
@@ -1,0 +1,5 @@
+-- There was an old bug where we would only pull skolems from the hole, rather
+-- than the entire hypothesis. Because of this, the 'b' here would be
+-- considered a univar, which could then be unified with the skolem 'c'.
+fish :: Monad m => (a -> m b) -> (b -> m c) -> a -> m c
+fish amb bmc a = _


### PR DESCRIPTION
The tactics plugin was only discovering skolem types present in the hole, rather than anywhere in the hypothesis. #541 gives the following repro:

```haskell
foo :: Monad m => (a -> m b) -> (b -> m c) -> (a -> m c)
foo f g a = _
```

here, the hole has type `_ :: m c`, which means tactics doesn't realize `a` and `b` are skolems, and instead treats them as unifiable variables. Thus the insane solution of `f a`.

Fixes #541 