### PR TITLE
Refactor the hypothesis type in hls-tactics-plugin

### DIFF
--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -132,6 +132,9 @@ commandTactic DestructLambdaCase     = const destructLambdaCase
 commandTactic HomomorphismLambdaCase = const homoLambdaCase
 
 
+------------------------------------------------------------------------------
+-- | Lift a function over 'HyInfo's to one that takes an 'OccName' and tries to
+-- look it up in the hypothesis.
 useNameFromHypothesis :: (HyInfo CType -> TacticsM a) -> OccName -> TacticsM a
 useNameFromHypothesis f name = do
   hy <- jHypothesis <$> goal

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -17,6 +17,7 @@ module Ide.Plugin.Tactic
 
 import           Control.Arrow
 import           Control.Monad
+import           Control.Monad.Error.Class (MonadError(throwError))
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Maybe
 import           Data.Aeson
@@ -38,6 +39,7 @@ import           Development.IDE.Core.Service (runAction)
 import           Development.IDE.Core.Shake (useWithStale, IdeState (..))
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error (realSrcSpanToRange)
+import           Development.IDE.GHC.ExactPrint (graft, transform, useAnnotatedSource)
 import           Development.IDE.Spans.LocalBindings (getDefiningBindings)
 import           Development.Shake (Action)
 import           DynFlags (xopt)
@@ -53,16 +55,14 @@ import           Ide.Plugin.Tactic.Tactics
 import           Ide.Plugin.Tactic.TestTypes
 import           Ide.Plugin.Tactic.Types
 import           Ide.PluginUtils
-import Development.IDE.GHC.ExactPrint (graft, transform, useAnnotatedSource)
 import           Ide.Types
 import           Language.Haskell.LSP.Core (clientCapabilities)
 import           Language.Haskell.LSP.Types
 import           OccName
+import           Refinery.Tactic (goal)
 import           SrcLoc (containsSpan)
 import           System.Timeout
 import           TcRnTypes (tcg_binds)
-import Refinery.Tactic (goal)
-import Control.Monad.Error (MonadError(throwError))
 
 
 descriptor :: PluginId -> PluginDescriptor IdeState

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -216,7 +216,7 @@ filterBindingType
 filterBindingType p tp dflags plId uri range jdg =
   let hy = jHypothesis jdg
       g  = jGoal jdg
-   in fmap join $ for (M.toList hy) $ \(occ, hi_type -> CType ty) ->
+   in fmap join $ for (M.toList $ hyByName hy) $ \(occ, hi_type -> CType ty) ->
         case p (unCType g) ty of
           True  -> tp occ ty dflags plId uri range jdg
           False -> pure []
