### PR TITLE
Hlint: bring over idea2Message for formatting

### DIFF
--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -122,11 +122,21 @@ rules = do
           -- we are encoding the fact that idea has refactorings in diagnostic code
           , _code     = Just (LSP.StringValue $ T.pack $ codePre ++ ideaHint idea)
           , _source   = Just "hlint"
-          , _message  = T.pack $ show idea
+          , _message  = idea2Message idea
           , _relatedInformation = Nothing
           , _tags     = Nothing
         }
         where codePre = if null $ ideaRefactoring idea then "" else "refact:"
+
+      idea2Message :: Idea -> T.Text
+      idea2Message idea = T.unlines $ [T.pack $ ideaHint idea, "Found:", "  " <> T.pack (ideaFrom idea)]
+                                     <> toIdea <> map (T.pack . show) (ideaNote idea)
+        where
+          toIdea :: [T.Text]
+          toIdea = case ideaTo idea of
+            Nothing -> []
+            Just i  -> [T.pack "Why not:", T.pack $ "  " ++ i]
+
 
       parseErrorToDiagnostic :: ParseError -> Diagnostic
       parseErrorToDiagnostic (Hlint.ParseError l msg contents) =


### PR DESCRIPTION
This restores the hlint formatting from haskell-ide-engine

Closes #553

What it looks like now (in emacs)

![image](https://user-images.githubusercontent.com/409607/99150235-eb4d8300-268a-11eb-9a59-06632856eb48.png)

![image](https://user-images.githubusercontent.com/409607/99150245-fd2f2600-268a-11eb-8167-372452f006d0.png)
