### PR TITLE
Enable code completion tests

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -197,6 +197,7 @@ common hls-test-utils
     , hslogger
     , hspec
     , hspec-core
+    , lens
     , lsp-test              >=0.11.0.6
     , stm
     , tasty-hunit

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -2,10 +2,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Completion(tests) where
 
-import Control.Applicative.Combinators
 import Control.Monad.IO.Class
 import Control.Lens hiding ((.=))
--- import Data.Aeson
+import Data.Aeson (object, (.=))
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Lens hiding (applyEdit)
@@ -13,385 +12,396 @@ import Test.Hls.Util
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
-
---TODO: Fix tests, some structural changed hav been made
+import qualified Data.Text as T
 
 tests :: TestTree
 tests = testGroup "completions" [
---     testCase "works" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+     testCase "works" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "put"
---         _ <- applyEdit doc te
+         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "put"
+         _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 5 9)
---         let item = head $ filter ((== "putStrLn") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "putStrLn"
---             item ^. kind @?= Just CiFunction
---             item ^. detail @?= Just "Prelude"
---         resolvedRes <- request CompletionItemResolve item
---         let Just (resolved :: CompletionItem) = resolvedRes ^. result
---         liftIO $ do
---             resolved ^. label @?= "putStrLn"
---             resolved ^. kind @?= Just CiFunction
---             resolved ^. detail @?= Just "String -> IO ()\nPrelude"
---             resolved ^. insertTextFormat @?= Just Snippet
---             resolved ^. insertText @?= Just "putStrLn ${1:String}"
+         compls <- getCompletions doc (Position 5 9)
+         let item = head $ filter ((== "putStrLn") . (^. label)) compls
+         liftIO $ do
+             item ^. label @?= "putStrLn"
+             item ^. kind @?= Just CiFunction
+             item ^. detail @?= Just ":: String -> IO ()"
+             item ^. insertTextFormat @?= Just PlainText
+             item ^. insertText @?= Nothing
 
---     , testCase "completes imports" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+     , ignoreTestBecause "no support for itemCompletion/resolve requests"
+       $ testCase "itemCompletion/resolve works" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 1 17) (Position 1 26)) "Data.M"
---         _ <- applyEdit doc te
+         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "put"
+         _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 1 22)
---         let item = head $ filter ((== "Maybe") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "Maybe"
---             item ^. detail @?= Just "Data.Maybe"
---             item ^. kind @?= Just CiModule
+         compls <- getCompletions doc (Position 5 9)
+         let item = head $ filter ((== "putStrLn") . (^. label)) compls
+         resolvedRes <- request CompletionItemResolve item
+         let Right (resolved :: CompletionItem) = resolvedRes ^. result
+         liftIO $ print resolved
+         liftIO $ do
+             resolved ^. label @?= "putStrLn"
+             resolved ^. kind @?= Just CiFunction
+             resolved ^. detail @?= Just "String -> IO ()\nPrelude"
+             resolved ^. insertTextFormat @?= Just Snippet
+             resolved ^. insertText @?= Just "putStrLn ${1:String}"
 
---     , testCase "completes qualified imports" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+     , testCase "completes imports" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 2 17) (Position 1 25)) "Dat"
---         _ <- applyEdit doc te
+         let te = TextEdit (Range (Position 1 17) (Position 1 26)) "Data.M"
+         _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 1 19)
---         let item = head $ filter ((== "Data.List") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "Data.List"
---             item ^. detail @?= Just "Data.List"
---             item ^. kind @?= Just CiModule
+         compls <- getCompletions doc (Position 1 22)
+         let item = head $ filter ((== "Maybe") . (^. label)) compls
+         liftIO $ do
+             item ^. label @?= "Maybe"
+             item ^. detail @?= Just "Data.Maybe"
+             item ^. kind @?= Just CiModule
 
---     , testCase "completes language extensions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+     , testCase "completes qualified imports" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 0 24) (Position 0 31)) ""
---         _ <- applyEdit doc te
+         let te = TextEdit (Range (Position 2 17) (Position 1 25)) "Dat"
+         _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 0 24)
---         let item = head $ filter ((== "OverloadedStrings") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "OverloadedStrings"
---             item ^. kind @?= Just CiKeyword
+         compls <- getCompletions doc (Position 1 19)
+         let item = head $ filter ((== "Data.List") . (^. label)) compls
+         liftIO $ do
+             item ^. label @?= "Data.List"
+             item ^. detail @?= Just "Data.List"
+             item ^. kind @?= Just CiModule
 
---     , testCase "completes pragmas" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+     , testCase "completes language extensions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 0 4) (Position 0 34)) ""
---         _ <- applyEdit doc te
+         let te = TextEdit (Range (Position 0 24) (Position 0 31)) ""
+         _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 0 4)
---         let item = head $ filter ((== "LANGUAGE") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "LANGUAGE"
---             item ^. kind @?= Just CiKeyword
---             item ^. insertTextFormat @?= Just Snippet
---             item ^. insertText @?= Just "LANGUAGE ${1:extension} #-}"
+         compls <- getCompletions doc (Position 0 24)
+         let item = head $ filter ((== "OverloadedStrings") . (^. label)) compls
+         liftIO $ do
+             item ^. label @?= "OverloadedStrings"
+             item ^. kind @?= Just CiKeyword
 
---     , testCase "completes pragmas no close" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+     , testCase "completes pragmas" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 0 4) (Position 0 24)) ""
---         _ <- applyEdit doc te
+         let te = TextEdit (Range (Position 0 4) (Position 0 34)) ""
+         _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 0 4)
---         let item = head $ filter ((== "LANGUAGE") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "LANGUAGE"
---             item ^. kind @?= Just CiKeyword
---             item ^. insertTextFormat @?= Just Snippet
---             item ^. insertText @?= Just "LANGUAGE ${1:extension}"
+         compls <- getCompletions doc (Position 0 4)
+         let item = head $ filter ((== "LANGUAGE") . (^. label)) compls
+         liftIO $ do
+             item ^. label @?= "LANGUAGE"
+             item ^. kind @?= Just CiKeyword
+             item ^. insertTextFormat @?= Just PlainText
+             item ^. insertText @?= Nothing
 
---     , testCase "completes options pragma" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+     , testCase "completes pragmas no close" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 0 4) (Position 0 34)) "OPTIONS"
---         _ <- applyEdit doc te
+         let te = TextEdit (Range (Position 0 4) (Position 0 24)) ""
+         _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 0 4)
---         let item = head $ filter ((== "OPTIONS_GHC") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "OPTIONS_GHC"
---             item ^. kind @?= Just CiKeyword
---             item ^. insertTextFormat @?= Just Snippet
---             item ^. insertText @?= Just "OPTIONS_GHC -${1:option} #-}"
+         compls <- getCompletions doc (Position 0 4)
+         let item = head $ filter ((== "LANGUAGE") . (^. label)) compls
+         liftIO $ do
+             item ^. label @?= "LANGUAGE"
+             item ^. kind @?= Just CiKeyword
+             item ^. insertTextFormat @?= Just PlainText
+             item ^. insertText @?= Nothing
 
---   -- -----------------------------------
+     , testCase "completes options pragma" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
 
---     , testCase "completes ghc options pragma values" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
+         let te = TextEdit (Range (Position 0 4) (Position 0 34)) "OPTIONS"
+         _ <- applyEdit doc te
 
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+         compls <- getCompletions doc (Position 0 4)
+         let item = head $ filter ((== "OPTIONS_GHC") . (^. label)) compls
+         liftIO $ do
+             item ^. label @?= "OPTIONS_GHC"
+             item ^. kind @?= Just CiKeyword
+             item ^. insertTextFormat @?= Just PlainText
+             item ^. insertText @?= Nothing
 
---         let te = TextEdit (Range (Position 0 0) (Position 0 0)) "{-# OPTIONS_GHC -Wno-red  #-}\n"
---         _ <- applyEdit doc te
+     , testCase "completes ghc options pragma values" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
 
---         compls <- getCompletions doc (Position 0 24)
---         let item = head $ filter ((== "Wno-redundant-constraints") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "Wno-redundant-constraints"
---             item ^. kind @?= Just CiKeyword
---             item ^. insertTextFormat @?= Nothing
---             item ^. insertText @?= Nothing
+         _ <- waitForDiagnosticsFrom doc
 
---   -- -----------------------------------
+         let te = TextEdit (Range (Position 0 0) (Position 0 0)) "{-# OPTIONS_GHC -Wno-red  #-}\n"
+         _ <- applyEdit doc te
 
---     , testCase "completes with no prefix" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
---         compls <- getCompletions doc (Position 5 7)
---         liftIO $ filter ((== "!!") . (^. label)) compls `shouldNotSatisfy` null
+         compls <- getCompletions doc (Position 0 24)
+         let item = head $ filter ((== "Wno-redundant-constraints") . (^. label)) compls
+         liftIO $ do
+             item ^. label @?= "Wno-redundant-constraints"
+             item ^. kind @?= Just CiKeyword
+             item ^. insertTextFormat @?= Nothing
+             item ^. insertText @?= Nothing
 
---     -- See https://github.com/haskell/haskell-ide-engine/issues/903
---     , testCase "strips compiler generated stuff from completions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "DupRecFields.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+     , testCase "completes with no prefix" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
+         compls <- getCompletions doc (Position 5 7)
+         liftIO $ any ((== "!!") . (^. label)) compls @? ""
 
---         let te = TextEdit (Range (Position 5 0) (Position 5 2)) "acc"
---         _ <- applyEdit doc te
+     -- See https://github.com/haskell/haskell-ide-engine/issues/903
+     , testCase "strips compiler generated stuff from completions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "DupRecFields.hs" "haskell"
 
---         compls <- getCompletions doc (Position 5 4)
---         let item = head $ filter (\c -> c^.label == "accessor") compls
---         liftIO $ do
---             item ^. label @?= "accessor"
---             item ^. kind @?= Just CiFunction
---             item ^. detail @?= Just "Two -> Int\nDupRecFields"
---             item ^. insertText @?= Just "accessor ${1:Two}"
+         let te = TextEdit (Range (Position 5 0) (Position 5 2)) "acc"
+         _ <- applyEdit doc te
 
---     , testCase "have implicit foralls on basic polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
---         let te = TextEdit (Range (Position 5 7) (Position 5 9)) "id"
---         _ <- applyEdit doc te
---         compls <- getCompletions doc (Position 5 9)
---         let item = head $ filter ((== "id") . (^. label)) compls
---         resolvedRes <- request CompletionItemResolve item
---         let Just (resolved :: CompletionItem) = resolvedRes ^. result
---         liftIO $
---             resolved ^. detail @?= Just "a -> a\nPrelude"
+         compls <- getCompletions doc (Position 5 4)
+         let item = head $ filter (\c -> c^.label == "accessor") compls
+         liftIO $ do
+             item ^. label @?= "accessor"
+             item ^. kind @?= Just CiFunction
 
---     , testCase "have implicit foralls with multiple type variables" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "flip"
---         _ <- applyEdit doc te
---         compls <- getCompletions doc (Position 5 11)
---         let item = head $ filter ((== "flip") . (^. label)) compls
---         resolvedRes <- request CompletionItemResolve item
---         let Just (resolved :: CompletionItem) = resolvedRes ^. result
---         liftIO $
---             resolved ^. detail @?= Just "(a -> b -> c) -> b -> a -> c\nPrelude"
+     , testCase "have implicit foralls on basic polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
+         let te = TextEdit (Range (Position 5 7) (Position 5 9)) "id"
+         _ <- applyEdit doc te
+         compls <- getCompletions doc (Position 5 9)
+         let item = head $ filter ((== "id") . (^. label)) compls
+         liftIO $ do
+             item ^. detail @?= Just ":: a -> a"
 
-       contextTests
---     , snippetTests
+     , testCase "have implicit foralls with multiple type variables" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "Completion.hs" "haskell"
+         _ <- waitForDiagnosticsFrom doc
+         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "flip"
+         _ <- applyEdit doc te
+         compls <- getCompletions doc (Position 5 11)
+         let item = head $ filter ((== "flip") . (^. label)) compls
+         liftIO $
+             item ^. detail @?= Just ":: (a -> b -> c) -> b -> a -> c"
+
+     , contextTests
+     , snippetTests
     ]
 
--- snippetTests :: TestTree
--- snippetTests = testGroup "snippets" [
---     testCase "work for argumentless constructors" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+snippetTests :: TestTree
+snippetTests = testGroup "snippets" [
+    ignoreTestBecause "no support for snippets" $
+    testCase "work for argumentless constructors" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+      doc <- openDoc "Completion.hs" "haskell"
+      _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "Nothing"
---         _ <- applyEdit doc te
+      let te = TextEdit (Range (Position 5 7) (Position 5 24)) "Nothing"
+      _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 5 14)
---         let item = head $ filter ((== "Nothing") . (^. label)) compls
---         liftIO $ do
---             item ^. insertTextFormat @?= Just Snippet
---             item ^. insertText @?= Just "Nothing"
+      compls <- getCompletions doc (Position 5 14)
+      let item = head $ filter ((== "Nothing") . (^. label)) compls
+      liftIO $ do
+          item ^. insertTextFormat @?= Just Snippet
+          item ^. insertText @?= Just "Nothing"
 
---     , testCase "work for polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+    , ignoreTestBecause "no support for snippets" $
+      testCase "work for polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+        doc <- openDoc "Completion.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "fold"
---         _ <- applyEdit doc te
+        let te = TextEdit (Range (Position 5 7) (Position 5 24)) "fold"
+        _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 5 11)
---         let item = head $ filter ((== "foldl") . (^. label)) compls
---         resolvedRes <- request CompletionItemResolve item
---         let Just (resolved :: CompletionItem) = resolvedRes ^. result
---         liftIO $ do
---             resolved ^. label @?= "foldl"
---             resolved ^. kind @?= Just CiFunction
---             resolved ^. insertTextFormat @?= Just Snippet
---             resolved ^. insertText @?= Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
+        compls <- getCompletions doc (Position 5 11)
+        let item = head $ filter ((== "foldl") . (^. label)) compls
+        liftIO $ do
+            item ^. label @?= "foldl"
+            item ^. kind @?= Just CiFunction
+            item ^. insertTextFormat @?= Just Snippet
+            item ^. insertText @?= Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
 
---     , testCase "work for complex types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+    , ignoreTestBecause "no support for snippets" $
+      testCase "work for complex types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+        doc <- openDoc "Completion.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "mapM"
---         _ <- applyEdit doc te
+        let te = TextEdit (Range (Position 5 7) (Position 5 24)) "mapM"
+        _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 5 11)
---         let item = head $ filter ((== "mapM") . (^. label)) compls
---         resolvedRes <- request CompletionItemResolve item
---         let Just (resolved :: CompletionItem) = resolvedRes ^. result
---         liftIO $ do
---             resolved ^. label @?= "mapM"
---             resolved ^. kind @?= Just CiFunction
---             resolved ^. insertTextFormat @?= Just Snippet
---             resolved ^. insertText @?= Just "mapM ${1:a -> m b} ${2:t a}"
+        compls <- getCompletions doc (Position 5 11)
+        let item = head $ filter ((== "mapM") . (^. label)) compls
+        liftIO $ do
+            item ^. label @?= "mapM"
+            item ^. kind @?= Just CiFunction
+            item ^. insertTextFormat @?= Just Snippet
+            item ^. insertText @?= Just "mapM ${1:a -> m b} ${2:t a}"
 
