### PR TITLE
Module Name Plugin: Treat modules starting with lowercase as Main module

### DIFF
--- a/test/functional/ModuleName.hs
+++ b/test/functional/ModuleName.hs
@@ -7,38 +7,26 @@ module ModuleName
   )
 where
 
-import           Control.Applicative.Combinators
-                                                ( skipManyTill )
-import           Control.Monad.IO.Class         ( MonadIO(liftIO) )
-import qualified Data.Text.IO                  as T
-import           Language.Haskell.LSP.Test      ( fullCaps
-                                                , documentContents
-                                                , executeCommand
-                                                , getCodeLenses
-                                                , openDoc
-                                                , runSession
-                                                , anyMessage
-                                                , message
-                                                )
-import           Language.Haskell.LSP.Types     ( ApplyWorkspaceEditRequest
-                                                , CodeLens(..)
-                                                )
-import           System.FilePath                ( (<.>)
-                                                , (</>)
-                                                )
-import           Test.Hls.Util                  ( hlsCommand )
-import           Test.Tasty                     ( TestTree
-                                                , testGroup
-                                                )
-import           Test.Tasty.HUnit               ( testCase
-                                                , (@?=)
-                                                )
+import           Control.Applicative.Combinators (skipManyTill)
+import           Control.Monad.IO.Class          (MonadIO (liftIO))
+import qualified Data.Text.IO                    as T
+import           Language.Haskell.LSP.Test       (anyMessage, documentContents,
+                                                  executeCommand, fullCaps,
+                                                  getCodeLenses, message,
+                                                  openDoc, runSession)
+import           Language.Haskell.LSP.Types      (ApplyWorkspaceEditRequest,
+                                                  CodeLens (..))
+import           System.FilePath                 ((<.>), (</>))
+import           Test.Hls.Util                   (hlsCommand)
+import           Test.Tasty                      (TestTree, testGroup)
+import           Test.Tasty.HUnit                (testCase, (@?=))
 
 tests :: TestTree
 tests = testGroup
   "moduleName"
   [ testCase "Add module header to empty module" $ goldenTest "TEmptyModule.hs"
   , testCase "Fix wrong module name" $ goldenTest "TWrongModuleName.hs"
+  , testCase "Must infer module name as Main, if the file name starts with a lowercase" $ goldenTest "mainlike.hs"
   ]
 
 goldenTest :: FilePath -> IO ()

--- a/test/testdata/moduleName/hie.yaml
+++ b/test/testdata/moduleName/hie.yaml
@@ -1,1 +1,1 @@
-cradle: { direct: { arguments: ["TEmptyModule", "TWrongModuleName"] } }
+cradle: { direct: { arguments: ["TEmptyModule", "TWrongModuleName", "mainlike"] } }

--- a/test/testdata/moduleName/mainlike.hs.expected
+++ b/test/testdata/moduleName/mainlike.hs.expected
@@ -1,0 +1,1 @@
+module Main where


### PR DESCRIPTION
Currently, module name plugin treats basename of file as module name.
This inferes, for example, the module name of `app/exe01.hs` as `exe01`, contrary to the expectation that they must be `Main`.

This pull-requests addresses this issue by defaulting to `Main` when the file name is starting with non-upper cases.

Perhaps, the logic itself can be refined so that it infers it `Main` only when the lowercased file is located right after the source-dirs?