### PR TITLE
Add a test for #1376

### DIFF
--- a/test/functional/Format.hs
+++ b/test/functional/Format.hs
@@ -64,15 +64,15 @@ providerTests = testGroup "formatting provider" [
         documentContents doc >>= liftIO . (@?= formattedFloskell)
 
     , testCase "can change on the fly" $ runSession hlsCommand fullCaps "test/testdata/format" $ do
-        formattedBrittany <- liftIO $ T.readFile "test/testdata/format/Format.ormolu.formatted.hs"
+        formattedOrmolu <- liftIO $ T.readFile "test/testdata/format/Format.ormolu.formatted.hs"
         formattedFloskell <- liftIO $ T.readFile "test/testdata/format/Format.floskell.formatted.hs"
-        formattedBrittanyPostFloskell <- liftIO $ T.readFile "test/testdata/format/Format.ormolu_post_floskell.formatted.hs"
+        formattedOrmoluPostFloskell <- liftIO $ T.readFile "test/testdata/format/Format.ormolu_post_floskell.formatted.hs"
 
         doc <- openDoc "Format.hs" "haskell"
 
         sendNotification SWorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))
         formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
-        documentContents doc >>= liftIO . (@?= formattedBrittany)
+        documentContents doc >>= liftIO . (@?= formattedOrmolu)
 
         sendNotification SWorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "floskell"))
         formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
@@ -80,16 +80,16 @@ providerTests = testGroup "formatting provider" [
 
         sendNotification SWorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))
         formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
-        documentContents doc >>= liftIO . (@?= formattedBrittanyPostFloskell)
+        documentContents doc >>= liftIO . (@?= formattedOrmoluPostFloskell)
     , testCase "supports both new and old configuration sections" $ runSession hlsCommand fullCaps "test/testdata/format" $ do
-       formattedBrittany <- liftIO $ T.readFile "test/testdata/format/Format.ormolu.formatted.hs"
+       formattedOrmolu <- liftIO $ T.readFile "test/testdata/format/Format.ormolu.formatted.hs"
        formattedFloskell <- liftIO $ T.readFile "test/testdata/format/Format.floskell.formatted.hs"
 
        doc <- openDoc "Format.hs" "haskell"
 
        sendNotification SWorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfigOld "ormolu"))
        formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
-       documentContents doc >>= liftIO . (@?= formattedBrittany)
+       documentContents doc >>= liftIO . (@?= formattedOrmolu)
 
        sendNotification SWorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfigOld "floskell"))
        formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)

--- a/test/testdata/format/Format.floskell.formatted.hs
+++ b/test/testdata/format/Format.floskell.formatted.hs
@@ -1,7 +1,7 @@
 module Format where
 
-import           Data.List
 import           Data.Int
+import           Data.List
 import           Prelude
 
 foo :: Int -> Int
@@ -14,4 +14,3 @@ bar s = do
   return "asdf"
 
 data Baz = Baz { a :: Int, b :: String }
-

--- a/test/testdata/format/Format.floskell.initial.hs
+++ b/test/testdata/format/Format.floskell.initial.hs
@@ -1,0 +1,17 @@
+module Format where
+
+import           Data.List
+import           Prelude
+import           Data.Int
+
+foo :: Int -> Int
+foo 3 = 2
+foo x = x
+
+bar :: String -> IO String
+bar s = do
+  x <- return "hello"
+  return "asdf"
+
+data Baz = Baz { a :: Int, b :: String }
+

--- a/test/testdata/format/Format.ormolu_post_floskell.formatted.hs
+++ b/test/testdata/format/Format.ormolu_post_floskell.formatted.hs
@@ -1,0 +1,16 @@
+module Format where
+
+import Data.Int
+import Data.List
+import Prelude
+
+foo :: Int -> Int
+foo 3 = 2
+foo x = x
+
+bar :: String -> IO String
+bar s = do
+  x <- return "hello"
+  return "asdf"
+
+data Baz = Baz {a :: Int, b :: String}


### PR DESCRIPTION
The test passes, and I cannot repro the issue with VSCode, so the issue must be down to a difference in how CoC and VSCode implement the LSP spec. 

I believe it worked before the lsp-1.0 upgrade, which means that something has changed between *haskell-lsp* and *lsp* in how the initial configuration is handled. 

The full LSP log (see the Gist below) from the test shows that *lsp-test* generates a `workspace/didChangeConfiguration` with the formatter config. It could be that CoC doesn't send this notification, and instead expects the server to request the config. @wz1000 @bubba is it possible that *haskell-lsp* does request the config at startup, whereas *lsp* does not?

https://gist.github.com/pepeiborra/fcad435bdf8717ceeecf392549329c19

There's nothing else to do here, so this closes #1376. The next step is to either teach *lsp* to request the config at startup, or get CoC to send the `workspace/didChangeConfiguration` as VSCode does. /cc @andys8 

I also took the chance to remove an unnecessary use of the AGPL flag in the test suite 