### PR TITLE
Enable ghc-8.10.2 for windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,6 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
           - os: windows-latest
-            ghc: '8.10.2' # broken due to https://gitlab.haskell.org/ghc/ghc/-/issues/18550
-          - os: windows-latest
             ghc: '8.8.4' # also fails due to segfault :(
           - os: windows-latest
             ghc: '8.8.3' # fails due to segfault

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.2', '8.10.1', '8.8.4', '8.8.3', '8.8.2', '8.6.5', '8.6.4']
+        ghc: ['8.10.2.2', '8.10.2', '8.10.1', '8.8.4', '8.8.3', '8.8.2', '8.6.5', '8.6.4']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
+          - os: ubuntu-latest
+            ghc: '8.10.2.2' # only valid for windows and chocolatey
+          - os: macOS-latest
+            ghc: '8.10.2.2' # only valid for windows and chocolatey:  
+          - os: windows-latest
+            ghc: '8.10.2' # unusable due to https://gitlab.haskell.org/ghc/ghc/-/issues/18550
           - os: windows-latest
             ghc: '8.8.4' # also fails due to segfault :(
           - os: windows-latest


### PR DESCRIPTION
As chocolatey applies the workaround: https://gitlab.haskell.org/ghc/ghc/-/issues/18550#note_309996