### PR TITLE
Pr 658 fix completion tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,8 +10,8 @@ packages:
 
 source-repository-package
   type: git
-  location: https://github.com/bubba/brittany.git
-  tag: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+  location: https://github.com/lspitzner/brittany.git
+  tag: 0a710ab27147d4f7981fe4ca343b43136ee36919
 
 tests: true
 

--- a/cabal.project
+++ b/cabal.project
@@ -25,6 +25,6 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-12-03T03:58:05Z
+index-state: 2020-12-09T06:57:58Z
 
 allow-newer: data-tree-print:base

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -7,7 +7,8 @@ import Control.Monad.Extra
 import Data.Foldable
 import Data.List
 import Data.Void
-import HIE.Bios
+import Development.IDE.Session (findCradle, defaultLoadingOptions)
+import HIE.Bios hiding (findCradle)
 import HIE.Bios.Environment
 import HIE.Bios.Types
 import Ide.Arguments
@@ -135,7 +136,7 @@ getRuntimeGhcVersion' cradle = do
 -- of the project that may or may not be accurate.
 findLocalCradle :: FilePath -> IO (Cradle Void)
 findLocalCradle fp = do
-  cradleConf <- findCradle fp
+  cradleConf <- (findCradle defaultLoadingOptions) fp
   crdl       <- case cradleConf of
     Just yaml -> do
       hPutStrLn stderr $ "Found \"" ++ yaml ++ "\" for \"" ++ fp ++ "\""

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -62,7 +62,6 @@ library
     , ghcide                >=0.6
     , gitrev
     , haskell-lsp           ^>=0.22
-    , hie-bios              >=0.7.1 && <0.8
     , hls-plugin-api        >=0.5
     , hslogger
     , optparse-applicative
@@ -170,6 +169,7 @@ executable haskell-language-server-wrapper
   build-depends:
     , ghc
     , ghc-paths
+    , ghcide
     , gitrev
     , haskell-language-server
     , hie-bios

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -59,10 +59,10 @@ library
     , containers
     , data-default
     , ghc
-    , ghcide                >=0.5
+    , ghcide                >=0.6
     , gitrev
     , haskell-lsp           ^>=0.22
