### PR TITLE
Test only last ghc minor version and fix windows cache

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,29 +6,42 @@ pull_request_rules:
   name: Automatically merge pull requests
   conditions:
   - status-success=bench (8.10.2, ubuntu-latest)
-  - status-success=bench (8.6.5, ubuntu-latest)
   - status-success=bench (8.8.4, ubuntu-latest)
-  - status-success=nix (default, macOS-latest)
-  - status-success=nix (default, ubuntu-latest)
-  - status-success=test (8.10.3, ubuntu-latest)
-  - status-success=test (8.10.3, windows-latest)
-  - status-success=test (8.10.2, ubuntu-latest)
-  - status-success=test (8.10.1, ubuntu-latest)
-  - status-success=test (8.8.4, ubuntu-latest)
-  - status-success=test (8.8.3, ubuntu-latest)
-  - status-success=test (8.8.2, ubuntu-latest)
-  - status-success=test (8.6.5, ubuntu-latest)
-  - status-success=test (8.6.4, ubuntu-latest)
-  - status-success=test (windows-latest, 8.10.2.2)
+  - status-success=bench (8.6.5, ubuntu-latest)
 
-  - 'status-success=ci/circleci: ghc-8.10.1'
+  - status-success=nix (default, ubuntu-latest)
+  - status-success=nix (default, macOS-latest)
+
+  - status-success=test (8.10.3, ubuntu-latest)
+  - status-success=test (8.10.3, macOS-latest)
+  - status-success=test (8.10.2, ubuntu-latest)
+  - status-success=test (8.10.2, macOS-latest)
+  - status-success=test (8.10.1, ubuntu-latest)
+  - status-success=test (8.10.1, macOS-latest)
+  - status-success=test (8.8.4, ubuntu-latest)
+  - status-success=test (8.8.4, macOS-latest)
+  - status-success=test (8.8.3, ubuntu-latest)
+  - status-success=test (8.8.3, macOS-latest)
+  - status-success=test (8.8.2, ubuntu-latest)
+  - status-success=test (8.8.2, macOS-latest)
+  - status-success=test (8.6.5, ubuntu-latest)
+  - status-success=test (8.6.5, macOS-latest)
+  - status-success=test (8.6.4, ubuntu-latest)
+  - status-success=test (8.6.4, macOS-latest)
+  - status-success=test (windows-latest, 8.10.3, true)
+  - status-success=test (windows-latest, 8.6.5, true)
+  - status-success=test (windows-latest, 8.10.2.2)
+  - status-success=test (windows-latest, 8.10.1)
+  - status-success=test (windows-latest, 8.6.4)
+
   - 'status-success=ci/circleci: ghc-8.10.3'
-  - 'status-success=ci/circleci: ghc-8.6.4'
-  - 'status-success=ci/circleci: ghc-8.8.2'
-  - 'status-success=ci/circleci: ghc-8.8.3'
   - 'status-success=ci/circleci: ghc-8.10.2'
-  - 'status-success=ci/circleci: ghc-8.6.5'
+  - 'status-success=ci/circleci: ghc-8.10.1'
   - 'status-success=ci/circleci: ghc-8.8.4'
+  - 'status-success=ci/circleci: ghc-8.8.3'
+  - 'status-success=ci/circleci: ghc-8.8.2'
+  - 'status-success=ci/circleci: ghc-8.6.5'
+  - 'status-success=ci/circleci: ghc-8.6.4'
   - 'status-success=ci/circleci: ghc-default'
 
   - label=merge me

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,46 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: ['8.10.3', "8.10.2", "8.10.1", "8.8.4", "8.8.3", "8.8.2", "8.6.5", "8.6.4"]
-        os: [ubuntu-latest, windows-latest]
-        exclude:
-          - os: windows-latest
-            ghc: "8.10.2" # broken due to https://gitlab.haskell.org/ghc/ghc/-/issues/18550
-          - os: windows-latest
-            ghc: "8.8.4" # also fails due to segfault :(
-          - os: windows-latest
-            ghc: "8.8.3" # fails due to segfault
-          - os: windows-latest
-            ghc: "8.8.2" # fails due to error with Cabal
-          - os: windows-latest
-            ghc: "8.6.4" # times out after 300m
+        ghc: ["8.10.3", "8.10.2", "8.10.1", "8.8.4", "8.8.3", "8.8.2", "8.6.5", "8.6.4"]
+        os: [ubuntu-latest, macOS-latest]
         include:
+          # one ghc-lib build
+          # should be renabled: #784
+          # - os: ubuntu-latest
+          #   ghc: '8.10.1'
+          #   ghc-lib: true
+          # only test supported ghc major versions
+          - os: macOS-latest
+            ghc: '8.10.3'
+            test: true
+          - os: ubuntu-latest
+            ghc: '8.10.3'
+            test: true
           - os: windows-latest
