### PR TITLE
Parenthesise type operators when extending import lists

### DIFF
--- a/ghcide/src/Development/IDE/Types/Exports.hs
+++ b/ghcide/src/Development/IDE/Types/Exports.hs
@@ -58,7 +58,7 @@ mkIdentInfos (AvailTC parent (n:nn) flds)
       ] ++
       [ IdentInfo (pack (prettyPrint n)) (pack (printName n)) Nothing (isDataConName n)]
     where
-        parentP = pack $ prettyPrint parent
+        parentP = pack $ printName parent
 
 mkIdentInfos (AvailTC _ nn flds)
     = [ IdentInfo (pack (prettyPrint n)) (pack (printName n)) Nothing (isDataConName n)

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1300,6 +1300,22 @@ extendImportTests = testGroup "extend import actions"
                     , "import ModuleA (bar)"
                     , "foo = bar"
                     ])
+        , testSession "extend import list with constructor of type operator" $ template
+            []
+            ("ModuleA.hs", T.unlines
+                    [ "module ModuleA where"
+                    , "import Data.Type.Equality ((:~:))"
+                    , "x :: (:~:) [] []"
+                    , "x = Refl"
+                    ])
+            (Range (Position 3 17) (Position 3 18))
+            ["Add (:~:)(Refl) to the import list of Data.Type.Equality"]
+            (T.unlines
+                    [ "module ModuleA where"
+                    , "import Data.Type.Equality ((:~:)(Refl))"
+                    , "x :: (:~:) [] []"
+                    , "x = Refl"
+                    ])
         ]
       where
         codeActionTitle CodeAction{_title=x} = x


### PR DESCRIPTION
Fixes #1211.

When extending the import of a type operator with one of its constructors, don't
forget to put parentheses around the type operator.