### PR TITLE
Disable HLS benchmark example

### DIFF
--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -24,15 +24,15 @@ examples:
         - src/Language/LSP/VFS.hs
         - src/Language/LSP/Types/Lens.hs
   # Small but heavily multi-component example
-  - path: bench/example/HLS
-    modules:
-        - hls-plugin-api/src/Ide/Plugin/Config.hs
-        - ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
-        # Things get too slow with more than 2 components, hie-bios 0.7.3 will help here
-        # - ghcide/bench/hist/Main.hs
-        # - ghcide/bench/lib/Experiments/Types.hs
-        # - ghcide/test/exe/Main.hs
-        # - exe/Plugins.hs
+  # Disabled as it is far to slow. hie-bios >0.7.2 should help
+  # - path: bench/example/HLS
+  #   modules:
+  #       - hls-plugin-api/src/Ide/Plugin/Config.hs
+  #       - ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+  #       - ghcide/bench/hist/Main.hs
+  #       - ghcide/bench/lib/Experiments/Types.hs
+  #       - ghcide/test/exe/Main.hs
+  #       - exe/Plugins.hs
 
 # The set of experiments to execute
 experiments:


### PR DESCRIPTION
It times out since the lsp-1.0 patch, and I don't have time to look into it