### PR TITLE
Fix document symbols unit tests.

### DIFF
--- a/test/testdata/hie.yaml
+++ b/test/testdata/hie.yaml
@@ -4,6 +4,7 @@ cradle:
       - "CodeActionImport"
       - "CodeActionOnly"
       - "CodeActionRename"
+      - "Symbols"
       - "TopLevelSignature"
       - "TypedHoles"
       - "TypedHoles2"


### PR DESCRIPTION
Actually I had to leave several of these tests disabled because it seems HLS can't extract as many symbols as HIE could. But the disabled tests are at least documented more clearly now.