### PR TITLE
Tone down some logInfos to logDebug

### DIFF
--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -662,7 +662,7 @@ readHieFileForSrcFromDisk file = do
 readHieFileFromDisk :: FilePath -> ExceptT SomeException IdeAction HieFile
 readHieFileFromDisk hie_loc = do
   nc <- asks ideNc
-  log <- asks $ L.logInfo . logger
+  log <- asks $ L.logDebug . logger
   res <- liftIO $ tryAny $ loadHieFile (mkUpdater nc) hie_loc
   liftIO . log $ either (const $ "FAILED LOADING HIE FILE FOR:" <> T.pack (show hie_loc))
                         (const $ "SUCCEEDED LOADING HIE FILE FOR:" <> T.pack (show hie_loc))
@@ -835,7 +835,7 @@ getModIfaceFromDiskAndIndexRule = defineEarlyCutoff $ \GetModIfaceFromDiskAndInd
         Left err -> fail $ "failed to read .hie file " ++ show hie_loc ++ ": " ++ displayException err
         -- can just re-index the file we read from disk
         Right hf -> liftIO $ do
-          L.logInfo (logger se) $ "Re-indexing hie file for" <> T.pack (show f)
+          L.logDebug (logger se) $ "Re-indexing hie file for" <> T.pack (show f)
           indexHieFile se ms f hash hf
 
   let fp = hiFileFingerPrint x

--- a/ghcide/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/ghcide/src/Development/IDE/LSP/HoverDefinition.hs
@@ -82,7 +82,7 @@ request label getResults notFound found ide (TextDocumentPositionParams (TextDoc
 logAndRunRequest :: T.Text -> (NormalizedFilePath -> Position -> IdeAction b) -> IdeState -> Position -> String -> IO b
 logAndRunRequest label getResults ide pos path = do
   let filePath = toNormalizedFilePath' path
-  logInfo (ideLogger ide) $
+  logDebug (ideLogger ide) $
     label <> " request at position " <> T.pack (showPosition pos) <>
     " in file: " <> T.pack path
   runIdeAction (T.unpack label) (shakeExtras ide) (getResults filePath pos)

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -50,7 +50,7 @@ setHandlersNotifications = mconcat
           -- For example, vscode restores previously unsaved contents on open
           modifyFilesOfInterest ide (M.insert file Modified{firstOpen=True})
           setFileModified ide False file
-          logInfo (ideLogger ide) $ "Opened text document: " <> getUri _uri
+          logDebug (ideLogger ide) $ "Opened text document: " <> getUri _uri
 
   , notificationHandler LSP.STextDocumentDidChange $
       \ide (DidChangeTextDocumentParams identifier@VersionedTextDocumentIdentifier{_uri} changes) -> liftIO $ do
@@ -58,14 +58,14 @@ setHandlersNotifications = mconcat
         whenUriFile _uri $ \file -> do
           modifyFilesOfInterest ide (M.insert file Modified{firstOpen=False})
           setFileModified ide False file
-        logInfo (ideLogger ide) $ "Modified text document: " <> getUri _uri
+        logDebug (ideLogger ide) $ "Modified text document: " <> getUri _uri
 
   , notificationHandler LSP.STextDocumentDidSave $
       \ide (DidSaveTextDocumentParams TextDocumentIdentifier{_uri} _) -> liftIO $ do
         whenUriFile _uri $ \file -> do
             modifyFilesOfInterest ide (M.insert file OnDisk)
             setFileModified ide True file
-        logInfo (ideLogger ide) $ "Saved text document: " <> getUri _uri
+        logDebug (ideLogger ide) $ "Saved text document: " <> getUri _uri
 
   , notificationHandler LSP.STextDocumentDidClose $
         \ide (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> liftIO $ do
@@ -74,7 +74,7 @@ setHandlersNotifications = mconcat
               -- Refresh all the files that depended on this
               checkParents <- optCheckParents =<< getIdeOptionsIO (shakeExtras ide)
               when (checkParents >= CheckOnClose) $ typecheckParents ide file
-              logInfo (ideLogger ide) $ "Closed text document: " <> getUri _uri
+              logDebug (ideLogger ide) $ "Closed text document: " <> getUri _uri
 
   , notificationHandler LSP.SWorkspaceDidChangeWatchedFiles $
       \ide (DidChangeWatchedFilesParams fileEvents) -> liftIO $ do
@@ -88,7 +88,7 @@ setHandlersNotifications = mconcat
                     )
                     ( F.toList fileEvents )
         let msg = Text.pack $ show events
-        logInfo (ideLogger ide) $ "Files created or deleted: " <> msg
+        logDebug (ideLogger ide) $ "Files created or deleted: " <> msg
         modifyFileExists ide events
         setSomethingModified ide
 
@@ -103,7 +103,7 @@ setHandlersNotifications = mconcat
   , notificationHandler LSP.SWorkspaceDidChangeConfiguration $
       \ide (DidChangeConfigurationParams cfg) -> liftIO $ do
         let msg = Text.pack $ show cfg
-        logInfo (ideLogger ide) $ "Configuration changed: " <> msg
+        logDebug (ideLogger ide) $ "Configuration changed: " <> msg
         modifyClientSettings ide (const $ Just cfg)
         setSomethingModified ide
 


### PR DESCRIPTION
HLS is too chatty. Lowering the severity of some log messages should indirectly
increase the visibility of all other messages