### PR TITLE
Streamline CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,23 +61,13 @@ defaults: &defaults
         command: grep '^resolver:\|^compiler:' stack-build.txt > plugins/hls-eval-plugin/test/testdata/stack.yaml
 
     - run:
-        name: Test haskell-language-server func-test suite
+        name: Build including tests
         # Tasty by default will run all the tests in parallel. Which should
         # work ok, but given that these CircleCI runners aren't the beefiest
         # machine can cause some flakiness. So pass -j1 to Tasty (NOT Stack) to
         # tell it to go slow and steady.
-        command: stack --stack-yaml=${STACK_FILE} test --no-run-tests haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun-update" || stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun"
+        command: stack --stack-yaml=${STACK_FILE} test --no-run-tests
         no_output_timeout: 120m
-
-    - run:
-        name: Test haskell-language-server wrapper-test suite
-        command: stack --stack-yaml=${STACK_FILE} test --no-run-tests  haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1" || stack --stack-yaml=${STACK_FILE} test haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1"
-        no_output_timeout: 30m
-
-    - run:
-        name: Test hls-tactics-plugin
-        command: stack --stack-yaml=${STACK_FILE} test  --no-run-tests hls-tactics-plugin:test:tests --dump-logs --test-arguments="-j1"
-        no_output_timeout: 30m
 
     - save_cache:
         key: stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,6 @@ defaults: &defaults
           - ~/build/ghcide/.stack-work
 
     - run:
-        name: Test ghcide
-        # Tests MUST run with -j1, since multiple ghc-mod sessions are not allowed
-        # command: stack -j 1 --stack-yaml=${STACK_FILE} test ghcide --dump-logs
-        command: echo "ghcide tests disabled until they got fixed, see https://github.com/mpickering/ghcide/issues/25"
-        no_output_timeout: 120m
-
-    - run:
         name: Setup stack eval hie.html
         command: cp plugins/hls-eval-plugin/test/testdata/hie-stack.yaml plugins/hls-eval-plugin/test/testdata/hie.yaml
 
@@ -73,24 +66,18 @@ defaults: &defaults
         # work ok, but given that these CircleCI runners aren't the beefiest
         # machine can cause some flakiness. So pass -j1 to Tasty (NOT Stack) to
         # tell it to go slow and steady.
-        command: stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun-update" || stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun"
+        command: stack --stack-yaml=${STACK_FILE} test --no-run-tests haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun-update" || stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack --stack-yaml=${STACK_FILE} test haskell-language-server:func-test --dump-logs --test-arguments="-j1 --rerun"
         no_output_timeout: 120m
 
     - run:
         name: Test haskell-language-server wrapper-test suite
-        command: stack --stack-yaml=${STACK_FILE} test haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1" || stack --stack-yaml=${STACK_FILE} test haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1"
+        command: stack --stack-yaml=${STACK_FILE} test --no-run-tests  haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1" || stack --stack-yaml=${STACK_FILE} test haskell-language-server:wrapper-test --dump-logs --test-arguments="-j1"
         no_output_timeout: 30m
 
     - run:
         name: Test hls-tactics-plugin
-        command: stack --stack-yaml=${STACK_FILE} test hls-tactics-plugin:test:tests --dump-logs --test-arguments="-j1"
+        command: stack --stack-yaml=${STACK_FILE} test  --no-run-tests hls-tactics-plugin:test:tests --dump-logs --test-arguments="-j1"
         no_output_timeout: 30m
-
-    - store_test_results:
-        path: test-results
-
-    - store_artifacts:
-        path: test-logs
 
     - save_cache:
         key: stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
@@ -156,3 +143,4 @@ workflows:
       - ghc-8.10.1
       - ghc-8.10.2
       - ghc-8.10.3
+      - ghc-default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,6 @@ defaults: &defaults
   steps:
     - checkout
     - run:
-        command: git submodule sync --recursive
-    - run:
-        command: git submodule update --recursive --init
-    - run:
         name: Write provided stack.yaml with predictable name
         command: cp ${STACK_FILE} stack-build.txt
 
@@ -147,45 +143,6 @@ jobs:
       - STACK_FILE: "stack.yaml"
     <<: *defaults
 
-  cabal:
-    working_directory: ~/build
-    docker:
-      # We have to wait to a docker image with ghc-8.10.3
-      # See https://github.com/haskell/docker-haskell/issues/31
-      - image: haskell:8.10.2
-    steps:
-      - checkout
-      - run:
-          name: Sync submodules
-          command: git submodule sync --recursive
-      - run:
-          name: Update submodules
-          command: git submodule update --recursive --init
-      - restore-cache:
-          keys:
-            - cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-      - run:
-          name: Update
-          command: cabal new-update
-      - run:
-          name: Configure
-          command: cabal new-configure --enable-tests
-      - run:
-          name: Build dependencies
-          command: cabal new-build -j1 --dependencies-only # need j1, else ghc-lib-parser triggers OOM
-          no_output_timeout: 30m
-      - save_cache:
-          key: cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-          paths:
-            - ~/.cabal
-      - run:
-          name: Build
-          command: cabal new-build -j1 # need j1, else ghc-lib-parser triggers OOM
-          no_output_timeout: 30m
-      - save_cache:
-          key: cabal-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
-          paths:
-            - ~/.cabal
 
 workflows:
   version: 2
@@ -199,5 +156,3 @@ workflows:
       - ghc-8.10.1
       - ghc-8.10.2
       - ghc-8.10.3
-      - ghc-default
-      - cabal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,6 @@ defaults: &defaults
 
     - run:
         name: Build including tests
-        # Tasty by default will run all the tests in parallel. Which should
-        # work ok, but given that these CircleCI runners aren't the beefiest
-        # machine can cause some flakiness. So pass -j1 to Tasty (NOT Stack) to
-        # tell it to go slow and steady.
         command: stack --stack-yaml=${STACK_FILE} test --no-run-tests
         no_output_timeout: 120m
 


### PR DESCRIPTION
Now that we have mostly streamlined the GitHub Actions (Windows cache still not working) the CircleCI jobs have become the bottleneck. 

Changes:

- Drop Cabal job (redundant)
- Drop ghc-default job (what is ghc-default?)
- Drop tests (already covered)

I have also enabled "auto cancel redundant builds" in the Project settings, which should help immensely.