### PR TITLE
Benchmark improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
             ~/.cabal/store
           key: ${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-bench-$${ hashFiles('cabal.project') }}
+            ${{ runner.os }}-${{ matrix.ghc }}-bench-${{ hashFiles('cabal.project') }}
             ${{ runner.os }}-${{ matrix.ghc }}-build-
             ${{ runner.os }}-${{ matrix.ghc }}
 

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -16,23 +16,23 @@ examples:
     version: 3.0.0.0
     module: Distribution/Simple.hs
   # Small-sized project with TH
-  - name: haskell-lsp-types
-    version: 0.22.0.0
-    module: src/Language/Haskell/LSP/Types/Lens.hs
+  - name: lsp-types
+    version: 1.0.0.1
+    module: src/Language/LSP/VFS.hs
 # - path: path-to-example
 #   module: path-to-module
 
 # The set of experiments to execute
 experiments:
-    - hover
-    - edit
-    - getDefinition
+    - "edit"
+    - "hover"
     - "hover after edit"
+    - "getDefinition"
+    - "getDefinition after edit"
     - "completions after edit"
     - "code actions"
     - "code actions after edit"
     - "documentSymbols after edit"
-    - "getDefinition after edit"
 
 # An ordered list of versions to analyze
 versions:

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -14,15 +14,15 @@ examples:
   # Medium-sized project without TH
   - name: Cabal
     version: 3.0.0.0
-    module: Distribution/Simple.hs
-    module: Distribution/Types/Module.hs
+    modules:
+        - Distribution/Simple.hs
+        - Distribution/Types/Module.hs
   # Small-sized project with TH
   - name: lsp-types
     version: 1.0.0.1
-    module: src/Language/LSP/VFS.hs
-    module: src/Language/LSP/Types/Lens.hs
-# - path: path-to-example
-#   module: path-to-module
+    modules:
+        - src/Language/LSP/VFS.hs
+        - src/Language/LSP/Types/Lens.hs
 
 # The set of experiments to execute
 experiments:

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -15,10 +15,12 @@ examples:
   - name: Cabal
     version: 3.0.0.0
     module: Distribution/Simple.hs
+    module: Distribution/Types/Module.hs
   # Small-sized project with TH
   - name: lsp-types
     version: 1.0.0.1
     module: src/Language/LSP/VFS.hs
+    module: src/Language/LSP/Types/Lens.hs
 # - path: path-to-example
 #   module: path-to-module
 

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -32,6 +32,7 @@ experiments:
     - "code actions"
     - "code actions after edit"
     - "documentSymbols after edit"
+    - "getDefinition after edit"
 
 # An ordered list of versions to analyze
 versions:

--- a/ghcide/bench/exe/Main.hs
+++ b/ghcide/bench/exe/Main.hs
@@ -38,17 +38,22 @@ import Control.Exception.Safe
 import Experiments
 import Options.Applicative
 import System.IO
+import           Control.Monad
+
+optsP :: Parser (Config, Bool)
+optsP = (,) <$> configP <*> switch (long "no-clean")
 
 main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
   hSetBuffering stderr LineBuffering
-  config <- execParser $ info (configP <**> helper) fullDesc
+  (config, noClean) <- execParser $ info (optsP <**> helper) fullDesc
   let ?config = config
+
   hPrint stderr config
 
   output "starting test"
 
   SetupResult{..} <- setup
 
-  runBenchmarks experiments `finally` cleanUp
+  runBenchmarks experiments `finally` unless noClean cleanUp

--- a/ghcide/bench/exe/Main.hs
+++ b/ghcide/bench/exe/Main.hs
@@ -45,6 +45,7 @@ main = do
   hSetBuffering stderr LineBuffering
   config <- execParser $ info (configP <**> helper) fullDesc
   let ?config = config
+  hPrint stderr config
 
   output "starting test"
 

--- a/ghcide/bench/exe/Main.hs
+++ b/ghcide/bench/exe/Main.hs
@@ -37,9 +37,12 @@
 import Control.Exception.Safe
 import Experiments
 import Options.Applicative
+import System.IO
 
 main :: IO ()
 main = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
   config <- execParser $ info (configP <**> helper) fullDesc
   let ?config = config
 

--- a/ghcide/bench/hist/Main.hs
+++ b/ghcide/bench/hist/Main.hs
@@ -98,8 +98,8 @@ createBuildSystem userRules = do
 
   _ <- addOracle $ \GetExperiments {} -> experiments <$> readConfig config
   _ <- addOracle $ \GetVersions {} -> versions <$> readConfig config
