### PR TITLE
Bump ormolu to 0.1.4.1

### DIFF
--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -29,7 +29,7 @@ extra-deps:
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
-- ormolu-0.1.3.0
+- ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1
 - stylish-haskell-0.12.2.0

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-10-19
+resolver: nightly-2020-11-22
 
 packages:
 - .

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -23,6 +23,7 @@ extra-deps:
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2
+- Diff-0.4.0
 - extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.2.0.0
@@ -51,7 +52,7 @@ extra-deps:
 - opentelemetry-0.4.2
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
-- ormolu-0.1.3.0
+- ormolu-0.1.4.1
 - parser-combinators-1.2.1
 - primitive-0.7.1.0
 - refinery-0.3.0.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -22,6 +22,7 @@ extra-deps:
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2
+- Diff-0.4.0
 - extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.2.0.0
@@ -50,7 +51,7 @@ extra-deps:
 - opentelemetry-0.4.2
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
-- ormolu-0.1.3.0
+- ormolu-0.1.4.1
 - parser-combinators-1.2.1
 - primitive-0.7.1.0
 - refinery-0.3.0.0

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -45,7 +45,7 @@ extra-deps:
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
-- ormolu-0.1.3.0
+- ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1
 - semigroups-0.18.5

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -38,7 +38,7 @@ extra-deps:
 - implicit-hie-0.1.2.3
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- ormolu-0.1.3.0
+- ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1
 - semigroups-0.18.5

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.19
+resolver: lts-16.23
 
 packages:
 - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,6 +22,7 @@ extra-deps:
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2
+- Diff-0.4.0
 - extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.2.0.0
@@ -50,7 +51,7 @@ extra-deps:
 - opentelemetry-0.4.2
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
-- ormolu-0.1.3.0
+- ormolu-0.1.4.1
 - parser-combinators-1.2.1
 - primitive-0.7.1.0
 - refinery-0.3.0.0


### PR DESCRIPTION
- For 8.8.4 + 8.10.2 I just bumped to latest resolvers which include ormolu 0.1.4.1
- For 8.6.* I had to also pin `Diff` to `0.4.0`.