### PR TITLE
Prepare 0.9.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 ## 0.9.0
 
 This release includes lot of refactorings and bug fixes over existing features, hlint and eval plugins among others.
+It contains a fix for a bug in ghcide involving stale diagnostics (#1204).
+
 The list of contributors continues to show healthy growth, many thanks to you all!
 
 And remember, we have a new brand logo, courtesy of @Ailrun :slightly_smiling_face:
@@ -11,6 +13,7 @@ And remember, we have a new brand logo, courtesy of @Ailrun :slightly_smiling_fa
 
 ### Pull requests merged for 0.9.0
 
+- Do not error out on failed rewrite
 ([#1269)](https://github.com/haskell/haskell-language-server/pull/1269) by @pepeiborra
 - Tighten dependency on apply-refact
 ([#1268)](https://github.com/haskell/haskell-language-server/pull/1268) by @hololeap

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 ## 0.9.0
 
 This release includes lot of refactorings and bug fixes over existing features, hlint and eval plugins among others.
-The list of contributors keeps growing healthy, many thanks to you all!
+The list of contributors continues to show healthy growth, many thanks to you all!
 
 And remember, we have a new brand logo, courtesy of @Ailrun :slightly_smiling_face:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ And remember, we have a new brand logo, courtesy of @Ailrun :slightly_smiling_fa
 
 ### Pull requests merged for 0.9.0
 
+([#1269)](https://github.com/haskell/haskell-language-server/pull/1269) by @pepeiborra
 - Tighten dependency on apply-refact
 ([#1268)](https://github.com/haskell/haskell-language-server/pull/1268) by @hololeap
 - Add the new logos
@@ -89,6 +90,8 @@ And remember, we have a new brand logo, courtesy of @Ailrun :slightly_smiling_fa
 ([#1199)](https://github.com/haskell/haskell-language-server/pull/1199) by @tittoassini
 - Disable win 8.6.4 job
 ([#1198)](https://github.com/haskell/haskell-language-server/pull/1198) by @jneira
+- Add custom cache layer for session loading
+([#1197)](https://github.com/haskell/haskell-language-server/pull/1197) by @fendor
 - Use completionSnippetsOn flag
 ([#1195)](https://github.com/haskell/haskell-language-server/pull/1195) by @takoeight0821
 - Remove runs dropped by #1173

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,13 @@
 
 ## 0.9.0
 
+This release includes lot of refactorings and bug fixes over existing features, hlint and eval plugins among others.
+The list of contributors keeps growing healthy, many thanks to you all!
+
+And remember, we have a new brand logo, courtesy of @Ailrun :slightly_smiling_face:
+
+![haskell-language-server](https://github.com/haskell/haskell-language-server/raw/master/docs/logos/logo-256.png)
+
 ### Pull requests merged for 0.9.0
 
 - Tighten dependency on apply-refact

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,164 @@
 # Changelog for haskell-language-server
 
+## 0.9.0
+
+### Pull requests merged for 0.9.0
+
+- Tighten dependency on apply-refact
+([#1268)](https://github.com/haskell/haskell-language-server/pull/1268) by @hololeap
+- Add the new logos
+([#1267)](https://github.com/haskell/haskell-language-server/pull/1267) by @Ailrun
+- Fix a bug in completions
+([#1265)](https://github.com/haskell/haskell-language-server/pull/1265) by @pepeiborra
+- Produce heap profiles the old fashioned way, from .hp files
+([#1261)](https://github.com/haskell/haskell-language-server/pull/1261) by @pepeiborra
+- Break down ghcide functionality in HLS plugins
+([#1257)](https://github.com/haskell/haskell-language-server/pull/1257) by @pepeiborra
+- Enforce max completions over all plugins
+([#1256)](https://github.com/haskell/haskell-language-server/pull/1256) by @pepeiborra
+- Reorder code actions to put remove redundant imports first
+([#1255)](https://github.com/haskell/haskell-language-server/pull/1255) by @pepeiborra
+- Update bench.yml to include all the relevant artifacts
+([#1254)](https://github.com/haskell/haskell-language-server/pull/1254) by @pepeiborra
+- Benchmarks: generate heap profiles
+([#1253)](https://github.com/haskell/haskell-language-server/pull/1253) by @pepeiborra
+- Add gh workflows badges
+([#1251)](https://github.com/haskell/haskell-language-server/pull/1251) by @jneira
+- Add dynamic linking common issue
+([#1249)](https://github.com/haskell/haskell-language-server/pull/1249) by @jneira
+- Add license for hls-tactics-plugin
+([#1248)](https://github.com/haskell/haskell-language-server/pull/1248) by @isovector
+- Use exact print to extend import lists
+([#1246)](https://github.com/haskell/haskell-language-server/pull/1246) by @berberman
+- Test apply-refact with TypeApplications
+([#1244)](https://github.com/haskell/haskell-language-server/pull/1244) by @jneira
+- Add non reversable pragma completion
+([#1243)](https://github.com/haskell/haskell-language-server/pull/1243) by @Ailrun
+- Delete redundant "category: Development".
+([#1241)](https://github.com/haskell/haskell-language-server/pull/1241) by @peterwicksstringfield
+- Complete the No- variants of language extensions and Strict extension
+([#1238)](https://github.com/haskell/haskell-language-server/pull/1238) by @mrBliss
+- Add code actions for disabling a warning in the current file
+([#1235)](https://github.com/haskell/haskell-language-server/pull/1235) by @georgefst
+- Change packages metadata and rename tactics subfolder
+([#1234)](https://github.com/haskell/haskell-language-server/pull/1234) by @jneira
+- Fix the bug that generating comments would duplicate existing comments
+([#1233)](https://github.com/haskell/haskell-language-server/pull/1233) by @berberman
+- Delete global hie.yaml config
+([#1230)](https://github.com/haskell/haskell-language-server/pull/1230) by @jneira
+- Easy hlint fixes
+([#1226)](https://github.com/haskell/haskell-language-server/pull/1226) by @peterwicksstringfield
+- Use the runtime ghc libdir for ghc-exactprint
+([#1225)](https://github.com/haskell/haskell-language-server/pull/1225) by @jneira
+- Add note in README/Tutorial regarding CPP support
+([#1224)](https://github.com/haskell/haskell-language-server/pull/1224) by @tittoassini
+- Test and fix for issue 1213
+([#1223)](https://github.com/haskell/haskell-language-server/pull/1223) by @tittoassini
+- Add traces for HLS providers
+([#1222)](https://github.com/haskell/haskell-language-server/pull/1222) by @pepeiborra
+- Use exact print for suggest missing constraint code actions
+([#1221)](https://github.com/haskell/haskell-language-server/pull/1221) by @pepeiborra
+- Fix changelog dates
+([#1220)](https://github.com/haskell/haskell-language-server/pull/1220) by @pepeiborra
+- Ignore .shake folder
+([#1219)](https://github.com/haskell/haskell-language-server/pull/1219) by @pepeiborra
+- Limit completions to top 40
+([#1218)](https://github.com/haskell/haskell-language-server/pull/1218) by @pepeiborra
+- Parenthesise type operators when extending import lists
+([#1212)](https://github.com/haskell/haskell-language-server/pull/1212) by @mrBliss
+- Expose shake options used
+([#1209)](https://github.com/haskell/haskell-language-server/pull/1209) by @pepeiborra
+- Prepare ghcide release v0.7.1
+([#1207)](https://github.com/haskell/haskell-language-server/pull/1207) by @pepeiborra
+- Documentation for the Eval Plugin
+([#1206)](https://github.com/haskell/haskell-language-server/pull/1206) by @tittoassini
+- Stale diagnostics fix
+([#1204)](https://github.com/haskell/haskell-language-server/pull/1204) by @pepeiborra
+- Extract Development.IDE.GHC.ExactPrint
+([#1203)](https://github.com/haskell/haskell-language-server/pull/1203) by @pepeiborra
+- Fix bug in Retrie "fold/unfold in local file" commands
+([#1202)](https://github.com/haskell/haskell-language-server/pull/1202) by @pepeiborra
+- Minor eval plugin fixes
+([#1199)](https://github.com/haskell/haskell-language-server/pull/1199) by @tittoassini
+- Disable win 8.6.4 job
+([#1198)](https://github.com/haskell/haskell-language-server/pull/1198) by @jneira
+- Use completionSnippetsOn flag
+([#1195)](https://github.com/haskell/haskell-language-server/pull/1195) by @takoeight0821
+- Remove runs dropped by #1173
+([#1194)](https://github.com/haskell/haskell-language-server/pull/1194) by @jneira
+- Remove undefined exports suggestions
+([#1193)](https://github.com/haskell/haskell-language-server/pull/1193) by @kderme
+- Update nixpkgs to ghc 8.10.3
+([#1191)](https://github.com/haskell/haskell-language-server/pull/1191) by @pepeiborra
+- Do not disable parallel GC
+([#1190)](https://github.com/haskell/haskell-language-server/pull/1190) by @pepeiborra
+- Switch module outline to useWtihStale
+([#1189)](https://github.com/haskell/haskell-language-server/pull/1189) by @pepeiborra
+- Fix sticky diagnostics
+([#1188)](https://github.com/haskell/haskell-language-server/pull/1188) by @pepeiborra
+- Fix class plugin cabal
+([#1186)](https://github.com/haskell/haskell-language-server/pull/1186) by @Ailrun
+- Update package description of haddock comments plugin
+([#1185)](https://github.com/haskell/haskell-language-server/pull/1185) by @berberman
+- Installation from Hackage - add README section
+([#1183)](https://github.com/haskell/haskell-language-server/pull/1183) by @pepeiborra
+- Preparation for Uploading Splice Plugin to Hackage
+([#1182)](https://github.com/haskell/haskell-language-server/pull/1182) by @konn
+- Preparation for uploading `hls-exactprint-utils`
+([#1181)](https://github.com/haskell/haskell-language-server/pull/1181) by @konn
+- Complete hls-hlint-plugin package metadata
+([#1180)](https://github.com/haskell/haskell-language-server/pull/1180) by @jneira
+- Benchmark improvements
+([#1178)](https://github.com/haskell/haskell-language-server/pull/1178) by @pepeiborra
+- Make adding missing constraint work in presence of 'forall' (fixes #1164)
+([#1177)](https://github.com/haskell/haskell-language-server/pull/1177) by @jhrcek
+- Prepare for Hackage
+([#1176)](https://github.com/haskell/haskell-language-server/pull/1176) by @pepeiborra
+- Test only last ghc minor version and fix windows cache
+([#1173)](https://github.com/haskell/haskell-language-server/pull/1173) by @jneira
+- Fix toMethodName bug of the Class plugin
+([#1170)](https://github.com/haskell/haskell-language-server/pull/1170) by @Ailrun
+- Quick fix for #1158
+([#1166)](https://github.com/haskell/haskell-language-server/pull/1166) by @Ailrun
+- Suggest adding pragmas for parse errors too
+([#1165)](https://github.com/haskell/haskell-language-server/pull/1165) by @mrBliss
+- Fix wrong component name of splice plugin in hie.yaml
+([#1162)](https://github.com/haskell/haskell-language-server/pull/1162) by @berberman
+- Revert "Auto cancel redundant workflows (attempt #2)"
+([#1156)](https://github.com/haskell/haskell-language-server/pull/1156) by @pepeiborra
+- Auto cancel redundant workflows (attempt #2)
+([#1154)](https://github.com/haskell/haskell-language-server/pull/1154) by @pepeiborra
+- Prepare 0.8.0 (versions)
+([#1153)](https://github.com/haskell/haskell-language-server/pull/1153) by @jneira
+- Streamline CircleCI jobs
+([#1152)](https://github.com/haskell/haskell-language-server/pull/1152) by @pepeiborra
+- Mergify: create configuration
+([#1151)](https://github.com/haskell/haskell-language-server/pull/1151) by @jneira
+- Bump haskell-lsp to 0.23
+([#1146)](https://github.com/haskell/haskell-language-server/pull/1146) by @berberman
+- Remove no longer needed git submodule update
+([#1145)](https://github.com/haskell/haskell-language-server/pull/1145) by @jhrcek
+- Enable more tests
+([#1143)](https://github.com/haskell/haskell-language-server/pull/1143) by @peterwicksstringfield
+- Update links to issues/PRs in ghcide tests.
+([#1142)](https://github.com/haskell/haskell-language-server/pull/1142) by @peterwicksstringfield
+- Fix #723 (Instance declarations in hs-boot files result in GHC errors)
+([#781)](https://github.com/haskell/haskell-language-server/pull/781) by @nitros12
+- Also suggest importing methods without parent class
+([#766)](https://github.com/haskell/haskell-language-server/pull/766) by @mrBliss
+- Delete unused utilities for controlling logging.
+([#764)](https://github.com/haskell/haskell-language-server/pull/764) by @peterwicksstringfield
+- Delete unused testdata
+([#763)](https://github.com/haskell/haskell-language-server/pull/763) by @peterwicksstringfield
+- Fix suggestAddTypeAnnotation regex
+([#760)](https://github.com/haskell/haskell-language-server/pull/760) by @kderme
+- Splice Plugin: expands TH splices and QuasiQuotes
+([#759)](https://github.com/haskell/haskell-language-server/pull/759) by @konn
+- Haddock comments plugin
+([#673)](https://github.com/haskell/haskell-language-server/pull/673) by @berberman
+- Leverage last apply-refact improvements in hlint plugin (include getParsedModuleWithComments in ghcide)
+([#635)](https://github.com/haskell/haskell-language-server/pull/635) by @jneira
+
 ## 0.8.0
 
 - This version adds support for ghc-8.10.3

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,15 @@ extension](https://github.com/alanz/vscode-hie-server) to provide automatic
 installation for users on VS Code, but they can also be installed manually
 when added to the path.
 
+## Minimal checklist
+
+* [ ] generate the list of pull requests finished since the las script using the [haskell script](https://github.com/haskell/haskell-language-server/blob/master/GenChangelogs.hs) in the project root.
+* [ ] add that list to the actual [Changelog](https://github.com/haskell/haskell-language-server/blob/master/ChangeLog.md) with a description of the release.
+* [ ] bump up versions of changed packages. All are optional but [haskell-language-server itself](https://github.com/haskell/haskell-language-server/blob/master/haskell-language-server.cabal).
+* [ ] create the tag and make an initial prerelease to trigger the ci workflow (see details below)
+* [ ] check uploaded binaries (see windows note below) and the release description (usually the changelog entry) and uncheck the prerelease box
+* [ ] make public the release in the usual social channels: irc, twitter, reddit, discord, discourse, mailing lists, etc (not required but useful to spread the word :slightly_smiling_face:)
+
 ## Making a new release of haskell-language-server
 
 Go to the [GitHub releases
@@ -70,6 +79,13 @@ One caveat is that we need to rename the binaries from
 haskell-language-server/haskell-language-server-wrapper to hls/hls-wrapper due to
 path length limitations on windows. But whenever we upload them to the release,
 we make sure to upload them as their full name variant.
+
+### Failing workflow
+
+If the workflow fail and all of some binaries has not been uploaded,
+the prerelease and the tag itself has to be recreated to start it again.
+If only some of the artefacts are missinf an alternative could be make
+the release in a fork and upload manually them.
 
 ### ghcup
 Ghcup can install hls binaries, provided that there is a tarfile

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,7 +10,7 @@ when added to the path.
 
 ## Minimal checklist
 
-* [ ] generate the list of pull requests finished since the las script using the [haskell script](https://github.com/haskell/haskell-language-server/blob/master/GenChangelogs.hs) in the project root.
+* [ ] generate the list of pull requests finished since the last release using the [haskell script](https://github.com/haskell/haskell-language-server/blob/master/GenChangelogs.hs) in the project root.
 * [ ] add that list to the actual [Changelog](https://github.com/haskell/haskell-language-server/blob/master/ChangeLog.md) with a description of the release.
 * [ ] bump up versions of changed packages. All are optional but [haskell-language-server itself](https://github.com/haskell/haskell-language-server/blob/master/haskell-language-server.cabal).
 * [ ] create the tag and make an initial prerelease to trigger the ci workflow (see details below)

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.2
 category:           Development
 name:               haskell-language-server
-version:            0.8.0.0
+version:            0.9.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>


### PR DESCRIPTION
* This is a minimal release, without revising subpackages versions or preparing anything to upload them to hackage.
  * Do you think we should update the cabal.project hackage index and stackage resolvers as part of the release?
* We cant upload to hackage at least until ghc-exactprint has a release including the commit we are checking in the source-repository-package
* I've added a [checklist](https://github.com/haskell/haskell-language-server/compare/master...jneira:prepare-0.9.0?expand=1#diff-ddff4241c2f41c415cbf4ff22e0dc609d1c50ace49f413673a8eb79ed2f02ff0) with the steps i've done for this one (see https://github.com/haskell/haskell-language-server/pull/704#issuecomment-769189470) //cc @bubba 

@pepeiborra feel free to add directly in the desctiption whatever you think is needed about ghcide and its new version (well, or whatever about everything :smile: )

Actually using the checklist added:

* [X] generate the list of pull requests finished since the last release using the [haskell script](https://github.com/haskell/haskell-language-server/blob/master/GenChangelogs.hs) in the project root.
* [X] add that list to the actual [Changelog](https://github.com/haskell/haskell-language-server/blob/master/ChangeLog.md) with a description of the release.
* [X] bump up versions of changed packages. All are optional but [haskell-language-server itself](https://github.com/haskell/haskell-language-server/blob/master/haskell-language-server.cabal).
* [ ] create the tag and make an initial prerelease to trigger the ci workflow (see details below)
* [ ] check uploaded binaries (see windows note below) and the release description (usually the changelog entry) and uncheck the prerelease box
* [ ] make public the release in the usual social channels: irc, twitter, reddit, discord, discourse, mailing lists, etc (not required but useful to spread the word :slightly_smiling_face:)