### PR TITLE
hls-splice-plugin-0.3.0.0-prepare

### DIFF
--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-splice-plugin
-version:            0.1.0.0
+version:            0.3.0.0
 synopsis:           HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 description:        HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes.
 license:            Apache-2.0
@@ -23,7 +23,7 @@ library
                   , hls-plugin-api
                   , ghc
                   , ghc-exactprint
-                  , ghcide
+                  , ghcide >= 0.7.3.0
                   , lens
                   , dlist
                   , retrie


### PR DESCRIPTION
As raised in #1287, current uploaded version of hls-splice-plugin-0.2.0.0 contradicts with the uploaded veresion of ghcide-0.7.3.0.

Since the code of hls-splice-plugin contained in 0.9.0-hackage compiles with ghcide-0.7.3.0 (I confirmedIt with ghc 8.8) and same functionality as in 0.9.0, just updating cabal file would suffice.