### PR TITLE
Reenable auto extend imports and drop snippets for infix completions

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -173,6 +173,7 @@ library
         Development.IDE.Types.Shake
         Development.IDE.Plugin
         Development.IDE.Plugin.Completions
+        Development.IDE.Plugin.Completions.Types
         Development.IDE.Plugin.CodeAction
         Development.IDE.Plugin.CodeAction.ExactPrint
         Development.IDE.Plugin.HLS
@@ -204,7 +205,6 @@ library
         Development.IDE.Plugin.CodeAction.Rules
         Development.IDE.Plugin.CodeAction.RuleTypes
         Development.IDE.Plugin.Completions.Logic
-        Development.IDE.Plugin.Completions.Types
         Development.IDE.Plugin.HLS.Formatter
         Development.IDE.Types.Action
     ghc-options: -Wall -Wno-name-shadowing -Wincomplete-uni-patterns

--- a/ghcide/src/Development/IDE/GHC/Compat.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat.hs
@@ -60,7 +60,7 @@ module Development.IDE.GHC.Compat(
     module Compat.HieTypes,
     module Compat.HieUtils,
     dropForAll
-    ) where
+    ,isQualifiedImport) where
 
 #if MIN_GHC_API_VERSION(8,10,0)
 import LinkerTypes
@@ -300,3 +300,12 @@ pattern FunTy arg res <- TyCoRep.FunTy {ft_arg = arg, ft_res = res}
 #else
 pattern FunTy arg res <- TyCoRep.FunTy arg res
 #endif
+
+isQualifiedImport :: ImportDecl a -> Bool
+#if MIN_GHC_API_VERSION(8,10,0)
+isQualifiedImport ImportDecl{ideclQualified = NotQualified} = False
+isQualifiedImport ImportDecl{} = True
+#else
+isQualifiedImport ImportDecl{ideclQualified} = ideclQualified
+#endif
+isQualifiedImport _ = False

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -203,8 +203,8 @@ extendImportTopLevel df idnetifier (L l it@ImportDecl {..})
     rdr <- liftParseAST df idnetifier
 
     let alreadyImported =
-            showNameWithoutUniques rdr `elem`
-            map (showNameWithoutUniques @RdrName) (listify (const True) lies)
+            showNameWithoutUniques (occName (unLoc rdr)) `elem`
+            map (showNameWithoutUniques @OccName) (listify (const True) lies)
     when alreadyImported $
         lift (Left $ idnetifier <> " already imported")
 
@@ -255,8 +255,8 @@ extendImportViaParent df parent child (L l it@ImportDecl {..})
           childRdr <- liftParseAST df child
 
           let alreadyImported =
