### PR TITLE
Add extra-source-files for split plugins

### DIFF
--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -8,6 +8,9 @@ author:        Pepe Iborra
 maintainer:    pepeiborra@gmail.com
 category:      Development
 build-type:    Simple
+extra-source-files:
+  LICENSE
+  include/ghc-api-version.h
 
 library
   exposed-modules:  Ide.Plugin.ExplicitImports

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -8,6 +8,9 @@ author:        Pepe Iborra
 maintainer:    pepeiborra@gmail.com
 category:      Development
 build-type:    Simple
+extra-source-files:
+  LICENSE
+  include/ghc-api-version.h
 
 library
   exposed-modules:  Ide.Plugin.Retrie


### PR DESCRIPTION
I can't install HLS master successfully, and this is my log: https://paste.ubuntu.com/p/Gf2gnjPhJc/ (I am using dynamic linked haskell packages on Arch Linux)
I noticed that we didn't write the header file to the sdist of the plugin. Is this necessary? I'm not sure, but after adding `extra-source-files` to the package description, I could install HLS without error.