### PR TITLE
Add plugins conditionally at compile time

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 module Main(main) where
@@ -8,68 +7,8 @@ module Main(main) where
 import           Ide.Arguments             (Arguments (..), LspArguments (..),
                                             getArguments)
 import           Ide.Main                  (defaultMain)
-import           Ide.Types                 (IdePlugins)
+import           Plugins
 
- -- haskell-language-server plugins
-
-import           Ide.Plugin.Eval           as Eval
-import           Ide.Plugin.Example        as Example
-import           Ide.Plugin.Example2       as Example2
-import           Ide.Plugin.Floskell       as Floskell
-import           Ide.Plugin.Fourmolu       as Fourmolu
-import           Ide.Plugin.GhcIde         as GhcIde
-import           Ide.Plugin.ExplicitImports as ExplicitImports
-import           Ide.Plugin.Ormolu         as Ormolu
-import           Ide.Plugin.Retrie         as Retrie
-import           Ide.Plugin.StylishHaskell as StylishHaskell
-import           Ide.Plugin.Tactic         as Tactic
-import           Ide.Plugin.Hlint          as Hlint
-#if AGPL
-import           Ide.Plugin.Brittany       as Brittany
-#endif
-import           Ide.Plugin                (pluginDescToIdePlugins)
-import           Ide.Plugin.ModuleName     as ModuleName
-import           Ide.Plugin.Pragmas        as Pragmas
-
-
--- ---------------------------------------------------------------------
-
--- | The plugins configured for use in this instance of the language
--- server.
--- These can be freely added or removed to tailor the available
--- features of the server.
-
-idePlugins :: Bool -> IdePlugins
-idePlugins includeExamples = pluginDescToIdePlugins allPlugins
-  where
-    allPlugins = if includeExamples
-                   then basePlugins ++ examplePlugins
-                   else basePlugins
-    basePlugins =
-      [ GhcIde.descriptor  "ghcide"
-      , Pragmas.descriptor  "pragmas"
-      , Floskell.descriptor "floskell"
-      , Fourmolu.descriptor "fourmolu"
-      , Tactic.descriptor "tactic"
-      -- , genericDescriptor     "generic"
-      -- , ghcmodDescriptor      "ghcmod"
-      , Ormolu.descriptor   "ormolu"
-      , StylishHaskell.descriptor "stylish-haskell"
-      , Retrie.descriptor "retrie"
-#if AGPL
-      , Brittany.descriptor "brittany"
-#endif
-      , Eval.descriptor "eval"
-      , ExplicitImports.descriptor "importLens"
-      , ModuleName.descriptor "moduleName"
-      , Hlint.descriptor "hlint"
-      ]
-    examplePlugins =
-      [Example.descriptor  "eg"
-      ,Example2.descriptor "eg2"
-      ]
-
--- ---------------------------------------------------------------------
 
 main :: IO ()
 main = do

--- a/exe/Plugins.hs
+++ b/exe/Plugins.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Plugins where
+
+import           Ide.Types                 (IdePlugins)
+import           Ide.Plugin                (pluginDescToIdePlugins)
+
+-- fixed plugins
+import           Ide.Plugin.Example        as Example
+import           Ide.Plugin.Example2       as Example2
+import           Ide.Plugin.GhcIde         as GhcIde
+
+-- haskell-language-server optional plugins
+
+#if eval
+import           Ide.Plugin.Eval           as Eval
+#endif
+
+#if importLens
+import           Ide.Plugin.ExplicitImports as ExplicitImports
+#endif
+
+#if retrie
+import           Ide.Plugin.Retrie         as Retrie
+#endif
+
+#if tactic
+import           Ide.Plugin.Tactic         as Tactic
+#endif
+
+#if hlint
+import           Ide.Plugin.Hlint          as Hlint
+#endif
+
+#if moduleName
+import           Ide.Plugin.ModuleName     as ModuleName
+#endif
+
+#if pragmas
+import           Ide.Plugin.Pragmas        as Pragmas
+#endif
+
+-- formatters
+
+#if floskell
+import           Ide.Plugin.Floskell       as Floskell
+#endif
+
+#if fourmolu
+import           Ide.Plugin.Fourmolu       as Fourmolu
+#endif
+
+#if ormolu
+import           Ide.Plugin.Ormolu         as Ormolu
+#endif
+
+#if stylishHaskell
+import           Ide.Plugin.StylishHaskell as StylishHaskell
+#endif
+
+#if AGPL && brittany
+import           Ide.Plugin.Brittany       as Brittany
+#endif
+
+-- ---------------------------------------------------------------------
+
+-- | The plugins configured for use in this instance of the language
+-- server.
+-- These can be freely added or removed to tailor the available
+-- features of the server.
+
+idePlugins :: Bool -> IdePlugins
+idePlugins includeExamples = pluginDescToIdePlugins allPlugins
+  where
+    allPlugins = if includeExamples
+                   then basePlugins ++ examplePlugins
+                   else basePlugins
+    basePlugins =
+      [ GhcIde.descriptor  "ghcide"
+#if pragmas
+      , Pragmas.descriptor  "pragmas"
+#endif
+#if floskell
+      , Floskell.descriptor "floskell"
+#endif
+#if fourmolu
+      , Fourmolu.descriptor "fourmolu"
+#endif
+#if tactic
+      , Tactic.descriptor "tactic"
+#endif
+#if ormolu
+      , Ormolu.descriptor   "ormolu"
+#endif
+#if stylishHaskell
+      , StylishHaskell.descriptor "stylish-haskell"
+#endif
+#if retrie
+      , Retrie.descriptor "retrie"
+#endif
+#if AGPL && brittany
+      , Brittany.descriptor "brittany"
+#endif
+#if eval
+      , Eval.descriptor "eval"
+#endif
+#if importLens
+      , ExplicitImports.descriptor "importLens"
+#endif
+#if moduleName
+      , ModuleName.descriptor "moduleName"
+#endif
+#if hlint
+      , Hlint.descriptor "hlint"
+#endif
+      ]
+    examplePlugins =
+      [Example.descriptor  "eg"
+      ,Example2.descriptor "eg2"
+      ]

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -77,21 +77,180 @@ library
 
   default-language: Haskell2010
 