-                showNameWithoutUniques childRdr `elem`
-                map (showNameWithoutUniques @RdrName) (listify (const True) lies')
+                showNameWithoutUniques(occName (unLoc childRdr)) `elem`
+                map (showNameWithoutUniques @OccName) (listify (const True) lies')
           when alreadyImported $
             lift (Left $ child <> " already included in " <> parent <> " imports")
 

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -40,6 +40,7 @@ import Retrie.GHC (rdrNameOcc, unpackFS, mkRealSrcSpan, realSrcSpanEnd)
 import Development.IDE.Spans.Common
 import Development.IDE.GHC.Error
 import Safe (lastMay)
+import Data.Generics (listify)
 
 ------------------------------------------------------------------------------
 
@@ -200,17 +201,25 @@ extendImportTopLevel df idnetifier (L l it@ImportDecl {..})
     src <- uniqueSrcSpanT
     top <- uniqueSrcSpanT
     rdr <- liftParseAST df idnetifier
+
+    let alreadyImported =
+            showNameWithoutUniques rdr `elem`
+            map (showNameWithoutUniques @RdrName) (listify (const True) lies)
+    when alreadyImported $
+        lift (Left $ idnetifier <> " already imported")
+
     let lie = L src $ IEName rdr
         x = L top $ IEVar noExtField lie
-    when hasSibling $
-      addTrailingCommaT (last lies)
-    addSimpleAnnT x (DP (0, if hasSibling then 1 else 0)) []
-    addSimpleAnnT rdr dp00 $ unqalDP $ hasParen idnetifier
-    -- Parens are attachted to `lies`, so if `lies` was empty previously,
-    -- we need change the ann key from `[]` to `:` to keep parens and other anns.
-    unless hasSibling $
-      transferAnn (L l' lies) (L l' [x]) id
-    return $ L l it {ideclHiding = Just (hide, L l' $ lies ++ [x])}
+    if x `elem` lies then lift (Left $ idnetifier <> " already imported") else do
+        when hasSibling $
+            addTrailingCommaT (last lies)
+        addSimpleAnnT x (DP (0, if hasSibling then 1 else 0)) []
+        addSimpleAnnT rdr dp00 $ unqalDP $ hasParen idnetifier
+        -- Parens are attachted to `lies`, so if `lies` was empty previously,
+        -- we need change the ann key from `[]` to `:` to keep parens and other anns.
+        unless hasSibling $
+            transferAnn (L l' lies) (L l' [x]) id
+        return $ L l it {ideclHiding = Just (hide, L l' $ lies ++ [x])}
 extendImportTopLevel _ _ _ = lift $ Left "Unable to extend the import list"
 
 -- | Add an identifier with its parent to import list
@@ -244,6 +253,13 @@ extendImportViaParent df parent child (L l it@ImportDecl {..})
         do
           srcChild <- uniqueSrcSpanT
           childRdr <- liftParseAST df child
+
+          let alreadyImported =
+                showNameWithoutUniques childRdr `elem`
+                map (showNameWithoutUniques @RdrName) (listify (const True) lies')
+          when alreadyImported $
+            lift (Left $ child <> " already included in " <> parent <> " imports")
+
           when hasSibling $
             addTrailingCommaT (last lies')
           let childLIE = L srcChild $ IEName childRdr

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -178,7 +178,7 @@ extendImportHandler' ideState ExtendImport {..}
       imp <- liftMaybe $ find (isWantedModule wantedModule) imps
       wedit <-
         liftEither $
-          rewriteToEdit df doc (annsA ps) $
+          rewriteToWEdit df doc (annsA ps) $
             extendImport (T.unpack <$> thingParent) (T.unpack newThing) imp
       return (WorkspaceApplyEdit, ApplyWorkspaceEditParams wedit)
   | otherwise =

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -185,7 +185,8 @@ extendImportHandler' ideState ExtendImport {..}
     mzero
 
 isWantedModule :: ModuleName -> GenLocated l (ImportDecl pass) -> Bool
-isWantedModule wantedModule (L _ ImportDecl{ideclName, ideclHiding = Just (False, _), ideclQualified = NotQualified}) = unLoc ideclName == wantedModule
+isWantedModule wantedModule (L _ it@ImportDecl{ideclName, ideclHiding = Just (False, _)}) =
+    not (isQualifiedImport it) && unLoc ideclName == wantedModule
 isWantedModule _ _ = False
 
 liftMaybe :: Monad m => Maybe a -> MaybeT m a

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -185,7 +185,7 @@ extendImportHandler' ideState ExtendImport {..}
     mzero
 
 isWantedModule :: ModuleName -> GenLocated l (ImportDecl pass) -> Bool
-isWantedModule wantedModule (L _ ImportDecl {..}) = unLoc ideclName == wantedModule
+isWantedModule wantedModule (L _ ImportDecl{ideclName, ideclHiding = Just (False, _), ideclQualified = NotQualified}) = unLoc ideclName == wantedModule
 isWantedModule _ _ = False
 
 liftMaybe :: Monad m => Maybe a -> MaybeT m a

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -284,6 +284,8 @@ cacheDataProducer uri packageState curMod rdrEnv limports deps = do
   let dflags = hsc_dflags packageState
       curModName = moduleName curMod
 
+      importMap = Map.fromList [ (getLoc imp, imp) | imp <- limports ]
+
       iDeclToModName :: ImportDecl name -> ModuleName
       iDeclToModName = unLoc . ideclName
 
@@ -312,7 +314,8 @@ cacheDataProducer uri packageState curMod rdrEnv limports deps = do
           (, mempty) <$> toCompItem par curMod curModName n Nothing
       getComplsForOne (GRE n par False prov) =
         flip foldMapM (map is_decl prov) $ \spec -> do
-          compItem <- toCompItem curMod (is_mod spec) n Nothing
+          let originalImportDecl = Map.lookup (is_dloc spec) importMap
+          compItem <- toCompItem par curMod (is_mod spec) n originalImportDecl
           let unqual
                 | is_qual spec = []
                 | otherwise = compItem

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -636,7 +636,7 @@ isUsedAsInfix line prefixMod prefixText pos
 
 openingBacktick :: T.Text -> T.Text -> T.Text -> Position -> Bool
 openingBacktick line prefixModule prefixText Position { _character }
-  | backtickIndex < 0 = False
+  | backtickIndex < 0 || backtickIndex > T.length line = False
   | otherwise = (line `T.index` backtickIndex) == '`'
     where
     backtickIndex :: Int

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -229,6 +229,7 @@ mkNameCompItem doc thingParent origName origMod thingType isInfix docs !imp = CI
           { doc,
             thingParent,
             importName = showModName $ unLoc $ ideclName $ unLoc x,
+            importQual = getImportQual x,
             newThing = showNameWithoutUniques origName
           }
 
@@ -742,6 +743,7 @@ mkRecordSnippetCompItem uri parent ctxStr compl mn docs imp = r
                 { doc = uri,
                   thingParent = parent,
                   importName = showModName $ unLoc $ ideclName $ unLoc x,
+                  importQual = getImportQual x,
                   newThing = ctxStr
                 }
           }
@@ -751,3 +753,8 @@ mkRecordSnippetCompItem uri parent ctxStr compl mn docs imp = r
       snippet = T.intercalate (T.pack ", ") snippet_parts
       buildSnippet = ctxStr <> " {" <> snippet <> "}"
       importedFrom = Right mn
+
+getImportQual :: LImportDecl GhcPs -> Maybe T.Text
+getImportQual (L _ imp)
+    | isQualifiedImport imp = Just $ T.pack $ moduleNameString $ maybe (unLoc $ ideclName imp) unLoc (ideclAs imp)
+    | otherwise = Nothing

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
 module Development.IDE.Plugin.Completions.Types (
   module Development.IDE.Plugin.Completions.Types
 ) where
@@ -8,13 +10,24 @@ import qualified Data.Text as T
 import SrcLoc
 
 import Development.IDE.Spans.Common
-import Language.Haskell.LSP.Types (TextEdit, CompletionItemKind)
-
--- From haskell-ide-engine/src/Haskell/Ide/Engine/LSP/Completions.hs
-
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Language.Haskell.LSP.Types (CompletionItemKind, Uri)
 data Backtick = Surrounded | LeftSide
   deriving (Eq, Ord, Show)
 
+extendImportCommandId :: Text
+extendImportCommandId = "extendImport"
+
+data ExtendImport = ExtendImport
+  { doc :: !Uri,
+    newThing :: !T.Text,
+    thingParent :: !(Maybe T.Text),
+    importName :: !T.Text
+  }
+  deriving (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
 data CompItem = CI
   { compKind     :: CompletionItemKind
   , insertText   :: T.Text         -- ^ Snippet for the completion
@@ -25,7 +38,7 @@ data CompItem = CI
                                    -- in the context of an infix notation.
   , docs         :: SpanDoc        -- ^ Available documentation.
   , isTypeCompl  :: Bool
-  , additionalTextEdits :: Maybe [TextEdit]
+  , additionalTextEdits :: Maybe ExtendImport
   }
   deriving (Eq, Show)
 

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -14,6 +14,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Language.Haskell.LSP.Types (CompletionItemKind, Uri)
+
 data Backtick = Surrounded | LeftSide
   deriving (Eq, Ord, Show)
 
@@ -28,6 +29,7 @@ data ExtendImport = ExtendImport
   }
   deriving (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
+
 data CompItem = CI
   { compKind     :: CompletionItemKind
   , insertText   :: T.Text         -- ^ Snippet for the completion

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -25,7 +25,8 @@ data ExtendImport = ExtendImport
   { doc :: !Uri,
     newThing :: !T.Text,
     thingParent :: !(Maybe T.Text),
-    importName :: !T.Text
+    importName :: !T.Text,
+    importQual :: !(Maybe T.Text)
   }
   deriving (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -3607,19 +3607,45 @@ nonLocalCompletionTests =
       , completionCommandTest
         "show imports not in list - names with _"
         ["{-# LANGUAGE NoImplicitPrelude #-}",
-        "module A where", "import qualified Control.Monad as M (msum)", "f = M.mapM_"]
+        "module A where", "import Control.Monad as M (msum)", "f = M.mapM_"]
         (Position 3 11)
         "mapM_"
         ["{-# LANGUAGE NoImplicitPrelude #-}",
-        "module A where", "import qualified Control.Monad as M (msum, mapM_)", "f = M.mapM_"]
+        "module A where", "import Control.Monad as M (msum, mapM_)", "f = M.mapM_"]
       , completionCommandTest
         "show imports not in list - initial empty list"
         ["{-# LANGUAGE NoImplicitPrelude #-}",
-        "module A where", "import qualified Control.Monad as M ()", "f = M.joi"]
+        "module A where", "import Control.Monad as M ()", "f = M.joi"]
         (Position 3 10)
         "join"
         ["{-# LANGUAGE NoImplicitPrelude #-}",
-        "module A where", "import qualified Control.Monad as M (join)", "f = M.joi"]
+        "module A where", "import Control.Monad as M (join)", "f = M.joi"]
+      , testGroup "qualified imports"
+        [ completionCommandTest
+            "single"
+            ["{-# LANGUAGE NoImplicitPrelude #-}",
+            "module A where", "import Control.Monad ()", "f = Control.Monad.joi"]
+            (Position 3 22)
+            "join"
+            ["{-# LANGUAGE NoImplicitPrelude #-}",
+            "module A where", "import Control.Monad (join)", "f = Control.Monad.joi"]
+        , completionCommandTest
+            "as"
+            ["{-# LANGUAGE NoImplicitPrelude #-}",
+            "module A where", "import Control.Monad as M ()", "f = M.joi"]
+            (Position 3 10)
+            "join"
+            ["{-# LANGUAGE NoImplicitPrelude #-}",
+            "module A where", "import Control.Monad as M (join)", "f = M.joi"]
+        , completionCommandTest
+            "multiple"
+            ["{-# LANGUAGE NoImplicitPrelude #-}",
+            "module A where", "import Control.Monad as M ()", "import Control.Monad as N ()", "f = N.joi"]
+            (Position 4 10)
+            "join"
+            ["{-# LANGUAGE NoImplicitPrelude #-}",
+            "module A where", "import Control.Monad as M ()", "import Control.Monad as N (join)", "f = N.joi"]
+        ]
       , testGroup "Data constructor"
         [ completionCommandTest
             "not imported"

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -30,6 +30,7 @@ import Development.IDE.Core.Shake (Q(..))
 import Development.IDE.GHC.Util
 import qualified Data.Text as T
 import Data.Typeable
+import Development.IDE.Plugin.Completions.Types (extendImportCommandId)
 import Development.IDE.Plugin.TypeLenses (typeLensCommandId)
 import Development.IDE.Spans.Common
 import Development.IDE.Test
@@ -156,7 +157,7 @@ initializeResponseTests = withResource acquire release tests where
     , chk "NO doc link"               _documentLinkProvider  Nothing
     , chk "NO color"                         _colorProvider (Just $ ColorOptionsStatic False)
     , chk "NO folding range"          _foldingRangeProvider (Just $ FoldingRangeOptionsStatic False)
-    , che "   execute command"      _executeCommandProvider [blockCommandId, typeLensCommandId]
+    , che "   execute command"      _executeCommandProvider [blockCommandId, extendImportCommandId, typeLensCommandId]
     , chk "   workspace"                         _workspace (Just $ WorkspaceOptions (Just WorkspaceFolderOptions{_supported = Just True, _changeNotifications = Just ( WorkspaceFolderChangeNotificationsBool True )}))
     , chk "NO experimental"                   _experimental  Nothing
     ] where
@@ -3409,6 +3410,35 @@ completionTest name src pos expected = testSessionWait name $ do
             when expectedDocs $
                 assertBool ("Missing docs: " <> T.unpack _label) (isJust _documentation)
 
+completionCommandTest ::
+  String ->
+  [T.Text] ->
+  Position ->
+  T.Text ->
+  [T.Text] ->
+  TestTree
+completionCommandTest name src pos wanted expected = testSession name $ do
+  docId <- createDoc "A.hs" "haskell" (T.unlines src)
+  _ <- waitForDiagnostics
+  compls <- getCompletions docId pos
+  let wantedC = find ( \case
+            CompletionItem {_insertText = Just x} -> wanted `T.isPrefixOf` x
+            _ -> False
+            ) compls
+  case wantedC of
+    Nothing ->
+      liftIO $ assertFailure $ "Cannot find expected completion in: " <> show [_label | CompletionItem {_label} <- compls]
+    Just CompletionItem {..} -> do
+      c <- assertJust "Expected a command" _command
+      executeCommand c
+      if src /= expected
+          then do
+            modifiedCode <- getDocumentEdit docId
+            liftIO $ modifiedCode @?= T.unlines expected
+          else do
+            expectMessages @ApplyWorkspaceEditRequest 1 $ \edit ->
+              liftIO $ assertFailure $ "Expected no edit but got: " <> show edit
+
 topLevelCompletionTests :: [TestTree]
 topLevelCompletionTests = [
     completionTest
@@ -3557,46 +3587,78 @@ nonLocalCompletionTests =
        ]
        (Position 3 6)
        [],
-    expectFailBecause "Auto import completion snippets were disabled in v0.6.0.2" $
-      testGroup "auto import snippets"
-      [ completionTest
+    testGroup "auto import snippets"
+      [ completionCommandTest
         "show imports not in list - simple"
         ["{-# LANGUAGE NoImplicitPrelude #-}",
         "module A where", "import Control.Monad (msum)", "f = joi"]
         (Position 3 6)
-        [("join", CiFunction, "join ${1:m (m a)}", False, False,
-            Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 26}, _end = Position {_line = 2, _character = 26}}, _newText = "join, "}]))]
-      , completionTest
+        "join"
+        ["{-# LANGUAGE NoImplicitPrelude #-}",
+        "module A where", "import Control.Monad (msum, join)", "f = joi"]
+      , completionCommandTest
         "show imports not in list - multi-line"
         ["{-# LANGUAGE NoImplicitPrelude #-}",
         "module A where", "import Control.Monad (\n    msum)", "f = joi"]
         (Position 4 6)
-        [("join", CiFunction, "join ${1:m (m a)}", False, False,
-            Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 8}}, _newText = "join, "}]))]
-      , completionTest
+        "join"
+        ["{-# LANGUAGE NoImplicitPrelude #-}",
+        "module A where", "import Control.Monad (\n    msum, join)", "f = joi"]
+      , completionCommandTest
         "show imports not in list - names with _"
         ["{-# LANGUAGE NoImplicitPrelude #-}",
         "module A where", "import qualified Control.Monad as M (msum)", "f = M.mapM_"]
         (Position 3 11)