@@ -278,7 +278,7 @@ judgementForHole state nfp range = do
         HieFresh ->
           pure ( resulting_range
                , mkFirstJudgement
-                   (local_hy <> cls_hy)
+                   (local_hy <> Hypothesis cls_hy)
                    (isRhsHole rss tcs)
                    goal
                , ctx
@@ -287,10 +287,10 @@ judgementForHole state nfp range = do
 
 spliceProvenance
     :: Map OccName Provenance
-    -> Map OccName (HyInfo a)
-    -> Map OccName (HyInfo a)
-spliceProvenance provs =
-  M.mapWithKey $ \name hi ->
+    -> Hypothesis a
+    -> Hypothesis a
+spliceProvenance provs x =
+  Hypothesis $ flip M.mapWithKey (hyByName x) $ \name hi ->
     overProvenance (maybe id const $ M.lookup name provs) hi
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -278,7 +278,7 @@ judgementForHole state nfp range = do
         HieFresh ->
           pure ( resulting_range
                , mkFirstJudgement
-                   (local_hy <> Hypothesis cls_hy)
+                   (local_hy <> cls_hy)
                    (isRhsHole rss tcs)
                    goal
                , ctx
@@ -290,8 +290,8 @@ spliceProvenance
     -> Hypothesis a
     -> Hypothesis a
 spliceProvenance provs x =
-  Hypothesis $ flip M.mapWithKey (hyByName x) $ \name hi ->
-    overProvenance (maybe id const $ M.lookup name provs) hi
+  Hypothesis $ flip fmap (unHypothesis x) $ \hi ->
+    overProvenance (maybe id const $ M.lookup (hi_name hi) provs) hi
 
 
 tacticCmd :: (OccName -> TacticsM ()) -> CommandFunction IdeState TacticParams

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -216,10 +216,11 @@ filterBindingType
 filterBindingType p tp dflags plId uri range jdg =
   let hy = jHypothesis jdg
       g  = jGoal jdg
-   in fmap join $ for (M.toList $ hyByName hy) $ \(occ, hi_type -> CType ty) ->
-        case p (unCType g) ty of
-          True  -> tp occ ty dflags plId uri range jdg
-          False -> pure []
+   in fmap join $ for (unHypothesis hy) $ \hi ->
+        let ty = unCType $ hi_type hi
+         in case p (unCType g) ty of
+              True  -> tp (hi_name hi) ty dflags plId uri range jdg
+              False -> pure []
 
 
 data TacticParams = TacticParams

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -35,7 +35,7 @@ import           Type hiding (Var)
 useOccName :: MonadState TacticState m => Judgement -> OccName -> m ()
 useOccName jdg name =
   -- Only score points if this is in the local hypothesis
-  case M.lookup name $ jLocalHypothesis jdg of
+  case M.lookup name $ hyByName $ jLocalHypothesis jdg of
     Just{}  -> modify
              $ (withUsedVals $ S.insert name)
              . (field @"ts_unused_top_vals" %~ S.delete name)
@@ -75,7 +75,7 @@ destructMatches f scrut t jdg = do
         [] -> throwError $ GoalMismatch "destruct" g
         _ -> fmap unzipTrace $ for dcs $ \dc -> do
           let args = dataConInstOrigArgTys' dc apps
-          names <- mkManyGoodNames hy args
+          names <- mkManyGoodNames (hyNamesInScope hy) args
           let hy' = zip names $ coerce args
               j = introducingPat scrut dc hy'
                 $ withNewGoal g jdg
@@ -154,7 +154,7 @@ destruct' :: (DataCon -> Judgement -> Rule) -> OccName -> Judgement -> Rule
 destruct' f term jdg = do
   when (isDestructBlacklisted jdg) $ throwError NoApplicableTactic
   let hy = jHypothesis jdg
-  case M.lookup term hy of
+  case M.lookup term (hyByName hy) of
     Nothing -> throwError $ UndefinedHypothesis term
     Just (hi_type -> t) -> do
       useOccName jdg term

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -150,23 +150,20 @@ dataConInstOrigArgTys' con uniTys =
 -- | Combinator for performing case splitting, and running sub-rules on the
 -- resulting matches.
 
-destruct' :: (DataCon -> Judgement -> Rule) -> OccName -> Judgement -> Rule
-destruct' f term jdg = do
+destruct' :: (DataCon -> Judgement -> Rule) -> HyInfo CType -> Judgement -> Rule
+destruct' f hi jdg = do
   when (isDestructBlacklisted jdg) $ throwError NoApplicableTactic
-  let hy = jHypothesis jdg
-  case M.lookup term $ hyByName hy of
-    Nothing -> throwError $ UndefinedHypothesis term
-    Just (hi_type -> t) -> do
-      useOccName jdg term
-      (tr, ms)
-          <- destructMatches
-               f
-               (Just term)
-               t
-               $ disallowing AlreadyDestructed [term] jdg
-      pure ( rose ("destruct " <> show term) $ pure tr
-           , noLoc $ case' (var' term) ms
-           )
+  let term = hi_name hi
+  useOccName jdg term
+  (tr, ms)
+      <- destructMatches
+           f
+           (Just term)
+           (hi_type hi)
+           $ disallowing AlreadyDestructed [term] jdg
+  pure ( rose ("destruct " <> show term) $ pure tr
+       , noLoc $ case' (var' term) ms
+       )
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -154,7 +154,7 @@ destruct' :: (DataCon -> Judgement -> Rule) -> OccName -> Judgement -> Rule
 destruct' f term jdg = do
   when (isDestructBlacklisted jdg) $ throwError NoApplicableTactic
   let hy = jHypothesis jdg
-  case M.lookup term (hyByName hy) of
+  case M.lookup term $ hyByName hy of
     Nothing -> throwError $ UndefinedHypothesis term
     Just (hi_type -> t) -> do
       useOccName jdg term

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Context.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Context.hs
@@ -35,9 +35,9 @@ mkContext locals tcg = Context
 
 ------------------------------------------------------------------------------
 -- | Find all of the class methods that exist from the givens in the context.
-contextMethodHypothesis :: Context -> Map OccName (HyInfo CType)
+contextMethodHypothesis :: Context -> Hypothesis CType
 contextMethodHypothesis ctx
