### PR TITLE
Suggest adding pragmas for parse errors too

### DIFF
--- a/plugins/default/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/default/src/Ide/Plugin/Pragmas.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
 -- | Provides code actions to add missing pragmas (whenever GHC suggests to)
@@ -67,13 +68,19 @@ codeActionProvider _ state _plId docId _ (J.CodeActionContext (J.List diags) _mo
     let mFile = docId ^. J.uri & uriToFilePath <&> toNormalizedFilePath'
     pm <- fmap join $ runAction "addPragma" state $ getParsedModule `traverse` mFile
     let dflags = ms_hspp_opts . pm_mod_summary <$> pm
-    -- Filter diagnostics that are from ghcmod
-        ghcDiags = filter (\d -> d ^. J.source == Just "typecheck") diags
+    -- Filter diagnostics that are from GHC
+        ghcDiags = filter isGhcDiag diags
     -- Get all potential Pragmas for all diagnostics.
         pragmas = concatMap (\d -> genPragma dflags (d ^. J.message)) ghcDiags
     cmds <- mapM mkCodeAction pragmas
     return $ Right $ List cmds
       where
+        isGhcDiag diag
+          | Just source <- diag ^. J.source
+          = source `elem` ["parser", "typecheck"]
+          | otherwise
+          = False
+
         mkCodeAction pragmaName = do
           let
             codeAction = J.CACodeAction $ J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [])) (Just edit) Nothing
@@ -81,13 +88,17 @@ codeActionProvider _ state _plId docId _ (J.CodeActionContext (J.List diags) _mo
             edit = mkPragmaEdit (docId ^. J.uri) pragmaName
           return codeAction
 
-        genPragma mDynflags target
-          | Just dynFlags <- mDynflags,
-            -- GHC does not export 'OnOff', so we have to view it as string
-            disabled <- [ e | Just e <- T.stripPrefix "Off " . T.pack . prettyPrint <$> extensions dynFlags]
-          = [ r | r <- findPragma target, r `notElem` disabled]
-          | otherwise = []
-
+        genPragma mDynflags target =
+            [ r | r <- findPragma target, r `notElem` disabled]
+          where
+            disabled
+              | Just dynFlags <- mDynflags
+                -- GHC does not export 'OnOff', so we have to view it as string
+              = [ e | Just e <- T.stripPrefix "Off " . T.pack . prettyPrint <$> extensions dynFlags]
+              | otherwise
+                -- When the module failed to parse, we don't have access to its
+                -- dynFlags. In that case, simply don't disable any pragmas.
+              = []
 
 -- ---------------------------------------------------------------------
 

--- a/test/testdata/addPragmas/NeedsPragmas.hs
+++ b/test/testdata/addPragmas/NeedsPragmas.hs
@@ -1,3 +1,4 @@
+module NeedsPragmas where
 
 import GHC.Generics
 

--- a/test/testdata/addPragmas/TypeApplications.hs
+++ b/test/testdata/addPragmas/TypeApplications.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module TypeApplications where
+
+foo :: forall a. a -> a
+foo = id @a

--- a/test/testdata/addPragmas/hie.yaml
+++ b/test/testdata/addPragmas/hie.yaml
@@ -2,3 +2,4 @@ cradle:
   direct:
     arguments:
       - "NeedsPragmas"
+      - "TypeApplications"

--- a/test/testdata/addPragmas/test.cabal
+++ b/test/testdata/addPragmas/test.cabal
@@ -10,8 +10,9 @@ category:            Web
 build-type:          Simple
 cabal-version:       >=1.10
 
-executable p
-  main-is:             NeedsPragmas.hs
+library
+  exposed-modules:     NeedsPragmas
+                       TypeApplications
   hs-source-dirs:      .
   build-depends:       base >= 4.7 && < 5
   default-language:    Haskell2010


### PR DESCRIPTION
Only errors produced by the type checker were checked for mentions of a pragma
that could be enabled. Many parse errors suggest enabling a pragma:

* `@` -> `TypeApplications`
* `forall` -> `RankNTypes`. Although `ScopedTypeVariables` would be a better
  suggestion, IMO.
* ...

Generate suggestions for these too.