### PR TITLE
Remove runs dropped by #1173

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,12 +14,10 @@ pull_request_rules:
   - status-success=test (8.10.3, windows-latest)
   - status-success=test (8.10.2, ubuntu-latest)
   - status-success=test (8.10.1, ubuntu-latest)
-  - status-success=test (8.10.1, windows-latest)
   - status-success=test (8.8.4, ubuntu-latest)
   - status-success=test (8.8.3, ubuntu-latest)
   - status-success=test (8.8.2, ubuntu-latest)
   - status-success=test (8.6.5, ubuntu-latest)
-  - status-success=test (8.6.5, windows-latest)
   - status-success=test (8.6.4, ubuntu-latest)
   - status-success=test (windows-latest, 8.10.2.2)
 


### PR DESCRIPTION
The mergify config is not completely updated and is required to remove them to unblock
https://github.com/haskell/haskell-language-server/pull/1173