---     , testCase "work for infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+    , ignoreTestBecause "no support for snippets" $
+      testCase "work for infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+        doc <- openDoc "Completion.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "even `filte"
---         _ <- applyEdit doc te
+        let te = TextEdit (Range (Position 5 7) (Position 5 24)) "even `filte"
+        _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 5 18)
---         let item = head $ filter ((== "filter") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "filter"
---             item ^. kind @?= Just CiFunction
---             item ^. insertTextFormat @?= Just Snippet
---             item ^. insertText @?= Just "filter`"
+        compls <- getCompletions doc (Position 5 18)
+        let item = head $ filter ((== "filter") . (^. label)) compls
+        liftIO $ do
+            item ^. label @?= "filter"
+            item ^. kind @?= Just CiFunction
+            item ^. insertTextFormat @?= Just Snippet
+            item ^. insertText @?= Just "filter`"
 
---     , testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+    , ignoreTestBecause "no support for snippets" $
+      testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+        doc <- openDoc "Completion.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "even `filte`"
---         _ <- applyEdit doc te
+        let te = TextEdit (Range (Position 5 7) (Position 5 24)) "even `filte`"
+        _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 5 18)
---         let item = head $ filter ((== "filter") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "filter"
---             item ^. kind @?= Just CiFunction
---             item ^. insertTextFormat @?= Just Snippet
---             item ^. insertText @?= Just "filter"
+        compls <- getCompletions doc (Position 5 18)
+        let item = head $ filter ((== "filter") . (^. label)) compls
+        liftIO $ do
+            item ^. label @?= "filter"
+            item ^. kind @?= Just CiFunction
+            item ^. insertTextFormat @?= Just Snippet
+            item ^. insertText @?= Just "filter"
 
---     , testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+    , ignoreTestBecause "no support for snippets" $
+      testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+        doc <- openDoc "Completion.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "\"\" `Data.List.interspe"
---         _ <- applyEdit doc te
+        let te = TextEdit (Range (Position 5 7) (Position 5 24)) "\"\" `Data.List.interspe"
+        _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 5 29)
---         let item = head $ filter ((== "intersperse") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "intersperse"
---             item ^. kind @?= Just CiFunction
---             item ^. insertTextFormat @?= Just Snippet
---             item ^. insertText @?= Just "intersperse`"
+        compls <- getCompletions doc (Position 5 29)
+        let item = head $ filter ((== "intersperse") . (^. label)) compls
+        liftIO $ do
+            item ^. label @?= "intersperse"
+            item ^. kind @?= Just CiFunction
+            item ^. insertTextFormat @?= Just Snippet
+            item ^. insertText @?= Just "intersperse`"
 
---     , testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
---         doc <- openDoc "Completion.hs" "haskell"
---         _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+    , ignoreTestBecause "no support for snippets" $
+      testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+        doc <- openDoc "Completion.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
 
---         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "\"\" `Data.List.interspe`"
---         _ <- applyEdit doc te
+        let te = TextEdit (Range (Position 5 7) (Position 5 24)) "\"\" `Data.List.interspe`"
+        _ <- applyEdit doc te
 
---         compls <- getCompletions doc (Position 5 29)
---         let item = head $ filter ((== "intersperse") . (^. label)) compls
---         liftIO $ do
---             item ^. label @?= "intersperse"
---             item ^. kind @?= Just CiFunction
---             item ^. insertTextFormat @?= Just Snippet
---             item ^. insertText @?= Just "intersperse"
+        compls <- getCompletions doc (Position 5 29)
+        let item = head $ filter ((== "intersperse") . (^. label)) compls
+        liftIO $ do
+            item ^. label @?= "intersperse"
+            item ^. kind @?= Just CiFunction
+            item ^. insertTextFormat @?= Just Snippet
+            item ^. insertText @?= Just "intersperse"
 
-    -- -- TODO : Fix compile issue in the test "Variable not in scope: object"
-    -- , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
-    --     doc <- openDoc "Completion.hs" "haskell"
-    --     _   <- count 2 $ skipManyTill loggingNotification noDiagnostics
+    , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+        doc <- openDoc "Completion.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
 
-    --     let config = object [ "haskell" .= (object ["completionSnippetsOn" .= False])]
+        let config = object [ "haskell" .= (object ["completionSnippetsOn" .= False])]
 
-    --     sendNotification WorkspaceDidChangeConfiguration
-    --                     (DidChangeConfigurationParams config)
+        sendNotification WorkspaceDidChangeConfiguration
+                        (DidChangeConfigurationParams config)
 
-    --     checkNoSnippets doc
+        checkNoSnippets doc
 
-    -- , testCase "respects client capabilities" $ runSession hlsCommand noSnippetsCaps "test/testdata/completion" $ do
-    --     doc <- openDoc "Completion.hs" "haskell"
-    --     _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+    , testCase "respects client capabilities" $ runSession hlsCommand noSnippetsCaps "test/testdata/completion" $ do
+        doc <- openDoc "Completion.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
 
-    --     checkNoSnippets doc
-    -- ]
-    -- where
-    --     checkNoSnippets doc = do
-    --         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "fold"
-    --         _      <- applyEdit doc te
+        checkNoSnippets doc
+    ]
+    where
+        checkNoSnippets doc = do
+            let te = TextEdit (Range (Position 5 7) (Position 5 24)) "fold"
+            _      <- applyEdit doc te
 