-            ghc: "8.10.2.2" # only available for windows and choco
+            ghc: '8.10.3'
+            test: true
+          - os: macOS-latest
+            ghc: '8.8.4'
+            test: true
+          - os: ubuntu-latest
+            ghc: '8.8.4'
+            test: true
+          - os: macOS-latest
+            ghc: '8.6.5'
+            test: true
+          - os: ubuntu-latest
+            ghc: '8.6.5'
+            test: true
+          - os: windows-latest
+            ghc: '8.6.5'
+            test: true
+          # only build rest of supported ghc versions for windows
+          - os: windows-latest
+            ghc: '8.10.2.2'
+          - os: windows-latest
+            ghc: '8.10.1'
+          - os: windows-latest
+            ghc: '8.6.4'
 
     steps:
       # Cancel queued workflows from earlier commits in this branch
@@ -71,11 +95,13 @@ jobs:
         run: cabal build || cabal build || cabal build
 
       - name: Test ghcide
+        if: ${{ !matrix.ghc-lib && matrix.test }}
         shell: bash
         # run the tests without parallelism to avoid running out of memory
         run: cabal test ghcide --test-options="-j1 --rerun-update" || cabal test ghcide --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test ghcide --test-options="-j1 --rerun"
 
       - name: Test func-test suite
+        if: ${{ !matrix.ghc-lib && matrix.test }}
         shell: bash
         env:
           HLS_TEST_EXE: hls
@@ -86,6 +112,7 @@ jobs:
         run: cabal test func-test --test-options="-j1 --rerun-update" || cabal test func-test --test-options="-j1 --rerun --rerun-update" || cabal test func-test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test func-test --test-options="-j1 --rerun"
 
       - name: Test wrapper-test suite
+        if: ${{ !matrix.ghc-lib && matrix.test }}
         shell: bash
         env:
           HLS_TEST_EXE: hls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,10 +88,6 @@ jobs:
             ${{ env.CABAL_PKGS_DIR }}
             ${{ env.CABAL_STORE_DIR }}
           key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
-            ${{ runner.os }}-${{ matrix.ghc }}-build-
-            ${{ runner.os }}-${{ matrix.ghc }}
 
       - run: cabal update
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
             ${{ env.CABAL_STORE_DIR }}
           key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-bench-${{ hashFiles('cabal.project') }}
+            ${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
             ${{ runner.os }}-${{ matrix.ghc }}-build-
             ${{ runner.os }}-${{ matrix.ghc }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Testing
 
+defaults:
+  run:
+    shell: bash
+
 on: [pull_request]
 jobs:
   test:
@@ -63,14 +67,26 @@ jobs:
       - run: ./fmt.sh
         name: "HLint via ./fmt.sh"
 
+      - name: Set some window specific things
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "CABAL_STORE_DIR=$SYSTEMDRIVE\\SR" >> $GITHUB_ENV
+          echo "CABAL_PKGS_DIR=~\\AppData\\cabal\\packages" >> $GITHUB_ENV
+
+      - name: Set some linux/macOS specific things
+        if: matrix.os != 'windows-latest'
+        run: |
+          echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
+          echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
+
       - name: Cache Cabal
         uses: actions/cache@v2
         env:
           cache-name: cache-cabal
         with:
           path: |
-            ~/.cabal/packages
-            ~/.cabal/store
+            ${{ env.CABAL_PKGS_DIR }}
+            ${{ env.CABAL_STORE_DIR }}
           key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.ghc }}-bench-${{ hashFiles('cabal.project') }}
@@ -81,7 +97,6 @@ jobs:
 
       # Need this to work around filepath length limits in Windows
       - name: Shorten binary names
-        shell: bash
         run: |
           sed -i.bak -e 's/haskell-language-server/hls/g' \
                      -e 's/haskell_language_server/hls/g' \
