### PR TITLE
Improve hlint cpp support using the preprocessed buffer

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -22,6 +22,7 @@ module Development.IDE.GHC.Util(
     textToStringBuffer,
     bytestringToStringBuffer,
     stringBufferToByteString,
+    stringBufferToString,
     moduleImportPath,
     cgGutsToCoreModule,
     fingerprintToBS,
@@ -119,6 +120,9 @@ runParser flags str parser = unP parser parseState
 
 stringBufferToByteString :: StringBuffer -> ByteString
 stringBufferToByteString StringBuffer{..} = PS buf cur len
+
+stringBufferToString :: StringBuffer -> String
+stringBufferToString =  T.unpack . T.decodeUtf8With T.lenientDecode . stringBufferToByteString
 
 bytestringToStringBuffer :: ByteString -> StringBuffer
 bytestringToStringBuffer (PS buf cur len) = StringBuffer{..}

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -53,7 +53,7 @@ library
     , transformers
     , unordered-containers
 
-  if ((!flag(ghc-lib) && impl(ghc >=8.10.1)) && impl(ghc <8.11.0))
+  if !flag(ghc-lib) && impl(ghc >=8.10.1) && impl(ghc <8.11.0)
     build-depends: ghc ^>= 8.10
 
   else

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -198,10 +198,16 @@ getIdeas nfp = do
               then return Nothing
               else do
                      flags' <- setExtensions flags
-                     (_, contents) <- getFileContents nfp
-                     let fp = fromNormalizedFilePath nfp
-                     let contents' = T.unpack <$> contents
-                     Just <$> (liftIO $ parseModuleEx flags' fp contents')
+                     (fp, contents) <- getPathAndContents
+                     Just <$> (liftIO $ parseModuleEx flags' fp contents)
+
+        getPathAndContents = do
+            (_, contents) <- getFileContents nfp
+            let fp = fromNormalizedFilePath nfp
+            return (fp, T.unpack <$> contents)
+
+        getPreprocessedPathAndContents m= do
+            let modsum = pm_mod_summary
 
         setExtensions flags = do
           hlintExts <- getExtensions flags nfp

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -197,17 +197,18 @@ getIdeas nfp = do
           if isNothing mbpm
               then return Nothing
               else do
-                     flags' <- setExtensions flags
-                     (fp, contents) <- getPathAndContents
-                     Just <$> (liftIO $ parseModuleEx flags' fp contents)
+                flags' <- setExtensions flags
+                (fp, contents) <- fromMaybe getPathAndContents getHsppPathAndContents
+                Just <$> (liftIO $ parseModuleEx flags' fp contents)
 
         getPathAndContents = do
             (_, contents) <- getFileContents nfp
             let fp = fromNormalizedFilePath nfp
             return (fp, T.unpack <$> contents)
 
-        getPreprocessedPathAndContents m= do
-            let modsum = pm_mod_summary
+        getHsppPathAndContents m = do
+            let modsum = pm_mod_summary m
+            sequence (ms_hspp_file modsum, show <$> ms_hspp_buf modsum)
 
         setExtensions flags = do
           hlintExts <- getExtensions flags nfp

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -113,13 +113,11 @@ hlintTests = testGroup "hlint suggestions" [
         changeDoc doc [change']
         testHlintDiagnostics doc
 
-    , knownBrokenForGhcVersions [GHC88, GHC86] "hlint doesn't take in account cpp flag as ghc -D argument" $
-      testCase "hlint diagnostics works with CPP via ghc -XCPP argument (#554)" $ runHlintSession "cpp" $ do
+    , testCase "hlint diagnostics works with CPP via ghc -XCPP argument (#554)" $ runHlintSession "cpp" $ do
         doc <- openDoc "ApplyRefact3.hs" "haskell"
         testHlintDiagnostics doc
 
-    , knownBrokenForGhcVersions [GHC88, GHC86] "hlint doesn't take in account cpp flag as ghc -D argument" $
-      testCase "hlint diagnostics works with CPP via language pragma (#554)" $ runHlintSession "" $ do
+    , testCase "hlint diagnostics works with CPP via language pragma (#554)" $ runHlintSession "" $ do
         doc <- openDoc "ApplyRefact3.hs" "haskell"
         testHlintDiagnostics doc
 


### PR DESCRIPTION
* As suggested by @ndmitchell [here](https://github.com/haskell/haskell-language-server/issues/554#issuecomment-719567136)
* It enables hlint suggestions for files with cpp conditions and ghc < 8.10