### PR TITLE
Make adding missing constraint work in presence of 'forall' (fixes #1164)

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat.hs
@@ -58,7 +58,7 @@ module Development.IDE.GHC.Compat(
     applyPluginsParsedResultAction,
     module Compat.HieTypes,
     module Compat.HieUtils,
-
+    dropForAll
     ) where
 
 #if MIN_GHC_API_VERSION(8,10,0)
@@ -283,3 +283,12 @@ pattern ExposePackage s a mr <- DynFlags.ExposePackage s a _ mr
 #else
 pattern ExposePackage s a mr = DynFlags.ExposePackage s a mr
 #endif
+
+-- | Take AST representation of type signature and drop `forall` part from it (if any), returning just type's body
+dropForAll :: LHsType pass -> LHsType pass
+#if MIN_GHC_API_VERSION(8,10,0)
+dropForAll = snd . GHC.splitLHsForAllTyInvis
+#else
+dropForAll = snd . GHC.splitLHsForAllTy
+#endif
+

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -803,13 +803,13 @@ suggestFunctionConstraint ParsedModule{pm_parsed_source = L _ HsModule{hsmodDecl
               | L _ (SigD _ (TypeSig _ identifiers (HsWC _ (HsIB _ locatedType)))) <- hsmodDecls
               , any (`isSameName` T.unpack typeSignatureName) $ fmap unLoc identifiers
               ]
-          srcSpanToRange $ case splitLHsForAllTy locatedType of
-            (_{-ignore `forall` if present-}, typeBody) -> case splitLHsQualTy typeBody of
-              (L contextSrcSpan _ , _) ->
-                if isGoodSrcSpan contextSrcSpan
-                  then contextSrcSpan -- The type signature has explicit context
-                  else -- No explicit context, return SrcSpan at the start of type (after a potential `forall`)
-                      let start = srcSpanStart $ getLoc typeBody in mkSrcSpan start start
+          let typeBody = dropForAll locatedType
+          srcSpanToRange $ case splitLHsQualTy typeBody of
+            (L contextSrcSpan _ , _) ->
+              if isGoodSrcSpan contextSrcSpan
+                then contextSrcSpan -- The type signature has explicit context
+                else -- No explicit context, return SrcSpan at the start of type (after a potential `forall`)
+                    let start = srcSpanStart $ getLoc typeBody in mkSrcSpan start start
 
       isSameName :: IdP GhcPs -> String -> Bool
       isSameName x name = showSDocUnsafe (ppr x) == name

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -803,12 +803,13 @@ suggestFunctionConstraint ParsedModule{pm_parsed_source = L _ HsModule{hsmodDecl
               | L _ (SigD _ (TypeSig _ identifiers (HsWC _ (HsIB _ locatedType)))) <- hsmodDecls
               , any (`isSameName` T.unpack typeSignatureName) $ fmap unLoc identifiers
               ]
-          srcSpanToRange $ case splitLHsQualTy locatedType of
-            (L contextSrcSpan _ , _) ->
-              if isGoodSrcSpan contextSrcSpan
-                then contextSrcSpan -- The type signature has explicit context
-                else -- No explicit context, return SrcSpan at the start of type sig where we can write context
-                     let start = srcSpanStart $ getLoc locatedType in mkSrcSpan start start
+          srcSpanToRange $ case splitLHsForAllTy locatedType of
+            (_{-ignore `forall` if present-}, typeBody) -> case splitLHsQualTy typeBody of
+              (L contextSrcSpan _ , _) ->
+                if isGoodSrcSpan contextSrcSpan
+                  then contextSrcSpan -- The type signature has explicit context
+                  else -- No explicit context, return SrcSpanqq at the start of type body (the part of type which follows the optional `forall`)
+                      let start = srcSpanStart $ getLoc typeBody in mkSrcSpan start start
 
       isSameName :: IdP GhcPs -> String -> Bool
       isSameName x name = showSDocUnsafe (ppr x) == name

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -808,7 +808,7 @@ suggestFunctionConstraint ParsedModule{pm_parsed_source = L _ HsModule{hsmodDecl
               (L contextSrcSpan _ , _) ->
                 if isGoodSrcSpan contextSrcSpan
                   then contextSrcSpan -- The type signature has explicit context
-                  else -- No explicit context, return SrcSpanqq at the start of type body (the part of type which follows the optional `forall`)
+                  else -- No explicit context, return SrcSpan at the start of type (after a potential `forall`)
                       let start = srcSpanStart $ getLoc typeBody in mkSrcSpan start start
 
       isSameName :: IdP GhcPs -> String -> Bool

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -2000,8 +2000,8 @@ addFunctionConstraintTests = let
     , "eq (Pair x y) (Pair x' y') = x == x' && y == y'"
     ]
 
-  check :: T.Text -> T.Text -> T.Text -> TestTree
-  check actionTitle originalCode expectedCode = testSession (T.unpack actionTitle) $ do
+  check :: String -> T.Text -> T.Text -> T.Text -> TestTree
+  check testName actionTitle originalCode expectedCode = testSession testName $ do
     doc <- createDoc "Testing.hs" "haskell" originalCode
     _ <- waitForDiagnostics
     actionsOrCommands <- getCodeActions doc (Range (Position 6 0) (Position 6 maxBound))
@@ -2012,30 +2012,37 @@ addFunctionConstraintTests = let
 
   in testGroup "add function constraint"
   [ check
+    "no preexisting constraint"
     "Add `Eq a` to the context of the type signature for `eq`"
     (missingConstraintSourceCode "")
     (missingConstraintSourceCode "Eq a => ")
   , check
+    "no preexisting constraint, with forall"
     "Add `Eq a` to the context of the type signature for `eq`"
     (missingConstraintWithForAllSourceCode "")
     (missingConstraintWithForAllSourceCode "Eq a => ")
   , check
+    "preexisting constraint, no parenthesis"
     "Add `Eq b` to the context of the type signature for `eq`"
     (incompleteConstraintSourceCode "Eq a")
     (incompleteConstraintSourceCode "(Eq a, Eq b)")
   , check
+    "preexisting constraints in parenthesis"
     "Add `Eq c` to the context of the type signature for `eq`"
     (incompleteConstraintSourceCode2 "(Eq a, Eq b)")
     (incompleteConstraintSourceCode2 "(Eq a, Eq b, Eq c)")
   , check 
+    "preexisting constraints with forall"
     "Add `Eq b` to the context of the type signature for `eq`"
     (incompleteConstraintWithForAllSourceCode "Eq a")
     (incompleteConstraintWithForAllSourceCode "(Eq a, Eq b)")
   , check
+    "preexisting constraint, with extra spaces in context"
     "Add `Eq b` to the context of the type signature for `eq`"
     (incompleteConstraintSourceCodeWithExtraCharsInContext "( Eq a )")
     (incompleteConstraintSourceCodeWithExtraCharsInContext "(Eq a, Eq b)")
   , check
+    "preexisting constraint, with newlines in type signature"
     "Add `Eq b` to the context of the type signature for `eq`"
     (incompleteConstraintSourceCodeWithNewlinesInTypeSignature "(Eq a)")
     (incompleteConstraintSourceCodeWithNewlinesInTypeSignature "(Eq a, Eq b)")

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -2004,7 +2004,7 @@ addFunctionConstraintTests = let
   check actionTitle originalCode expectedCode = testSession (T.unpack actionTitle) $ do
     doc <- createDoc "Testing.hs" "haskell" originalCode
     _ <- waitForDiagnostics
-    actionsOrCommands <- getCodeActions doc (Range (Position 0 0) (Position 6 maxBound))
+    actionsOrCommands <- getCodeActions doc (Range (Position 6 0) (Position 6 maxBound))
     chosenAction <- liftIO $ pickActionWithTitle actionTitle actionsOrCommands
     executeCodeAction chosenAction
     modifiedCode <- documentContents doc


### PR DESCRIPTION
Fixes https://github.com/haskell/haskell-language-server/issues/1164

![worksWithForall](https://user-images.githubusercontent.com/2716069/104092643-90e53300-5285-11eb-866c-a64fbc8aa56e.gif)
