### PR TITLE
Add a known tactic for writing arbitrary instances

### DIFF
--- a/plugins/tactics/hls-tactics-plugin.cabal
+++ b/plugins/tactics/hls-tactics-plugin.cabal
@@ -30,6 +30,7 @@ library
     Ide.Plugin.Tactic.GHC
     Ide.Plugin.Tactic.Judgements
     Ide.Plugin.Tactic.KnownStrategies
+    Ide.Plugin.Tactic.KnownStrategies.QuickCheck
     Ide.Plugin.Tactic.Machinery
     Ide.Plugin.Tactic.Naming
     Ide.Plugin.Tactic.Range

--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -236,3 +236,16 @@ var' = var . fromString . occNameString
 bvar' :: BVar a => OccName -> a
 bvar' = bvar . fromString . occNameString
 
+
+mkFunc :: String -> HsExpr GhcPs
+mkFunc = var' . mkVarOcc
+
+mkVal :: String -> HsExpr GhcPs
+mkVal = var' . mkVarOcc
+
+infixCall :: String -> HsExpr GhcPs -> HsExpr GhcPs -> HsExpr GhcPs
+infixCall s = flip op (fromString s)
+
+appDollar :: HsExpr GhcPs -> HsExpr GhcPs -> HsExpr GhcPs
+appDollar = infixCall "$"
+

--- a/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -237,15 +237,26 @@ bvar' :: BVar a => OccName -> a
 bvar' = bvar . fromString . occNameString
 
 
+------------------------------------------------------------------------------
+-- | Get an HsExpr corresponding to a function name.
 mkFunc :: String -> HsExpr GhcPs
 mkFunc = var' . mkVarOcc
 
+
+------------------------------------------------------------------------------
+-- | Get an HsExpr corresponding to a value name.
 mkVal :: String -> HsExpr GhcPs
 mkVal = var' . mkVarOcc
 
+
+------------------------------------------------------------------------------
+-- | Like 'op', but easier to call.
 infixCall :: String -> HsExpr GhcPs -> HsExpr GhcPs -> HsExpr GhcPs
 infixCall s = flip op (fromString s)
 
+
+------------------------------------------------------------------------------
+-- | Like '(@@)', but uses a dollar instead of parentheses.
 appDollar :: HsExpr GhcPs -> HsExpr GhcPs -> HsExpr GhcPs
 appDollar = infixCall "$"
 

--- a/plugins/tactics/src/Ide/Plugin/Tactic/KnownStrategies.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/KnownStrategies.hs
@@ -9,11 +9,13 @@ import Ide.Plugin.Tactic.Types
 import OccName (mkVarOcc)
 import Refinery.Tactic
 import Ide.Plugin.Tactic.Machinery (tracing)
+import Ide.Plugin.Tactic.KnownStrategies.QuickCheck (deriveArbitrary)
 
 
 knownStrategies :: TacticsM ()
 knownStrategies = choice