-  = M.fromList
+  = Hypothesis
   . excludeForbiddenMethods
   . join
   . concatMap
@@ -54,8 +54,8 @@ contextMethodHypothesis ctx
 -- | Many operations are defined in typeclasses for performance reasons, rather
 -- than being a true part of the class. This function filters out those, in
 -- order to keep our hypothesis space small.
-excludeForbiddenMethods :: [(OccName, a)] -> [(OccName, a)]
-excludeForbiddenMethods = filter (not . flip S.member forbiddenMethods  . fst)
+excludeForbiddenMethods :: [HyInfo a] -> [HyInfo a]
+excludeForbiddenMethods = filter (not . flip S.member forbiddenMethods . hi_name)
   where
     forbiddenMethods :: Set OccName
     forbiddenMethods = S.map mkVarOcc $ S.fromList

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
@@ -30,7 +30,7 @@ module Ide.Plugin.Tactic.Judgements
   , hyByName
   ) where
 
-import Control.Arrow
+import           Control.Arrow
 import           Control.Lens hiding (Context)
 import           Data.Bool
 import           Data.Char

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
@@ -61,7 +61,7 @@ buildHypothesis
   where
     go (occName -> occ, t)
       | Just ty <- t
-      , isAlpha . head . occNameString $ occ = Just (occ, HyInfo UserPrv $ CType ty)
+      , isAlpha . head . occNameString $ occ = Just (occ, HyInfo occ UserPrv $ CType ty)
       | otherwise = Nothing
 
 
@@ -97,7 +97,7 @@ introducing
     -> Judgement' a
 introducing f ns =
   field @"_jHypothesis" <>~ M.fromList (zip [0..] ns <&>
-    \(pos, (name, ty)) -> (name, HyInfo (f pos) ty))
+    \(pos, (name, ty)) -> (name, HyInfo name (f pos) ty))
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
@@ -309,8 +309,8 @@ unsetIsTopHole = field @"_jIsTopHole" .~ False
 
 ------------------------------------------------------------------------------
 -- | What names are currently in scope in the hypothesis?
-hyNamesInScope :: Hypothesis a -> [OccName]
-hyNamesInScope = M.keys . hyByName
+hyNamesInScope :: Hypothesis a -> Set OccName
+hyNamesInScope = M.keysSet . hyByName
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
@@ -282,7 +282,11 @@ disallowing reason (S.fromList -> ns) =
 -- | The hypothesis, consisting of local terms and the ambient environment
 -- (impors and class methods.) Hides disallowed values.
 jHypothesis :: Judgement' a -> Hypothesis a
-jHypothesis = Hypothesis . filter (not . isDisallowed . hi_provenance) . unHypothesis . jEntireHypothesis
+jHypothesis
+  = Hypothesis
+  . filter (not . isDisallowed . hi_provenance)
+  . unHypothesis
+  . jEntireHypothesis
 
 
 ------------------------------------------------------------------------------
@@ -294,7 +298,11 @@ jEntireHypothesis = _jHypothesis
 ------------------------------------------------------------------------------
 -- | Just the local hypothesis.
 jLocalHypothesis :: Judgement' a -> Hypothesis a
-jLocalHypothesis = Hypothesis . filter (isLocalHypothesis . hi_provenance) . unHypothesis . jHypothesis
+jLocalHypothesis
+  = Hypothesis
+  . filter (isLocalHypothesis . hi_provenance)
+  . unHypothesis
+  . jHypothesis
 
 
 ------------------------------------------------------------------------------
@@ -322,14 +330,16 @@ hyByName :: Hypothesis a -> Map OccName (HyInfo a)
 hyByName
   = M.fromList
   . fmap (hi_name &&& id)
-  -- . filter (not . isDisallowed . hi_provenance)
   . unHypothesis
 
 
 ------------------------------------------------------------------------------
 -- | Only the hypothesis members which are pattern vals
 jPatHypothesis :: Judgement' a -> Map OccName PatVal
-jPatHypothesis = M.mapMaybe (getPatVal . hi_provenance) . hyByName . jHypothesis
+jPatHypothesis
+  = M.mapMaybe (getPatVal . hi_provenance)
+  . hyByName
+  . jHypothesis
 
 
 getPatVal :: Provenance-> Maybe PatVal

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
@@ -313,8 +313,17 @@ unsetIsTopHole = field @"_jIsTopHole" .~ False
 hyNamesInScope :: Hypothesis a -> Set OccName
 hyNamesInScope = M.keysSet . hyByName
 
