### PR TITLE
fixed hie.yaml.stack

### DIFF
--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -18,12 +18,6 @@ cradle:
             - path: "./src"
               component: "haskell-language-server:lib"
 
-            - path: "./.stack-work/"
-              component: "haskell-language-server:lib"
-
-            - path: "./exe/Arguments.hs"
-              component: "haskell-language-server:exe:haskell-language-server"
-
             - path: "./exe/Main.hs"
               component: "haskell-language-server:exe:haskell-language-server"
 

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -3,36 +3,17 @@
 # file called 'hie.yaml'
 cradle:
   multi:
-    - path: "./test/testdata/"
-      config: { cradle: { none:  } }
-
+    - path: "./test/testdata"
+      config: { cradle: { none } }
     - path: "./"
       config:
         cradle:
           stack:
-            - path: "./test/functional/"
-              component: "haskell-language-server:func-test"
+            - path: "./ghcide/src"
+              component: "ghcide:lib"
 
-            - path: "./test/utils/"
-              component: "haskell-language-server:func-test"
-
-            - path: "./exe/Main.hs"
-              component: "haskell-language-server:exe:haskell-language-server"
-
-            - path: "./plugins/default/src"
-              component: "haskell-language-server:exe:haskell-language-server"
-
-            - path: "./plugins/tactics/src"
-              component: "hls-tactics-plugin:lib:hls-tactics-plugin"
-
-            - path: "./plugins/tactics/test"
-              component: "hls-tactics-plugin:test:tests"
-
-            - path: "./exe/Arguments.hs"
-              component: "haskell-language-server:exe:haskell-language-server"
-
-            - path: "./exe/Wrapper.hs"
-              component: "haskell-language-server:exe:haskell-language-server-wrapper"
+            - path: "./ghcide/exe"
+              component: "ghcide:exe:ghcide"
 
             - path: "./src"
               component: "haskell-language-server:lib"
@@ -40,14 +21,41 @@ cradle:
             - path: "./.stack-work/"
               component: "haskell-language-server:lib"
 
-            - path: "./ghcide/src"
-              component: "ghcide:lib:ghcide"
+            - path: "./exe/Arguments.hs"
+              component: "haskell-language-server:exe:haskell-language-server"
 
-            - path: "./ghcide/exe"
-              component: "ghcide:exe:ghcide"
+            - path: "./exe/Main.hs"
+              component: "haskell-language-server:exe:haskell-language-server"
 
-            - path: "./hls-plugin-api/src"
-              component: "hls-plugin-api:lib:hls-plugin-api"
+            - path: "./plugins/default/src"
+              component: "haskell-language-server:exe:haskell-language-server"
+
+            - path: "./exe/Wrapper.hs"
+              component: "haskell-language-server:exe:haskell-language-server-wrapper"
+
+            - path: "./test/utils/"
+              component: "haskell-language-server:test:func-test"
+
+            - path: "./test/functional"
+              component: "haskell-language-server:test:func-test"
+
+            - path: "./test/wrapper"
+              component: "haskell-language-server:test:wrapper-test"
+
+            - path: "./plugins/hls-explicit-imports-plugin/src"
+              component: "hls-explicit-imports-plugin:lib"
 
             - path: "./plugins/hls-hlint-plugin/src"
-              component: "hls-hlint-plugin:lib:hls-hlint-plugin"
+              component: "hls-hlint-plugin:lib"
+
+            - path: "./hls-plugin-api/src"
+              component: "hls-plugin-api:lib"
+
+            - path: "./plugins/hls-retrie-plugin/src"
+              component: "hls-retrie-plugin:lib"
+
+            - path: "./plugins/tactics/src"
+              component: "hls-tactics-plugin:lib"
+
+            - path: "./plugins/tactics/test"
+              component: "hls-tactics-plugin:test:tests"


### PR DESCRIPTION
I am submitting this hoping that someone more knowledgable than me will have a long look at it.

Changes:

- fixed some incorrect component name (e.g. hls-hlint-plugin:lib:hls-hlint-plugin)

- added entries for recently added plugins

- ordered components alphabetically

- all targets reported by 'stack ide targets' are now covered, except for:

ghcide:exe:ghcide-bench
ghcide:exe:ghcide-test-preprocessor
ghcide:test:ghcide-tests
ghcide:bench:benchHist
hie-compat:lib

Doubts/Notes:

* Coverage is not comprehensive, haskell-language-server still returns a lot of 'Files that failed"

* What is this for?
 - path: "./.stack-work/"
   component: "haskell-language-server:lib"

* What is this for?
  - path: "./exe/Arguments.hs"
    component: "haskell-language-server:exe:haskell-language-server"

  as ./exe/Arguments.hs does not exist

* Isn't it inconsistent to mark test/testdata as 'none' here and then have it its own hie.yaml? This leads to a lot of Failed files
