### PR TITLE
Fix wrong component name of splice plugin in hie.yaml

### DIFF
--- a/hie-cabal.yaml
+++ b/hie-cabal.yaml
@@ -122,7 +122,7 @@ cradle:
       component: "lib:hls-retrie-plugin"
 
     - path: "./plugins/hls-splice-plugin/src"
-      component: "hls-splice-plugin:lib"
+      component: "lib:hls-splice-plugin"
 
     - path: "./plugins/tactics/src"
       component: "lib:hls-tactics-plugin"


### PR DESCRIPTION
```
Failed to parse result of calling cabal

cabal: Unknown target 'hls-splice-plugin:lib'.
The package hls-splice-plugin has no component 'lib'.

```

IIRC,  the prefix `lib:` can be left out in this case, but in order to keep the consistency with other components, I keep it.