-    --         compls <- getCompletions doc (Position 5 11)
-    --         let item = head $ filter ((== "foldl") . (^. label)) compls
-    --         liftIO $ do
-    --             item ^. label @?= "foldl"
-    --             item ^. kind @?= Just CiFunction
-    --             item ^. insertTextFormat @?= Just PlainText
-    --             item ^. insertText @?= Nothing
+            compls <- getCompletions doc (Position 5 11)
+            let item = head $ filter ((== "foldl") . (^. label)) compls
+            liftIO $ do
+                item ^. label @?= "foldl"
+                item ^. kind @?= Just CiFunction
+                item ^. insertTextFormat @?= Just PlainText
+                item ^. insertText @?= Nothing
 
-    --         resolvedRes <- request CompletionItemResolve item
-    --         let Just (resolved :: CompletionItem) = resolvedRes ^. result
-    --         liftIO $ do
-    --             resolved ^. label @?= "foldl"
-    --             resolved ^. kind @?= Just CiFunction
-    --             resolved ^. insertTextFormat @?= Just PlainText
-    --             resolved ^. insertText @?= Nothing
-
-    --     noSnippetsCaps =
-    --         (  textDocument
-    --         .  _Just
-    --         .  completion
-    --         .  _Just
-    --         .  completionItem
-    --         .  _Just
-    --         .  snippetSupport
-    --         ?~ False
-    --         )
-    --         fullCaps
+        noSnippetsCaps =
+            (  textDocument
+            .  _Just
+            .  completion
+            .  _Just
+            .  completionItem
+            .  _Just
+            .  snippetSupport
+            ?~ False
+            )
+            fullCaps
 
 contextTests :: TestTree
 contextTests = testGroup "contexts" [
-    ignoreTestBecause "Broken: Timed out waiting to receive a message from the server" $
     testCase "only provides type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Context.hs" "haskell"
-      _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+      _ <- waitForDiagnosticsFrom doc
       compls <- getCompletions doc (Position 2 17)
       liftIO $ do
         compls `shouldContainCompl` "Integer"
         compls `shouldNotContainCompl` "interact"
 
-    , ignoreTestBecause "Broken: Timed out waiting to receive a message from the server" $
-      testCase "only provides type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "only provides value suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Context.hs" "haskell"
-      _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+      _ <- waitForDiagnosticsFrom doc
       compls <- getCompletions doc (Position 3 9)
       liftIO $ do
         compls `shouldContainCompl` "abs"
         compls `shouldNotContainCompl` "Applicative"
 
-    -- This currently fails if , testCase takes too long to typecheck the module
-    -- , testCase "completes qualified type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
-    --     doc <- openDoc "Context.hs" "haskell"
-    --     _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
-    --     let te = TextEdit (Range (Position 2 17) (Position 2 17)) " -> Conc."
-    --     _ <- applyEdit doc te
-    --     compls <- getCompletions doc (Position 2 26)
-    --     liftIO $ do
-    --         compls `shouldNotContainCompl` "forkOn"
-    --         compls `shouldContainCompl` "MVar"
-    --         compls `shouldContainCompl` "Chan"
+    , testCase "completes qualified type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+        doc <- openDoc "Context.hs" "haskell"
+        _ <- waitForDiagnosticsFrom doc
+        let te = TextEdit (Range (Position 2 17) (Position 2 17)) " -> Conc."
+        _ <- applyEdit doc te
+        -- The module doesn't parse right now. So we are using stale data. HLS
+        -- can give us completions for "Conc." but it can't tell that we are in
+        -- a context where we expect a type.
+        compls <- getCompletions doc (Position 2 26)
+        liftIO $ do
+            -- forkOn is an inappropriate completion in a type context.
+            compls `shouldContainCompl` "forkOn"
+            compls `shouldContainCompl` "MVar"
+            compls `shouldContainCompl` "Chan"
+        let te' = TextEdit (Range (Position 2 26) (Position 2 26)) "MVar"
+        _ <- applyEdit doc te'
+        -- The module can now be parsed. Wait until it has been.
+        _ <- waitForDiagnosticsFrom doc
+        -- HLS can see that we are expecting a type.
+        compls' <- getCompletions doc (Position 2 26)
+        liftIO $ do
+            -- forkOn is gone.
+            compls' `shouldNotContainCompl` "forkOn"
+            compls' `shouldContainCompl` "MVar"
+            compls' `shouldContainCompl` "Chan"
     ]
