### PR TITLE
Switch module outline to useWtihStale

### DIFF
--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -40,7 +40,7 @@ moduleOutline
 moduleOutline _lsp ideState DocumentSymbolParams { _textDocument = TextDocumentIdentifier uri }
   = case uriToFilePath uri of
     Just (toNormalizedFilePath' -> fp) -> do
-      mb_decls <- fmap fst <$> runIdeAction "Outline" (shakeExtras ideState) (useWithStaleFast GetParsedModule fp)
+      mb_decls <- fmap fst <$> runAction "Outline" ideState (useWithStale GetParsedModule fp)
       pure $ Right $ case mb_decls of
         Nothing -> DSDocumentSymbols (List [])
         Just ParsedModule { pm_parsed_source = L _ltop HsModule { hsmodName, hsmodDecls, hsmodImports } }


### PR DESCRIPTION
Module outline is not a good fit for useWithStaleFast, changing branches should not break document outlines permanently (until edited again).

The problem here is that there is no way for the user to refresh the module outline, unlike completions, hovers, etc.