### PR TITLE
Prepare 0.7.0 release (includes bump ghcide to 0.6.0.1)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,79 @@
 # Changelog for haskell-language-server
 
+## 0.7.0
+
+* This version contains mainly refactors and updates of upstream packages
+* It bumps up some formatter versions:
+  * ormolu is 0.1.4.1
+  * fourmolu is 0.3.0.0
+  * brittany is 0.13.1.0
+* It uses last implicit-hie-cradle-0.3.0.2, with some [bug](https://github.com/Avi-D-coder/implicit-hie/issues/29) [fixes](https://github.com/Avi-D-coder/implicit-hie/issues/30)
+* It uses last ghcide-0.6.0.1 with [improvements and bug fixes](https://github.com/haskell/ghcide/blob/master/CHANGELOG.md#060-2020-12-06):
+  * Do not enable every "unnecessary" warning by default
+  * Improvements over completions:
+    * record fields
+    * identifiers not in explicit import lists
+    * extend explicit import list automatically
+
+Thanks to all haskell-language-server, ghcide and other upstream packages contributors (the list continue growing healthy) for make this release possible.
+
+### Pull requests merged
+
+- Miscellanous fixes: correct tactic plugin package metadata and cabal.hie.yaml/stack.hie.yaml
+([#672)](https://github.com/haskell/haskell-language-server/pull/672) by @berberman
+- Remove unnecessary pluginId setting and user Better Map functions in tactics plugin
+([#669)](https://github.com/haskell/haskell-language-server/pull/669) by @jhrcek
+- Do not suggest explicitly disabled pragmas
+([#666)](https://github.com/haskell/haskell-language-server/pull/666) by @berberman
+- fixed hie.yaml.stack
+([#664)](https://github.com/haskell/haskell-language-server/pull/664) by @tittoassini
+- Add pragmas completions
+([#662)](https://github.com/haskell/haskell-language-server/pull/662) by @gdevanla
+- Enable code completion tests
+([#657)](https://github.com/haskell/haskell-language-server/pull/657) by @peterwicksstringfield
+- Enable highlight unittests
+([#656)](https://github.com/haskell/haskell-language-server/pull/656) by @peterwicksstringfield
+- Fix document symbols unit tests.
+([#655)](https://github.com/haskell/haskell-language-server/pull/655) by @peterwicksstringfield
+- Delete duplicate cabal clause for applyrefact2
+([#654)](https://github.com/haskell/haskell-language-server/pull/654) by @peterwicksstringfield
+- Add extra-source-files for split plugins
+([#650)](https://github.com/haskell/haskell-language-server/pull/650) by @berberman
+- [nix-shell] Actually use gitignore
+([#649)](https://github.com/haskell/haskell-language-server/pull/649) by @pepeiborra
+-  idempotent command and code cleanup
+([#648)](https://github.com/haskell/haskell-language-server/pull/648) by @tittoassini
+- Split the Imports and Retrie plugins
+([#647)](https://github.com/haskell/haskell-language-server/pull/647) by @pepeiborra
+- Simplify and Bump implicit-hie version constraints
+([#645)](https://github.com/haskell/haskell-language-server/pull/645) by @Avi-D-coder
+- Fix and enable disabled code action unit tests, fix fallback handler
+([#643)](https://github.com/haskell/haskell-language-server/pull/643) by @peterwicksstringfield
+- Add Ghcide hie.yaml instruction for Stack users
+([#641)](https://github.com/haskell/haskell-language-server/pull/641) by @Sir4ur0n
+- Upgrade the Nix build system
+([#639)](https://github.com/haskell/haskell-language-server/pull/639) by @pepeiborra
+- No longer needed to build once for Stack
+([#637)](https://github.com/haskell/haskell-language-server/pull/637) by @Sir4ur0n
+- Preserve the last empty comment line after eval plugin
+([#631)](https://github.com/haskell/haskell-language-server/pull/631) by @expipiplus1
+- Update fourmolu to 0.3.0.0
+([#624)](https://github.com/haskell/haskell-language-server/pull/624) by @gwils
+- Add hspec-discover to build-tool-depends in tactics plugin
+([#623)](https://github.com/haskell/haskell-language-server/pull/623) by @gwils
+- Add build to ghc-8.10.2 and windows
+([#619)](https://github.com/haskell/haskell-language-server/pull/619) by @jneira
+- Module Name Plugin: Treat modules starting with lowercase as Main module
+([#616)](https://github.com/haskell/haskell-language-server/pull/616) by @konn
+- Bump ormolu to 0.1.4.1
+([#614)](https://github.com/haskell/haskell-language-server/pull/614) by @AlistairB
+- Fix fourmolu plugin inconsistent formatting
+([#599)](https://github.com/haskell/haskell-language-server/pull/599) by @zweimach
+- Hlint: bring over idea2Message for formatting
+([#598)](https://github.com/haskell/haskell-language-server/pull/598) by @alanz
+- Makes dictionary argument exclusion logic in Tactic plugin more robust
+([#508)](https://github.com/haskell/haskell-language-server/pull/508) by @konn
+
 ## 0.6.0
 
 0.6.0 includes two brand new plugins!

--- a/cabal.project
+++ b/cabal.project
@@ -10,8 +10,8 @@ packages:
 
 source-repository-package
   type: git
-  location: https://github.com/bubba/brittany.git
-  tag: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+  location: https://github.com/lspitzner/brittany.git
+  tag: 0a710ab27147d4f7981fe4ca343b43136ee36919
 
 tests: true
 

--- a/cabal.project
+++ b/cabal.project
@@ -20,6 +20,6 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-12-11T18:53:33Z
+index-state: 2020-12-13T11:31:58Z
 
 allow-newer: data-tree-print:base

--- a/cabal.project
+++ b/cabal.project
@@ -8,11 +8,6 @@ packages:
          ./plugins/hls-explicit-imports-plugin
          ./plugins/hls-retrie-plugin
 
-source-repository-package
-  type: git
-  location: https://github.com/lspitzner/brittany.git
-  tag: 0a710ab27147d4f7981fe4ca343b43136ee36919
-
 tests: true
 
 package *
@@ -25,6 +20,6 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-12-09T06:57:58Z
+index-state: 2020-12-11T18:53:33Z
 
 allow-newer: data-tree-print:base

--- a/cabal.project
+++ b/cabal.project
@@ -25,6 +25,6 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-12-03T03:58:05Z
+index-state: 2020-12-09T06:57:58Z
 
 allow-newer: data-tree-print:base

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -7,7 +7,8 @@ import Control.Monad.Extra
 import Data.Foldable
 import Data.List
 import Data.Void
-import HIE.Bios
+import Development.IDE.Session (findCradle, defaultLoadingOptions)
+import HIE.Bios hiding (findCradle)
 import HIE.Bios.Environment
 import HIE.Bios.Types
 import Ide.Arguments
@@ -135,7 +136,7 @@ getRuntimeGhcVersion' cradle = do
 -- of the project that may or may not be accurate.
 findLocalCradle :: FilePath -> IO (Cradle Void)
 findLocalCradle fp = do
-  cradleConf <- findCradle fp
+  cradleConf <- (findCradle defaultLoadingOptions) fp
   crdl       <- case cradleConf of
     Just yaml -> do
       hPutStrLn stderr $ "Found \"" ++ yaml ++ "\" for \"" ++ fp ++ "\""

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -59,7 +59,7 @@ library
     , containers
     , data-default
     , ghc
-    , ghcide                >=0.6
+    , ghcide                >=0.6.0.1
     , gitrev
     , haskell-lsp           ^>=0.22
     , hls-plugin-api        >=0.5

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -62,7 +62,6 @@ library
     , ghcide                >=0.6
     , gitrev
     , haskell-lsp           ^>=0.22
-    , hie-bios              >=0.7.1 && <0.8
     , hls-plugin-api        >=0.5
     , hslogger
     , optparse-applicative
@@ -170,6 +169,7 @@ executable haskell-language-server-wrapper
   build-depends:
     , ghc
     , ghc-paths
+    , ghcide
     , gitrev
     , haskell-language-server
     , hie-bios

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -59,10 +59,10 @@ library
     , containers
     , data-default
     , ghc
-    , ghcide                >=0.5
+    , ghcide                >=0.6
     , gitrev
     , haskell-lsp           ^>=0.22
-    , hie-bios              >=0.6.1 && <0.8
+    , hie-bios              >=0.7.1 && <0.8
     , hls-plugin-api        >=0.5
     , hslogger
     , optparse-applicative

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -143,7 +143,7 @@ executable haskell-language-server
     , unordered-containers
 
   if flag(agpl)
-    build-depends: brittany
+    build-depends: brittany     >= 0.13.1.0
     other-modules: Ide.Plugin.Brittany
 
   include-dirs:     include

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.2
 category:           Development
 name:               haskell-language-server
-version:            0.6.0.0
+version:            0.7.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hls-plugin-api
-version:       0.5.0.0
+version:       0.5.0.1
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,6 +17,7 @@ let
           haskellPackages.extend (pkgs.haskell.lib.packageSourceOverrides {
             haskell-language-server = gitignoreSource ../.;
             ghcide = gitignoreSource ../ghcide;
+            shake-bench = gitignoreSource ../ghcide/shake-bench;
             hie-compat = gitignoreSource ../ghcide/hie-compat;
             hls-plugin-api = gitignoreSource ../hls-plugin-api;
             hls-tactics-plugin = gitignoreSource ../plugins/tactics;

--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,7 @@ let defaultCompiler = "ghc" + lib.replaceStrings ["."] [""] haskellPackages.ghc.
 
     packages = p: [ p.haskell-language-server
                     p.ghcide
+                    p.shake-bench
                     p.hie-compat
                     p.hls-plugin-api
                     p.hls-tactics-plugin

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -34,19 +34,18 @@ import Development.IDE.Core.Shake
 import Development.IDE.LSP.LanguageServer
 import Development.IDE.LSP.Protocol
 import Development.IDE.Plugin
-import Development.IDE.Session
+import Development.IDE.Session (loadSession, findCradle, defaultLoadingOptions)
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import Development.IDE.Types.Logger
 import Development.IDE.Types.Options
-import HIE.Bios.Cradle
 import qualified Language.Haskell.LSP.Core as LSP
 import Ide.Arguments
 import Ide.Logger
 import Ide.Plugin
 import Ide.Version
 import Ide.Plugin.Config
-import Ide.Types                                (IdePlugins, ipMap)
+import Ide.Types (IdePlugins, ipMap)
 import Language.Haskell.LSP.Messages
 import Language.Haskell.LSP.Types
 import qualified System.Directory.Extra as IO
@@ -158,7 +157,7 @@ runLspMode lspArgs@LspArguments{..} idePlugins = do
         putStrLn $ "Found " ++ show (length files) ++ " files"
 
         putStrLn "\nStep 2/4: Looking for hie.yaml files that control setup"
-        cradles <- mapM findCradle files
+        cradles <- mapM (findCradle defaultLoadingOptions) files
         let ucradles = nubOrd cradles
         let n = length ucradles
         putStrLn $ "Found " ++ show n ++ " cradle" ++ ['s' | n /= 1]

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -18,19 +18,21 @@ extra-deps:
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 - Cabal-3.0.2.0
 - clock-0.7.2
-- data-tree-print-0.1.0.2
+- data-tree-print-0.1.0.2@rev:2
 - floskell-0.10.4
 - fourmolu-0.3.0.0
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.3.0.2
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1
@@ -44,7 +46,8 @@ flags:
   retrie:
     BuildExecutable: false
 
-# for data-tree-print's bounds on base (>=4.8 && <4.14); using base-4.14.0.0.
+# for brittany's bounds on strict (>=0.3.2 && <0.4); using strict-0.4.0.1.
+# https://github.com/lspitzner/brittany/issues/328
 allow-newer: true
 
 nix:

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -14,8 +14,8 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - Cabal-3.0.2.0
 - clock-0.7.2
 - data-tree-print-0.1.0.2@rev:2
@@ -45,10 +45,6 @@ flags:
     pedantic: true
   retrie:
     BuildExecutable: false
-
-# for brittany's bounds on strict (>=0.3.2 && <0.4); using strict-0.4.0.1.
-# https://github.com/lspitzner/brittany/issues/328
-allow-newer: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -14,8 +14,7 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-- github: lspitzner/brittany
-  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
+- brittany-0.13.1.0
 - Cabal-3.0.2.0
 - clock-0.7.2
 - data-tree-print-0.1.0.2@rev:2

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -14,8 +14,7 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-- github: lspitzner/brittany
-  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
+- brittany-0.13.1.0
 - Cabal-3.0.2.0
 - clock-0.7.2
 - data-tree-print-0.1.0.2@rev:2

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -14,8 +14,8 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - Cabal-3.0.2.0
 - clock-0.7.2
 - data-tree-print-0.1.0.2@rev:2
@@ -37,10 +37,6 @@ flags:
     pedantic: true
   retrie:
     BuildExecutable: false
-
-# for brittany's bounds on strict (>=0.3.2 && <0.4); using strict-0.4.0.1.
-# https://github.com/lspitzner/brittany/issues/328
-allow-newer: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-11-22
+resolver: nightly-2020-12-09
 
 packages:
 - .
@@ -18,14 +18,14 @@ extra-deps:
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 - Cabal-3.0.2.0
 - clock-0.7.2
-- data-tree-print-0.1.0.2
+- data-tree-print-0.1.0.2@rev:2
 - floskell-0.10.4
 - fourmolu-0.3.0.0
+- heapsize-0.3.0
 - implicit-hie-cradle-0.3.0.2
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
 - refinery-0.3.0.0
 - retrie-0.1.1.1
 - stylish-haskell-0.12.2.0
@@ -38,7 +38,8 @@ flags:
   retrie:
     BuildExecutable: false
 
-# for data-tree-print's bounds on base (>=4.8 && <4.14); using base-4.14.0.0.
+# for brittany's bounds on strict (>=0.3.2 && <0.4); using strict-0.4.0.1.
+# https://github.com/lspitzner/brittany/issues/328
 allow-newer: true
 
 nix:

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -19,8 +19,7 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: lspitzner/brittany
-  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
+- brittany-0.13.1.0
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -19,8 +19,8 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -32,17 +32,21 @@ extra-deps:
 - fuzzy-0.1.0.0
 # - ghcide-0.1.0
 - ghc-check-0.5.0.1
+- ghc-events-0.13.0
 - ghc-exactprint-0.6.3.2
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
 - ghc-source-gen-0.4.0.0
+- ghc-trace-events-0.1.2.1
 - haddock-api-2.22.0@rev:1
 - haddock-library-1.8.0
+- hashable-1.3.0.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.3.0.2
@@ -51,7 +55,8 @@ extra-deps:
 - lens-4.18
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
 - ormolu-0.1.4.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -18,8 +18,7 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: lspitzner/brittany
-  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
+- brittany-0.13.1.0
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -18,8 +18,8 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -31,17 +31,21 @@ extra-deps:
 - fuzzy-0.1.0.0
 # - ghcide-0.1.0
 - ghc-check-0.5.0.1
+- ghc-events-0.13.0
 - ghc-exactprint-0.6.3.2
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
 - ghc-source-gen-0.4.0.0
+- ghc-trace-events-0.1.2.1
 - haddock-api-2.22.0@rev:1
 - haddock-library-1.8.0
+- hashable-1.3.0.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.3.0.2
@@ -50,7 +54,8 @@ extra-deps:
 - lens-4.18
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
 - ormolu-0.1.4.1

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -15,8 +15,7 @@ ghc-options:
 
 extra-deps:
 - aeson-1.5.2.0
-- github: lspitzner/brittany
-  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
+- brittany-0.13.1.0
 - butcher-1.3.3.2
 - bytestring-trie-0.2.5.0
 - clock-0.7.2

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -15,9 +15,8 @@ ghc-options:
 
 extra-deps:
 - aeson-1.5.2.0
-- apply-refact-0.8.2.1
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - butcher-1.3.3.2
 - bytestring-trie-0.2.5.0
 - clock-0.7.2

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -15,6 +15,7 @@ ghc-options:
 
 extra-deps:
 - aeson-1.5.2.0
+- apply-refact-0.8.2.1
 - brittany-0.13.1.0
 - butcher-1.3.3.2
 - bytestring-trie-0.2.5.0

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -25,18 +25,21 @@ extra-deps:
 - extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.3.0.0
-# - ghcide-0.1.0
+# - ghcide-0.6.0
 - ghc-check-0.5.0.1
+- ghc-events-0.13.0
 - ghc-exactprint-0.6.3.2
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
+- ghc-trace-events-0.1.2.1
 - haddock-library-1.8.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - HsYAML-0.2.1.0@rev:1
@@ -46,7 +49,8 @@ extra-deps:
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -16,8 +16,8 @@ ghc-options:
 extra-deps:
 - aeson-1.5.2.0
 - apply-refact-0.8.2.1
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - bytestring-trie-0.2.5.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -16,8 +16,7 @@ ghc-options:
 extra-deps:
 - aeson-1.5.2.0
 - apply-refact-0.8.2.1
-- github: lspitzner/brittany
-  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
+- brittany-0.13.1.0
 - bytestring-trie-0.2.5.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -25,13 +25,15 @@ extra-deps:
 - extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.3.0.0
-# - ghcide-0.1.0
+# - ghcide-0.6.0
 - ghc-exactprint-0.6.3.2
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
+- ghc-trace-events-0.1.2.1
 - haskell-src-exts-1.21.1
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-aeson-0.2.0.0@rev:2
 - hoogle-5.0.17.11
 - hsimport-0.11.0
@@ -40,6 +42,8 @@ extra-deps:
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.23
+resolver: lts-16.25
 
 packages:
 - .
@@ -22,14 +22,15 @@ extra-deps:
 - cabal-plan-0.6.2.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
-- extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.3.0.0
-# - ghcide-0.1.0
+# - ghcide-0.6.0
 - ghc-exactprint-0.6.3.2
+- ghc-trace-events-0.1.2.1
 - haskell-src-exts-1.21.1
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-aeson-0.2.0.0@rev:2
 - hoogle-5.0.17.11
 - hsimport-0.11.0
@@ -38,6 +39,8 @@ extra-deps:
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1
 - semigroups-0.18.5

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -16,8 +16,8 @@ ghc-options:
 extra-deps:
 - aeson-1.5.2.0
 - apply-refact-0.8.2.1
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - bytestring-trie-0.2.5.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -16,8 +16,7 @@ ghc-options:
 extra-deps:
 - aeson-1.5.2.0
 - apply-refact-0.8.2.1
-- github: lspitzner/brittany
-  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
+- brittany-0.13.1.0
 - bytestring-trie-0.2.5.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,8 +18,7 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: lspitzner/brittany
-  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
+- brittany-0.13.1.0
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,17 +29,21 @@ extra-deps:
 - floskell-0.10.4
 - fourmolu-0.3.0.0
 - fuzzy-0.1.0.0
-# - ghcide-0.1.0
+# - ghcide-0.6.0
 - ghc-check-0.5.0.1
 - ghc-exactprint-0.6.3.2
+- ghc-events-0.13.0
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
 - ghc-source-gen-0.4.0.0
+- ghc-trace-events-0.1.2.1
 - haddock-api-2.22.0@rev:1
 - haddock-library-1.8.0
+- hashable-1.3.0.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
+- heapsize-0.3.0
 - hie-bios-0.7.1
 - hlint-3.2
 - HsYAML-0.2.1.0@rev:1
@@ -50,7 +54,8 @@ extra-deps:
 - lens-4.18
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
 - ormolu-0.1.4.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,8 +18,8 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -199,7 +199,6 @@ tests = testGroup "completions" [
 
 snippetTests :: TestTree
 snippetTests = testGroup "snippets" [
-    ignoreTestBecause "no support for snippets" $
     testCase "work for argumentless constructors" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Completion.hs" "haskell"
       _ <- waitForDiagnosticsFrom doc
@@ -211,10 +210,9 @@ snippetTests = testGroup "snippets" [
       let item = head $ filter ((== "Nothing") . (^. label)) compls
       liftIO $ do
           item ^. insertTextFormat @?= Just Snippet
-          item ^. insertText @?= Just "Nothing"
+          item ^. insertText @?= Just "Nothing "
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -229,8 +227,7 @@ snippetTests = testGroup "snippets" [
             item ^. insertTextFormat @?= Just Snippet
             item ^. insertText @?= Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for complex types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for complex types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -245,8 +242,7 @@ snippetTests = testGroup "snippets" [
             item ^. insertTextFormat @?= Just Snippet
             item ^. insertText @?= Just "mapM ${1:a -> m b} ${2:t a}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -259,10 +255,9 @@ snippetTests = testGroup "snippets" [
             item ^. label @?= "filter"
             item ^. kind @?= Just CiFunction
             item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "filter`"
+            item ^. insertText @?= Just "filter ${1:a -> Bool} ${2:[a]}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -275,10 +270,9 @@ snippetTests = testGroup "snippets" [
             item ^. label @?= "filter"
             item ^. kind @?= Just CiFunction
             item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "filter"
+            item ^. insertText @?= Just "filter ${1:a -> Bool} ${2:[a]}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -291,10 +285,9 @@ snippetTests = testGroup "snippets" [
             item ^. label @?= "intersperse"
             item ^. kind @?= Just CiFunction
             item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "intersperse`"
+            item ^. insertText @?= Just "intersperse ${1:a} ${2:[a]}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -307,7 +300,7 @@ snippetTests = testGroup "snippets" [
             item ^. label @?= "intersperse"
             item ^. kind @?= Just CiFunction
             item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "intersperse"
+            item ^. insertText @?= Just "intersperse ${1:a} ${2:[a]}"
 
     , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -302,7 +302,8 @@ snippetTests = testGroup "snippets" [
             item ^. insertTextFormat @?= Just Snippet
             item ^. insertText @?= Just "intersperse ${1:a} ${2:[a]}"
 
-    , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , ignoreTestBecause "ghcide does not support the completionSnippetsOn option" $
+      testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -13,12 +13,12 @@ import Test.Tasty
 import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
 import qualified Data.Text as T
+import System.Time.Extra (sleep)
 
 tests :: TestTree
 tests = testGroup "completions" [
      testCase "works" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
 
          let te = TextEdit (Range (Position 5 7) (Position 5 24)) "put"
          _ <- applyEdit doc te
@@ -35,7 +35,6 @@ tests = testGroup "completions" [
      , ignoreTestBecause "no support for itemCompletion/resolve requests"
        $ testCase "itemCompletion/resolve works" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
 
          let te = TextEdit (Range (Position 5 7) (Position 5 24)) "put"
          _ <- applyEdit doc te
@@ -54,7 +53,8 @@ tests = testGroup "completions" [
 
      , testCase "completes imports" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
+
+         liftIO $ sleep 4
 
          let te = TextEdit (Range (Position 1 17) (Position 1 26)) "Data.M"
          _ <- applyEdit doc te
@@ -68,7 +68,8 @@ tests = testGroup "completions" [
 
      , testCase "completes qualified imports" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
+
+         liftIO $ sleep 4
 
          let te = TextEdit (Range (Position 2 17) (Position 1 25)) "Dat"
          _ <- applyEdit doc te
@@ -82,7 +83,8 @@ tests = testGroup "completions" [
 
      , testCase "completes language extensions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
+
+         liftIO $ sleep 4
 
          let te = TextEdit (Range (Position 0 24) (Position 0 31)) ""
          _ <- applyEdit doc te
@@ -95,7 +97,8 @@ tests = testGroup "completions" [
 
      , testCase "completes pragmas" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
+
+         liftIO $ sleep 4
 
          let te = TextEdit (Range (Position 0 4) (Position 0 34)) ""
          _ <- applyEdit doc te
@@ -110,7 +113,6 @@ tests = testGroup "completions" [
 
      , testCase "completes pragmas no close" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
 
          let te = TextEdit (Range (Position 0 4) (Position 0 24)) ""
          _ <- applyEdit doc te
@@ -125,7 +127,8 @@ tests = testGroup "completions" [
 
      , testCase "completes options pragma" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
+
+         liftIO $ sleep 4
 
          let te = TextEdit (Range (Position 0 4) (Position 0 34)) "OPTIONS"
          _ <- applyEdit doc te
@@ -141,8 +144,6 @@ tests = testGroup "completions" [
      , testCase "completes ghc options pragma values" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
 
-         _ <- waitForDiagnosticsFrom doc
-
          let te = TextEdit (Range (Position 0 0) (Position 0 0)) "{-# OPTIONS_GHC -Wno-red  #-}\n"
          _ <- applyEdit doc te
 
@@ -156,7 +157,7 @@ tests = testGroup "completions" [
 
      , testCase "completes with no prefix" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
+
          compls <- getCompletions doc (Position 5 7)
          liftIO $ any ((== "!!") . (^. label)) compls @? ""
 
@@ -175,7 +176,7 @@ tests = testGroup "completions" [
 
      , testCase "have implicit foralls on basic polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
+
          let te = TextEdit (Range (Position 5 7) (Position 5 9)) "id"
          _ <- applyEdit doc te
          compls <- getCompletions doc (Position 5 9)
@@ -185,7 +186,7 @@ tests = testGroup "completions" [
 
      , testCase "have implicit foralls with multiple type variables" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
-         _ <- waitForDiagnosticsFrom doc
+
          let te = TextEdit (Range (Position 5 7) (Position 5 24)) "flip"
          _ <- applyEdit doc te
          compls <- getCompletions doc (Position 5 11)
@@ -201,7 +202,6 @@ snippetTests :: TestTree
 snippetTests = testGroup "snippets" [
     testCase "work for argumentless constructors" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Completion.hs" "haskell"
-      _ <- waitForDiagnosticsFrom doc
 
       let te = TextEdit (Range (Position 5 7) (Position 5 24)) "Nothing"
       _ <- applyEdit doc te
@@ -214,7 +214,6 @@ snippetTests = testGroup "snippets" [
 
     , testCase "work for polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
 
         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "fold"
         _ <- applyEdit doc te
@@ -229,7 +228,6 @@ snippetTests = testGroup "snippets" [
 
     , testCase "work for complex types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
 
         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "mapM"
         _ <- applyEdit doc te
@@ -244,7 +242,6 @@ snippetTests = testGroup "snippets" [
 
     , testCase "work for infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
 
         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "even `filte"
         _ <- applyEdit doc te
@@ -259,7 +256,6 @@ snippetTests = testGroup "snippets" [
 
     , testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
 
         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "even `filte`"
         _ <- applyEdit doc te
@@ -274,7 +270,6 @@ snippetTests = testGroup "snippets" [
 
     , testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
 
         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "\"\" `Data.List.interspe"
         _ <- applyEdit doc te
@@ -289,7 +284,6 @@ snippetTests = testGroup "snippets" [
 
     , testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
 
         let te = TextEdit (Range (Position 5 7) (Position 5 24)) "\"\" `Data.List.interspe`"
         _ <- applyEdit doc te
@@ -305,7 +299,6 @@ snippetTests = testGroup "snippets" [
     , ignoreTestBecause "ghcide does not support the completionSnippetsOn option" $
       testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
 
         let config = object [ "haskell" .= (object ["completionSnippetsOn" .= False])]
 
@@ -316,7 +309,6 @@ snippetTests = testGroup "snippets" [
 
     , testCase "respects client capabilities" $ runSession hlsCommand noSnippetsCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
 
         checkNoSnippets doc
     ]
@@ -349,7 +341,7 @@ contextTests :: TestTree
 contextTests = testGroup "contexts" [
     testCase "only provides type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Context.hs" "haskell"
-      _ <- waitForDiagnosticsFrom doc
+
       compls <- getCompletions doc (Position 2 17)
       liftIO $ do
         compls `shouldContainCompl` "Integer"
@@ -357,7 +349,7 @@ contextTests = testGroup "contexts" [
 
     , testCase "only provides value suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Context.hs" "haskell"
-      _ <- waitForDiagnosticsFrom doc
+
       compls <- getCompletions doc (Position 3 9)
       liftIO $ do
         compls `shouldContainCompl` "abs"
@@ -365,7 +357,7 @@ contextTests = testGroup "contexts" [
 
     , testCase "completes qualified type suggestions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Context.hs" "haskell"
-        _ <- waitForDiagnosticsFrom doc
+
         compls <- getCompletions doc (Position 2 26)
         liftIO $ do
             compls `shouldNotContainCompl` "forkOn"

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -29,8 +29,8 @@ tests = testGroup "completions" [
              item ^. label @?= "putStrLn"
              item ^. kind @?= Just CiFunction
              item ^. detail @?= Just ":: String -> IO ()"
-             item ^. insertTextFormat @?= Just PlainText
-             item ^. insertText @?= Nothing
+             item ^. insertTextFormat @?= Just Snippet
+             item ^. insertText @?= Just "putStrLn ${1:String}"
 
      , ignoreTestBecause "no support for itemCompletion/resolve requests"
        $ testCase "itemCompletion/resolve works" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
@@ -105,8 +105,8 @@ tests = testGroup "completions" [
          liftIO $ do
              item ^. label @?= "LANGUAGE"
              item ^. kind @?= Just CiKeyword
-             item ^. insertTextFormat @?= Just PlainText
-             item ^. insertText @?= Nothing
+             item ^. insertTextFormat @?= Just Snippet
+             item ^. insertText @?= Just "LANGUAGE ${1:extension} #-}"
 
      , testCase "completes pragmas no close" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
@@ -120,8 +120,8 @@ tests = testGroup "completions" [
          liftIO $ do
              item ^. label @?= "LANGUAGE"
              item ^. kind @?= Just CiKeyword
-             item ^. insertTextFormat @?= Just PlainText
-             item ^. insertText @?= Nothing
+             item ^. insertTextFormat @?= Just Snippet
+             item ^. insertText @?= Just "LANGUAGE ${1:extension}"
 
      , testCase "completes options pragma" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
@@ -135,8 +135,8 @@ tests = testGroup "completions" [
          liftIO $ do
              item ^. label @?= "OPTIONS_GHC"
              item ^. kind @?= Just CiKeyword
-             item ^. insertTextFormat @?= Just PlainText
-             item ^. insertText @?= Nothing
+             item ^. insertTextFormat @?= Just Snippet
+             item ^. insertText @?= Just "OPTIONS_GHC -${1:option} #-}"
 
      , testCase "completes ghc options pragma values" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -276,7 +276,7 @@ redundantImportTests = testGroup "redundant import code actions" [
             -- provides workspace edit property which skips round trip to
             -- the server
             contents <- documentContents doc
-            liftIO $ contents @?= "module CodeActionRedundant where\nmain :: IO ()\nmain = putStrLn \"hello\""
+            liftIO $ contents @?= "{-# OPTIONS_GHC -Wunused-imports #-}\nmodule CodeActionRedundant where\nmain :: IO ()\nmain = putStrLn \"hello\"\n"
 
     , testCase "doesn't touch other imports" $ runSession hlsCommand noLiteralCaps "test/testdata/redundantImportTest/" $ do
         doc <- openDoc "src/MultipleImports.hs" "haskell"
@@ -285,7 +285,8 @@ redundantImportTests = testGroup "redundant import code actions" [
         executeCommand cmd
         contents <- documentContents doc
         liftIO $ (T.lines contents) @?=
-                [ "module MultipleImports where"
+                [ "{-# OPTIONS_GHC -Wunused-imports #-}"
+                , "module MultipleImports where"
                 , "import Data.Maybe"
                 , "foo :: Int"
                 , "foo = fromJust (Just 3)"

--- a/test/testdata/Format.brittany.formatted.hs
+++ b/test/testdata/Format.brittany.formatted.hs
@@ -1,8 +1,8 @@
 module Format where
 import           Data.List
 
-import           Prelude
 import           Data.Int
+import           Prelude
 foo :: Int -> Int
 foo 3 = 2
 foo x = x

--- a/test/testdata/Format.brittany_post_floskell.formatted.hs
+++ b/test/testdata/Format.brittany_post_floskell.formatted.hs
@@ -1,8 +1,8 @@
 module Format where
 
+import           Data.Int
 import           Data.List
 import           Prelude
-import           Data.Int
 
 foo :: Int -> Int
 foo 3 = 2

--- a/test/testdata/Format.floskell.formatted.hs
+++ b/test/testdata/Format.floskell.formatted.hs
@@ -1,8 +1,8 @@
 module Format where
 
 import           Data.List
-import           Prelude
 import           Data.Int
+import           Prelude
 
 foo :: Int -> Int
 foo 3 = 2

--- a/test/testdata/Highlight.hs
+++ b/test/testdata/Highlight.hs
@@ -2,4 +2,4 @@ module Highlight where
 foo :: Int
 foo = 3
 bar = foo
-  where baz = let x = foo in x
+  where baz = let x = foo in id x

--- a/test/testdata/completion/Completion.hs
+++ b/test/testdata/completion/Completion.hs
@@ -6,4 +6,4 @@ main :: IO ()
 main = putStrLn "hello"
 
 foo :: Either a b -> Either a b
-foo = id id
+foo = id

--- a/test/testdata/completion/Completion.hs
+++ b/test/testdata/completion/Completion.hs
@@ -6,4 +6,4 @@ main :: IO ()
 main = putStrLn "hello"
 
 foo :: Either a b -> Either a b
-foo = id
+foo = id id

--- a/test/testdata/completion/Context.hs
+++ b/test/testdata/completion/Context.hs
@@ -1,4 +1,4 @@
 module Context where
 import Control.Concurrent as Conc
 foo :: Int -> Int -> Conc.MVar
-foo x = abs $ id 42
+foo x = abs 42

--- a/test/testdata/completion/Context.hs
+++ b/test/testdata/completion/Context.hs
@@ -1,4 +1,4 @@
 module Context where
 import Control.Concurrent as Conc
-foo :: Int -> Int
+foo :: Int -> Int -> Conc.MVar
 foo x = abs $ id 42

--- a/test/testdata/completion/Context.hs
+++ b/test/testdata/completion/Context.hs
@@ -1,4 +1,4 @@
 module Context where
 import Control.Concurrent as Conc
 foo :: Int -> Int
-foo x = abs 42
+foo x = abs $ id 42

--- a/test/testdata/redundantImportTest/src/CodeActionRedundant.hs
+++ b/test/testdata/redundantImportTest/src/CodeActionRedundant.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
 module CodeActionRedundant where
 import Data.List
 main :: IO ()

--- a/test/testdata/redundantImportTest/src/MultipleImports.hs
+++ b/test/testdata/redundantImportTest/src/MultipleImports.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
 module MultipleImports where
 import Data.Foldable
 import Data.Maybe


### PR DESCRIPTION
* This will not be the final commit ([ghcide has to be released yet](https://github.com/haskell/ghcide/pull/940)) but let's see what has to say ci.