### PR TITLE
Add pragmas completions

### DIFF
--- a/plugins/default/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/default/src/Ide/Plugin/Pragmas.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 -- | Provides code actions to add missing pragmas (whenever GHC suggests to)
 module Ide.Plugin.Pragmas
@@ -182,38 +183,22 @@ completion lspFuncs _ide complParams = do
                     = Completions $ List []
                 result Nothing = Completions $ List []
                 buildCompletion p =
-                   CompletionItem
-                     label
-                     kind
-                     tags
-                     detail
-                     documentation
-                     deprecated
-                     preselect
-                     sortText
-                     filterText
-                     insertText
-                     insertTextFormat
-                     textEdit
-                     additionalTextEdits
-                     commitCharacters
-                     command
-                     xd
-                    where
-                         label = p
-                         kind = Nothing
-                         tags = List []
-                         detail = Nothing
-                         documentation = Nothing
-                         deprecated = Nothing
-                         preselect = Nothing
-                         sortText = Nothing
-                         filterText = Nothing
-                         insertText = Nothing
-                         insertTextFormat = Nothing
-                         textEdit = Nothing
-                         additionalTextEdits = Nothing
-                         commitCharacters = Nothing
-                         command = Nothing
-                         xd = Nothing
+                    CompletionItem
+                      { _label = p,
+                        _kind = Nothing,
+                        _tags = List [],
+                        _detail = Nothing,
+                        _documentation = Nothing,
+                        _deprecated = Nothing,
+                        _preselect = Nothing,
+                        _sortText = Nothing,
+                        _filterText = Nothing,
+                        _insertText = Nothing,
+                        _insertTextFormat = Nothing,
+                        _textEdit = Nothing,
+                        _additionalTextEdits = Nothing,
+                        _commitCharacters = Nothing,
+                        _command = Nothing,
+                        _xdata = Nothing
+                      }
         _ -> return $ Completions $ List []

--- a/plugins/default/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/default/src/Ide/Plugin/Pragmas.hs
@@ -185,7 +185,7 @@ completion lspFuncs _ide complParams = do
                 buildCompletion p =
                     CompletionItem
                       { _label = p,
-                        _kind = Nothing,
+                        _kind = Just CiKeyword,
                         _tags = List [],
                         _detail = Nothing,
                         _documentation = Nothing,

--- a/plugins/default/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/default/src/Ide/Plugin/Pragmas.hs
@@ -21,12 +21,16 @@ import qualified Language.Haskell.LSP.Types.Lens as J
 import           Development.IDE as D
 import           Language.Haskell.LSP.Types
 
+import qualified Language.Haskell.LSP.Core as LSP
+import qualified Language.Haskell.LSP.VFS as VFS
+
 -- ---------------------------------------------------------------------
 
 descriptor :: PluginId -> PluginDescriptor
 descriptor plId = (defaultPluginDescriptor plId)
   { pluginCommands = commands
   , pluginCodeActionProvider = Just codeActionProvider
+  , pluginCompletionProvider = Just completion
   }
 
 -- ---------------------------------------------------------------------
@@ -160,3 +164,54 @@ possiblePragmas =
   ]
 
 -- ---------------------------------------------------------------------
