### PR TITLE
Fix toMethodName bug of the Class plugin

### DIFF
--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class.hs
@@ -119,7 +119,7 @@ addMethodPlaceholders lf state AddMinimalMethodsParams{..} = fmap (fromMaybe err
 
     toMethodName n
       | Just (h, _) <- T.uncons n
-      , not (isAlpha h)
+      , not (isAlpha h || h == '_')
       = "(" <> n <> ")"
       | otherwise
       = n

--- a/test/testdata/class/T4.expected.hs
+++ b/test/testdata/class/T4.expected.hs
@@ -1,0 +1,8 @@
+module T4 where
+
+class Test a where
+  _f :: a
+  {-# MINIMAL _f #-}
+
+instance Test Int where
+  _f = _

--- a/test/testdata/class/T4.hs
+++ b/test/testdata/class/T4.hs
@@ -1,0 +1,7 @@
+module T4 where
+
+class Test a where
+  _f :: a
+  {-# MINIMAL _f #-}
+
+instance Test Int where


### PR DESCRIPTION
The previous version wraps a method starting with `_` wrongly with parentheses.