### PR TITLE
Update nixpkgs to ghc 8.10.3

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,5 +21,5 @@ jobs:
     - uses: cachix/cachix-action@v8
       with:
         name: haskell-language-server
-        authToken: '${{ secrets.HLS_CACHIX_AUTH_TOKEN }}'
+        authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
     - run: nix-shell --argstr compiler ${{ matrix.ghc }} --run "cabal update && cabal build"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,7 +6,7 @@ let
             mkDerivation = args: super.mkDerivation (args //
                 {
                     # skip running tests for Hackage packages
-                    doCheck = args.pname != "ghcide" && args.pname != "haskell-language-server";
+                    doCheck = args.pname == "ghcide" || args.pname == "haskell-language-server";
                     # relax upper bounds
                     jailbreak = args.pname != "jailbreak-cabal";
                 });
@@ -38,6 +38,7 @@ let
                 # relax upper bounds on ghc 8.10.x versions (and skip running tests)
                 ghc8101 = extended (pkgs.haskell.packages.ghc8101.override sharedOverrides);
                 ghc8102 = extended (pkgs.haskell.packages.ghc8102.override sharedOverrides);
+                ghc8103 = extended (pkgs.haskell.packages.ghc8103.override sharedOverrides);
             };
         };
         };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbf707b2af4cd66bdcdd84b2bddfb627194b39c0",
-        "sha256": "1bj55jkgdzx7lv6dvy26l354c7vsxaa1jipm99axgqqax905m8sa",
+        "rev": "8911c99c2f1bf44210be7ff35314430f02f0f33d",
+        "sha256": "06mi91yxidjyyrc7q5dbi1j8bxi2iird0ivqcnb4kiglpw0ivpkr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cbf707b2af4cd66bdcdd84b2bddfb627194b39c0.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/8911c99c2f1bf44210be7ff35314430f02f0f33d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This also updates the all-hackage snapshot to include hiedb, required for #704 