-    where
-        compls `shouldContainCompl` x  =
-            any ((== x) . (^. label)) compls
-            @? "Should contain completion: " ++ show x
-        compls `shouldNotContainCompl` x =
-            all ((/= x) . (^. label)) compls
-            @? "Should not contain completion: " ++ show x
+
+shouldContainCompl :: [CompletionItem] -> T.Text -> Assertion
+compls `shouldContainCompl` x  =
+    any ((== x) . (^. label)) compls
+    @? "Should contain completion: " ++ show x
+
+shouldNotContainCompl :: [CompletionItem] -> T.Text -> Assertion
+compls `shouldNotContainCompl` x =
+    all ((/= x) . (^. label)) compls
+    @? "Should not contain completion: " ++ show x

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -390,6 +390,8 @@ contextTests = testGroup "contexts" [
     ]
     where
         compls `shouldContainCompl` x  =
-            null (filter ((== x) . (^. label)) compls) @? "Should contain completion"
+            any ((== x) . (^. label)) compls
+            @? "Should contain completion: " ++ show x
         compls `shouldNotContainCompl` x =
-            null (filter ((== x) . (^. label)) compls) @? "Should not contain completion"
+            all ((/= x) . (^. label)) compls
+            @? "Should not contain completion: " ++ show x

--- a/test/testdata/completion/hie.yaml
+++ b/test/testdata/completion/hie.yaml
@@ -1,0 +1,6 @@
+cradle:
+  direct:
+    arguments:
+      - "Completion"
+      - "Context"
+      - "DupRecFields"

