### PR TITLE
Add test for multi-component goto def and make runLanguageServer responsible for hiedb

### DIFF
--- a/ghcide/.hlint.yaml
+++ b/ghcide/.hlint.yaml
@@ -105,7 +105,7 @@
 #
 - functions:
   # Things that are unsafe in Haskell base library
-  - {name: unsafeInterleaveIO, within: []}
+  - {name: unsafeInterleaveIO, within: [Development.IDE.LSP.LanguageServer]}
   - {name: unsafeDupablePerformIO, within: []}
   - {name: unsafeCoerce, within: []}
   # Things that are a bit dangerous in the GHC API

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -32,7 +32,7 @@ import UnliftIO.Directory
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Ide.Types (traceWithSpan)
-import Development.IDE.Session (runWithDb, getHieDbLoc)
+import Development.IDE.Session (runWithDb)
 
 import Development.IDE.Core.IdeConfiguration
 import Development.IDE.Core.Shake
@@ -47,11 +47,12 @@ import System.IO.Unsafe (unsafeInterleaveIO)
 runLanguageServer
     :: forall config. (Show config)
     => LSP.Options
+    -> (FilePath -> IO FilePath) -- ^ Map root paths to the location of the hiedb for the project
     -> (IdeState -> Value -> IO (Either T.Text config))
     -> LSP.Handlers (ServerM config)
     -> (LSP.LanguageContextEnv config -> VFSHandle -> Maybe FilePath -> HieDb -> IndexQueue -> IO IdeState)
     -> IO ()
-runLanguageServer options onConfigurationChange userHandlers getIdeState = do
+runLanguageServer options getHieDbLoc onConfigurationChange userHandlers getIdeState = do
     -- Move stdout to another file descriptor and duplicate stderr
     -- to stdout. This guards against stray prints from corrupting the JSON-RPC
     -- message stream.

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -49,7 +49,7 @@ import Development.IDE.Plugin (
     Plugin (pluginHandlers, pluginRules),
  )
 import Development.IDE.Plugin.HLS (asGhcIdePlugin)
