### PR TITLE
Always use utf-8 when opening file handles

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE RecordWildCards   #-}
 module Main(main) where
 
+import           Main.Utf8                 (withUtf8)
+
 import           Ide.Arguments             (Arguments (..), LspArguments (..),
                                             getArguments)
 import           Ide.Main                  (defaultMain)
@@ -72,7 +74,7 @@ idePlugins includeExamples = pluginDescToIdePlugins allPlugins
 -- ---------------------------------------------------------------------
 
 main :: IO ()
-main = do
+main = withUtf8 $ do
     args <- getArguments "haskell-language-server"
 
     let withExamples =

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -4,6 +4,7 @@
 module Main where
 
 import Control.Monad.Extra
+import Main.Utf8
 import Data.Foldable
 import Data.List
 import Data.Void
@@ -23,7 +24,7 @@ import System.Process
 -- ---------------------------------------------------------------------
 
 main :: IO ()
-main = do
+main = withUtf8 $ do
   -- WARNING: If you write to stdout before runLanguageServer
   --          then the language server will not work
   args <- getArguments "haskell-language-server-wrapper"

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -144,6 +144,7 @@ executable haskell-language-server
     , time
     , transformers
     , unordered-containers
+    , with-utf8
 
   if flag(agpl)
     build-depends: brittany
@@ -177,6 +178,7 @@ executable haskell-language-server-wrapper
     , hie-bios
     , optparse-applicative
     , optparse-simple
+    , with-utf8
     , process
 
   default-language: Haskell2010


### PR DESCRIPTION
Inspired by a recent blog post https://www.snoyman.com/blog/2020/10/haskell-bad-parts-1, I started using `with-utf8` everywhere to avoid encoding bugs in the future.

Since #601 looks like such an encoding bug, I thought, maybe this can be fixed with `with-utf8`, too. 