### PR TITLE
Tighten dependency on apply-refact

### DIFF
--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -27,7 +27,7 @@ library
   hs-source-dirs:   src
   build-depends:
     , aeson
-    , apply-refact
+    , apply-refact           >=0.9
     , base                   >=4.12 && <5
     , binary
     , bytestring


### PR DESCRIPTION
`Ide.Plugin.Hlint` uses `applyRefactorings'`, which is only available in `apply-refact >= 0.9`