### PR TITLE
Update implicit-hie & ghcide

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,10 +28,11 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-11-10T05:11:46Z
+index-state: 2020-11-12T03:53:09Z
 
 allow-newer: data-tree-print:base
 
 -- To ensure the build get the version with the fix for #498
 -- Remove when the constraint is included upstream
-constraints: implicit-hie >= 0.1.2.0
+constraints: implicit-hie >= 0.1.2.3
+constraints: implicit-hie-cradle >= 0.3.0.0

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -24,8 +24,8 @@ extra-deps:
 - hie-bios-0.7.1
 - hlint-3.2
 - HsYAML-aeson-0.2.0.0@rev:2
-- implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.2.0
+- implicit-hie-cradle-0.3.0.0
+- implicit-hie-0.1.2.3
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -19,8 +19,8 @@ extra-deps:
 - data-tree-print-0.1.0.2
 - floskell-0.10.4
 - fourmolu-0.2.0.0
-- implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.2.0
+- implicit-hie-cradle-0.3.0.0
+- implicit-hie-0.1.2.3
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -42,8 +42,8 @@ extra-deps:
 - hlint-3.2
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
-- implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.2.0
+- implicit-hie-cradle-0.3.0.0
+- implicit-hie-0.1.2.3
 - indexed-profunctors-0.1
 - lens-4.18
 - lsp-test-0.11.0.6

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -41,8 +41,8 @@ extra-deps:
 - hlint-3.2
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
-- implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.2.0
+- implicit-hie-cradle-0.3.0.0
+- implicit-hie-0.1.2.3
 - indexed-profunctors-0.1
 - lens-4.18
 - lsp-test-0.11.0.6

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -40,8 +40,8 @@ extra-deps:
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
 - ilist-0.3.1.0
-- implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.2.0
+- implicit-hie-cradle-0.3.0.0
+- implicit-hie-0.1.2.3
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -34,8 +34,8 @@ extra-deps:
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - ilist-0.3.1.0
-- implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.2.0
+- implicit-hie-cradle-0.3.0.0
+- implicit-hie-0.1.2.3
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - ormolu-0.1.3.0

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -32,8 +32,8 @@ extra-deps:
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - ilist-0.3.1.0
-- implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.2.0
+- implicit-hie-cradle-0.3.0.0
+- implicit-hie-0.1.2.3
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - refinery-0.3.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,8 +41,8 @@ extra-deps:
 - hlint-3.2
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
-- implicit-hie-cradle-0.2.0.1
-- implicit-hie-0.1.2.0
+- implicit-hie-cradle-0.3.0.0
+- implicit-hie-0.1.2.3
 - indexed-profunctors-0.1
 - lens-4.18
 - lsp-test-0.11.0.6


### PR DESCRIPTION
> # Changelog for implicit-hie-cradle
> 
> ## 0.3.0.0
> Match `implicit-hie`'s cradle type ordering.
> This is technically a breaking change.