### PR TITLE
Delete redundant "category: Development".

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -13,7 +13,6 @@ maintainer:         alan.zimm@gmail.com
 copyright:          The Haskell IDE Team
 license:            Apache-2.0
 license-file:       LICENSE
-category:           Development
 build-type:         Simple
 tested-with:        GHC == 8.6.4 || == 8.6.5 || == 8.8.2 || == 8.8.3 || == 8.8.4 || == 8.10.1 || == 8.10.2 || == 8.10.3
 extra-source-files:


### PR DESCRIPTION
#1234 duplicated the "category: Development" in haskell-language-server.cabal and it's giving a warning when I build.