### PR TITLE
Prepare for Hackage

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -79,12 +79,12 @@ library
 
 flag all-plugins
   description: Enable all non formatter plugins
-  default:     True
+  default:     False
   manual:      True
 
 flag all-formatters
   description: Enable all fomatters
-  default:     True
+  default:     False
   manual:      True
 
 flag class

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -77,6 +77,12 @@ library
 
   default-language: Haskell2010
 
+-- Plugin flags are designed for 'cabal install haskell-language-server':
+-- - Packaged plugins should be manual:False
+-- - Non packaged plugins and bulk flags should be manual:True
+-- - Bulk flags should be default:False
+-- - Individual flags should be default:True
+
 flag all-plugins
   description: Enable all non formatter plugins
   default:     False

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -89,79 +89,79 @@ flag all-formatters
 
 flag class
   description: Enable class plugin
-  default:     False
+  default:     True
   manual:      False
 
 flag haddockComments
   description: Enable haddockComments plugin
-  default:     False
+  default:     True
   manual:      False
 
 flag eval
   description: Enable eval plugin
-  default:     False
+  default:     True
   manual:      False
 
 flag importLens
   description: Enable importLens plugin
-  default:     False
+  default:     True
   manual:      False
 
 flag retrie
   description: Enable retrie plugin
-  default:     False
+  default:     True
   manual:      False
 
 flag tactic
   description: Enable tactic plugin
-  default:     False
+  default:     True
   manual:      False
 
 flag hlint
   description: Enable hlint plugin
-  default:     False
+  default:     True
   manual:      False
 
 flag moduleName
   description: Enable moduleName plugin
-  default:     False
+  default:     True
   manual:      True
 
 flag pragmas
   description: Enable pragmas plugin
-  default:     False
+  default:     True
   manual:      True
 
 flag splice
   description: Enable splice plugin
-  default:     False
+  default:     True
   manual:      False
 
 -- formatters
 
 flag floskell
   description: Enable floskell plugin
-  default:     False
+  default:     True
   manual:      True
 
 flag fourmolu
   description: Enable fourmolu plugin
-  default:     False
+  default:     True
   manual:      True
 
 flag ormolu
   description: Enable ormolu plugin
-  default:     False
+  default:     True
   manual:      True
 
 flag stylishHaskell
   description: Enable stylishHaskell plugin
-  default:     False
+  default:     True
   manual:      True
 
 flag brittany
   description: Enable brittany plugin
-  default:     False
+  default:     True
   manual:      True
 
 common example-plugins

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -90,37 +90,37 @@ flag all-formatters
 flag class
   description: Enable class plugin
   default:     False
-  manual:      True
+  manual:      False
 
 flag haddockComments
   description: Enable haddockComments plugin
   default:     False
-  manual:      True
+  manual:      False
 
 flag eval
   description: Enable eval plugin
   default:     False
-  manual:      True
+  manual:      False
 
 flag importLens
   description: Enable importLens plugin
   default:     False
-  manual:      True
+  manual:      False
 
 flag retrie
   description: Enable retrie plugin
   default:     False
-  manual:      True
+  manual:      False
 
 flag tactic
   description: Enable tactic plugin
   default:     False
-  manual:      True
+  manual:      False
 
 flag hlint
   description: Enable hlint plugin
   default:     False
-  manual:      True
+  manual:      False
 
 flag moduleName
   description: Enable moduleName plugin
@@ -135,7 +135,7 @@ flag pragmas
 flag splice
   description: Enable splice plugin
   default:     False
-  manual:      True
+  manual:      False
 
 -- formatters
 

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -13,7 +13,7 @@ library
   exposed-modules:  Ide.Plugin.Class
   hs-source-dirs:   src
   build-depends:    aeson
-                  , base
+                  , base       >=4.12 && <5
                   , containers
                   , haskell-lsp
                   , hls-plugin-api

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -25,7 +25,7 @@ library
 
   build-depends:
     , aeson
-    , base
+    , base       >=4.12 && <5
     , containers
     , deepseq
     , Diff

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -16,7 +16,7 @@ library
   exposed-modules:  Ide.Plugin.ExplicitImports
   hs-source-dirs:   src
   build-depends:    aeson
-               ,    base
+               ,    base        >=4.12 && <5
                ,    containers
                ,    deepseq
                ,    haskell-lsp-types

--- a/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
+++ b/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
@@ -18,7 +18,7 @@ library
   hs-source-dirs:   src
   ghc-options:      -Wall -Wno-name-shadowing -Wredundant-constraints
   build-depends:
-    , base
+    , base       >=4.12 && <5
     , containers
     , ghc
     , ghc-exactprint

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -28,7 +28,7 @@ library
   build-depends:
     , aeson
     , apply-refact
-    , base
+    , base       >=4.12 && <5
     , binary
     , bytestring
     , containers

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -16,7 +16,7 @@ library
   exposed-modules:  Ide.Plugin.Retrie
   hs-source-dirs:   src
   build-depends:    aeson
-               ,    base
+               ,    base       >=4.12 && <5
                ,    containers
                ,    deepseq
                ,    directory

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -15,7 +15,7 @@ library
   other-modules:    Ide.Plugin.Splice.Types
   hs-source-dirs:   src
   build-depends:    aeson
-                  , base
+                  , base       >=4.12 && <5
                   , containers
                   , foldl
                   , haskell-lsp


### PR DESCRIPTION
Fixes #1175 

Backport branch: https://github.com/haskell/haskell-language-server/tree/0.8.0-hackage

Tested: 
```
[nix-shell:/tmp]$ tar xzf ~/scratch/ide/dist-newstyle/sdist/haskell-language-server-0.8.0.0.tar.gz 

[nix-shell:/tmp]$ cd haskell-language-server-0.8.0.0/

[nix-shell:/tmp/haskell-language-server-0.8.0.0]$ cabal configure && cabal build
Resolving dependencies...
Build profile: -w ghc-8.10.2 -O1
In order, the following would be built (use -v for more details):
 - brittany-0.13.1.0 (exe:brittany) (requires build)
 - fourmolu-0.3.0.0 (exe:fourmolu) (requires build)
 - ghcide-0.7.0.0 (exe:ghcide-test-preprocessor) (requires build)
 - ghcide-0.7.0.0 (exe:ghcide) (requires build)
 - haskell-language-server-0.8.0.0 (lib) (first run)
 - ghcide-0.7.0.0 (exe:ghcide-bench) (requires build)
 - haskell-language-server-0.8.0.0 (exe:haskell-language-server-wrapper) (first run)
 - haskell-language-server-0.8.0.0 (exe:haskell-language-server) (first run)
Build profile: -w ghc-8.10.2 -O1
In order, the following will be built (use -v for more details):
 - haskell-language-server-0.8.0.0 (lib) (first run)
 - haskell-language-server-0.8.0.0 (exe:haskell-language-server-wrapper) (first run)
 - haskell-language-server-0.8.0.0 (exe:haskell-language-server) (first run)
...
```