### PR TITLE
Bump plugins versions

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -67,9 +67,9 @@ library
     , ghcide                >=0.7.5
     , gitrev
     , lsp
-    , hls-plugin-api        >=0.7
     , hie-bios
     , hiedb
+    , hls-plugin-api        >=0.7.1
     , hslogger
     , optparse-applicative
     , optparse-simple
@@ -187,37 +187,37 @@ common example-plugins
 
 common class
   if flag(class) || flag(all-plugins)
-    build-depends: hls-class-plugin
+    build-depends: hls-class-plugin  >=0.1.0.2
     cpp-options: -Dclass
 
 common haddockComments
   if flag(haddockComments) || flag(all-plugins)
-    build-depends: hls-haddock-comments-plugin
+    build-depends: hls-haddock-comments-plugin  >=0.1.1.1
     cpp-options: -DhaddockComments
 
 common eval
   if flag(eval) || flag(all-plugins)
-    build-depends: hls-eval-plugin
+    build-depends: hls-eval-plugin  >=0.2.0.1
     cpp-options: -Deval
 
 common importLens
   if flag(importLens) || flag(all-plugins)
-    build-depends: hls-explicit-imports-plugin
+    build-depends: hls-explicit-imports-plugin >=0.1.0.2
     cpp-options: -DimportLens
 
 common retrie
   if flag(retrie) || flag(all-plugins)
-    build-depends: hls-retrie-plugin
+    build-depends: hls-retrie-plugin >=0.1.1.1
     cpp-options: -Dretrie
 
 common tactic
   if flag(tactic) || flag(all-plugins)
-    build-depends: hls-tactics-plugin
+    build-depends: hls-tactics-plugin  >=0.5.1.1
     cpp-options: -Dtactic
 
 common hlint
   if flag(hlint) || flag(all-plugins)
-    build-depends: hls-hlint-plugin
+    build-depends: hls-hlint-plugin >=0.2.0.1
     cpp-options: -Dhlint
 
 common moduleName
@@ -235,7 +235,7 @@ common pragmas
 
 common splice
   if flag(splice) || flag(all-plugins)
-    build-depends: hls-splice-plugin
+    build-depends: hls-splice-plugin >= 0.4.0.1
     cpp-options: -Dsplice
 
 -- formatters

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-class-plugin
-version:            0.1.0.1
+version:            0.1.0.2
 synopsis:           Class/instance management plugin for Haskell Language Server
 description:
     Class/instance management plugin for Haskell Language Server.

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-eval-plugin
-version:            0.2.0.0
+version:            0.2.0.1
 synopsis:           Eval plugin for Haskell Language Server
 description:        Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
 category:           Development

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hls-explicit-imports-plugin
-version:       0.1.0.1
+version:       0.1.0.2
 synopsis:      Explicit imports plugin for Haskell Language Server
 license:       Apache-2.0
 license-file:  LICENSE

--- a/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
+++ b/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hls-haddock-comments-plugin
-version:       0.1.1.0
+version:       0.1.1.1
 synopsis:      Haddock comments plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server>

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hls-hlint-plugin
-version:       0.2.0.0
+version:       0.2.0.1
 synopsis:      Hlint integration plugin with Haskell Language Server
 description:   Please see Haskell Language Server Readme (https://github.com/haskell/haskell-language-server#readme)
 license:       Apache-2.0

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hls-retrie-plugin
-version:       0.1.1.0
+version:       0.1.1.1
 synopsis:      Retrie integration plugin for Haskell Language Server
 license:       Apache-2.0
 license-file:  LICENSE

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-splice-plugin
-version:            0.4.0.0
+version:            0.4.0.1
 synopsis:           HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 description:        HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes.
 license:            Apache-2.0

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.2
 category:           Development
 name:               hls-tactics-plugin
-version:            0.5.1.0
+version:            0.5.1.1
 synopsis:           Tactics plugin for Haskell Language Server
 description:        Please see README.md
 author:             Sandy Maguire, Reed Mullanix


### PR DESCRIPTION
The plugins were all updated to lsp-1.0 in #1284 and need a minor version bump in order to be upload able to Hackage. 

I am also going to upload all the plugins I have Hackage maintainer access (class, imports, and retrie). This is in order to make them usable with ghcide 0.7.5.0, which was released earlier today. 

Ideally we would have a CI job that would detect Cabal version updates and automatically upload to Hackage.