### PR TITLE
Introduce generic config for plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributors Guide
+
+## Testing
+
+The tests make use of the [Tasty](https://github.com/feuerbach/tasty) test framework.
+
+There are two test suites, functional tests, and wrapper tests.
+
+### Testing with Cabal
+
+Running all the tests
+
+```bash
+$ cabal test
+```
+
+Running just the functional tests
+
+```bash
+$ cabal test func-test
+```
+
+Running just the wrapper tests
+
+```bash
+$ cabal test wrapper-test
+```
+
+Running a subset of tests
+
+Tasty supports providing
+[Patterns](https://github.com/feuerbach/tasty#patterns) as command
+line arguments, to select the specific tests to run.
+
+```bash
+$ cabal test func-test --test-option "-p hlint"
+```
+
+The above recompiles everything every time you use a different test option though.
+
+An alternative is
+
+```bash
+$ cabal run haskell-language-server:func-test -- -p "hlint enables"
+```

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -381,6 +381,7 @@ test-suite func-test
   other-modules:
     Command
     Completion
+    Config
     Deferred
     Definition
     Diagnostic

--- a/test/functional/Config.hs
+++ b/test/functional/Config.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Config (tests) where
+
+import           Control.Lens hiding (List)
+import           Control.Monad.IO.Class
+import           Data.Aeson
+import           Data.Default
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import           Ide.Plugin.Config
+import           Language.Haskell.LSP.Test as Test
+import           Language.Haskell.LSP.Types
+import qualified Language.Haskell.LSP.Types.Lens as L
+import           System.FilePath ((</>))
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+{-# ANN module ("HLint: ignore Reduce duplication"::String) #-}
+
+tests :: TestTree
+tests = testGroup "plugin config" [
+      -- Note: because the flag is treated generically in the plugin handler, we
+      -- do not have to test each individual plugin
+      hlintTests
+    ]
+
+hlintTests :: TestTree
+hlintTests = testGroup "hlint plugin enables" [
+
+      testCase "changing hlintOn configuration enables or disables hlint diagnostics" $ runHlintSession "" $ do
+        let config = def { hlintOn = True }
+        sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+        doc <- openDoc "ApplyRefact2.hs" "haskell"
+        testHlintDiagnostics doc
+
+        let config' = def { hlintOn = False }
+        sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config'))
+
+        diags' <- waitForDiagnosticsFrom doc
+
+        liftIO $ noHlintDiagnostics diags'
+
+    , testCase "changing hlint plugin configuration enables or disables hlint diagnostics" $ runHlintSession "" $ do
+        let config = def { hlintOn = True }
+        sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+        doc <- openDoc "ApplyRefact2.hs" "haskell"
+        testHlintDiagnostics doc
+
+        let config' = pluginGlobalOn config "hlint" False
+        sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config'))
+
+        diags' <- waitForDiagnosticsFrom doc
+
+        liftIO $ noHlintDiagnostics diags'
+
+    ]
+    where
+        runHlintSession :: FilePath -> Session a -> IO a
+        runHlintSession subdir  =
+            failIfSessionTimeout . runSession hlsCommand fullCaps ("test/testdata/hlint" </> subdir)
+
+        noHlintDiagnostics :: [Diagnostic] -> Assertion
+        noHlintDiagnostics diags =
+            Just "hlint" `notElem` map (^. L.source) diags @? "There are no hlint diagnostics"
+
+        testHlintDiagnostics doc = do
+            diags <- waitForDiagnosticsFromSource doc "hlint"
+            liftIO $ length diags > 0 @? "There are hlint diagnostics"
+
+pluginGlobalOn :: Config -> T.Text -> Bool -> Config
+pluginGlobalOn config pid state = config'
+  where
+      pluginConfig = def { plcGlobalOn = state }
+      config' = def { plugins = Map.insert pid pluginConfig (plugins config) }

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -132,10 +132,6 @@ hlintTests = testGroup "hlint suggestions" [
         runHlintSession subdir  =
             failIfSessionTimeout . runSession hlsCommand fullCaps ("test/testdata/hlint" </> subdir)
 
-        noHlintDiagnostics :: [Diagnostic] -> Assertion
-        noHlintDiagnostics diags =
-            Just "hlint" `notElem` map (^. L.source) diags @? "There are no hlint diagnostics"
-
         testHlintDiagnostics doc = do
             diags <- waitForDiagnosticsFromSource doc "hlint"
             liftIO $ length diags > 0 @? "There are hlint diagnostics"

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -81,20 +81,6 @@ hlintTests = testGroup "hlint suggestions" [
         contents <- skipManyTill anyMessage $ getDocumentEdit doc
         liftIO $ contents @?= "main = undefined\nfoo = id\n"
 
-    , testCase "changing configuration enables or disables hlint diagnostics" $ runHlintSession "" $ do
-        let config = def { hlintOn = True }
-        sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
-
-        doc <- openDoc "ApplyRefact2.hs" "haskell"
-        testHlintDiagnostics doc
-
-        let config' = def { hlintOn = False }
-        sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config'))
-
-        diags' <- waitForDiagnosticsFrom doc
-
-        liftIO $ noHlintDiagnostics diags'
-
     , knownBrokenForGhcVersions [GHC88, GHC86] "hlint doesn't take in account cpp flag as ghc -D argument" $
       testCase "hlint diagnostics works with CPP via ghc -XCPP argument (#554)" $ runHlintSession "cpp" $ do
         doc <- openDoc "ApplyRefact3.hs" "haskell"

--- a/test/functional/Main.hs
+++ b/test/functional/Main.hs
@@ -8,6 +8,7 @@ import           Test.Tasty.Ingredients.Rerun
 import           Test.Tasty.Runners.AntXML
 
 import           Command
+import           Config
 import           Completion
 import           Deferred
 import           Definition
@@ -37,6 +38,7 @@ main =
         "haskell-language-server"
         [ Command.tests
         , Completion.tests
+        , Config.tests
         , Deferred.tests
         , Definition.tests
         , Diagnostic.tests


### PR DESCRIPTION
Make it possible to provide config for a plugin in a regular way, by
using a namespace in the json config space. So we have

```
haskell.plugin.hlint.globalOn
haskell.plugin.importLens.globalOn
```

It is also possible to have finer-grain config, so the individual
parts of a plugin can also be separately enabled/disabled.

Closes #513