-        [("mapM_", CiFunction, "mapM_ ${1:a -> m b} ${2:t a}", False, False,
-            Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 41}, _end = Position {_line = 2, _character = 41}}, _newText = "mapM_, "}]))]
-      , completionTest
+        "mapM_"
+        ["{-# LANGUAGE NoImplicitPrelude #-}",
+        "module A where", "import qualified Control.Monad as M (msum, mapM_)", "f = M.mapM_"]
+      , completionCommandTest
         "show imports not in list - initial empty list"
         ["{-# LANGUAGE NoImplicitPrelude #-}",
         "module A where", "import qualified Control.Monad as M ()", "f = M.joi"]
         (Position 3 10)
-        [("join", CiFunction, "join ${1:m (m a)}", False, False,
-            Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 37}, _end = Position {_line = 2, _character = 37}}, _newText = "join, "}]))]
-      , completionTest
-        "record snippet on import"
-        ["module A where", "import Text.Printf (FormatParse(FormatParse))", "FormatParse"]
-        (Position 2 10)
-        [("FormatParse", CiStruct, "FormatParse ", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}])),
-        ("FormatParse", CiConstructor, "FormatParse ${1:String} ${2:Char} ${3:String}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}])),
-        ("FormatParse", CiSnippet, "FormatParse {fpModifiers=${1:_fpModifiers}, fpChar=${2:_fpChar}, fpRest=${3:_fpRest}}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}]))
+        "join"
+        ["{-# LANGUAGE NoImplicitPrelude #-}",
+        "module A where", "import qualified Control.Monad as M (join)", "f = M.joi"]
+      , testGroup "Data constructor"
+        [ completionCommandTest
+            "not imported"
+            ["module A where", "import Text.Printf ()", "ZeroPad"]
+            (Position 2 4)
+            "ZeroPad"
+            ["module A where", "import Text.Printf (FormatAdjustment (ZeroPad))", "ZeroPad"]
+        , completionCommandTest
+            "parent imported"
+            ["module A where", "import Text.Printf (FormatAdjustment)", "ZeroPad"]
+            (Position 2 4)
+            "ZeroPad"
+            ["module A where", "import Text.Printf (FormatAdjustment (ZeroPad))", "ZeroPad"]
+        , completionCommandTest
+            "already imported"
+            ["module A where", "import Text.Printf (FormatAdjustment (ZeroPad))", "ZeroPad"]
+            (Position 2 4)
+            "ZeroPad"
+            ["module A where", "import Text.Printf (FormatAdjustment (ZeroPad))", "ZeroPad"]
+        ]
+      , testGroup "Record completion"
+        [ completionCommandTest
+            "not imported"
+            ["module A where", "import Text.Printf ()", "FormatParse"]
+            (Position 2 10)
+            "FormatParse {"
+            ["module A where", "import Text.Printf (FormatParse (FormatParse))", "FormatParse"]
+        , completionCommandTest
+            "parent imported"
+            ["module A where", "import Text.Printf (FormatParse)", "FormatParse"]
+            (Position 2 10)
+            "FormatParse {"
+            ["module A where", "import Text.Printf (FormatParse (FormatParse))", "FormatParse"]
+        , completionCommandTest
+            "already imported"
+            ["module A where", "import Text.Printf (FormatParse (FormatParse))", "FormatParse"]
+            (Position 2 10)
+            "FormatParse {"
+            ["module A where", "import Text.Printf (FormatParse (FormatParse))", "FormatParse"]
         ]
       ],
       -- we need this test to make sure the ghcide completions module does not return completions for language pragmas. this functionality is turned on in hls

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -43,7 +43,7 @@ import Development.IDE.Test
       flushMessages,
       standardizeQuotes,
       waitForAction,
-      Cursor )
+      Cursor, expectMessages )
 import Development.IDE.Test.Runfiles
 import qualified Development.IDE.Types.Diagnostics as Diagnostics
 import Development.IDE.Types.Location

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -248,15 +248,6 @@ runIde state = runAction "importLens" state
 
 --------------------------------------------------------------------------------
 
