### PR TITLE
Add hspec-discover to build-tool-depends in tactics plugin

### DIFF
--- a/plugins/tactics/hls-tactics-plugin.cabal
+++ b/plugins/tactics/hls-tactics-plugin.cabal
@@ -99,5 +99,6 @@ test-suite tests
     , hie-bios
     , ghc
     , containers
+  build-tool-depends: hspec-discover:hspec-discover
   default-language: Haskell2010
 


### PR DESCRIPTION
`cabal build all` was failing for me.

```
Preprocessing test suite 'tests' for hls-tactics-plugin-0.5.1.0..
Building test suite 'tests' for hls-tactics-plugin-0.5.1.0..
ghc: could not execute: hspec-discover
cabal: Failed to build test:tests from hls-tactics-plugin-0.5.1.0.
```

Adding `hspec-discover` to the `build-tool-depends` fixes this.