### PR TITLE
Fix fourmolu plugin inconsistent formatting

### DIFF
--- a/plugins/default/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/default/src/Ide/Plugin/Fourmolu.hs
@@ -59,7 +59,7 @@ provider lf ideState typ contents fp fo = withIndefiniteProgress lf title Cancel
                     , cfgDebug = True
                     , cfgPrinterOpts =
                         fillMissingPrinterOpts
-                            (lspPrinterOpts <> printerOpts)
+                            (printerOpts <> lspPrinterOpts)
                             defaultPrinterOpts
                     }
 


### PR DESCRIPTION
![fix-fourmolu](https://user-images.githubusercontent.com/4299733/99155331-85dcaf00-26e9-11eb-8196-0048f49bc89a.gif)
~~**The Problem**: fourmolu plugin sets its indentation size from the editor (inferred from source file tab size or EditorConfig) when no `fourmolu.yaml` found. In other words: different formatting results between the plugin and the cli.~~

~~This little fix will prevent fourmolu from getting the editor's `tabSize`.~~
~~Hopefully, it will solve the problem.~~

**EDIT**:
> > And when I test it with fourmolu.yaml, it prioritizes the editor's indentation level over the config file even without EditorConfig.
>
> Ah, that is the wrong way round. Should be a one line fix.

 It fixes fourmolu plugin's use of FormattingOptions.