--- a/test/utils/Test/Hls/Util.hs
+++ b/test/utils/Test/Hls/Util.hs
@@ -306,7 +306,7 @@ fromCommand (CACommand command) = command
 fromCommand _ = error "Not a command"
 
 onMatch :: [a] -> (a -> Bool) -> String -> IO a
-onMatch as pred err = maybe (fail err) return (find pred as)
+onMatch as predicate err = maybe (fail err) return (find predicate as)
 
 inspectDiagnostic :: [Diagnostic] -> [T.Text] -> IO Diagnostic
 inspectDiagnostic diags s = onMatch diags (\ca -> all (`T.isInfixOf` (ca ^. L.message)) s) err
@@ -316,18 +316,18 @@ expectDiagnostic :: [Diagnostic] -> [T.Text] -> IO ()
 expectDiagnostic diags s = void $ inspectDiagnostic diags s
 
 inspectCodeAction :: [CAResult] -> [T.Text] -> IO CodeAction
-inspectCodeAction cars s = fromAction <$> onMatch cars pred err
-    where pred (CACodeAction ca) = all (`T.isInfixOf` (ca ^. L.title)) s
-          pred _ = False
+inspectCodeAction cars s = fromAction <$> onMatch cars predicate err
+    where predicate (CACodeAction ca) = all (`T.isInfixOf` (ca ^. L.title)) s
+          predicate _ = False
           err = "expected code action matching '" ++ show s ++ "' but did not find one"
 
 expectCodeAction :: [CAResult] -> [T.Text] -> IO ()
 expectCodeAction cars s = void $ inspectCodeAction cars s
 
 inspectCommand :: [CAResult] -> [T.Text] -> IO Command
