### PR TITLE
Disable win 8.6.4 job

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -32,7 +32,7 @@ pull_request_rules:
   - status-success=test (windows-latest, 8.6.5, true)
   - status-success=test (windows-latest, 8.10.2.2)
   - status-success=test (windows-latest, 8.10.1)
-  - status-success=test (windows-latest, 8.6.4)
+  # - status-success=test (windows-latest, 8.6.4)
 
   - 'status-success=ci/circleci: ghc-8.10.3'
   - 'status-success=ci/circleci: ghc-8.10.2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,9 @@ jobs:
             ghc: '8.10.2.2'
           - os: windows-latest
             ghc: '8.10.1'
-          - os: windows-latest
-            ghc: '8.6.4'
+          # This build get stuck frequently
+          # - os: windows-latest
+          #   ghc: '8.6.4'
 
     steps:
       # Cancel queued workflows from earlier commits in this branch


### PR DESCRIPTION
* As it continues being unreliable (taking more than 1h30m to finish): https://github.com/haskell/haskell-language-server/pull/635/checks?check_run_id=1686429279
* ~~We have to remove them from github settings check~~removed