-    , hie-bios              >=0.6.1 && <0.8
+    , hie-bios              >=0.7.1 && <0.8
     , hls-plugin-api        >=0.5
     , hslogger
     , optparse-applicative

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,6 +17,7 @@ let
           haskellPackages.extend (pkgs.haskell.lib.packageSourceOverrides {
             haskell-language-server = gitignoreSource ../.;
             ghcide = gitignoreSource ../ghcide;
+            shake-bench = gitignoreSource ../ghcide/shake-bench;
             hie-compat = gitignoreSource ../ghcide/hie-compat;
             hls-plugin-api = gitignoreSource ../hls-plugin-api;
             hls-tactics-plugin = gitignoreSource ../plugins/tactics;

--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,7 @@ let defaultCompiler = "ghc" + lib.replaceStrings ["."] [""] haskellPackages.ghc.
 
     packages = p: [ p.haskell-language-server
                     p.ghcide
+                    p.shake-bench
                     p.hie-compat
                     p.hls-plugin-api
                     p.hls-tactics-plugin

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -34,19 +34,18 @@ import Development.IDE.Core.Shake
 import Development.IDE.LSP.LanguageServer
 import Development.IDE.LSP.Protocol
 import Development.IDE.Plugin
-import Development.IDE.Session
+import Development.IDE.Session (loadSession, findCradle, defaultLoadingOptions)
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
 import Development.IDE.Types.Logger
 import Development.IDE.Types.Options
-import HIE.Bios.Cradle
 import qualified Language.Haskell.LSP.Core as LSP
 import Ide.Arguments
 import Ide.Logger
 import Ide.Plugin
 import Ide.Version
 import Ide.Plugin.Config
-import Ide.Types                                (IdePlugins, ipMap)
+import Ide.Types (IdePlugins, ipMap)
 import Language.Haskell.LSP.Messages
 import Language.Haskell.LSP.Types
 import qualified System.Directory.Extra as IO
@@ -158,7 +157,7 @@ runLspMode lspArgs@LspArguments{..} idePlugins = do
         putStrLn $ "Found " ++ show (length files) ++ " files"
 
         putStrLn "\nStep 2/4: Looking for hie.yaml files that control setup"
-        cradles <- mapM findCradle files
+        cradles <- mapM (findCradle defaultLoadingOptions) files
         let ucradles = nubOrd cradles
         let n = length ucradles
         putStrLn $ "Found " ++ show n ++ " cradle" ++ ['s' | n /= 1]

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -18,19 +18,21 @@ extra-deps:
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 - Cabal-3.0.2.0
 - clock-0.7.2
-- data-tree-print-0.1.0.2
+- data-tree-print-0.1.0.2@rev:2
 - floskell-0.10.4
 - fourmolu-0.3.0.0
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.3.0.2
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1
@@ -44,7 +46,8 @@ flags:
   retrie:
     BuildExecutable: false
 
-# for data-tree-print's bounds on base (>=4.8 && <4.14); using base-4.14.0.0.
+# for brittany's bounds on strict (>=0.3.2 && <0.4); using strict-0.4.0.1.
+# https://github.com/lspitzner/brittany/issues/328
 allow-newer: true
 
 nix:

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -14,8 +14,8 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - Cabal-3.0.2.0
 - clock-0.7.2
 - data-tree-print-0.1.0.2@rev:2
@@ -45,10 +45,6 @@ flags:
     pedantic: true
   retrie:
     BuildExecutable: false
-
-# for brittany's bounds on strict (>=0.3.2 && <0.4); using strict-0.4.0.1.
-# https://github.com/lspitzner/brittany/issues/328
-allow-newer: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -14,8 +14,8 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - Cabal-3.0.2.0
 - clock-0.7.2
 - data-tree-print-0.1.0.2@rev:2
@@ -37,10 +37,6 @@ flags:
     pedantic: true
   retrie:
     BuildExecutable: false
-
-# for brittany's bounds on strict (>=0.3.2 && <0.4); using strict-0.4.0.1.
-# https://github.com/lspitzner/brittany/issues/328
-allow-newer: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-11-22
+resolver: nightly-2020-12-09
 
 packages:
 - .
@@ -18,14 +18,14 @@ extra-deps:
   commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
 - Cabal-3.0.2.0
 - clock-0.7.2
-- data-tree-print-0.1.0.2
+- data-tree-print-0.1.0.2@rev:2
 - floskell-0.10.4
 - fourmolu-0.3.0.0
+- heapsize-0.3.0
 - implicit-hie-cradle-0.3.0.2
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
 - refinery-0.3.0.0
 - retrie-0.1.1.1
 - stylish-haskell-0.12.2.0
@@ -38,7 +38,8 @@ flags:
   retrie:
     BuildExecutable: false
 
-# for data-tree-print's bounds on base (>=4.8 && <4.14); using base-4.14.0.0.
+# for brittany's bounds on strict (>=0.3.2 && <0.4); using strict-0.4.0.1.
+# https://github.com/lspitzner/brittany/issues/328
 allow-newer: true
 
 nix:

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -19,8 +19,8 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -32,17 +32,21 @@ extra-deps:
 - fuzzy-0.1.0.0
 # - ghcide-0.1.0
 - ghc-check-0.5.0.1
+- ghc-events-0.13.0
 - ghc-exactprint-0.6.3.2
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
 - ghc-source-gen-0.4.0.0
+- ghc-trace-events-0.1.2.1
 - haddock-api-2.22.0@rev:1
 - haddock-library-1.8.0
+- hashable-1.3.0.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.3.0.2
@@ -51,7 +55,8 @@ extra-deps:
 - lens-4.18
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
 - ormolu-0.1.4.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -18,8 +18,8 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -31,17 +31,21 @@ extra-deps:
 - fuzzy-0.1.0.0
 # - ghcide-0.1.0
 - ghc-check-0.5.0.1
+- ghc-events-0.13.0
 - ghc-exactprint-0.6.3.2
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
 - ghc-source-gen-0.4.0.0
+- ghc-trace-events-0.1.2.1
 - haddock-api-2.22.0@rev:1
 - haddock-library-1.8.0
+- hashable-1.3.0.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-0.2.1.0@rev:1
 - HsYAML-aeson-0.2.0.0@rev:2
 - implicit-hie-cradle-0.3.0.2
@@ -50,7 +54,8 @@ extra-deps:
 - lens-4.18
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
 - ormolu-0.1.4.1

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -15,9 +15,8 @@ ghc-options:
 
 extra-deps:
 - aeson-1.5.2.0
-- apply-refact-0.8.2.1
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - butcher-1.3.3.2
 - bytestring-trie-0.2.5.0
 - clock-0.7.2

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -25,18 +25,21 @@ extra-deps:
 - extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.3.0.0
-# - ghcide-0.1.0
+# - ghcide-0.6.0
 - ghc-check-0.5.0.1
+- ghc-events-0.13.0
 - ghc-exactprint-0.6.3.2
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
+- ghc-trace-events-0.1.2.1
 - haddock-library-1.8.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
 - haskell-src-exts-1.21.1
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - HsYAML-0.2.1.0@rev:1
@@ -46,7 +49,8 @@ extra-deps:
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -16,8 +16,8 @@ ghc-options:
 extra-deps:
 - aeson-1.5.2.0
 - apply-refact-0.8.2.1
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - bytestring-trie-0.2.5.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -25,13 +25,15 @@ extra-deps:
 - extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.3.0.0
-# - ghcide-0.1.0
+# - ghcide-0.6.0
 - ghc-exactprint-0.6.3.2
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
+- ghc-trace-events-0.1.2.1
 - haskell-src-exts-1.21.1
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-aeson-0.2.0.0@rev:2
 - hoogle-5.0.17.11
 - hsimport-0.11.0
@@ -40,6 +42,8 @@ extra-deps:
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - ormolu-0.1.4.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.23
+resolver: lts-16.25
 
 packages:
 - .
@@ -22,14 +22,15 @@ extra-deps:
 - cabal-plan-0.6.2.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
-- extra-1.7.3
 - floskell-0.10.4
 - fourmolu-0.3.0.0
-# - ghcide-0.1.0
+# - ghcide-0.6.0
 - ghc-exactprint-0.6.3.2
+- ghc-trace-events-0.1.2.1
 - haskell-src-exts-1.21.1
+- heapsize-0.3.0
 - hie-bios-0.7.1
-- hlint-3.2
+- hlint-3.2.3
 - HsYAML-aeson-0.2.0.0@rev:2
 - hoogle-5.0.17.11
 - hsimport-0.11.0
@@ -38,6 +39,8 @@ extra-deps:
 - implicit-hie-0.1.2.5
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - refinery-0.3.0.0
 - retrie-0.1.1.1
 - semigroups-0.18.5

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -16,8 +16,8 @@ ghc-options:
 extra-deps:
 - aeson-1.5.2.0
 - apply-refact-0.8.2.1
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - bytestring-trie-0.2.5.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,17 +29,21 @@ extra-deps:
 - floskell-0.10.4
 - fourmolu-0.3.0.0
 - fuzzy-0.1.0.0
-# - ghcide-0.1.0
+# - ghcide-0.6.0
 - ghc-check-0.5.0.1
 - ghc-exactprint-0.6.3.2
+- ghc-events-0.13.0
 - ghc-lib-8.10.2.20200916
 - ghc-lib-parser-8.10.2.20200916
 - ghc-lib-parser-ex-8.10.0.16
 - ghc-source-gen-0.4.0.0
+- ghc-trace-events-0.1.2.1
 - haddock-api-2.22.0@rev:1
 - haddock-library-1.8.0
+- hashable-1.3.0.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
+- heapsize-0.3.0
 - hie-bios-0.7.1
 - hlint-3.2
 - HsYAML-0.2.1.0@rev:1
@@ -50,7 +54,8 @@ extra-deps:
 - lens-4.18
 - lsp-test-0.11.0.6
 - monad-dijkstra-0.1.1.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - optics-core-0.2
 - optparse-applicative-0.15.1.0
 - ormolu-0.1.4.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,8 +18,8 @@ extra-deps:
 - apply-refact-0.8.2.1
 - ansi-terminal-0.10.3
 - base-compat-0.10.5
-- github: bubba/brittany
-  commit: c59655f10d5ad295c2481537fc8abf0a297d9d1c
+- github: lspitzner/brittany
+  commit: 0a710ab27147d4f7981fe4ca343b43136ee36919
 - butcher-1.3.3.1
 - Cabal-3.0.2.0
 - cabal-plan-0.6.2.0

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -199,7 +199,6 @@ tests = testGroup "completions" [
 
 snippetTests :: TestTree
 snippetTests = testGroup "snippets" [
-    ignoreTestBecause "no support for snippets" $
     testCase "work for argumentless constructors" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Completion.hs" "haskell"
       _ <- waitForDiagnosticsFrom doc
@@ -211,10 +210,9 @@ snippetTests = testGroup "snippets" [
       let item = head $ filter ((== "Nothing") . (^. label)) compls
       liftIO $ do
           item ^. insertTextFormat @?= Just Snippet
-          item ^. insertText @?= Just "Nothing"
+          item ^. insertText @?= Just "Nothing "
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for polymorphic types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -229,8 +227,7 @@ snippetTests = testGroup "snippets" [
             item ^. insertTextFormat @?= Just Snippet
             item ^. insertText @?= Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for complex types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for complex types" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -245,8 +242,7 @@ snippetTests = testGroup "snippets" [
             item ^. insertTextFormat @?= Just Snippet
             item ^. insertText @?= Just "mapM ${1:a -> m b} ${2:t a}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -259,10 +255,9 @@ snippetTests = testGroup "snippets" [
             item ^. label @?= "filter"
             item ^. kind @?= Just CiFunction
             item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "filter`"
+            item ^. insertText @?= Just "filter ${1:a -> Bool} ${2:[a]}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -275,10 +270,9 @@ snippetTests = testGroup "snippets" [
             item ^. label @?= "filter"
             item ^. kind @?= Just CiFunction
             item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "filter"
+            item ^. insertText @?= Just "filter ${1:a -> Bool} ${2:[a]}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -291,10 +285,9 @@ snippetTests = testGroup "snippets" [
             item ^. label @?= "intersperse"
             item ^. kind @?= Just CiFunction
             item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "intersperse`"
+            item ^. insertText @?= Just "intersperse ${1:a} ${2:[a]}"
 
-    , ignoreTestBecause "no support for snippets" $
-      testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 
@@ -307,7 +300,7 @@ snippetTests = testGroup "snippets" [
             item ^. label @?= "intersperse"
             item ^. kind @?= Just CiFunction
             item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "intersperse"
+            item ^. insertText @?= Just "intersperse ${1:a} ${2:[a]}"
 
     , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -302,7 +302,8 @@ snippetTests = testGroup "snippets" [
             item ^. insertTextFormat @?= Just Snippet
             item ^. insertText @?= Just "intersperse ${1:a} ${2:[a]}"
 
-    , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+    , ignoreTestBecause "ghcide does not support the completionSnippetsOn option" $
+      testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
         _ <- waitForDiagnosticsFrom doc
 

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -29,8 +29,8 @@ tests = testGroup "completions" [
              item ^. label @?= "putStrLn"
              item ^. kind @?= Just CiFunction
              item ^. detail @?= Just ":: String -> IO ()"
-             item ^. insertTextFormat @?= Just PlainText
-             item ^. insertText @?= Nothing
+             item ^. insertTextFormat @?= Just Snippet
+             item ^. insertText @?= Just "putStrLn ${1:String}"
 
      , ignoreTestBecause "no support for itemCompletion/resolve requests"
        $ testCase "itemCompletion/resolve works" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
@@ -105,8 +105,8 @@ tests = testGroup "completions" [
          liftIO $ do
              item ^. label @?= "LANGUAGE"
              item ^. kind @?= Just CiKeyword
-             item ^. insertTextFormat @?= Just PlainText
-             item ^. insertText @?= Nothing
+             item ^. insertTextFormat @?= Just Snippet
+             item ^. insertText @?= Just "LANGUAGE ${1:extension} #-}"
 
      , testCase "completes pragmas no close" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
@@ -120,8 +120,8 @@ tests = testGroup "completions" [
          liftIO $ do
              item ^. label @?= "LANGUAGE"
              item ^. kind @?= Just CiKeyword
-             item ^. insertTextFormat @?= Just PlainText
-             item ^. insertText @?= Nothing
+             item ^. insertTextFormat @?= Just Snippet
+             item ^. insertText @?= Just "LANGUAGE ${1:extension}"
 
      , testCase "completes options pragma" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"
@@ -135,8 +135,8 @@ tests = testGroup "completions" [
          liftIO $ do
              item ^. label @?= "OPTIONS_GHC"
              item ^. kind @?= Just CiKeyword
-             item ^. insertTextFormat @?= Just PlainText
-             item ^. insertText @?= Nothing
+             item ^. insertTextFormat @?= Just Snippet
+             item ^. insertText @?= Just "OPTIONS_GHC -${1:option} #-}"
 
      , testCase "completes ghc options pragma values" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "Completion.hs" "haskell"

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -276,7 +276,7 @@ redundantImportTests = testGroup "redundant import code actions" [
             -- provides workspace edit property which skips round trip to
             -- the server
             contents <- documentContents doc
-            liftIO $ contents @?= "module CodeActionRedundant where\nmain :: IO ()\nmain = putStrLn \"hello\""
+            liftIO $ contents @?= "{-# OPTIONS_GHC -Wunused-imports #-}\nmodule CodeActionRedundant where\nmain :: IO ()\nmain = putStrLn \"hello\"\n"
 
     , testCase "doesn't touch other imports" $ runSession hlsCommand noLiteralCaps "test/testdata/redundantImportTest/" $ do
         doc <- openDoc "src/MultipleImports.hs" "haskell"
@@ -285,7 +285,8 @@ redundantImportTests = testGroup "redundant import code actions" [
         executeCommand cmd
         contents <- documentContents doc
         liftIO $ (T.lines contents) @?=
-                [ "module MultipleImports where"
+                [ "{-# OPTIONS_GHC -Wunused-imports #-}"
+                , "module MultipleImports where"
                 , "import Data.Maybe"
                 , "foo :: Int"
                 , "foo = fromJust (Just 3)"

--- a/test/testdata/Highlight.hs
+++ b/test/testdata/Highlight.hs
@@ -2,4 +2,4 @@ module Highlight where
 foo :: Int
 foo = 3
 bar = foo
-  where baz = let x = foo in x
+  where baz = let x = foo in id x

--- a/test/testdata/completion/Completion.hs
+++ b/test/testdata/completion/Completion.hs
@@ -6,4 +6,4 @@ main :: IO ()
 main = putStrLn "hello"
 
 foo :: Either a b -> Either a b
-foo = id
+foo = id id

--- a/test/testdata/completion/Context.hs
+++ b/test/testdata/completion/Context.hs
@@ -1,4 +1,4 @@
 module Context where
 import Control.Concurrent as Conc
-foo :: Int -> Int
+foo :: Int -> Int -> Conc.MVar
 foo x = abs $ id 42

--- a/test/testdata/completion/Context.hs
+++ b/test/testdata/completion/Context.hs
@@ -1,4 +1,4 @@
 module Context where
 import Control.Concurrent as Conc
 foo :: Int -> Int
-foo x = abs 42
+foo x = abs $ id 42

--- a/test/testdata/redundantImportTest/src/CodeActionRedundant.hs
+++ b/test/testdata/redundantImportTest/src/CodeActionRedundant.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
 module CodeActionRedundant where
 import Data.List
 main :: IO ()

--- a/test/testdata/redundantImportTest/src/MultipleImports.hs
+++ b/test/testdata/redundantImportTest/src/MultipleImports.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wunused-imports #-}
 module MultipleImports where
 import Data.Foldable
 import Data.Maybe


### PR DESCRIPTION
This PR is based on #658 . See the discussion there. It is an attempt to fix the code completion tests which are failing after the upgrade to ghcide 0.6.0.

This is a WIP, these tests are not reliable. I think they weren't reliable even before ghcide 0.6.0 ... but it seems like they are less reliable now. Not enough time to debug it all today, so I'm dumping what I have here.

There are three problems:

1. ghcide 0.6.0 reports fewer diagnostics by default that ghcide 0.5.0. This was causing some tests to fail because they expected certain files to produce diagnostics, and those files no longer produced diagnostics. Such failures manifest as timeouts but they aren't really about time. Fixed.

2. ghcide 0.6.0 has code completion snippets, so the code completion tests need to be updated to account for that. Fixed.

3. There's a third issue that is making the tests randomly fail. I think it was pre-existing but rare and I've only just now noticed. I might know what's happening but I don't have time to really figure it out right now. (We load a file, make a change to it, request code completions, and then check that the completions we get are the ones we expect. But maybe the code completions are based on the contents of the file from before we made the change, because we aren't doing whatever it is we need to do to get the freshest possible results. I thought the way we were doing it was okay but clearly I'm wrong about something. Or maybe that's not the problem at all and its something totally different.)