### PR TITLE
Prepare 0.8.0 (versions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,13 @@ jobs:
         echo "LINUX_CABAL_ARGS=--enable-executable-static --ghc-options=-split-sections" >> $GITHUB_ENV
         echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
 
+    - name: Set some macOs specific things
+      if: matrix.os == 'macOS-latest'
+      env:
+        GHC_VER: ${{ matrix.ghc }}
+      run: |
+        echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
+
     - name: Build Server
       # Try building it twice in case of flakey builds on Windows
       run: |

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,8 +3,7 @@
 ## 0.8.0
 
 - This version adds support for ghc-8.10.3
-- `hls-plugin-api` is 0.6.0.0 and `ghcide`, 0.7.0.0
-  - so this include [changes from `ghcide-0.6.0.2`](https://github.com/haskell/haskell-language-server/blob/master/ghcide/CHANGELOG.md#0602-2020-12-26)
+- `hls-plugin-api` has been bumped to 0.6.0.0 and `ghcide` has been bumped from 0.6.0.1 to 0.7.0.0.
 - It has a new brand plugin: hls-class-plugin, which helps to write class instances
 
 ![gif](https://user-images.githubusercontent.com/12473268/103059293-af071f80-4572-11eb-963a-7e76b45f28b9.gif)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 ## 0.8.0
 
 - This version adds support for ghc-8.10.3
+- `hls-plugin-api` is 0.6.0.0 and `ghcide`, 0.7.0.0
+  - so this include [changes from `ghcide-0.6.0.2`](https://github.com/haskell/haskell-language-server/blob/master/ghcide/CHANGELOG.md#0602-2020-12-26)
 - It has a new brand plugin: hls-class-plugin, which helps to write class instances
 
 ![gif](https://user-images.githubusercontent.com/12473268/103059293-af071f80-4572-11eb-963a-7e76b45f28b9.gif)
@@ -19,7 +21,8 @@
   - ghcide lives now directly in this repository
   - the test suite has been cleaned and improved (continuing the work done in 0.7.0)
 
-thanks to all contributors and happy new year!
+
+Thanks to all contributors and happy new year!
 
 ### Pull requests merged for 0.8.0
 

--- a/cabal.project
+++ b/cabal.project
@@ -23,7 +23,7 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2020-12-13T11:31:58Z
+index-state: 2021-01-03T11:58:44Z
 
 allow-newer:
 	active:base,

--- a/ghcide/CHANGELOG.md
+++ b/ghcide/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.7.0 (2020-01-03)
+
+* Retry a failed cradle if the cradle descriptor changes (#762) - (Pepe Iborra)
+* Fix extend imports regression (#769) - (Pepe Iborra)
+* Perform memory measurement on SIGUSR1 (#761) - (Pepe Iborra)
+
 ### 0.6.0.2 (2020-12-26)
 * Fix disappearing diagnostics bug (#959) - (Pepe Iborra)
 * Deduplicate module not found diagnostics (#952) - (Pepe Iborra)

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      1.20
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            0.6.0.2
+version:            0.7.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -56,7 +56,7 @@ library
         haskell-lsp-types == 0.22.*,
         haskell-lsp == 0.22.*,
         hie-compat,
-        hls-plugin-api,
+        hls-plugin-api >= 0.6,
         lens,
         mtl,
         network-uri,

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.2
 category:           Development
 name:               haskell-language-server
-version:            0.7.1.0
+version:            0.8.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -62,7 +62,7 @@ library
     , ghcide                >=0.6.0.1
     , gitrev
     , haskell-lsp           ^>=0.22
-    , hls-plugin-api        >=0.5
+    , hls-plugin-api        >=0.6
     , hslogger
     , optparse-applicative
     , optparse-simple
@@ -346,7 +346,7 @@ common hls-test-utils
     , data-default
     , haskell-lsp
     , hie-bios
-    , hls-plugin-api
+    , hls-plugin-api        >=0.6
     , hslogger
     , hspec
     , hspec-core

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -59,7 +59,7 @@ library
     , containers
     , data-default
     , ghc
-    , ghcide                >=0.6.0.1
+    , ghcide                >=0.7
     , gitrev
     , haskell-lsp           ^>=0.22
     , hls-plugin-api        >=0.6

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hls-plugin-api
-version:       0.5.0.1
+version:       0.6.0.0
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>


### PR DESCRIPTION
* This pr include version bumps for all components (hls itself, hls-plugin-api and ghcide)
* A hackage index update
* Also a fix to macos builds
* And a mention to lib versions and ghcide-0.6.0.2 changelog

Follow up of #1149