### PR TITLE
[benchmark] check digests for input files only

### DIFF
--- a/ghcide/bench/hist/Main.hs
+++ b/ghcide/bench/hist/Main.hs
@@ -66,7 +66,7 @@ type instance RuleResult GetExample = Maybe Example
 type instance RuleResult GetExamples = [Example]
 
 main :: IO ()
-main = shakeArgs shakeOptions {shakeChange = ChangeModtimeAndDigest, shakeThreads = 0} $ do
+main = shakeArgs shakeOptions {shakeChange = ChangeModtimeAndDigestInput, shakeThreads = 0} $ do
   createBuildSystem $ \resource -> do
       configStatic <- liftIO $ readConfigIO config
       let build = outputFolder configStatic


### PR DESCRIPTION
As mentioned in #1306 the benchmark suite can occasionally fail with errors like below. I don't know what causes this. One theory is that it's caused by Shake trying to compute the output file digest. To eliminate potential variables and since we don't need output digests, let's disable them. 

After doing this, I've run the benchmark suite several times without seeing any more errors

Fixes #1306 (hopefully)

```
Error when running Shake build system:
  at want, called at bench/hist/Main.hs:87:16 in main:Main
* Depends on: bench_example_HLS
  at need, called at src/Development/Benchmark/Rules.hs:154:37 in shake-bench-0.1.0.0-inplace:Development.Benchmark.Rules
* Depends on: bench-results/bench_example_HLS/HEAD/edit.heap.svg
* Raised the exception:
bench-results/bench_example_HLS/HEAD/edit.heap.svg: openFile: resource busy (file is locked)

Benchmark benchHist: ERROR
cabal: Benchmarks failed for bench:benchHist from ghcide-0.7.2.0.
```