### PR TITLE
Move Linux & Mac OS tests into the Nix GitHub action

### DIFF
--- a/.github/workflows/ghc-lib.yml
+++ b/.github/workflows/ghc-lib.yml
@@ -1,0 +1,34 @@
+name: ghc-lib
+
+on: [pull_request]
+jobs:
+  nix:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['ghc8102']
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-20.03
+    - uses: cachix/cachix-action@v8
+      with:
+        name: haskell-language-server
+        authToken: '${{ secrets.HLS_CACHIX_AUTH_TOKEN }}'
+
+    - name: ghc-lib
+      run: |
+        echo "package ghcide" >> cabal.project.local
+        echo "  flags: ghc-lib" >> cabal.project.local
+        echo "package hie-compat" >> cabal.project.local
+        echo "  flags: ghc-lib" >> cabal.project.local
+
+    - name: Build ghcide
+      run: nix-shell --argstr compiler ${{ matrix.ghc }} --run "cabal update && cabal build ghcide"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,8 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['default', 'ghc8102', 'ghc884', 'ghc865']
+        ghc: ['ghc8101', 'ghc8102', 'ghc882', 'ghc883', 'ghc884', 'ghc865']
         os: [ubuntu-latest, macOS-latest]
+        ghc-lib: [false]
+        include:
+          # one ghc-lib build
+          - os: ubuntu-latest
+            ghc: 'ghc8101'
+            ghc-lib: true
 
     steps:
     - uses: actions/checkout@v2
@@ -22,4 +28,27 @@ jobs:
       with:
         name: haskell-language-server
         authToken: '${{ secrets.HLS_CACHIX_AUTH_TOKEN }}'
-    - run: nix-shell --argstr compiler ${{ matrix.ghc }} --run "cabal update && cabal build"
+    - name: Build
+      run: nix-shell --argstr compiler ${{ matrix.ghc }} --run "cabal update && cabal build"
+
+    - name: Test ghcide
+      if: ${{ !matrix.ghc-lib }}
+      shell: bash
+      # run the tests without parallelism to avoid running out of memory
+      run: nix-shell --argstr compiler ${{ matrix.ghc}} --run "cabal test ghcide --test-options='-j1 --rerun-update' || cabal test ghcide --test-options='-j1 --rerun' || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test ghcide --test-options='-j1 --rerun'"
+
+    - name: Test func-test suite
+      if: ${{ !matrix.ghc-lib }}
+      shell: bash
+      # run the tests without parallelism, otherwise tasty will attempt to run
+      # all functional test cases simultaneously which causes way too many hls
+      # instances to be spun up for the poor github actions runner to handle
+      run: nix-shell --argstr compiler ${{ matrix.ghc}} --run "cabal test func-test --test-options='-j1 --rerun-update' || cabal test func-test --test-options='-j1 --rerun --rerun-update' || cabal test func-test --test-options='-j1 --rerun' || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test func-test --test-options='-j1 --rerun'"
+
+    - name: Test wrapper-test suite
+      if: ${{ !matrix.ghc-lib }}
+      shell: bash
+      # run the tests without parallelism, otherwise tasty will attempt to run
+      # all functional test cases simultaneously which causes way too many hls
+      # instances to be spun up for the poor github actions runner to handle
+      run: nix-shell --argstr compiler ${{ matrix.ghc}} --run "cabal test wrapper-test --test-options=-j1 || cabal test wrapper-test --test-options=-j1 || cabal test wrapper-test --test-options=-j1"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,12 +10,6 @@ jobs:
       matrix:
         ghc: ['ghc8101', 'ghc8102', 'ghc882', 'ghc883', 'ghc884', 'ghc865']
         os: [ubuntu-latest, macOS-latest]
-        ghc-lib: [false]
-        include:
-          # one ghc-lib build
-          - os: ubuntu-latest
-            ghc: 'ghc8101'
-            ghc-lib: true
 
     steps:
     - uses: actions/checkout@v2
@@ -28,17 +22,16 @@ jobs:
       with:
         name: haskell-language-server
         authToken: '${{ secrets.HLS_CACHIX_AUTH_TOKEN }}'
+
     - name: Build
       run: nix-shell --argstr compiler ${{ matrix.ghc }} --run "cabal update && cabal build"
 
     - name: Test ghcide