+
+------------------------------------------------------------------------------
+-- | Fold a hypothesis into a single mapping from name to info. This
+-- unavoidably will cause duplicate names (things like methods) to shadow one
+-- another.
 hyByName :: Hypothesis a -> Map OccName (HyInfo a)
-hyByName = M.fromList . fmap (hi_name &&& id) . unHypothesis
+hyByName
+  = M.fromList
+  . fmap (hi_name &&& id)
+  -- . filter (not . isDisallowed . hi_provenance)
+  . unHypothesis
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
@@ -231,7 +231,7 @@ methodHypothesis ty = do
   pure $ mappend sc_methods $ methods <&> \method ->
     let (_, _, ty) = tcSplitSigmaTy $ idType method
     in ( occName method
-       , HyInfo (ClassMethodPrv $ Uniquely cls) $ CType $ substTy subst ty
+       , HyInfo (occName method) (ClassMethodPrv $ Uniquely cls) $ CType $ substTy subst ty
        )
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
@@ -220,7 +220,7 @@ unify goal inst = do
 ------------------------------------------------------------------------------
 -- | Get the class methods of a 'PredType', correctly dealing with
 -- instantiation of quantified class types.
-methodHypothesis :: PredType -> Maybe [(OccName, HyInfo CType)]
+methodHypothesis :: PredType -> Maybe [HyInfo CType]
 methodHypothesis ty = do
   (tc, apps) <- splitTyConApp_maybe ty
   cls <- tyConClass_maybe tc
@@ -232,8 +232,7 @@ methodHypothesis ty = do
               $ classSCTheta cls
   pure $ mappend sc_methods $ methods <&> \method ->
     let (_, _, ty) = tcSplitSigmaTy $ idType method
