### PR TITLE
Add Ghcide hie.yaml instruction for Stack users

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ $ cp install/hie.yaml.cbl install/hie.yaml
 ```shell
 $ cp hie.yaml.stack hie.yaml
 $ cp install/hie.yaml.stack install/hie.yaml
+$ cp ghcide/hie.yaml.stack ghcide/hie.yaml
 $ stack build --test --no-run-tests
 $ cd install
 $ stack build


### PR DESCRIPTION
I noticed browsing the GHCIDE code would blow things up spectacularly, and by looking at the LSP error buffer, I noticed it tried to build using Cabal :sweat_smile: 