### PR TITLE
Plugin Config: Add maxCompletions to JSON instance

### DIFF
--- a/hls-plugin-api/src/Ide/Plugin/Config.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Config.hs
@@ -117,6 +117,7 @@ instance A.ToJSON Config where
                  , "completionSnippetsOn"        .= completionSnippetsOn
                  , "formatOnImportOn"            .= formatOnImportOn
                  , "formattingProvider"          .= formattingProvider
+                 , "maxCompletions"              .= maxCompletions
                  , "plugin"                      .= plugins
                  ]
 


### PR DESCRIPTION
It was likely forgotten to add in this change:
<https://github.com/haskell/haskell-language-server/pull/1218/files>