### PR TITLE
Restore code actions order

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -18,7 +18,6 @@ import Control.Monad
 import Control.Monad.Trans
 import Data.Data (Data)
 import Data.Functor
-import qualified Data.HashMap.Strict as HMap
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
 import qualified Data.Text as T
@@ -50,22 +49,15 @@ data Rewrite where
 -- | Convert a 'Rewrite' into a 'WorkspaceEdit'.
 rewriteToEdit ::
   DynFlags ->
-  Uri ->
   Anns ->
   Rewrite ->
-  Either String WorkspaceEdit
-rewriteToEdit dflags uri anns (Rewrite dst f) = do
+  Either String [TextEdit]
+rewriteToEdit dflags anns (Rewrite dst f) = do
   (ast, (anns, _), _) <- runTransformT anns $ f dflags
-  let editMap =
-        HMap.fromList
-          [ ( uri,
-              List
-                [ TextEdit (fromJust $ srcSpanToRange dst) $
+  let editMap = [ TextEdit (fromJust $ srcSpanToRange dst) $
                     T.pack $ tail $ exactPrint ast anns
                 ]
-            )
-          ]
-  pure $ WorkspaceEdit (Just editMap) Nothing
+  pure editMap
 
 srcSpanToRange :: SrcSpan -> Maybe Range
 srcSpanToRange (UnhelpfulSpan _) = Nothing


### PR DESCRIPTION
An unfortunate side effect of recent changes is that the extend import suggestions ended up at the bottom of the list.

This change puts back all code actions provider together so they can be reordered more easily, and restores the previous order where extend imports would be near the top of the list