@@ -90,30 +105,26 @@ jobs:
                      src/**/*.hs exe/*.hs
 
       - name: Build
-        shell: bash
         # Retry it three times to workaround compiler segfaults in windows
         run: cabal build || cabal build || cabal build
 
       - name: Test ghcide
         if: ${{ !matrix.ghc-lib && matrix.test }}
-        shell: bash
         # run the tests without parallelism to avoid running out of memory
         run: cabal test ghcide --test-options="-j1 --rerun-update" || cabal test ghcide --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test ghcide --test-options="-j1 --rerun"
 
       - name: Test func-test suite
         if: ${{ !matrix.ghc-lib && matrix.test }}
-        shell: bash
         env:
           HLS_TEST_EXE: hls
           HLS_WRAPPER_TEST_EXE: hls-wrapper
         # run the tests without parallelism, otherwise tasty will attempt to run
         # all functional test cases simultaneously which causes way too many hls
         # instances to be spun up for the poor github actions runner to handle
-        run: cabal test func-test --test-options="-j1 --rerun-update" || cabal test func-test --test-options="-j1 --rerun --rerun-update" || cabal test func-test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test func-test --test-options="-j1 --rerun"
+        run: cabal test func-test --test-options="-j1 --rerun --rerun-update" || cabal test func-test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test func-test --test-options="-j1 --rerun"
 
       - name: Test wrapper-test suite
         if: ${{ !matrix.ghc-lib && matrix.test }}
-        shell: bash
         env:
           HLS_TEST_EXE: hls
           HLS_WRAPPER_TEST_EXE: hls-wrapper

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,10 @@ jobs:
             ${{ env.CABAL_PKGS_DIR }}
             ${{ env.CABAL_STORE_DIR }}
           key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-bench-${{ hashFiles('cabal.project') }}
+            ${{ runner.os }}-${{ matrix.ghc }}-build-
+            ${{ runner.os }}-${{ matrix.ghc }}
 
       - run: cabal update
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,23 +20,14 @@ jobs:
           #   ghc: '8.10.1'
           #   ghc-lib: true
           # only test supported ghc major versions
-          - os: macOS-latest
-            ghc: '8.10.3'
-            test: true
           - os: ubuntu-latest
             ghc: '8.10.3'
             test: true
           - os: windows-latest
             ghc: '8.10.3'
             test: true
-          - os: macOS-latest
-            ghc: '8.8.4'
-            test: true
           - os: ubuntu-latest
             ghc: '8.8.4'
-            test: true
-          - os: macOS-latest
-            ghc: '8.6.5'
             test: true
           - os: ubuntu-latest
             ghc: '8.6.5'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,12 +96,12 @@ jobs:
         run: cabal build || cabal build || cabal build
 
       - name: Test ghcide
-        if: ${{ !matrix.ghc-lib && matrix.test }}
+        if: ${{ matrix.test }}
         # run the tests without parallelism to avoid running out of memory
         run: cabal test ghcide --test-options="-j1 --rerun-update" || cabal test ghcide --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test ghcide --test-options="-j1 --rerun"
 
       - name: Test func-test suite
-        if: ${{ !matrix.ghc-lib && matrix.test }}
+        if: ${{ matrix.test }}
         env:
           HLS_TEST_EXE: hls
           HLS_WRAPPER_TEST_EXE: hls-wrapper
@@ -111,7 +111,7 @@ jobs:
         run: cabal test func-test --test-options="-j1 --rerun --rerun-update" || cabal test func-test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test func-test --test-options="-j1 --rerun"
 
       - name: Test wrapper-test suite
-        if: ${{ !matrix.ghc-lib && matrix.test }}
+        if: ${{ matrix.test }}
         env:
           HLS_TEST_EXE: hls
           HLS_WRAPPER_TEST_EXE: hls-wrapper

--- a/cabal.project
+++ b/cabal.project
@@ -26,7 +26,7 @@ package ghcide
 
 write-ghc-environment-files: never
 
-index-state: 2021-01-03T11:58:44Z
+index-state: 2021-01-07T18:06:52Z
 
 allow-newer:
 	active:base,

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -13,7 +13,7 @@ description:
     A library for building Haskell IDE's on top of the GHC API.
 homepage:           https://github.com/haskell/ghcide#readme
 bug-reports:        https://github.com/haskell/ghcide/issues
-tested-with:        GHC>=8.6.5
+tested-with:        GHC == 8.6.4 || == 8.6.5 || == 8.8.2 || == 8.8.3 || == 8.8.4 || == 8.10.1 || == 8.10.2 || == 8.10.3
 extra-source-files: include/ghc-api-version.h README.md CHANGELOG.md
                     test/data/hover/*.hs
                     test/data/multi/cabal.project

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -14,6 +14,7 @@ copyright:          Alan Zimmerman
 license:            Apache-2.0
 license-file:       LICENSE
 build-type:         Simple
+tested-with:        GHC == 8.6.4 || == 8.6.5 || == 8.8.2 || == 8.8.3 || == 8.8.4 || == 8.10.1 || == 8.10.2 || == 8.10.3
 extra-source-files:
   README.md
   ChangeLog.md


### PR DESCRIPTION
* With this configuration, even including macOS builds, the full test workflow takes 47 minutes (https://github.com/jneira/haskell-language-server/actions/runs/471611988). Now it takes 1h 27m 24s (https://github.com/haskell/haskell-language-server/actions/runs/471363372)
  * Testing macOs builds takes only 58 min: https://github.com/jneira/haskell-language-server/actions/runs/471344446 so maybe we could add them
* I've dropped optional restore keys cause the builds were hitting other incompatible cache, so it was rebuilding everything in every run cause the final store was not being saved. 😟 
