### PR TITLE
Prepare ghcide release v0.7.1

### DIFF
--- a/ghcide/CHANGELOG.md
+++ b/ghcide/CHANGELOG.md
@@ -1,5 +1,20 @@
+### 0.7.1 (2020-01-13)
+
+* Fix sticky diagnostics bug (#1188) - (Pepe Iborra)
+* Use completionSnippetsOn flag (#1195) - (Yuya Kono)
+* Update tested-with GHC in cabal config - (jneira)
+* Do not disable parallel GC by default (#1190) - (Pepe Iborra)
+* Fix module outline becoming stale after switching branches (#1189) - (Pepe Iborra)
+* Make adding missing constraint work in presence of 'forall' (fixes #1164) (#1177) - (Jan Hrcek)
+* Bump haskell-lsp to 0.23 (#1146) - (Potato Hatsue)
+* Fix #723 (Instance declarations in hs-boot files result in GHC errors) (#781) - (Ben Simms)
+* Also suggest importing methods without parent class (#766) - (Thomas Winant)
+* Update links to issues/PRs in ghcide tests. (#1142) - (Peter Wicks Stringfield)
+* fix suggestAddTypeAnnotation regex (#760) - (Kostas Dermentzis)
+
 ### 0.7.0 (2020-01-03)
 
+* Ghcide now loads HLS plugins internally - (Pepe Iborra)
 * Retry a failed cradle if the cradle descriptor changes (#762) - (Pepe Iborra)
 * Fix extend imports regression (#769) - (Pepe Iborra)
 * Perform memory measurement on SIGUSR1 (#761) - (Pepe Iborra)

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -58,5 +58,7 @@ versions:
 # - v0.4.0
 # - v0.5.0
 # - v0.6.0
+# - v0.7.0
+# - v0.7.1
 - upstream: origin/master
 - HEAD

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      1.20
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            0.7.0.0
+version:            0.7.1.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -11,8 +11,10 @@
 --   using the "Shaker" abstraction layer for in-memory use.
 --
 module Development.IDE.Core.Rules(
+    -- * Types
     IdeState, GetDependencies(..), GetParsedModule(..), TransitiveDependencies(..),
     Priority(..), GhcSessionIO(..), GetClientSettings(..),
+    -- * Functions
     priorityTypeCheck,
     priorityGenerateCore,
     priorityFilesOfInterest,
@@ -28,6 +30,30 @@ module Development.IDE.Core.Rules(
     getDependencies,
     getParsedModule,
     getClientConfigAction,
+    -- * Rules
+    CompiledLinkables(..),
+    IsHiFileStable(..),
+    getParsedModuleRule,
+    getLocatedImportsRule,
+    getDependencyInformationRule,
+    reportImportCyclesRule,
+    getDependenciesRule,
+    typeCheckRule,
+    getDocMapRule,
+    loadGhcSession,
+    getModIfaceFromDiskRule,
+    getModIfaceRule,
+    getModIfaceWithoutLinkableRule,
+    getModSummaryRule,
+    isHiFileStableRule,
+    getModuleGraphRule,
+    knownFilesRule,
+    getClientSettingsRule,
+    getHieAstsRule,
+    getBindingsRule,
+    needsCompilationRule,
+    generateCoreRule,
+    getImportMapRule
     ) where
 
 import Fingerprint


### PR DESCRIPTION
Mainly to get rid of the sticky diagnostics bug, although there's quite a few more nice changes in there