### PR TITLE
Fix tasty rerun 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
             - cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Build
-          command: nix-shell -j4 --run "cabal new-update && cabal new-build -j1 --enable-tests"
+          command: nix-shell -j4 --run "cabal new-update && (cabal new-build -j1 --enable-tests || cabal new-build -j1 --enable-tests) "
           no_output_timeout: 30m
       - save_cache:
           key: cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,20 +64,21 @@ defaults: &defaults
         no_output_timeout: 120m
 
     - run:
-        name: Test haskell-language-server
+        name: Test haskell-language-server func-test suite
         # Tasty by default will run all the tests in parallel. Which should
         # work ok, but given that these CircleCI runners aren't the beefiest
         # machine can cause some flakiness. So pass -j1 to Tasty (NOT Stack) to
         # tell it to go slow and steady.
-        command: stack --stack-yaml=${STACK_FILE} test haskell-language-server --dump-logs --test-arguments="-j1 --rerun-update" || stack --stack-yaml=${STACK_FILE} test haskell-language-server --dump-logs --test-arguments="-j1 --rerun" || stack --stack-yaml=${STACK_FILE} test haskell-language-server --dump-logs --test-arguments="-j1 --rerun"
+        command: stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun-update" || stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun"
         no_output_timeout: 120m
 
     - run:
+        name: Test haskell-language-server wrapper-test suite
+        command: stack --stack-yaml=${STACK_FILE} test haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1"
+        no_output_timeout: 30m
+
+    - run:
         name: Test hls-tactics-plugin
-        # Tasty by default will run all the tests in parallel. Which should
-        # work ok, but given that these CircleCI runners aren't the beefiest
-        # machine can cause some flakiness. So pass -j1 to Tasty (NOT Stack) to
-        # tell it to go slow and steady.
         command: stack --stack-yaml=${STACK_FILE} test hls-tactics-plugin:test:tests --dump-logs --test-arguments="-j1"
         no_output_timeout: 30m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ defaults: &defaults
 
     - run:
         name: Test haskell-language-server wrapper-test suite
-        command: stack --stack-yaml=${STACK_FILE} test haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1"
+        command: stack --stack-yaml=${STACK_FILE} test haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1" || stack --stack-yaml=${STACK_FILE} test haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1"
         no_output_timeout: 30m
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,10 +129,10 @@ jobs:
       - STACK_FILE: "stack-8.10.2.yaml"
     <<: *defaults
 
-  # ghc-nightly:
-  #   environment:
-  #     - STACK_FILE: "stack.yaml"
-  #   <<: *defaults
+  ghc-nightly:
+    environment:
+      - STACK_FILE: "stack.yaml"
+    <<: *defaults
 
   cabal:
     working_directory: ~/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,4 @@ jobs:
       # run the tests without parallelism, otherwise tasty will attempt to run
       # all functional test cases simultaneously which causes way too many hls
       # instances to be spun up for the poor github actions runner to handle
-      run: cabal test wrapper-test --test-options="-j1"
+      run: cabal test wrapper-test --test-options="-j1" || cabal test wrapper-test --test-options="-j1" || cabal test wrapper-test --test-options="-j1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,8 @@ jobs:
       shell: bash
       # Retry it three times to workaround compiler segfaults in windows
       run: cabal build || cabal build || cabal build
-    - name: Test
+    
+    - name: Test func-test suite
       shell: bash
       env:
         HLS_TEST_EXE: hls
@@ -66,5 +67,14 @@ jobs:
       # run the tests without parallelism, otherwise tasty will attempt to run
       # all functional test cases simultaneously which causes way too many hls
       # instances to be spun up for the poor github actions runner to handle
-      run: cabal test --test-options="-j1 --rerun-update" || cabal test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test --test-options="-j1 --rerun"
+      run: cabal test func-test --test-options="-j1 --rerun-update" || cabal test func-test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test func-test --test-options="-j1 --rerun"
 
+    - name: Test wrapper-test suite
+      shell: bash
+      env:
+        HLS_TEST_EXE: hls
+        HLS_WRAPPER_TEST_EXE: hls-wrapper
+      # run the tests without parallelism, otherwise tasty will attempt to run
+      # all functional test cases simultaneously which causes way too many hls
+      # instances to be spun up for the poor github actions runner to handle
+      run: cabal test wrapper-test --test-options="-j1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       shell: bash
       # Retry it three times to workaround compiler segfaults in windows
       run: cabal build || cabal build || cabal build
-    
+
     - name: Test func-test suite
       shell: bash
       env:

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,8 +29,8 @@ extra-deps:
 # - ghcide-0.1.0
 - ghc-check-0.5.0.1
 - ghc-exactprint-0.6.3.2
-- ghc-lib-8.10.2.20200808
-- ghc-lib-parser-8.10.2.20200808
+- ghc-lib-8.10.2.20200916
+- ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
 - ghc-source-gen-0.4.0.0
 - haddock-api-2.22.0@rev:1
@@ -42,7 +42,7 @@ extra-deps:
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.1.0
+- implicit-hie-0.1.2.0
 - indexed-profunctors-0.1
 - lens-4.18
 - lsp-test-0.11.0.6


### PR DESCRIPTION
* Fix `stack.yaml` extra-deps
* Add default `stack.yaml` to circleci, to prevent more breakages
* Fix `tasty --rerun` separating `func-test` from `wrapper-test`
  * `wrapper-test` is the last suite and it was updating `.tasty-rerun-log`, marking it as all green, so the next execution was executing all tests again always