### PR TITLE
Do not disable parallel GC

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -253,9 +253,8 @@ executable ghcide
                 -- allow user RTS overrides
                 -rtsopts
                 -- disable idle GC
-                -- disable parallel GC
                 -- increase nursery size
-                "-with-rtsopts=-I0 -qg -A128M"
+                "-with-rtsopts=-I0 -A128M"
     main-is: Main.hs
     build-depends:
         aeson,

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -294,9 +294,8 @@ executable haskell-language-server
     -- allow user RTS overrides
     -rtsopts
     -- disable idle GC
-    -- disable parallel GC
     -- increase nursery size
-    "-with-rtsopts=-I0 -qg -A128M"
+    "-with-rtsopts=-I0 -A128M"
   if flag(pedantic)
     ghc-options: -Werror
 
@@ -341,9 +340,8 @@ executable haskell-language-server-wrapper
     -- allow user RTS overrides
     -rtsopts
     -- disable idle GC
-    -- disable parallel GC
     -- increase nursery size
-    "-with-rtsopts=-I0 -qg -A128M"
+    "-with-rtsopts=-I0 -A128M"
   if flag(pedantic)
     ghc-options: -Werror
 
@@ -468,7 +466,3 @@ test-suite wrapper-test
   hs-source-dirs:     test/wrapper
   main-is:            Main.hs
   ghc-options:        -Wall
-
-
-
-


### PR DESCRIPTION
Parallel GC is a win in my machine (16 cores) as well as in the Github workers: https://github.com/pepeiborra/ide/actions/runs/475393491

Total time is up to 15% shorter, depending on the amount of allocations:

