### PR TITLE
Splice Plugin: preparatory version bump for the next (not 0.9.0) HLS release

### DIFF
--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,12 +1,12 @@
 cabal-version:      2.2
 name:               hls-splice-plugin
-version:            0.2.0.0
+version:            0.4.0.0
 synopsis:           HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 description:        HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes.
 license:            Apache-2.0
 license-file:       LICENSE
-author:             Hiromi ISHII
-maintainer:         konn.jinro_at_gmail.com
+author:             https://github.com/haskell/haskell-language-server/contributors
+maintainer:         https://github.com/haskell/haskell-language-server/contributors
 category:           Development
 build-type:         Simple
 
@@ -23,7 +23,7 @@ library
                   , hls-plugin-api
                   , ghc
                   , ghc-exactprint
-                  , ghcide >= 0.7.1
+                  , ghcide >= 0.7.3
                   , lens
                   , dlist
                   , retrie


### PR DESCRIPTION
**NOTE**: This PR is NOT for releasing 0.9.0 to Hackage; it is preparatory PR to make sure we make another release of the Splice Plugin on Hackage when the next (not 0.9.0) release of HLS has been made; no immediate Hackage release of the bumped version of Splice Plugin is planned.

This PR further bumps the version of `hls-splice-plugin` to 0.4.0.0 and also changes author and maintainer fields to `https://github.com/haskell/haskell-language-server/contributors`, rather than my names and address alone.
Note that code of hls-splice-pluigin-0.3.0.0 is inconsistent with the current master branch - it uses locally defined `rangeToRealSrcSpan` function, which collides with (not yet released) the most recent ghcide's API.

This PR  is to make sure the further release of hls-splice-plugin to be made when the next (not 0.9.0) release of HLS is uploaded to Hackage.