### PR TITLE
Ignore flakey tactics test

### DIFF
--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -9,6 +9,7 @@ module Tactic
 where
 
 import           Control.Applicative.Combinators ( skipManyTill )
+import           Control.Monad (unless)
 import           Control.Monad.IO.Class
 import           Data.Foldable
 import           Data.Maybe
@@ -18,12 +19,12 @@ import qualified Data.Text.IO as T
 import           Ide.Plugin.Tactic.TestTypes
 import           Language.Haskell.LSP.Test
 import           Language.Haskell.LSP.Types (ApplyWorkspaceEditRequest, Position(..) , Range(..) , CAResult(..) , CodeAction(..))
+import           System.Directory (doesFileExist)
+import           System.FilePath
 import           Test.Hls.Util
 import           Test.Tasty
+import           Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import           Test.Tasty.HUnit
-import           System.FilePath
-import System.Directory (doesFileExist)
-import Control.Monad (unless)
 
 
 ------------------------------------------------------------------------------
@@ -106,8 +107,8 @@ tests = testGroup
   , goldenTest "GoldenShowCompose.hs"       2 15 Auto ""
   , goldenTest "GoldenShowMapChar.hs"       2 8  Auto ""
   , goldenTest "GoldenSuperclass.hs"        7 8  Auto ""
-  -- TODO(sandy): ignored, as it's slow and flakey in CI
-  -- , goldenTest "GoldenApplicativeThen.hs"   2 11 Auto ""
+  , ignoreTestBecause "It is unreliable in circleci builds"
+      $ goldenTest "GoldenApplicativeThen.hs"   2 11 Auto ""
   ]
 
 

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -106,7 +106,8 @@ tests = testGroup
   , goldenTest "GoldenShowCompose.hs"       2 15 Auto ""
   , goldenTest "GoldenShowMapChar.hs"       2 8  Auto ""
   , goldenTest "GoldenSuperclass.hs"        7 8  Auto ""
-  , goldenTest "GoldenApplicativeThen.hs"   2 11 Auto ""
+  -- TODO(sandy): ignored, as it's slow and flakey in CI
+  -- , goldenTest "GoldenApplicativeThen.hs"   2 11 Auto ""
   ]
 
 


### PR DESCRIPTION
Due to an oversight in how we handle polymorphic class methods (fixed in #537), having an applicative context introduces `(*>)` into scope, which causes an exponential explosion in the search space. On fast machines it seems like we can get through this test before the timeout, but on CI it's flakey.