```
example             version    name                         success   samples   startup              setup                   userTime              delayedTime             totalTime             maxResidency   allocatedBytes
Cabal-3.0.0.0       upstream   edit                         True      100       10.606544538000001   0.0                     40.510003497          5.165696400000001e-2    40.575701216000006    2MB            402MB
Cabal-3.0.0.0       HEAD       edit                         True      100       10.203424828000001   0.0                     36.683176274999994    4.989549900000002e-2    36.745949376000006    2MB            403MB
Cabal-3.0.0.0       upstream   hover                        True      100       10.674920896000001   0.0                     0.6228912189999994    5.110306199999998e-2    0.68373899            2MB            244MB
Cabal-3.0.0.0       HEAD       hover                        True      100       10.254879756000001   0.0                     0.3924263400000001    5.090440100000001e-2    0.452560114           2MB            244MB
Cabal-3.0.0.0       upstream   hover after edit             True      100       10.699591808000001   0.0                     1.9956586649999994    31.71138437200001       33.722408412          3MB            499MB
Cabal-3.0.0.0       HEAD       hover after edit             True      100       10.093899127         0.0                     2.0653485639999993    28.485690980000008      30.563243146          3MB            500MB
Cabal-3.0.0.0       upstream   getDefinition                True      100       11.148686844         0.0                     0.5310894970000001    5.1670180999999996e-2   0.59241979            2MB            295MB
Cabal-3.0.0.0       HEAD       getDefinition                True      100       10.200312214         0.0                     0.6129946319999998    5.0532303000000015e-2   0.6731919150000001    2MB            294MB
Cabal-3.0.0.0       upstream   getDefinition after edit     True      100       10.785035519000001   0.0                     3.0235643620000006    29.162074662999995      32.198844373          3MB            551MB
Cabal-3.0.0.0       HEAD       getDefinition after edit     True      100       10.441212551000001   0.0                     2.7007223010000003    25.771782374000004      28.483891770000003    3MB            551MB
Cabal-3.0.0.0       upstream   completions after edit       True      100       10.598126156000001   0.0                     19.263908383          16.750844093999998      36.034283703          24MB           4770MB
Cabal-3.0.0.0       HEAD       completions after edit       True      100       10.115316777         0.0                     16.15941421199999     15.446331901999997      31.625586079          24MB           4765MB
Cabal-3.0.0.0       upstream   code actions                 True      100       10.597361019000001   0.514045217             0.7629388249999999    3.5064613999999994e-2   0.807554752           2MB            284MB
Cabal-3.0.0.0       HEAD       code actions                 True      100       10.143675172         0.37361005              0.6707472709999995    3.3788179e-2            0.713678425           1MB            285MB
Cabal-3.0.0.0       upstream   code actions after edit      True      100       10.650572701000002   0.0                     26.594838787999997    4.1882890000000006e-2   26.646926702000002    4MB            609MB
Cabal-3.0.0.0       HEAD       code actions after edit      True      100       10.129994784         0.0                     24.965128403000005    3.806001e-2             25.0137572            3MB            609MB
Cabal-3.0.0.0       upstream   documentSymbols after edit   True      100       10.609898978         0.0                     4.663198507999998     0.8631682150000004      5.557773798           6MB            4211MB
Cabal-3.0.0.0       HEAD       documentSymbols after edit   True      100       22.781294081000002   0.0                     4.701100410000001     0.40237201100000003     5.124589197000001     9MB            4435MB
lsp-types-1.0.0.1   upstream   edit                         True      100       16.021053910000003   0.0                     156.17502144500006    4.546637300000001e-2    156.23712251700002    4MB            482MB
lsp-types-1.0.0.1   HEAD       edit                         True      100       15.187014501         0.0                     135.48325535600003    4.5418978000000006e-2   135.543897464         4MB            479MB
lsp-types-1.0.0.1   upstream   hover                        True      100       16.22087172          0.0                     0.18245858600000003   5.1347465e-2            0.24302167200000002   1MB            162MB
lsp-types-1.0.0.1   HEAD       hover                        True      100       15.210498026000002   0.0                     0.15602954000000002   4.534269000000003e-2    0.21039790200000003   1MB            162MB
lsp-types-1.0.0.1   upstream   hover after edit             True      100       16.041374618000003   0.0                     3.0816972249999997    151.40656952            154.500841116         4MB            516MB
lsp-types-1.0.0.1   HEAD       hover after edit             True      100       15.358283461000001   0.0                     2.008406385999999     135.335797613           137.35569169800002    3MB            508MB
lsp-types-1.0.0.1   upstream   getDefinition                True      100       16.014559634         0.0                     0.141957677           5.2520972000000006e-2   0.204011889           1MB            153MB
lsp-types-1.0.0.1   HEAD       getDefinition                True      100       15.330201850000002   0.0                     0.133046395           5.917913000000002e-2    0.20206531900000002   1MB            153MB
lsp-types-1.0.0.1   upstream   getDefinition after edit     True      100       16.136770534         0.0                     1.3807413410000002    156.130782373           157.522874491         4MB            505MB
lsp-types-1.0.0.1   HEAD       getDefinition after edit     True      100       15.310652439000002   0.0                     1.2901003769999992    135.21775882500003      136.518490202         4MB            502MB
lsp-types-1.0.0.1   upstream   completions after edit       True      100       16.214068162         0.0                     16.760102634000003    138.31530484400005      155.091398072         28MB           6345MB
lsp-types-1.0.0.1   HEAD       completions after edit       True      100       15.447449049000001   0.0                     15.268771436000003    121.41247209300003      136.701950133         28MB           6346MB
lsp-types-1.0.0.1   upstream   code actions                 True      100       16.276668154         1.65275337              1.4890272400000002    4.080451400000001e-2    1.5443014430000002    3MB            1250MB
lsp-types-1.0.0.1   HEAD       code actions                 True      100       15.252827756         5.7224193000000007e-2   1.4959421900000016    4.486597200000001e-2    1.5591204520000002    3MB            1249MB
lsp-types-1.0.0.1   upstream   code actions after edit      True      100       19.139172077         0.0                     147.50509534699998    6.980284600000002e-2    147.585994977         6MB            1569MB
lsp-types-1.0.0.1   HEAD       code actions after edit      True      100       15.468586396000001   0.0                     138.948766725         7.846114800000001e-2    139.038474395         6MB            1571MB
lsp-types-1.0.0.1   upstream   documentSymbols after edit   True      100       16.199064607         0.0                     4.4055052             0.4333826890000001      4.858276535           6MB            3987MB
lsp-types-1.0.0.1   HEAD       documentSymbols after edit   True      100       409.570257151        0.0                     4.469895183           0.33956242300000017     4.829891143           123MB          6968MB
```