### PR TITLE
Stale diagnostics fix

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -201,6 +201,17 @@ diagnosticTests = testGroup "diagnostics"
             }
       changeDoc doc [change]
       expectDiagnostics [("Testing.hs", [(DsError, (0, 15), "parse error")])]
+  , testSessionWait "update syntax error" $ do
+      let content = T.unlines [ "module Testing(missing) where" ]
+      doc <- createDoc "Testing.hs" "haskell" content
+      expectDiagnostics [("Testing.hs", [(DsError, (0, 15), "Not in scope: 'missing'")])]
+      let change = TextDocumentContentChangeEvent
+            { _range = Just (Range (Position 0 15) (Position 0 16))
+            , _rangeLength = Nothing
+            , _text = "l"
+            }
+      changeDoc doc [change]
+      expectDiagnostics [("Testing.hs", [(DsError, (0, 15), "Not in scope: 'lissing'")])]
   , testSessionWait "variable not in scope" $ do
       let content = T.unlines
             [ "module Testing where"


### PR DESCRIPTION
This PR fixes another diagnostics bug introduced by #1188. Diagnostics are tricky but this was a silly mistake.

When a rule runs, the ide must always send the diagnostics returned by the rule. The only case where saved diagnostics are to be reused is early cutoff. 

This is what the description of #1188 stated, I have no idea why then in the implementation I changed the non early-cutoff case.