-  _ <- addOracle $ \GetExamples{} -> examples <$> readConfig config
-  _ <- addOracle $ \(GetExample name) -> find (\e -> getExampleName e == name) . examples <$> readConfig config
+  _ <- versioned 1 $ addOracle $ \GetExamples{} -> examples <$> readConfig config
+  _ <- versioned 1 $ addOracle $ \(GetExample name) -> find (\e -> getExampleName e == name) . examples <$> readConfig config
   _ <- addOracle $ \GetBuildSystem {} -> buildTool <$> readConfig config
 
   benchResource <- newResource "ghcide-bench" 1

--- a/ghcide/bench/hist/Main.hs
+++ b/ghcide/bench/hist/Main.hs
@@ -138,6 +138,7 @@ benchGhcide
 benchGhcide samples buildSystem args BenchProject{..} = do
   command_ args "ghcide-bench" $
     [ "--timeout=3000",
+      "--no-clean",
         "-v",
         "--samples=" <> show samples,
         "--csv="     <> outcsv,

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -83,6 +83,10 @@ experiments =
       bench "getDefinition" 10 $ \doc ->
         not . null <$> getDefinitions doc ?identifierP,
       ---------------------------------------------------------------------------------------
+      bench "getDefinition after edit" 10 $ \doc -> do
+        changeDoc doc [hygienicEdit]
+        not . null <$> getDefinitions doc ?identifierP,
+      ---------------------------------------------------------------------------------------
       bench "documentSymbols" 100 $
         fmap (either (not . null) (not . null)) . getDocumentSymbols,
       ---------------------------------------------------------------------------------------

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -97,6 +97,10 @@ experiments =
         flip allM docs $ \DocumentPositions{..} ->
           either (not . null) (not . null) <$> getDocumentSymbols doc,
       ---------------------------------------------------------------------------------------
+      bench "completions" 10 $ \docs -> do
+        flip allWithIdentifierPos docs $ \DocumentPositions{..} ->
+          not . null <$> getCompletions doc (fromJust identifierP),
+      ---------------------------------------------------------------------------------------
       bench "completions after edit" 10 $ \docs -> do
         forM_ docs $ \DocumentPositions{..} ->
           changeDoc doc [charEdit stringLiteralP]

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -293,7 +293,8 @@ runBenchmarksFun dir allBenchmarks = do
           "--lsp",
           "--test",
           "--cwd",
-          dir
+          dir,
+          "+RTS"
         ]
     cmd name dir =
       unwords $

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -48,8 +48,8 @@ charEdit :: Position -> TextDocumentContentChangeEvent
 charEdit p =
     TextDocumentContentChangeEvent
     { _range = Just (Range p p),
-        _rangeLength = Nothing,
-        _text = "a"
+      _rangeLength = Nothing,
+      _text = "a"
     }
 
 data DocumentPositions = DocumentPositions {

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -344,16 +344,17 @@ runBench ::
 runBench runSess b = handleAny (\e -> print e >> return badRun)
   $ runSess
   $ do
-    (d, docs) <- duration $ setupDocumentContents ?config
-    output $ "Setting up document contents took " <> showDuration d
     case b of
      Bench{..} -> do
-      (startup, _) <- duration $ do
+      (startup, docs) <- duration $ do
+        (d, docs) <- duration $ setupDocumentContents ?config
+        output $ "Setting up document contents took " <> showDuration d
         -- wait again, as the progress is restarted once while loading the cradle
         -- make an edit, to ensure this doesn't block
         let DocumentPositions{..} = head docs
         changeDoc doc [charEdit stringLiteralP]
         waitForProgressDone
+        return docs
 
       liftIO $ output $ "Running " <> name <> " benchmark"
       (runSetup, ()) <- duration $ benchSetup docs

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -387,14 +387,15 @@ callCommandLogging cmd = do
 
 setup :: HasConfig => IO SetupResult
 setup = do
-  alreadyExists <- doesDirectoryExist examplesPath
-  when alreadyExists $ removeDirectoryRecursive examplesPath
+--   when alreadyExists $ removeDirectoryRecursive examplesPath
   benchDir <- case example ?config of
       UsePackage{..} -> return examplePath
       GetPackage{..} -> do
         let path = examplesPath </> package
             package = exampleName <> "-" <> showVersion exampleVersion
-        case buildTool ?config of
+        alreadySetup <- doesDirectoryExist path
+        unless alreadySetup $
+          case buildTool ?config of
             Cabal -> do
                 let cabalVerbosity = "-v" ++ show (fromEnum (verbose ?config))
                 callCommandLogging $ "cabal get " <> cabalVerbosity <> " " <> package <> " -d " <> examplesPath


### PR DESCRIPTION
Couple of changes:

- Fix an issue with allocation stats, moving all the logic to the `shake-bench` package
- Support examples with multiple files of interest
- Extend the 2 examples we have with an additional file of interest 
- add two new experiments: 
  - "getCompletions": to measure the performance of completions alone
  - "getDefinition after edit": to measure the performance of getDefinition when stale
  