### PR TITLE
[shake-bench] collect eventlogs

### DIFF
--- a/ghcide/bench/hist/Main.hs
+++ b/ghcide/bench/hist/Main.hs
@@ -141,6 +141,7 @@ buildGhcide Cabal args out = do
         ,"--install-method=copy"
         ,"--overwrite-policy=always"
         ,"--ghc-options=-rtsopts"
+        ,"--ghc-options=-eventlog"
         ]
 
 buildGhcide Stack args out =
@@ -150,6 +151,7 @@ buildGhcide Stack args out =
         ,"ghcide:ghcide"
         ,"--copy-bins"
         ,"--ghc-options=-rtsopts"
+        ,"--ghc-options=-eventlog"
         ]
 
 benchGhcide

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -267,8 +267,9 @@ benchRules build MkBenchRules{..} = do
     [ build -/- "*/*/*/*.csv",
       build -/- "*/*/*/*.gcStats.log",
       build -/- "*/*/*/*.output.log",
+      build -/- "*/*/*/*.eventlog",
       build -/- "*/*/*/*.hp"
-    ] &%> \[outcsv, outGc, outLog, outHp] -> do
+    ] &%> \[outcsv, outGc, outLog, outEventlog, outHp] -> do
         let [_, flavour, exampleName, ver, exp] = splitDirectories outcsv
             prof = fromMaybe (error $ "Not a valid profiling mode: " <> flavour) $ profilingP flavour
         example <- fromMaybe (error $ "Unknown example " <> exampleName)
@@ -279,6 +280,7 @@ benchRules build MkBenchRules{..} = do
         let exePath    = build </> "binaries" </> ver </> executableName
             exeExtraArgs =
                 [ "+RTS"
+                , "-l-au"
                 , "-S" <> outGc]
              ++ concat
                 [[ "-h"
@@ -299,6 +301,7 @@ benchRules build MkBenchRules{..} = do
                 AddPath [takeDirectory ghcPath, "."] []
               ]
               BenchProject {..}
+        liftIO $ renameFile "ghcide.eventlog" outEventlog
         liftIO $ case prof of
             CheapHeapProfiling{} -> renameFile "ghcide.hp" outHp
             NoProfiling -> writeFile outHp dummyHp


### PR DESCRIPTION
The eventless contain opentelemetry traces of various ghcide actions and handlers, and can be inspected with e.g. `eventlog-to-tracy`. 