-  [ deriveFmap
+  [ known "fmap" deriveFmap
+  , known "arbitrary" deriveArbitrary
   ]
 
 
@@ -26,7 +28,7 @@ known name t = do
 
 
 deriveFmap :: TacticsM ()
-deriveFmap = known "fmap" $ do
+deriveFmap = do
   try intros
   overAlgebraicTerms homo
   choice

--- a/plugins/tactics/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Ide.Plugin.Tactic.KnownStrategies.QuickCheck where
+
+import Data.Bool (bool)
+import Data.List (partition)
+import DataCon ( DataCon, dataConName )
+import Development.IDE.GHC.Compat (HsExpr, GhcPs, noLoc)
+import GHC.Exts ( IsString(fromString) )
+import GHC.List ( foldl' )
+import GHC.SourceGen (int)
+import GHC.SourceGen.Binds ( match, valBind )
+import GHC.SourceGen.Expr ( case', lambda, let' )
+import GHC.SourceGen.Overloaded ( App((@@)), HasList(list) )
+import GHC.SourceGen.Pat ( conP )
+import Ide.Plugin.Tactic.CodeGen
+import Ide.Plugin.Tactic.Judgements (jGoal)
+import Ide.Plugin.Tactic.Machinery (tracePrim)
+import Ide.Plugin.Tactic.Types ( Type, TacticsM, CType(unCType) )
+import OccName ( mkVarOcc, HasOccName(occName) )
+import Refinery.Tactic ( rule )
+import TyCon ( TyCon, tyConDataCons )
+import Type ( splitTyConApp_maybe )
+
+
+deriveArbitrary :: TacticsM ()
+deriveArbitrary = rule $ \jdg -> do
+  let arb_ty = unCType $ jGoal jdg
+  case splitTyConApp_maybe arb_ty of
+    Just (_gen_tc, [splitTyConApp_maybe -> Just (tc, apps)]) -> do
+      let dcs = tyConDataCons tc
+          (small, big) = partition ((== 0) . genRecursiveCount)
+                       $ fmap (mkGenerator tc apps) dcs
+          small_expr = mkVal "small"
+          oneof_expr = mkVal "oneof"
+      pure
+        ( tracePrim "hi"
+        , noLoc $
+            let' [valBind (fromString "small") $ list $ fmap genExpr small] $
+              appDollar (mkFunc "sized") $ lambda [bvar' (mkVarOcc "n")] $
+                case' (infixCall "<=" (mkVal "n") (int 1))
+                  [ match [conP (fromString "True") []] $
+                      oneof_expr @@ small_expr
+                  , match [conP (fromString "False") []] $
+                      appDollar oneof_expr $
+                        infixCall "<>"
+                          (list $ fmap genExpr big)
+                          small_expr
+                  ]
+        )
+
+
+data Generator = Generator
+  { genRecursiveCount :: Integer
+  , genExpr :: HsExpr GhcPs
+  }
+
+
+mkGenerator :: TyCon -> [Type] -> DataCon -> Generator
+mkGenerator tc apps dc = do
+  let dc_expr   = var' $ occName $ dataConName dc
+      args = dataConInstOrigArgTys' dc apps
+      num_recursive_calls = sum $ fmap (bool 0 1 . isRecursiveValue tc) args
+      mkArbitrary = mkArbitraryCall tc num_recursive_calls
+  Generator num_recursive_calls $ case args of
+    []  -> mkFunc "pure" @@ dc_expr
+    (a : as) ->
+      foldl'
+        (infixCall "<*>")
+        (infixCall "<$>" dc_expr $ mkArbitrary a)
+        (fmap mkArbitrary as)
+
+
+isRecursiveValue :: TyCon -> Type -> Bool
+isRecursiveValue recursive_tc (splitTyConApp_maybe -> Just (tc, _))
+  = recursive_tc == tc
+isRecursiveValue _ _ = False
+
+
+mkArbitraryCall :: TyCon -> Integer -> Type -> HsExpr GhcPs
+mkArbitraryCall recursive_tc n ty =
+  let arbitrary = mkFunc "arbitrary"
+   in case splitTyConApp_maybe ty of
+        Just (tc, _) | tc == recursive_tc ->
+          mkFunc "scale"
+            @@ bool (mkFunc "div" @@ int n)
+                    (mkFunc "subtract" @@ int 1)
+                    (n == 1)
+            @@ arbitrary
+        _ -> arbitrary
+

--- a/plugins/tactics/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
+++ b/plugins/tactics/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
@@ -89,7 +89,7 @@ mkArbitraryCall recursive_tc n ty =
    in case isRecursiveValue recursive_tc ty of
         True ->
           mkFunc "scale"
-            @@ bool (mkFunc "div" @@ int n)
+            @@ bool (mkFunc "flip" @@ mkFunc "div" @@ int n)
                     (mkFunc "subtract" @@ int 1)
                     (n == 1)
             @@ arbitrary

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -116,6 +116,7 @@ tests = testGroup
       $ goldenTest "GoldenApplicativeThen.hs"   2 11 Auto ""
   , goldenTest "GoldenSafeHead.hs"          2 12 Auto ""
   , expectFail "GoldenFish.hs"              5 18 Auto ""
+  , goldenTest "GoldenArbitrary.hs"         25 13 Auto ""
   ]
 
 

--- a/test/testdata/tactic/GoldenArbitrary.hs
+++ b/test/testdata/tactic/GoldenArbitrary.hs
@@ -1,0 +1,26 @@
+-- Emulate a quickcheck import; deriveArbitrary works on any type with the
+-- right name and kind
+data Gen a
+
+data Obj
+  = Square Int Int
+  | Circle Int
+  | Polygon [(Int, Int)]
+  | Rotate2 Double Obj
+  | Empty
+  | Full
+  | Complement Obj
+  | UnionR Double [Obj]
+  | DifferenceR Double Obj [Obj]
+  | IntersectR Double [Obj]
+  | Translate Double Double Obj
+  | Scale Double Double Obj
+  | Mirror Double Double Obj
+  | Outset Double Obj
+  | Shell Double Obj
+  | WithRounding Double Obj
+
+
+arbitrary :: Gen Obj
+arbitrary = _
+

--- a/test/testdata/tactic/GoldenArbitrary.hs.expected
+++ b/test/testdata/tactic/GoldenArbitrary.hs.expected
@@ -1,0 +1,52 @@
+-- Emulate a quickcheck import; deriveArbitrary works on any type with the
+-- right name and kind
+data Gen a
+
+data Obj
+  = Square Int Int
+  | Circle Int
+  | Polygon [(Int, Int)]
+  | Rotate2 Double Obj
+  | Empty
+  | Full
+  | Complement Obj
+  | UnionR Double [Obj]
+  | DifferenceR Double Obj [Obj]
+  | IntersectR Double [Obj]
+  | Translate Double Double Obj
+  | Scale Double Double Obj
+  | Mirror Double Double Obj
+  | Outset Double Obj
+  | Shell Double Obj
+  | WithRounding Double Obj
+
+
+arbitrary :: Gen Obj
+arbitrary = (let
+               terminal
+                 = [(Square <$> arbitrary) <*> arbitrary, Circle <$> arbitrary,
+                    Polygon <$> arbitrary, pure Empty, pure Full]
+             in
+               sized
+                 $ (\ n
+                      -> case n <= 1 of
+                           True -> oneof terminal
+                           False
+                             -> oneof
+                                  $ ([(Rotate2 <$> arbitrary) <*> scale (subtract 1) arbitrary,
+                                      Complement <$> scale (subtract 1) arbitrary,
+                                      (UnionR <$> arbitrary) <*> scale (subtract 1) arbitrary,
+                                      ((DifferenceR <$> arbitrary) <*> scale (div 2) arbitrary)
+                                        <*> scale (div 2) arbitrary,
+                                      (IntersectR <$> arbitrary) <*> scale (subtract 1) arbitrary,
+                                      ((Translate <$> arbitrary) <*> arbitrary)
+                                        <*> scale (subtract 1) arbitrary,
+                                      ((Scale <$> arbitrary) <*> arbitrary)
+                                        <*> scale (subtract 1) arbitrary,
+                                      ((Mirror <$> arbitrary) <*> arbitrary)
+                                        <*> scale (subtract 1) arbitrary,
+                                      (Outset <$> arbitrary) <*> scale (subtract 1) arbitrary,
+                                      (Shell <$> arbitrary) <*> scale (subtract 1) arbitrary,
+                                      (WithRounding <$> arbitrary) <*> scale (subtract 1) arbitrary]
+                                       <> terminal)))
+

--- a/test/testdata/tactic/GoldenArbitrary.hs.expected
+++ b/test/testdata/tactic/GoldenArbitrary.hs.expected
@@ -36,8 +36,8 @@ arbitrary = (let
                                   $ ([(Rotate2 <$> arbitrary) <*> scale (subtract 1) arbitrary,
                                       Complement <$> scale (subtract 1) arbitrary,
                                       (UnionR <$> arbitrary) <*> scale (subtract 1) arbitrary,
-                                      ((DifferenceR <$> arbitrary) <*> scale (div 2) arbitrary)
-                                        <*> scale (div 2) arbitrary,
+                                      ((DifferenceR <$> arbitrary) <*> scale (flip div 2) arbitrary)
+                                        <*> scale (flip div 2) arbitrary,
                                       (IntersectR <$> arbitrary) <*> scale (subtract 1) arbitrary,
                                       ((Translate <$> arbitrary) <*> arbitrary)
                                         <*> scale (subtract 1) arbitrary,


### PR DESCRIPTION
Christmas comes early for QuickCheck users! This PR adds support for generating `arbitrary` --- including the tricky business of ensuring termination. It can be run by calling `Attempt to fill hole` on anything of the form `arbitrary :: Gen A` for some type `A`.