### PR TITLE
Add missing imports

### DIFF
--- a/install/src/Env.hs
+++ b/install/src/Env.hs
@@ -20,6 +20,7 @@ import           Data.List                                ( sort
                                                           , isInfixOf
                                                           , nubBy
                                                           )
+import           Data.List.Extra                          ( nubOrdBy )
 import           Data.Ord                                 ( comparing )
 import           Control.Monad.Extra                      ( mapMaybeM )
 

--- a/install/src/Print.hs
+++ b/install/src/Print.hs
@@ -4,6 +4,9 @@ import           Development.Shake
 import           Control.Monad.IO.Class
 import           Data.List                                ( dropWhileEnd
                                                           )
+import           Data.List.Extra                          ( trimStart,
+                                                            trimEnd
+                                                          )
 import           Data.Char                                ( isSpace )
 
 -- | lift putStrLn to MonadIO


### PR DESCRIPTION
Without these `./cabal-hls-install` doesn't compile. Not sure how this got passed the CI.