### PR TITLE
Fix and enable disabled code action unit tests, fix fallback handler

### DIFF
--- a/hls-plugin-api/src/Ide/Plugin.hs
+++ b/hls-plugin-api/src/Ide/Plugin.hs
@@ -238,9 +238,8 @@ makeExecuteCommands ecs lf ide = wrapUnhandledExceptions $ do
                 -- Send off the workspace request if it has one
                 forM_ mEdit $ \edit -> do
                   let eParams = J.ApplyWorkspaceEditParams edit
-                  -- TODO: Use lspfuncs to send an applyedit message. Or change
-                  -- the API to allow a list of messages to be returned.
-                  return (Right J.Null, Just(J.WorkspaceApplyEdit, eParams))
+                  reqId <- LSP.getNextReqId lf
+                  LSP.sendFunc lf $ ReqApplyWorkspaceEdit $ RequestMessage "2.0" reqId WorkspaceApplyEdit eParams
 
                 case mCmd of
                   -- If we have a command, continue to execute it

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -404,32 +404,31 @@ missingPragmaTests = testGroup "missing pragma warning code actions" [
 
 unusedTermTests :: TestTree
 unusedTermTests = testGroup "unused term code actions" [
-    -- ignoreTestBecause "Broken" $ testCase "Prefixes with '_'" $ pendingWith "removed because of HaRe"
-    --     runSession hlsCommand fullCaps "test/testdata/" $ do
-    --       doc <- openDoc "UnusedTerm.hs" "haskell"
-    --
-    --       _ <- waitForDiagnosticsSource "typecheck"
-    --       cas <- map fromAction <$> getAllCodeActions doc
-    --
-    --       liftIO $ map (^. L.title) cas `shouldContain` [ "Prefix imUnused with _"]
-    --
-    --       executeCodeAction $ head cas
-    --
-    --       edit <- skipManyTill anyMessage $ getDocumentEdit doc
-    --
-    --       let expected = [ "{-# OPTIONS_GHC -Wall #-}"
-    --                      , "module UnusedTerm () where"
-    --                      , "_imUnused :: Int -> Int"
-    --                      , "_imUnused 1 = 1"
-    --                      , "_imUnused 2 = 2"
-    --                      , "_imUnused _ = 3"
-    --                      ]
-    --
-    --       liftIO $ edit @?= T.unlines expected
+    ignoreTestBecause "no support for prefixing unused names with _" $ testCase "Prefixes with '_'" $
+        runSession hlsCommand fullCaps "test/testdata/" $ do
+          doc <- openDoc "UnusedTerm.hs" "haskell"
+
+          _ <- waitForDiagnosticsSource "typecheck"
+          cars <- getAllCodeActions doc
+          prefixImUnused <- liftIO $ inspectCodeAction cars ["Prefix imUnused with _"]
+
+          executeCodeAction prefixImUnused
+
+          edit <- skipManyTill anyMessage $ getDocumentEdit doc
+
+          let expected = [ "{-# OPTIONS_GHC -Wall #-}"
+                         , "module UnusedTerm () where"
+                         , "_imUnused :: Int -> Int"
+                         , "_imUnused 1 = 1"
+                         , "_imUnused 2 = 2"
+                         , "_imUnused _ = 3"
+                         ]
+
+          liftIO $ edit @?= T.unlines expected
 
     -- See https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#textDocument_codeAction
     -- `CodeActionContext`
-    testCase "respect 'only' parameter" $ runSession hlsCommand fullCaps "test/testdata" $ do
+    , testCase "respect 'only' parameter" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc   <- openDoc "CodeActionOnly.hs" "haskell"
         _     <- waitForDiagnostics
         diags <- getCurrentDiagnostics doc

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -64,7 +64,7 @@ hlintTests = testGroup "hlint suggestions" [
 
         executeCodeAction (fromJust redId)
 
-        contents <- getDocumentEdit doc
+        contents <- skipManyTill anyMessage $ getDocumentEdit doc
         liftIO $ contents @?= "main = undefined\nfoo x = x\n"
 
     , testCase "falls back to pre 3.8 code actions" $ runSession hlsCommand noLiteralCaps "test/testdata/hlint" $ do
@@ -77,7 +77,7 @@ hlintTests = testGroup "hlint suggestions" [
 
         executeCommand etaReduce
 
-        contents <- skipManyTill publishDiagnosticsNotification $ getDocumentEdit doc
+        contents <- skipManyTill anyMessage $ getDocumentEdit doc
         liftIO $ contents @?= "main = undefined\nfoo = id\n"
 
     , testCase "changing configuration enables or disables hlint diagnostics" $ runSession hlsCommand fullCaps "test/testdata/hlint" $ do
@@ -214,7 +214,7 @@ packageTests = testGroup "add package suggestions" [
 
             executeCodeAction action
 
-            contents <- getDocumentEdit . TextDocumentIdentifier =<< getDocUri "add-package-test.cabal"
+            contents <- skipManyTill anyMessage $ getDocumentEdit . TextDocumentIdentifier =<< getDocUri "add-package-test.cabal"
             liftIO $
                 any (\l -> "text -any" `T.isSuffixOf` l || "text : {} -any" `T.isSuffixOf` l) (T.lines contents) @? "Contains text package"
 
@@ -243,7 +243,7 @@ packageTests = testGroup "add package suggestions" [
 
             executeCodeAction action
 
-            contents <- getDocumentEdit . TextDocumentIdentifier =<< getDocUri "package.yaml"
+            contents <- skipManyTill anyMessage $ getDocumentEdit . TextDocumentIdentifier =<< getDocUri "package.yaml"
             liftIO $ do
                 "zlib" `T.isSuffixOf` (T.lines contents !! 3) @? "Contains zlib"
                 "zlib" `T.isSuffixOf` (T.lines contents !! 21) @? "Does not contain zlib in unrelated component"
@@ -415,7 +415,7 @@ unusedTermTests = testGroup "unused term code actions" [
     --
     --       executeCodeAction $ head cas
     --
-    --       edit <- getDocumentEdit doc
+    --       edit <- skipManyTill anyMessage $ getDocumentEdit doc
     --
     --       let expected = [ "{-# OPTIONS_GHC -Wall #-}"
     --                      , "module UnusedTerm () where"

--- a/test/testdata/addPragmas/hie.yaml
+++ b/test/testdata/addPragmas/hie.yaml
@@ -1,0 +1,4 @@
+cradle:
+  direct:
+    arguments:
+      - "NeedsPragmas"

--- a/test/testdata/hie.yaml
+++ b/test/testdata/hie.yaml
@@ -1,0 +1,9 @@
+cradle:
+  direct:
+    arguments:
+      - "CodeActionImport"
+      - "CodeActionOnly"
+      - "CodeActionRename"
+      - "TopLevelSignature"
+      - "TypedHoles"
+      - "TypedHoles2"

--- a/test/testdata/redundantImportTest/hie.yaml
+++ b/test/testdata/redundantImportTest/hie.yaml
@@ -1,0 +1,5 @@
+cradle:
+  direct:
+    arguments:
+      - "src/CodeActionRedundant"
+      - "src/MultipleImports"

--- a/test/utils/Test/Hls/Util.hs
+++ b/test/utils/Test/Hls/Util.hs
@@ -116,9 +116,9 @@ ghcVersion = GHC84
 logFilePath :: String
 logFilePath = "hls-" ++ show ghcVersion ++ ".log"
 
--- | The command to execute the version of hie for the current compiler.
+-- | The command to execute the version of hls for the current compiler.
 --
--- Both @stack test@ and @cabal new-test@ setup the environment so @hie@ is
+-- Both @stack test@ and @cabal new-test@ setup the environment so @hls@ is
 -- on PATH. Cabal seems to respond to @build-tool-depends@ specifically while
 -- stack just puts all project executables on PATH.
 hlsCommand :: String


### PR DESCRIPTION
Enable and fix most of the tests in test/functional/FunctionalCodeAction.hs.

Fix the fallback handler for code action literals. It was stubbed out, so the tests that disabled code action literal support were all failing.

HLS has no support right now for adding dependencies to the the cabal file, which means there can be no "Add <module> as a dependency" code action, and the related tests are still disabled (but with a better message than just "Broken").

In #611, OP reports that the test "falls back to pre 3.8 code actions" is flaky. Even on master, this test is passing consistently on my end, so I'm not sure ... but I think I know what's causing the flakiness and I think I fixed it. In that test, the client sends an executeCommand request; the client waits for an applyEdit request; the server sends back a response to the executeCommand request; and the server sends its own applyEdit request. I think that test fails when the response to the executeCommand request comes back before the applyEdit request. I've changed the test to skip extraneous messages while waiting for the applyEdit request, so the order in which they arrive should now be irrelevant. So that bug might be fixed as well.

This PR partially addresses #527 .

Tests pass on my end, but I'm sort of expecting a CI failure anyway. I hope to make these tests robust enough that they can stay enabled long term.