-    in ( occName method
-       , HyInfo (occName method) (ClassMethodPrv $ Uniquely cls) $ CType $ substTy subst ty
+    in ( HyInfo (occName method) (ClassMethodPrv $ Uniquely cls) $ CType $ substTy subst ty
        )
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
@@ -74,9 +74,11 @@ runTactic ctx jdg t =
                 $ (:) (jGoal jdg)
                 $ fmap hi_type
                 $ toList
+                $ hyByName
                 $ jHypothesis jdg
         unused_topvals = M.keysSet
                        $ M.filter (isTopLevel . hi_provenance)
+                       $ hyByName
                        $ jHypothesis jdg
         tacticState =
           defaultTacticState

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Naming.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Naming.hs
@@ -29,6 +29,9 @@ mkTyName (tcSplitFunTys -> (_:_, b))
 -- eg. mkTyName (Either A B) = "eab"
 mkTyName (splitTyConApp_maybe -> Just (c, args))
   = mkTyConName c ++ foldMap mkTyName args
+-- eg. mkTyName (f a) = "fa"
+mkTyName (tcSplitAppTys -> (t, args@(_:_)))
+  = mkTyName t ++ foldMap mkTyName args
 -- eg. mkTyName a = "a"
 mkTyName (getTyVar_maybe -> Just tv)
   = occNameString $ occName tv

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Naming.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Naming.hs
@@ -75,11 +75,11 @@ mkGoodName in_scope t =
 -- | Like 'mkGoodName' but creates several apart names.
 mkManyGoodNames
   :: (Traversable t, Monad m)
-  => M.Map OccName a
+  => [OccName]
   -> t Type
   -> m (t OccName)
-mkManyGoodNames hy args =
-  flip evalStateT (getInScope hy) $ for args $ \at -> do
+mkManyGoodNames in_scope args =
+  flip evalStateT in_scope $ for args $ \at -> do
     in_scope <- get
     let n = mkGoodName in_scope at
     modify (n :)

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Naming.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Naming.hs
@@ -2,13 +2,13 @@
 
 module Ide.Plugin.Tactic.Naming where
 
-import qualified Data.Set as S
-import Data.Set (Set)
 import           Control.Monad.State.Strict
 import           Data.Bool (bool)
 import           Data.Char
 import           Data.Map (Map)
 import qualified Data.Map as M
+import           Data.Set (Set)
+import qualified Data.Set as S
 import           Data.Traversable
 import           Name
 import           TcType

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -20,6 +20,7 @@ import           Data.Foldable
 import           Data.List
 import qualified Data.Map as M
 import           Data.Maybe
+import           Data.Set (Set)
 import qualified Data.Set as S
 import           DataCon
 import           Development.IDE.GHC.Compat
@@ -43,7 +44,7 @@ import           Type hiding (Var)
 ------------------------------------------------------------------------------
 -- | Use something in the hypothesis to fill the hole.
 assumption :: TacticsM ()
-assumption = attemptOn allNames assume
+assumption = attemptOn (S.toList . allNames) assume
 
 
 ------------------------------------------------------------------------------
@@ -278,6 +279,6 @@ overAlgebraicTerms =
     M.keys . M.filter (isJust . algebraicTyCon . unCType . hi_type) . hyByName . jHypothesis
 
 
-allNames :: Judgement -> [OccName]
+allNames :: Judgement -> Set OccName
 allNames = hyNamesInScope . jHypothesis
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -99,7 +99,6 @@ intros = rule $ \jdg -> do
 -- | Case split, and leave holes in the matches.
 destructAuto :: HyInfo CType -> TacticsM ()
 destructAuto hi = requireConcreteHole $ tracing "destruct(auto)" $ do
-  let name = hi_name hi
   jdg <- goal
   let subtactic = rule $ destruct' (const subgoal) hi
   case isPatternMatch $ hi_provenance hi of
@@ -109,7 +108,7 @@ destructAuto hi = requireConcreteHole $ tracing "destruct(auto)" $ do
             new_hy = foldMap getHyTypes jdgs
             old_hy = getHyTypes jdg
         in case S.null $ new_hy S.\\ old_hy of
-              True  -> Just $ UnhelpfulDestruct name
+              True  -> Just $ UnhelpfulDestruct $ hi_name hi
               False -> Nothing
     False -> subtactic
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -107,7 +107,7 @@ destructAuto name = requireConcreteHole $ tracing "destruct(auto)" $ do
       in case isPatternMatch $ hi_provenance hi of
             True ->
               pruning subtactic $ \jdgs ->
-                let getHyTypes = S.fromList . fmap hi_type . M.elems . hyByName . jHypothesis
+                let getHyTypes = S.fromList . fmap hi_type . unHypothesis . jHypothesis
                     new_hy = foldMap getHyTypes jdgs
                     old_hy = getHyTypes jdg
                 in case S.null $ new_hy S.\\ old_hy of
@@ -271,12 +271,17 @@ auto' n = do
 
 overFunctions :: (OccName -> TacticsM ()) -> TacticsM ()
 overFunctions =
-  attemptOn $ M.keys . M.filter (isFunction . unCType . hi_type) . hyByName . jHypothesis
+  attemptOn $ fmap hi_name
+           . filter (isFunction . unCType . hi_type)
+           . unHypothesis
+           . jHypothesis
 
 overAlgebraicTerms :: (OccName -> TacticsM ()) -> TacticsM ()
 overAlgebraicTerms =
-  attemptOn $
-    M.keys . M.filter (isJust . algebraicTyCon . unCType . hi_type) . hyByName . jHypothesis
+  attemptOn $ fmap hi_name
+            . filter (isJust . algebraicTyCon . unCType . hi_type)
+            . unHypothesis
+            . jHypothesis
 
 
 allNames :: Judgement -> Set OccName

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
@@ -216,10 +216,10 @@ instance Uniquable a => Ord (Uniquely a) where
 
 
 newtype Hypothesis a = Hypothesis
-  { hyByName :: Map OccName (HyInfo a)
+  { unHypothesis :: [HyInfo a]
   }
   deriving stock (Functor, Eq, Show, Generic, Ord)
-  deriving (Semigroup, Monoid) via Map OccName (HyInfo a)
+  deriving newtype (Semigroup, Monoid)
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
@@ -215,6 +215,13 @@ instance Uniquable a => Ord (Uniquely a) where
   compare = nonDetCmpUnique `on` getUnique . getViaUnique
 
 
+newtype Hypothesis a = Hypothesis
+  { hyByName :: Map OccName (HyInfo a)
+  }
+  deriving stock (Functor, Eq, Show, Generic, Ord)
+  deriving (Semigroup, Monoid) via Map OccName (HyInfo a)
+
+
 ------------------------------------------------------------------------------
 -- | The provenance and type of a hypothesis term.
 data HyInfo a = HyInfo
@@ -234,7 +241,7 @@ overProvenance f (HyInfo name prv ty) = HyInfo name (f prv) ty
 ------------------------------------------------------------------------------
 -- | The current bindings and goal for a hole to be filled by refinery.
 data Judgement' a = Judgement
-  { _jHypothesis :: !(Map OccName (HyInfo a))
+  { _jHypothesis :: !(Hypothesis a)
   , _jBlacklistDestruct :: !Bool
   , _jWhitelistSplit :: !Bool
   , _jIsTopHole    :: !Bool

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
@@ -218,7 +218,8 @@ instance Uniquable a => Ord (Uniquely a) where
 ------------------------------------------------------------------------------
 -- | The provenance and type of a hypothesis term.
 data HyInfo a = HyInfo
-  { hi_provenance :: Provenance
+  { hi_name       :: OccName
+  , hi_provenance :: Provenance
   , hi_type       :: a
   }
   deriving stock (Functor, Eq, Show, Generic, Ord)
@@ -227,7 +228,7 @@ data HyInfo a = HyInfo
 ------------------------------------------------------------------------------
 -- | Map a function over the provenance.
 overProvenance :: (Provenance -> Provenance) -> HyInfo a -> HyInfo a
-overProvenance f (HyInfo prv ty) = HyInfo (f prv) ty
+overProvenance f (HyInfo name prv ty) = HyInfo name (f prv) ty
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/test/AutoTupleSpec.hs
+++ b/plugins/hls-tactics-plugin/test/AutoTupleSpec.hs
@@ -42,7 +42,7 @@ spec = describe "auto for tuple" $ do
           runTactic
             emptyContext
             (mkFirstJudgement
-              (M.singleton (mkVarOcc "x") $ HyInfo UserPrv $ CType in_type)
+              (Hypothesis $ pure $ HyInfo (mkVarOcc "x") UserPrv $ CType in_type)
               True
               out_type)
             (auto' $ n * 2) `shouldSatisfy` isRight

--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -116,6 +116,7 @@ tests = testGroup
   , goldenTest "GoldenSafeHead.hs"          2 12 Auto ""
   , expectFail "GoldenFish.hs"              5 18 Auto ""
   , goldenTest "GoldenArbitrary.hs"         25 13 Auto ""
+  , goldenTest "FmapBoth.hs"                2 12 Auto ""
   ]
 
 

--- a/test/testdata/tactic/FmapBoth.hs
+++ b/test/testdata/tactic/FmapBoth.hs
@@ -1,0 +1,3 @@
+fmapBoth :: (Functor f, Functor g) => (a -> b) -> (f a, g a) -> (f b, g b)
+fmapBoth = _
+

--- a/test/testdata/tactic/FmapBoth.hs.expected
+++ b/test/testdata/tactic/FmapBoth.hs.expected
@@ -1,0 +1,4 @@
+fmapBoth :: (Functor f, Functor g) => (a -> b) -> (f a, g a) -> (f b, g b)
+fmapBoth = (\ fab p_xx
+   -> case p_xx of { (x, x5) -> (fmap fab x, fmap fab x5) })
+

--- a/test/testdata/tactic/FmapBoth.hs.expected
+++ b/test/testdata/tactic/FmapBoth.hs.expected
@@ -1,4 +1,4 @@
 fmapBoth :: (Functor f, Functor g) => (a -> b) -> (f a, g a) -> (f b, g b)
-fmapBoth = (\ fab p_xx
-   -> case p_xx of { (x, x5) -> (fmap fab x, fmap fab x5) })
+fmapBoth = (\ fab p_faga
+   -> case p_faga of { (fa, ga) -> (fmap fab fa, fmap fab ga) })
 


### PR DESCRIPTION
The `Hypothesis` is all of the values in scope that the tactics engine knows about. It used to be a `Map OccName HyInfo`, mapping names to the information we have about them. But this is unhelpful for two reasons:

1. Almost nowhere in the code do we lookup by name
2. Class methods get instantiated for every concrete type, meaning we couldn't have two givens for different types in scope

Worse, it actively encouraged a bad style where we'd iterate through the keys of the hypothesis, and then need to look up the value in the map we were iterating. All of these callsites have now been simplified to just take the `HyInfo` directly, rather than an `OccName` that we'd subsequently need to lookup.

This PR refactors some of the underlying machinery. It's a bit simplistic now, but paves the way for a smarter implementation when I figure out what it should look like. In the meantime, it means we can now solve goals like

```haskell
fmapBoth :: (Functor f, Functor g) => (a -> b) -> (f a, g a) -> (f b, g b)
fmapBoth = _
```

since the fmaps for `f` and `g` no longer clash.