### PR TITLE
Better scoring metric for deriving safeHead

### DIFF
--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -35,7 +35,7 @@ useOccName :: MonadState TacticState m => Judgement -> OccName -> m ()
 useOccName jdg name =
   -- Only score points if this is in the local hypothesis
   case M.lookup name $ jLocalHypothesis jdg of
-    Just{}  -> traceX "using occname " name $ modify
+    Just{}  -> modify
              $ (withUsedVals $ S.insert name)
              . (field @"ts_unused_top_vals" %~ S.delete name)
     Nothing -> pure ()

--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -1,12 +1,16 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections    #-}
 {-# LANGUAGE ViewPatterns     #-}
 
 module Ide.Plugin.Tactic.CodeGen where
 
+import           Control.Lens ((+~), (%~), (<>~))
 import           Control.Monad.Except
 import           Control.Monad.State (MonadState)
 import           Control.Monad.State.Class (modify)
+import           Data.Generics.Product (field)
 import           Data.List
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -31,8 +35,23 @@ useOccName :: MonadState TacticState m => Judgement -> OccName -> m ()
 useOccName jdg name =
   -- Only score points if this is in the local hypothesis
   case M.lookup name $ jLocalHypothesis jdg of
-    Just{}  -> modify $ withUsedVals $ S.insert name
+    Just{}  -> traceX "using occname " name $ modify
+             $ (withUsedVals $ S.insert name)
+             . (field @"ts_unused_top_vals" %~ S.delete name)
     Nothing -> pure ()
+
+
+------------------------------------------------------------------------------
+-- | Doing recursion incurs a small penalty in the score.
+penalizeRecursion :: MonadState TacticState m => m ()
+penalizeRecursion = modify $ field @"ts_recursion_penality" +~ 1
+
+
+------------------------------------------------------------------------------
+-- | Insert some values into the unused top values field. These are
+-- subsequently removed via 'useOccName'.
+addUnusedTopVals :: MonadState TacticState m => S.Set OccName -> m ()
+addUnusedTopVals vals = modify $ field @"ts_unused_top_vals" <>~ vals
 
 
 destructMatches

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Judgements.hs
@@ -75,6 +75,13 @@ introducing ns =
   field @"_jHypothesis" <>~ M.fromList ns
 
 
+------------------------------------------------------------------------------
+-- | Add some terms to the ambient hypothesis
+introducingAmbient :: [(OccName, a)] -> Judgement' a -> Judgement' a
+introducingAmbient ns =
+  field @"_jAmbientHypothesis" <>~ M.fromList ns
+
+
 filterPosition :: OccName -> Int -> Judgement -> Judgement
 filterPosition defn pos jdg =
     withHypothesis (M.filterWithKey go) jdg

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Tactics.hs
@@ -69,8 +69,9 @@ recursion = requireConcreteHole $ tracing "recursion" $ do
   defs <- getCurrentDefinitions
   attemptOn (const $ fmap fst defs) $ \name -> do
     modify $ withRecursionStack (False :)
+    penalizeRecursion
     ensure recursiveCleanup (withRecursionStack tail) $ do
-      (localTactic (apply name) $ introducing defs)
+      (localTactic (apply name) $ introducingAmbient defs)
         <@> fmap (localTactic assumption . filterPosition name) [0..]
 
 
@@ -88,6 +89,7 @@ intros = rule $ \jdg -> do
       let jdg' = introducing (zip vs $ coerce as)
                $ withNewGoal (CType b) jdg
       modify $ withIntroducedVals $ mappend $ S.fromList vs
+      when (isTopHole jdg) $ addUnusedTopVals $ S.fromList vs
       (tr, sg)
         <- newSubgoal
           $ bool

--- a/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/Types.hs
@@ -74,10 +74,21 @@ instance Show DataCon where
 ------------------------------------------------------------------------------
 data TacticState = TacticState
     { ts_skolems   :: !([TyVar])
+      -- ^ The known skolems.
     , ts_unifier   :: !(TCvSubst)
+      -- ^ The current substitution of univars.
     , ts_used_vals :: !(Set OccName)
+      -- ^ Set of values used by tactics.
     , ts_intro_vals :: !(Set OccName)
+      -- ^ Set of values introduced by tactics.
+    , ts_unused_top_vals :: !(Set OccName)
+      -- ^ Set of currently unused arguments to the function being defined.
     , ts_recursion_stack :: ![Bool]
+      -- ^ Stack for tracking whether or not the current recursive call has
+      -- used at least one smaller pat val. Recursive calls for which this
+      -- value is 'False' are guaranteed to loop, and must be pruned.
+    , ts_recursion_penality :: !Int
+      -- ^ Number of calls to recursion. We penalize each.
     , ts_unique_gen :: !UniqSupply
     } deriving stock (Show, Generic)
 
@@ -100,7 +111,9 @@ defaultTacticState =
     , ts_unifier         = emptyTCvSubst
     , ts_used_vals       = mempty
     , ts_intro_vals      = mempty
+    , ts_unused_top_vals = mempty
     , ts_recursion_stack = mempty
+    , ts_recursion_penality = 0
     , ts_unique_gen      = unsafeDefaultUniqueSupply
     }
 

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -107,6 +107,7 @@ tests = testGroup
   , goldenTest "GoldenShowMapChar.hs"       2 8  Auto ""
   , goldenTest "GoldenSuperclass.hs"        7 8  Auto ""
   , goldenTest "GoldenApplicativeThen.hs"   2 11 Auto ""
+  , goldenTest "GoldenSafeHead.hs"          2 12 Auto ""
   ]
 
 

--- a/test/testdata/tactic/GoldenSafeHead.hs
+++ b/test/testdata/tactic/GoldenSafeHead.hs
@@ -1,0 +1,2 @@
+safeHead :: [x] -> Maybe x
+safeHead = _

--- a/test/testdata/tactic/GoldenSafeHead.hs.expected
+++ b/test/testdata/tactic/GoldenSafeHead.hs.expected
@@ -1,0 +1,5 @@
+safeHead :: [x] -> Maybe x
+safeHead = (\ l_x
+   -> case l_x of
+        [] -> Nothing
+        (x : l_x2) -> Just x)


### PR DESCRIPTION
This PR tweaks the scoring metric to heavily penalize not using top-level function arguments when defining functions. Presumably if they were added to the type sig, someone had intention behind it. Note that this doesn't prevent us from deriving `const`, since we have no better alternatives in that case.

Furthermore, this fixes a bug where recursive calls were added to the `jLocalHypothesis` rather than `jAmbientHypothesis`. The former is for locally introduced variables, for which usage is rewarded. The result was that we were accidentally rewarding recursive calls! Instead we'd like to penalize them, so this PR adds a field which counts recursive calls and penalizes them.

Fixes #539 