+flag all-plugins
+  description: Enable all non formatter plugins
+  default:     True
+  manual:      True
+
+flag all-formatters
+  description: Enable all fomatters
+  default:     True
+  manual:      True
+
+flag eval
+  description: Enable eval plugin
+  default:     False
+  manual:      True
+
+flag importLens
+  description: Enable importLens plugin
+  default:     False
+  manual:      True
+
+flag retrie
+  description: Enable retrie plugin
+  default:     False
+  manual:      True
+
+flag tactic
+  description: Enable tactic plugin
+  default:     False
+  manual:      True
+
+flag hlint
+  description: Enable hlint plugin
+  default:     False
+  manual:      True
+
+flag moduleName
+  description: Enable moduleName plugin
+  default:     False
+  manual:      True
+
+flag pragmas
+  description: Enable pragmas plugin
+  default:     False
+  manual:      True
+
+-- formatters
+
+flag floskell
+  description: Enable floskell plugin
+  default:     False
+  manual:      True
+
+flag fourmolu
+  description: Enable fourmolu plugin
+  default:     False
+  manual:      True
+
+flag ormolu
+  description: Enable ormolu plugin
+  default:     False
+  manual:      True
+
+flag stylishHaskell
+  description: Enable stylishHaskell plugin
+  default:     False
+  manual:      True
+
+flag brittany
+  description: Enable brittany plugin
+  default:     False
+  manual:      True
+
+common example-plugins
+  hs-source-dirs: plugins/default/src
+  other-modules: Ide.Plugin.Example,
+                 Ide.Plugin.Example2
+
+common eval
+  if flag(eval) || flag(all-plugins)
+    hs-source-dirs: plugins/default/src
+    other-modules: Ide.Plugin.Eval
+    build-depends:
+    cpp-options: -Deval
+
+common importLens
+  if flag(importLens) || flag(all-plugins)
+    build-depends: hls-explicit-imports-plugin
+    cpp-options: -DimportLens
+
+common retrie
+  if flag(retrie) || flag(all-plugins)
+    build-depends: hls-retrie-plugin
+    cpp-options: -Dretrie
+
+common tactic
+  if flag(tactic) || flag(all-plugins)
+    build-depends: hls-tactics-plugin
+    cpp-options: -Dtactic
+
+common hlint
+  if flag(hlint) || flag(all-plugins)
+    build-depends: hls-hlint-plugin
+    cpp-options: -Dhlint
+
+common moduleName
+  if flag(moduleName) || flag(all-plugins)
+    hs-source-dirs: plugins/default/src
+    other-modules: Ide.Plugin.ModuleName
+    cpp-options: -DmoduleName
+
+common pragmas
+  if flag(pragmas) || flag(all-plugins)
+    hs-source-dirs: plugins/default/src
+    other-modules: Ide.Plugin.Pragmas
+    cpp-options: -Dpragmas
+
+-- formatters
+
+common floskell
+  if flag(floskell) || flag(all-formatters)
+    hs-source-dirs: plugins/default/src
+    other-modules: Ide.Plugin.Floskell
+    build-depends: floskell                 ^>=0.10
+    cpp-options: -Dfloskell
+
+common fourmolu
+  if flag(fourmolu) || flag(all-formatters)
+    hs-source-dirs: plugins/default/src
+    other-modules: Ide.Plugin.Fourmolu
+    build-depends: fourmolu                 ^>=0.3
+    cpp-options: -Dfourmolu
+
+common ormolu
+  if flag(ormolu) || flag(all-formatters)
+    hs-source-dirs: plugins/default/src
+    other-modules: Ide.Plugin.Ormolu
+    build-depends: ormolu                   ^>=0.1.2
+    cpp-options: -Dormolu
+
+common stylishHaskell
+  if flag(stylishHaskell) || flag(all-formatters)
+    hs-source-dirs: plugins/default/src
+    other-modules: Ide.Plugin.StylishHaskell
+    build-depends: stylish-haskell          ^>=0.12
+    cpp-options: -DstylishHaskell
+
+common brittany
+  if (flag(brittany) || flag(all-formatters)) && flag(agpl)
+    hs-source-dirs: plugins/default/src
+    other-modules: Ide.Plugin.Brittany
+    build-depends: brittany                 >= 0.13.1.0
+    cpp-options: -Dbrittany
 
 executable haskell-language-server