-inspectCommand cars s = fromCommand <$> onMatch cars pred err
-    where pred (CACommand command) = all  (`T.isInfixOf` (command ^. L.title)) s
-          pred _ = False
+inspectCommand cars s = fromCommand <$> onMatch cars predicate err
+    where predicate (CACommand command) = all  (`T.isInfixOf` (command ^. L.title)) s
+          predicate _ = False
           err = "expected code action matching '" ++ show s ++ "' but did not find one"
 
 waitForDiagnosticsFrom :: TextDocumentIdentifier -> T.Session [Diagnostic]


### PR DESCRIPTION
Fix and enable the unit tests for code completion.

My understanding is that we use the request textDocument/completion to get code completions at a point, and the request completionItem/resolve to get more details about a particular suggested completion. E.g. we might ask "Complete 'Pub_'." and get "['Publish', 'Public']" and then ask "resolve 'Publish'" and get "'Publish' is a method defined in ...". Right now, there is no support for the resolve request, so the relevant tests are disabled.

"Pub_" |-> "Publish" is a plain text completion, but there is a more sophisticated kind of completion called a snippet that does things like "Pub_" |-> "Publish ${something special}". There's code for handling snippets, but its disabled in ghcide. The relevant tests are disabled as well.

The diff is worthless unfortunately.