+
+completion :: CompletionProvider
+completion lspFuncs _ide complParams = do
+    let (TextDocumentIdentifier uri) = complParams ^. J.textDocument
+        position = complParams ^. J.position
+    putStrLn $ "Uri" ++ show uri
+    putStrLn $ "nor uri" ++ show (toNormalizedUri uri)
+    contents <- LSP.getVirtualFileFunc lspFuncs $ toNormalizedUri uri
+    fmap Right $ case (contents, uriToFilePath' uri) of
+        (Just cnts, Just _path) -> do
+            pfix <- VFS.getCompletionPrefix position cnts
+            putStrLn $ "pfix" ++ show pfix
+            return $ Completions $ List [r]
+            where
+                r =
+                   CompletionItem
+                     label
+                     kind
+                     tags
+                     detail
+                     documentation
+                     deprecated
+                     preselect
+                     sortText
+                     filterText
+                     insertText
+                     insertTextFormat
+                     textEdit
+                     additionalTextEdits
+                     commitCharacters
+                     command
+                     xd
+                label = "Example Pragma completion"
+                kind = Nothing
+                tags = List []
+                detail = Nothing
+                documentation = Nothing
+                deprecated = Nothing
+                preselect = Nothing
+                sortText = Nothing
+                filterText = Nothing
+                insertText = Nothing
+                insertTextFormat = Nothing
+                textEdit = Nothing
+                additionalTextEdits = Nothing
+                commitCharacters = Nothing
+                command = Nothing
+                xd = Nothing
+        _ -> do
+            putStrLn $ "Need to handle this path"'
+            return $ Completions $ List []

--- a/plugins/default/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/default/src/Ide/Plugin/Pragmas.hs
@@ -23,7 +23,6 @@ import           Language.Haskell.LSP.Types
 
 import qualified Language.Haskell.LSP.Core as LSP
 import qualified Language.Haskell.LSP.VFS as VFS
-import Development.IDE.Core.Shake (ShakeExtras(logger))
 
 -- ---------------------------------------------------------------------
 
@@ -166,24 +165,14 @@ possiblePragmas =
 
 -- ---------------------------------------------------------------------
 
-logStuff :: IdeState -> T.Text -> IO ()
-logStuff ide = logInfo (logger (shakeExtras ide))
-
 completion :: CompletionProvider
 completion lspFuncs _ide complParams = do
     let (TextDocumentIdentifier uri) = complParams ^. J.textDocument
         position = complParams ^. J.position
-    logStuff _ide (T.pack "test ---------------------.......")
-    putStrLn $ "Uri" ++ show uri
-    putStrLn $ "nor uri" ++ show (toNormalizedUri uri)
-    logStuff _ide (T.pack "--------------------------------.......")
     contents <- LSP.getVirtualFileFunc lspFuncs $ toNormalizedUri uri
     fmap Right $ case (contents, uriToFilePath' uri) of
         (Just cnts, Just _path) -> do
             pfix <- VFS.getCompletionPrefix position cnts
-            logStuff _ide (T.pack "test &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&.......")
-            logStuff _ide $ "pfix" <> (T.pack. show $ pfix)
-            logStuff _ide (T.pack "test &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&.......")
             return $ result pfix
             where
                 result (Just pfix)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.27 # Last 8.6.5
+resolver: nightly-2020-11-22
 
 packages:
 - .
@@ -14,62 +14,23 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-- aeson-1.5.2.0
-- apply-refact-0.8.2.1
-- ansi-terminal-0.10.3
-- base-compat-0.10.5
 - github: bubba/brittany
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
-- butcher-1.3.3.1
 - Cabal-3.0.2.0
-- cabal-plan-0.6.2.0
 - clock-0.7.2
-- Diff-0.4.0
-- extra-1.7.3
+- data-tree-print-0.1.0.2
 - floskell-0.10.4
 - fourmolu-0.3.0.0
-- fuzzy-0.1.0.0
-# - ghcide-0.1.0
-- ghc-check-0.5.0.1
-- ghc-exactprint-0.6.3.2
-- ghc-lib-8.10.2.20200916
-- ghc-lib-parser-8.10.2.20200916
-- ghc-lib-parser-ex-8.10.0.16
-- ghc-source-gen-0.4.0.0
-- haddock-api-2.22.0@rev:1
-- haddock-library-1.8.0
-- haskell-lsp-0.22.0.0
-- haskell-lsp-types-0.22.0.0
-- hie-bios-0.7.1
-- hlint-3.2
-- HsYAML-0.2.1.0@rev:1
-- HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.3.0.2
 - implicit-hie-0.1.2.5
-- indexed-profunctors-0.1
-- lens-4.18
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
-- optics-core-0.2
-- optparse-applicative-0.15.1.0
-- ormolu-0.1.4.1
-- parser-combinators-1.2.1
-- primitive-0.7.1.0
 - refinery-0.3.0.0
-- regex-base-0.94.0.0
-- regex-pcre-builtin-0.95.1.1.8.43
-- regex-tdfa-1.3.1.0
 - retrie-0.1.1.1
-- semialign-1.1
-# - github: wz1000/shake
-#   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - stylish-haskell-0.12.2.0
-- tasty-rerun-1.1.17
+- semigroups-0.18.5
 - temporary-1.2.1.1
-- these-1.1.1.1
-- type-equality-1
-- topograph-1
 
 flags:
   haskell-language-server:
@@ -77,7 +38,8 @@ flags:
   retrie:
     BuildExecutable: false
 
-# allow-newer: true
+# for data-tree-print's bounds on base (>=4.8 && <4.14); using base-4.14.0.0.
+allow-newer: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-11-22
+resolver: lts-14.27 # Last 8.6.5
 
 packages:
 - .
@@ -14,23 +14,62 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
+- aeson-1.5.2.0
+- apply-refact-0.8.2.1
+- ansi-terminal-0.10.3
+- base-compat-0.10.5
 - github: bubba/brittany
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- butcher-1.3.3.1
 - Cabal-3.0.2.0
+- cabal-plan-0.6.2.0
 - clock-0.7.2
-- data-tree-print-0.1.0.2
+- Diff-0.4.0
+- extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.3.0.0
+- fuzzy-0.1.0.0
+# - ghcide-0.1.0
+- ghc-check-0.5.0.1
+- ghc-exactprint-0.6.3.2
+- ghc-lib-8.10.2.20200916
+- ghc-lib-parser-8.10.2.20200916
+- ghc-lib-parser-ex-8.10.0.16
+- ghc-source-gen-0.4.0.0
+- haddock-api-2.22.0@rev:1
+- haddock-library-1.8.0
+- haskell-lsp-0.22.0.0
+- haskell-lsp-types-0.22.0.0
+- hie-bios-0.7.1
+- hlint-3.2
+- HsYAML-0.2.1.0@rev:1
+- HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.3.0.2
 - implicit-hie-0.1.2.5
+- indexed-profunctors-0.1
+- lens-4.18
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
 - opentelemetry-0.4.2
+- optics-core-0.2
+- optparse-applicative-0.15.1.0
+- ormolu-0.1.4.1
+- parser-combinators-1.2.1
+- primitive-0.7.1.0
 - refinery-0.3.0.0
+- regex-base-0.94.0.0
+- regex-pcre-builtin-0.95.1.1.8.43
+- regex-tdfa-1.3.1.0
 - retrie-0.1.1.1
+- semialign-1.1
+# - github: wz1000/shake
+#   commit: fb3859dca2e54d1bbb2c873e68ed225fa179fbef
 - stylish-haskell-0.12.2.0
-- semigroups-0.18.5
+- tasty-rerun-1.1.17
 - temporary-1.2.1.1
+- these-1.1.1.1
+- type-equality-1
+- topograph-1
 
 flags:
   haskell-language-server:
@@ -38,8 +77,7 @@ flags:
   retrie:
     BuildExecutable: false
 
-# for data-tree-print's bounds on base (>=4.8 && <4.14); using base-4.14.0.0.
-allow-newer: true
+# allow-newer: true
 
 nix:
   packages: [ icu libcxx zlib ]


### PR DESCRIPTION
This PR adds the completions of language pragmas to the `Pragmas` plugin.  Once this change is accepted, the completion code [here](https://github.com/haskell/ghcide/blob/baafe2cb82215f992ded3e3c1bd03507553aae86/src/Development/IDE/Plugin/Completions/Logic.hs#L564-L565) can be removed.

Also, starts addressing https://github.com/haskell/ghcide/issues/936