-      if: ${{ !matrix.ghc-lib }}
       shell: bash
       # run the tests without parallelism to avoid running out of memory
       run: nix-shell --argstr compiler ${{ matrix.ghc}} --run "cabal test ghcide --test-options='-j1 --rerun-update' || cabal test ghcide --test-options='-j1 --rerun' || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test ghcide --test-options='-j1 --rerun'"
 
     - name: Test func-test suite
-      if: ${{ !matrix.ghc-lib }}
       shell: bash
       # run the tests without parallelism, otherwise tasty will attempt to run
       # all functional test cases simultaneously which causes way too many hls
@@ -46,7 +39,6 @@ jobs:
       run: nix-shell --argstr compiler ${{ matrix.ghc}} --run "cabal test func-test --test-options='-j1 --rerun-update' || cabal test func-test --test-options='-j1 --rerun --rerun-update' || cabal test func-test --test-options='-j1 --rerun' || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test func-test --test-options='-j1 --rerun'"
 
     - name: Test wrapper-test suite
-      if: ${{ !matrix.ghc-lib }}
       shell: bash
       # run the tests without parallelism, otherwise tasty will attempt to run
       # all functional test cases simultaneously which causes way too many hls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,33 +1,13 @@
-name: Testing
+name: Windows
 
 on: [pull_request]
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.2", "8.10.1", "8.8.4", "8.8.3", "8.8.2", "8.6.5", "8.6.4"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc-lib: [false]
-        exclude:
-          - os: windows-latest
-            ghc: "8.10.2" # broken due to https://gitlab.haskell.org/ghc/ghc/-/issues/18550
-          - os: windows-latest
-            ghc: "8.8.4" # also fails due to segfault :(
-          - os: windows-latest
-            ghc: "8.8.3" # fails due to segfault
-          - os: windows-latest
-            ghc: "8.8.2" # fails due to error with Cabal
-        include:
-          - os: windows-latest
-            ghc: "8.6.4" # times out after 300m
-          - os: windows-latest
-            ghc: "8.10.2.2" # only available for windows and choco
-          # one ghc-lib build
-          - os: ubuntu-latest
-            ghc: '8.10.1'
-            ghc-lib: true
+        ghc: ["8.10.2.2", "8.10.1", "8.6.5"]
 
     steps:
       - uses: actions/checkout@v2
@@ -48,11 +28,11 @@ jobs:
           cache-name: cache-cabal
         with:
           path: ~/.cabal/
-          key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+          key: ${{ matrix.ghc }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-${{ matrix.ghc }}-build-
-            ${{ runner.os }}-${{ matrix.ghc }}
+            ${{ matrix.ghc }}-build-${{ env.cache-name }}-
+            ${{ matrix.ghc }}-build-
+            ${{ matrix.ghc }}
 
       - run: cabal update
 
@@ -72,13 +52,11 @@ jobs:
         run: cabal build || cabal build || cabal build
 
       - name: Test ghcide
-        if: ${{ !matrix.ghc-lib }}
         shell: bash
         # run the tests without parallelism to avoid running out of memory
         run: cabal test ghcide --test-options="-j1 --rerun-update" || cabal test ghcide --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test ghcide --test-options="-j1 --rerun"
 
       - name: Test func-test suite
-        if: ${{ !matrix.ghc-lib }}
         shell: bash
         env:
           HLS_TEST_EXE: hls
@@ -89,7 +67,6 @@ jobs:
         run: cabal test func-test --test-options="-j1 --rerun-update" || cabal test func-test --test-options="-j1 --rerun --rerun-update" || cabal test func-test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test func-test --test-options="-j1 --rerun"
 
       - name: Test wrapper-test suite
-        if: ${{ !matrix.ghc-lib }}
         shell: bash
         env:
           HLS_TEST_EXE: hls


### PR DESCRIPTION
Merge the Test Github Action into the Nix one, leaving the Windows tests on their own Github action.

Reasons:

- Avoid redundant work, saving 6 jobs. The CI is very heavily overloaded right now and every bit helps.
- The Nix caching seems much more reliable, taking only ~10m to build everything whereas the Test action takes >30m since Cabal rebuilds all the dependencies
- https://github.com/cachix/pre-commit-hooks.nix can be useful in the future