-isQualifiedImport :: ImportDecl a -> Bool
-#if MIN_GHC_API_VERSION(8,10,0)
-isQualifiedImport ImportDecl{ideclQualified = NotQualified} = False
-isQualifiedImport ImportDecl{} = True
-#else
-isQualifiedImport ImportDecl{ideclQualified} = ideclQualified
-#endif
-isQualifiedImport _ = False
-
 within :: Range -> SrcSpan -> Bool
 within (Range start end) span =
   isInsideSrcSpan start span || isInsideSrcSpan end span

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -286,8 +286,8 @@ snippetTests = testGroup "snippets" [
         liftIO $ do
             item ^. label @?= "filter"
             item ^. kind @?= Just CiFunction
-            item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "filter ${1:a -> Bool} ${2:[a]}"
+            item ^. insertTextFormat @?= Just PlainText
+            item ^. insertText @?= Nothing
 
     , testCase "work for infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
@@ -300,8 +300,8 @@ snippetTests = testGroup "snippets" [
         liftIO $ do
             item ^. label @?= "filter"
             item ^. kind @?= Just CiFunction
-            item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "filter ${1:a -> Bool} ${2:[a]}"
+            item ^. insertTextFormat @?= Just PlainText
+            item ^. insertText @?= Nothing
 
     , testCase "work for qualified infix functions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
@@ -314,8 +314,8 @@ snippetTests = testGroup "snippets" [
         liftIO $ do
             item ^. label @?= "intersperse"
             item ^. kind @?= Just CiFunction
-            item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "intersperse ${1:a} ${2:[a]}"
+            item ^. insertTextFormat @?= Just PlainText
+            item ^. insertText @?= Nothing
 
     , testCase "work for qualified infix functions in backticks" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
@@ -328,8 +328,8 @@ snippetTests = testGroup "snippets" [
         liftIO $ do
             item ^. label @?= "intersperse"
             item ^. kind @?= Just CiFunction
-            item ^. insertTextFormat @?= Just Snippet
-            item ^. insertText @?= Just "intersperse ${1:a} ${2:[a]}"
+            item ^. insertTextFormat @?= Just PlainText
+            item ^. insertText @?= Nothing
 
     , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"


### PR DESCRIPTION
This builds on the work done by @gdevanla in haskell/ghcide#930 and @berberman in #1246  to reenable completions to automatically extend import lists. 

There were two issues that led to this feature getting disabled:

1. the imports were extended multiple times. This is addressed by using a Command that recomputes the edit on invocation, instead reusing the edit computed at completion time
2. the imports were extended wrongly. This is addressed by using ghc-exactprint to ensure the extension is always well formed

While I was there, I also took the chance to drop snippets when typing an infix combinator