### PR TITLE
Correctly split non-varpats in tactics

### DIFF
--- a/test/functional/Tactic.hs
+++ b/test/functional/Tactic.hs
@@ -128,6 +128,7 @@ tests = testGroup
   , goldenTest "FmapJoin.hs"                2 14 Auto ""
   , goldenTest "Fgmap.hs"                   2 9  Auto ""
   , goldenTest "FmapJoinInLet.hs"           4 19 Auto ""
+  , goldenTest "SplitPattern.hs"            7 25 Destruct "a"
   ]
 
 

--- a/test/testdata/tactic/SplitPattern.hs
+++ b/test/testdata/tactic/SplitPattern.hs
@@ -1,0 +1,8 @@
+data ADT = One | Two Int | Three | Four Bool ADT | Five
+
+case_split :: ADT -> Int
+case_split One = _
+case_split (Two i) = _
+case_split Three = _
+case_split (Four b a) = _
+case_split Five = _

--- a/test/testdata/tactic/SplitPattern.hs.expected
+++ b/test/testdata/tactic/SplitPattern.hs.expected
@@ -1,0 +1,12 @@
+data ADT = One | Two Int | Three | Four Bool ADT | Five
+
+case_split :: ADT -> Int
+case_split One = _
+case_split (Two i) = _
+case_split Three = _
+case_split (Four b One) = _
+case_split (Four b (Two i)) = _
+case_split (Four b Three) = _
+case_split (Four b (Four b2 a3)) = _
+case_split (Four b Five) = _
+case_split Five = _


### PR DESCRIPTION
This PR fixes #1426. The old logic accidentally would only replace top-level `VarPat`s. This one instead does an SYB traversal over the bound patterns and replaces a `VarPat` with its case-matches. The implementation here is a bit stupid --- it does one traversal for each `body`, but this is user-written code, so all inputs involved are small constants.