-import Development.IDE.Session (SessionLoadingOptions, defaultLoadingOptions, loadSessionWithOptions, setInitialDynFlags)
+import Development.IDE.Session (SessionLoadingOptions, defaultLoadingOptions, loadSessionWithOptions, setInitialDynFlags, getHieDbLoc, runWithDb)
 import Development.IDE.Types.Location (toNormalizedFilePath')
 import Development.IDE.Types.Logger (Logger)
 import Development.IDE.Types.Options (
@@ -77,8 +77,6 @@ data Arguments = Arguments
     { argsOTMemoryProfiling :: Bool
     , argFiles :: Maybe [FilePath]   -- ^ Nothing: lsp server ;  Just: typecheck and exit
     , argsLogger :: Logger
-    , argsHiedb :: HieDb
-    , argsHieChan :: IndexQueue
     , argsRules :: Rules ()
     , argsHlsPlugins :: IdePlugins IdeState
     , argsGhcidePlugin :: Plugin Config  -- ^ Deprecated
@@ -88,14 +86,12 @@ data Arguments = Arguments
     , argsDefaultHlsConfig :: Config
     }
 
-defArguments :: HieDb -> IndexQueue -> Arguments
-defArguments hiedb hiechan =
+defArguments :: Arguments
+defArguments =
     Arguments
         { argsOTMemoryProfiling = False
         , argFiles = Nothing
         , argsLogger = noLogging
-        , argsHiedb = hiedb
-        , argsHieChan = hiechan
         , argsRules = mainRule >> action kick
         , argsGhcidePlugin = mempty
         , argsHlsPlugins = pluginDescToIdePlugins Ghcide.descriptors
@@ -107,7 +103,6 @@ defArguments hiedb hiechan =
 
 defaultMain :: Arguments -> IO ()
 defaultMain Arguments{..} = do
-    dir <- IO.getCurrentDirectory
     pid <- T.pack . show <$> getProcessID
 
     let hlsPlugin = asGhcIdePlugin argsHlsPlugins
@@ -121,9 +116,11 @@ defaultMain Arguments{..} = do
             t <- offsetTime
             hPutStrLn stderr "Starting LSP server..."
             hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcide WITHOUT the --lsp option!"
-            runLanguageServer options argsOnConfigChange (pluginHandlers plugins) $ \env vfs rootPath -> do
+            runLanguageServer options argsOnConfigChange (pluginHandlers plugins) $ \env vfs rootPath hiedb hieChan -> do
                 t <- t
                 hPutStrLn stderr $ "Started LSP server in " ++ showDuration t
+
+                dir <- IO.getCurrentDirectory
 
                 -- We want to set the global DynFlags right now, so that we can use
                 -- `unsafeGlobalDynFlags` even before the project is configured
@@ -148,9 +145,12 @@ defaultMain Arguments{..} = do
                     debouncer
                     options
                     vfs
-                    argsHiedb
-                    argsHieChan
+                    hiedb
+                    hieChan
         Just argFiles -> do
+          dir <- IO.getCurrentDirectory
+          dbLoc <- getHieDbLoc dir
+          runWithDb dbLoc $ \hiedb hieChan -> do
             -- GHC produces messages with UTF8 in them, so make sure the terminal doesn't error
             hSetEncoding stdout utf8
             hSetEncoding stderr utf8
@@ -178,7 +178,7 @@ defaultMain Arguments{..} = do
                         { optCheckParents = pure NeverCheck
                         , optCheckProject = pure False
                         }
-            ide <- initialise mainRule Nothing argsLogger debouncer options vfs argsHiedb argsHieChan
+            ide <- initialise mainRule Nothing argsLogger debouncer options vfs hiedb hieChan
 
             putStrLn "\nStep 4/4: Type checking the files"
             setFilesOfInterest ide $ HashMap.fromList $ map ((,OnDisk) . toNormalizedFilePath') files

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -82,6 +82,7 @@ data Arguments = Arguments
     , argsIdeOptions :: Maybe Config -> Action IdeGhcSession -> IdeOptions
     , argsLspOptions :: LSP.Options
     , argsDefaultHlsConfig :: Config
+    , argsGetHieDbLoc :: FilePath -> IO FilePath -- ^ Map project roots to the location of the hiedb for the project
     }
 
 defArguments :: Arguments
@@ -97,6 +98,7 @@ defArguments =
         , argsIdeOptions = const defaultIdeOptions
         , argsLspOptions = def {LSP.completionTriggerCharacters = Just "."}
         , argsDefaultHlsConfig = def
+        , argsGetHieDbLoc = getHieDbLoc
         }
 
 defaultMain :: Arguments -> IO ()
@@ -114,7 +116,7 @@ defaultMain Arguments{..} = do
             t <- offsetTime
             hPutStrLn stderr "Starting LSP server..."
             hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcide WITHOUT the --lsp option!"
-            runLanguageServer options argsOnConfigChange (pluginHandlers plugins) $ \env vfs rootPath hiedb hieChan -> do
+            runLanguageServer options argsGetHieDbLoc argsOnConfigChange (pluginHandlers plugins) $ \env vfs rootPath hiedb hieChan -> do
                 t <- t
                 hPutStrLn stderr $ "Started LSP server in " ++ showDuration t
 

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -37,9 +37,7 @@ import Development.IDE.Core.Rules (
  )
 import Development.IDE.Core.Service (initialise, runAction)
 import Development.IDE.Core.Shake (
-    HieDb,
     IdeState (shakeExtras),
-    IndexQueue,
     ShakeExtras (state),
     uses,
  )

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4511,11 +4511,10 @@ simpleMultiDefTest = testCase "simple-multi-def-test" $ runWithExtraFiles "multi
     adoc <- liftIO $ runInDir dir $ do
       aSource <- liftIO $ readFileUtf8 aPath
       adoc <- createDoc aPath "haskell" aSource
-      liftIO $ hPutStrLn stderr $ "Looking for references/ready from: " ++ aPath
       ~() <- skipManyTill anyMessage $ satisfyMaybe $ \case
         FromServerMess (SCustomMethod "ghcide/reference/ready") (NotMess NotificationMessage{_params = fp}) -> do
           A.Success fp' <- pure $ fromJSON fp
-          if fp' == aPath then pure () else Nothing
+          if equalFilePath fp' aPath then pure () else Nothing
         _ -> Nothing
       closeDoc adoc
       pure adoc

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4343,7 +4343,7 @@ cradleTests = testGroup "cradle"
     [testGroup "dependencies" [sessionDepsArePickedUp]
     ,testGroup "ignore-fatal" [ignoreFatalWarning]
     ,testGroup "loading" [loadCradleOnlyonce, retryFailedCradle]
-    ,testGroup "multi"   [simpleMultiTest, simpleMultiTest2]
+    ,testGroup "multi"   [simpleMultiTest, simpleMultiTest2, simpleMultiDefTest]
     ,testGroup "sub-directory"   [simpleSubDirectoryTest]
     ]
 
@@ -4500,6 +4500,28 @@ simpleMultiTest2 = testCase "simple-multi-test2" $ runWithExtraFiles "multi" $ \
     expectNoMoreDiagnostics 10
     locs <- getDefinitions bdoc (Position 2 7)
     let fooL = mkL adoc 2 0 2 3
+    checkDefs locs (pure [fooL])
+    expectNoMoreDiagnostics 0.5
+
+-- Like simpleMultiTest but open the files in component 'a' in a seperate session
+simpleMultiDefTest :: TestTree
+simpleMultiDefTest = testCase "simple-multi-def-test" $ runWithExtraFiles "multi" $ \dir -> do
+    let aPath = dir </> "a/A.hs"
+        bPath = dir </> "b/B.hs"
+    adoc <- liftIO $ runInDir dir $ do
+      aSource <- liftIO $ readFileUtf8 aPath
+      adoc <- createDoc aPath "haskell" aSource
+      ~() <- skipManyTill anyMessage $ satisfyMaybe $ \case
+        FromServerMess (SCustomMethod "ghcide/reference/ready") (NotMess NotificationMessage{_params = fp}) -> do
+          A.Success fp' <- pure $ fromJSON fp
+          if fp' == aPath then pure () else Nothing
+        _ -> Nothing
+      closeDoc adoc
+      pure adoc
+    bSource <- liftIO $ readFileUtf8 bPath
+    bdoc <- createDoc bPath "haskell" bSource
+    locs <- getDefinitions bdoc (Position 2 7)
+    let fooL = mkL (adoc ^. L.uri) 2 0 2 3
     checkDefs locs (pure [fooL])
     expectNoMoreDiagnostics 0.5
 

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4511,6 +4511,7 @@ simpleMultiDefTest = testCase "simple-multi-def-test" $ runWithExtraFiles "multi
     adoc <- liftIO $ runInDir dir $ do
       aSource <- liftIO $ readFileUtf8 aPath
       adoc <- createDoc aPath "haskell" aSource
+      liftIO $ hPutStrLn stderr $ "Looking for references/ready from: " ++ aPath
       ~() <- skipManyTill anyMessage $ satisfyMaybe $ \case
         FromServerMess (SCustomMethod "ghcide/reference/ready") (NotMess NotificationMessage{_params = fp}) -> do
           A.Success fp' <- pure $ fromJSON fp

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -16,7 +16,7 @@ import Control.Monad.Extra
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Development.IDE.Core.Rules
-import Development.IDE.Session (setInitialDynFlags, getHieDbLoc, runWithDb)
+import Development.IDE.Session (setInitialDynFlags, getHieDbLoc)
 import Development.IDE.Types.Logger as G
 import qualified Language.LSP.Server as LSP
 import Ide.Arguments
@@ -82,6 +82,7 @@ hlsLogger = G.Logger $ \pri txt ->
 runLspMode :: LspArguments -> IdePlugins IdeState -> IO ()
 runLspMode lspArgs@LspArguments{..} idePlugins = do
     whenJust argsCwd IO.setCurrentDirectory
+    dir <- IO.getCurrentDirectory
     LSP.setupLogger argsLogFile ["hls", "hie-bios"]
       $ if argsDebugOn then L.DEBUG else L.INFO
 


### PR DESCRIPTION
Test for https://github.com/haskell/haskell-language-server/pull/1357

Involved re-jigging 'runWithDb' to be within the callback to 'runLanguageServer' so that the database location
is derived from the 'rootPath' of the LSP session, and not the starting CWD of the ghcide process.

I have verified that the test fails without the mentioned commit.
