### PR TITLE
hls-splice-plugin-0.2.0.0

### DIFF
--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-splice-plugin
-version:            0.1.0.0
+version:            0.2.0.0
 synopsis:           HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 description:        HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes.
 license:            Apache-2.0
@@ -23,7 +23,7 @@ library
                   , hls-plugin-api
                   , ghc
                   , ghc-exactprint
-                  , ghcide
+                  , ghcide >= 0.7.1
                   , lens
                   , dlist
                   , retrie


### PR DESCRIPTION
Required for #1287. Sets version lower bound for `ghcide` (for `Development.IDE.GHC.ExactPrint `) and bumps version to `0.2.0.0`.