-  import:           agpl, common-deps
+  import:             agpl
+                    , common-deps
+                    -- plugins
+                    , example-plugins
+                    , eval
+                    , importLens
+                    , retrie
+                    , tactic
+                    , hlint
+                    , moduleName
+                    , pragmas
+                    , floskell
+                    , fourmolu
+                    , ormolu
+                    , stylishHaskell
+                    , brittany
+
   main-is:          Main.hs
-  hs-source-dirs:   exe plugins/default/src
-  other-modules:
-    Ide.Plugin.Eval
-    Ide.Plugin.Example
-    Ide.Plugin.Example2
-    Ide.Plugin.Floskell
-    Ide.Plugin.Fourmolu
-    Ide.Plugin.ModuleName
-    Ide.Plugin.Ormolu
-    Ide.Plugin.Pragmas
-    Ide.Plugin.StylishHaskell
+  hs-source-dirs:   exe
+  other-modules:    Plugins
 
   ghc-options:
     -threaded -Wall -Wno-name-shadowing -Wredundant-constraints
@@ -110,42 +269,26 @@ executable haskell-language-server
     , bytestring
     , containers
     , deepseq
-    , floskell                 ^>=0.10
-    , fourmolu                 ^>=0.3
     , ghc
     , ghc-boot-th
     , ghcide
     , hashable
     , haskell-language-server
     , haskell-lsp              ^>=0.22
-    , hls-hlint-plugin
-    , hls-plugin-api
-    , hls-tactics-plugin
-    , hls-explicit-imports-plugin
-    , hls-retrie-plugin
     , lens
-    , ormolu                   ^>=0.1.2
     , regex-tdfa
     , hslogger
     , optparse-applicative
-    , haskell-lsp              ^>=0.22
     , hls-plugin-api
     , lens
     , mtl
-    , ormolu                   ^>=0.1.2
     , regex-tdfa
     , safe-exceptions
     , shake                    >=0.17.5
-    , stylish-haskell          ^>=0.12
     , temporary
-    , text
     , time
     , transformers
     , unordered-containers
-
-  if flag(agpl)
-    build-depends: brittany     >= 0.13.1.0
-    other-modules: Ide.Plugin.Brittany
 
   include-dirs:     include
   default-language: Haskell2010


### PR DESCRIPTION
- To make progress towards #164
- It uses cabal flags and cpp conditions to let users install the project with a specific plugin set

To assemble the desired hls version you could do:

- `cabal install`: all plugins and formatters by default like the actual behaviour
- `cabal install -f-all-plugins -f-all-formatters`: only ghcide plugin (it is fixed)
- `cabal install -f-all-formatters -f+floskell`: all non formatting plugins and only floskell as formatter
- `cabal install -f-all-plugins -f-all-formatters -f+hlint -f+fourmolu`: only ghcide (fixed) and hlint plugins and fourmolu as formatter

The plan would be change the install script to take in account plugins and:
* let user list the concrete list of plugins
* prepare some predefined plugins sets and set the appropiate cabal flags underneath:
  * all
  * none
  * floskell (all non formatter plugins and floskell). Each formatter would have a equivalent.
  * etc

The .cabal file has grown with quite boilerplate and add a plugin involves insert more locs, but it is almost mechanical. So add a new one it could be automated if we find it too cumbersome.