### PR TITLE
Use object code for TH+UnboxedTuples/Sums

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -27,6 +27,11 @@ source-repository head
     type:     git
     location: https://github.com/haskell/ghcide.git
 
+flag ghc-patched-unboxed-bytecode
+    description: The GHC version we link against supports unboxed sums and tuples in bytecode
+    default:     False
+    manual:      True
+
 library
     default-language:   Haskell2010
     build-depends:
@@ -189,6 +194,9 @@ library
         Development.IDE.Session.VersionCheck
         Development.IDE.Types.Action
     ghc-options: -Wall -Wno-name-shadowing -Wincomplete-uni-patterns -Wno-unticked-promoted-constructors
+
+    if flag(ghc-patched-unboxed-bytecode)
+      cpp-options: -DGHC_PATCHED_UNBOXED_BYTECODE
 
 executable ghcide-test-preprocessor
     default-language: Haskell2010

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -325,7 +325,12 @@ generateObjectCode session summary guts = do
               (warnings, dot_o_fp) <-
                 withWarnings "object" $ \_tweak -> do
                       let summary' = _tweak summary
-                          session' = session { hsc_dflags = (ms_hspp_opts summary') { outputFile = Just dot_o }}
+#if MIN_GHC_API_VERSION(8,10,0)
+                          target = defaultObjectTarget $ hsc_dflags session
+#else
+                          target = defaultObjectTarget $ targetPlatform $ hsc_dflags session
+#endif
+                          session' = session { hsc_dflags = updOptLevel 0 $ (ms_hspp_opts summary') { outputFile = Just dot_o , hscTarget = target}}
                       (outputFilename, _mStub, _foreign_files) <- hscGenHardCode session' guts
 #if MIN_GHC_API_VERSION(8,10,0)
                                 (ms_location summary')

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -45,7 +45,9 @@ import Data.Int (Int64)
 import GHC.Serialized (Serialized)
 
 data LinkableType = ObjectLinkable | BCOLinkable
-  deriving (Eq,Ord,Show)
+  deriving (Eq,Ord,Show, Generic)
+instance Hashable LinkableType
+instance NFData   LinkableType
 
 -- NOTATION
 --   Foo+ means Foo for the dependencies
@@ -337,7 +339,7 @@ instance NFData   GetLocatedImports
 instance Binary   GetLocatedImports
 
 -- | Does this module need to be compiled?
-type instance RuleResult NeedsCompilation = Bool
+type instance RuleResult NeedsCompilation = Maybe LinkableType
 
 data NeedsCompilation = NeedsCompilation
     deriving (Eq, Show, Typeable, Generic)

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -1080,8 +1080,12 @@ needsCompilationRule = defineEarlyCutoff $ \NeedsCompilation file -> do
         -- How should we compile this module? (assuming we do in fact need to compile it)
         -- Depends on whether it uses unboxed tuples or sums
         this_type
+#if defined(GHC_PATCHED_UNBOXED_BYTECODE)
+          = BCOLinkable
+#else
           | unboxed_tuples_or_sums this = ObjectLinkable
           | otherwise                   = BCOLinkable
+#endif
 
 -- | Tracks which linkables are current, so we don't need to unload them
 newtype CompiledLinkables = CompiledLinkables { getCompiledLinkables :: Var (ModuleEnv UTCTime) }

--- a/ghcide/test/data/THUnboxed/THA.hs
+++ b/ghcide/test/data/THUnboxed/THA.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE TemplateHaskell, UnboxedTuples #-}
+module THA where
+import Language.Haskell.TH
+
+f :: Int -> (# Int, Int #)
+f x = (# x , x+1 #)
+
+th_a :: DecsQ
+th_a = case f 1 of (# a , b #) -> [d| a = () |]

--- a/ghcide/test/data/THUnboxed/THB.hs
+++ b/ghcide/test/data/THUnboxed/THB.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+module THB where
+import THA
+
+$th_a

--- a/ghcide/test/data/THUnboxed/THC.hs
+++ b/ghcide/test/data/THUnboxed/THC.hs
@@ -1,0 +1,5 @@
+module THC where
+import THB
+
+c ::()
+c = a

--- a/ghcide/test/data/THUnboxed/hie.yaml
+++ b/ghcide/test/data/THUnboxed/hie.yaml
@@ -1,0 +1,1 @@
+cradle: {direct: {arguments: ["-Wmissing-signatures", "-package template-haskell", "THA", "THB", "THC"]}}

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -3504,9 +3504,11 @@ thTests =
         _ <- createDoc "A.hs" "haskell" sourceA
         _ <- createDoc "B.hs" "haskell" sourceB
         return ()
-    , thReloadingTest
+    , thReloadingTest False
+    , thReloadingTest True
     -- Regression test for https://github.com/haskell/haskell-language-server/issues/891
-    , thLinkingTest
+    , thLinkingTest False
+    , thLinkingTest True
     , testSessionWait "findsTHIdentifiers" $ do
         let sourceA =
               T.unlines
@@ -3539,8 +3541,8 @@ thTests =
     ]
 
 -- | test that TH is reevaluated on typecheck
-thReloadingTest :: TestTree
-thReloadingTest = testCase "reloading-th-test" $ runWithExtraFiles "TH" $ \dir -> do
+thReloadingTest :: Bool -> TestTree
+thReloadingTest unboxed = testCase name $ runWithExtraFiles dir $ \dir -> do
 
     let aPath = dir </> "THA.hs"
         bPath = dir </> "THB.hs"
@@ -3572,9 +3574,13 @@ thReloadingTest = testCase "reloading-th-test" $ runWithExtraFiles "TH" $ \dir -
     closeDoc adoc
     closeDoc bdoc
     closeDoc cdoc
+  where
+    name = "reloading-th-test" <> if unboxed then "-unboxed" else ""
+    dir | unboxed = "THUnboxed"
+        | otherwise = "TH"
 
-thLinkingTest :: TestTree
-thLinkingTest = testCase "th-linking-test" $ runWithExtraFiles "TH" $ \dir -> do
+thLinkingTest :: Bool -> TestTree
+thLinkingTest unboxed = testCase name $ runWithExtraFiles dir $ \dir -> do
 
     let aPath = dir </> "THA.hs"
         bPath = dir </> "THB.hs"
@@ -3598,7 +3604,10 @@ thLinkingTest = testCase "th-linking-test" $ runWithExtraFiles "TH" $ \dir -> do
 
     closeDoc adoc
     closeDoc bdoc
-
+  where
+    name = "th-linking-test" <> if unboxed then "-unboxed" else ""
+    dir | unboxed = "THUnboxed"
+        | otherwise = "TH"
 
 completionTests :: TestTree
 completionTests

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -3505,10 +3505,10 @@ thTests =
         _ <- createDoc "B.hs" "haskell" sourceB
         return ()
     , thReloadingTest False
-    , thReloadingTest True
+    , ignoreInWindowsBecause "Broken in windows" $ thReloadingTest True
     -- Regression test for https://github.com/haskell/haskell-language-server/issues/891
     , thLinkingTest False
-    , thLinkingTest True
+    , ignoreInWindowsBecause "Broken in windows" $ thLinkingTest True
     , testSessionWait "findsTHIdentifiers" $ do
         let sourceA =
               T.unlines


### PR DESCRIPTION
1. Modules that use TH themselves but aren't depended on by anything that uses TH don't need to be compiled
2. Any module that needs to be compiled and uses unboxed sums/tuples needs to be compiled using object code
3. Any module that is depended on by anything that uses object code needs to be compiled using object code.

Logic from https://gitlab.haskell.org/ghc/ghc/-/blob/963e1e9aedf0ee70d4e817640ec9845ed00ce0cf/compiler/GHC/Driver/Make.hs#L2268