### PR TITLE
Produce heap profiles the old fashioned way, from .hp files

### DIFF
--- a/ghcide/bench/hist/Main.hs
+++ b/ghcide/bench/hist/Main.hs
@@ -74,7 +74,7 @@ main = shakeArgs shakeOptions {shakeChange = ChangeModtimeAndDigest, shakeThread
       benchRules build resource (MkBenchRules (askOracle $ GetSamples ()) benchGhcide "ghcide")
       csvRules build
       svgRules build
-      eventlogRules build
+      heapProfileRules build
       action $ allTargets build
 
 ghcideBuildRules :: MkBuildRules BuildSystem
@@ -123,7 +123,6 @@ buildGhcide Cabal args out = do
         ,"--install-method=copy"
         ,"--overwrite-policy=always"
         ,"--ghc-options=-rtsopts"
-        ,"--ghc-options=-eventlog"
         ]
 
 buildGhcide Stack args out =
@@ -133,7 +132,6 @@ buildGhcide Stack args out =
         ,"ghcide:ghcide"
         ,"--copy-bins"
         ,"--ghc-options=-rtsopts"
-        ,"--ghc-options=-eventlog"
         ]
 
 benchGhcide

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -221,7 +221,7 @@ benchmark benchHist
     other-modules: Experiments.Types
     build-tool-depends:
         ghcide:ghcide-bench,
-        eventlog2html:eventlog2html
+        hp2pretty:hp2pretty
     default-extensions:
         BangPatterns
         DeriveFunctor


### PR DESCRIPTION
The -eventlog runtime is not reliable when combined with +RTS -h
leading to undiagnosed crashes and infinite loops.

The crashes are sporadic and seem to arise more frequently in the lsp-types
example, although we have not investigated deeply since there is a simple
alternative that doesn't crash: the vanilla runtime.