### PR TITLE
Fix bug in Retrie "fold/unfold in local file" commands

### DIFF
--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -106,29 +106,19 @@ retrieCommand =
 data RunRetrieParams = RunRetrieParams
   { description               :: T.Text,
     rewrites                  :: [RewriteSpec],
-    originatingFile           :: NormalizedUriJSON,
+    originatingFile           :: Uri,
     restrictToOriginatingFile :: Bool
   }
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
-
-newtype NormalizedUriJSON = NormalizedUriJSON NormalizedUri
-  deriving (Eq, Show)
-
-instance FromJSON NormalizedUriJSON where
-    parseJSON = fmap NormalizedUriJSON . genericParseJSON Aeson.defaultOptions
-
-instance ToJSON NormalizedUriJSON where
-    toJSON (NormalizedUriJSON x) = Aeson.genericToJSON Aeson.defaultOptions x
-
 runRetrieCmd ::
   LspFuncs a ->
   IdeState ->
   RunRetrieParams ->
   IO (Either ResponseError Value, Maybe (ServerMethod, ApplyWorkspaceEditParams))
-runRetrieCmd lsp state RunRetrieParams{originatingFile = NormalizedUriJSON nuri, ..} =
+runRetrieCmd lsp state RunRetrieParams{originatingFile = uri, ..} =
   withIndefiniteProgress lsp description Cancellable $ do
     res <- runMaybeT $ do
-        nfp <- MaybeT $ return $ uriToNormalizedFilePath nuri
+        nfp <- MaybeT $ return $ uriToNormalizedFilePath $ toNormalizedUri uri
         (session, _) <- MaybeT $
             runAction "Retrie.GhcSessionDeps" state $
                 useWithStale GhcSessionDeps $
@@ -181,7 +171,6 @@ provider :: CodeActionProvider IdeState
 provider _a state plId (TextDocumentIdentifier uri) range ca = response $ do
   let (J.CodeActionContext _diags _monly) = ca
       nuri = toNormalizedUri uri
-      nuriJson = NormalizedUriJSON nuri
   nfp <- handleMaybe "uri" $ uriToNormalizedFilePath nuri
 
   (ModSummary{ms_mod}, topLevelBinds, posMapping, hs_ruleds, hs_tyclds)
@@ -189,12 +178,12 @@ provider _a state plId (TextDocumentIdentifier uri) range ca = response $ do
 
   pos <- handleMaybe "pos" $ _start <$> fromCurrentRange posMapping range
   let rewrites =
-        concatMap (suggestBindRewrites nuriJson pos ms_mod) topLevelBinds
-          ++ concatMap (suggestRuleRewrites nuriJson pos ms_mod) hs_ruleds
+        concatMap (suggestBindRewrites uri pos ms_mod) topLevelBinds
+          ++ concatMap (suggestRuleRewrites uri pos ms_mod) hs_ruleds
           ++ [ r
                | TyClGroup {group_tyclds} <- hs_tyclds,
                  L l g <- group_tyclds,
-                 r <- suggestTypeRewrites nuriJson ms_mod g,
+                 r <- suggestTypeRewrites uri ms_mod g,
                  pos `isInsideSrcSpan` l
 
              ]
@@ -233,7 +222,7 @@ getBinds nfp = runMaybeT $ do
   return (tmrModSummary tm, topLevelBinds, posMapping, hs_ruleds, hs_tyclds)
 
 suggestBindRewrites ::
-  NormalizedUriJSON ->
+  Uri ->
   Position ->
   GHC.Module ->
   HsBindLR GhcRn GhcRn ->
@@ -260,7 +249,7 @@ describeRestriction restrictToOriginatingFile =
 
 suggestTypeRewrites ::
   (Outputable (IdP pass)) =>
-  NormalizedUriJSON ->
+  Uri ->
   GHC.Module ->
   TyClDecl pass ->
   [(T.Text, CodeActionKind, RunRetrieParams)]
@@ -279,7 +268,7 @@ suggestTypeRewrites originatingFile ms_mod (SynDecl {tcdLName = L _ rdrName}) =
 suggestTypeRewrites _ _ _ = []
 
 suggestRuleRewrites ::
-  NormalizedUriJSON ->
+  Uri ->
   Position ->
   GHC.Module ->
   LRuleDecls pass ->
@@ -351,7 +340,6 @@ callRetrie ::
   IO ([CallRetrieError], WorkspaceEdit)
 callRetrie state session rewrites origin restrictToOriginatingFile = do
   knownFiles <- toKnownFiles . unhashed <$> readVar (knownTargetsVar $ shakeExtras state)
-  print knownFiles
   let reuseParsedModule f = do
         pm <-
           useOrFail "GetParsedModule" NoParse GetParsedModule f


### PR DESCRIPTION
`NormalizedUriJSON` was wrapping a `NormalizedUri` to add JSON encoding/decoding capabilities. This was a bad idea because `NormalizedUri` embeds a hash, which was not decoding cleanly. This was making some Retrie commands fail.

The Retrie plugin needs a test suite, but I don't want to embed the test suite in `func-test`. I have a plan to make it easy, or at least possible, to package integration test suites with plugins, but there's a few pieces missing yet