### PR TITLE
Customize the unitId used for the fake internal component

### DIFF
--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -90,6 +90,9 @@ import           HieDb.Types
 import           HieDb.Utils
 import           Maybes                               (MaybeT (runMaybeT))
 
+-- | Bump this version number when making changes to the format of the data stored in hiedb
+hiedbDataVersion :: String
+hiedbDataVersion = "1"
 
 data CacheDirs = CacheDirs
   { hiCacheDir, hieCacheDir, oCacheDir :: Maybe FilePath}
@@ -173,7 +176,7 @@ runWithDb fp k = do
 
 getHieDbLoc :: FilePath -> IO FilePath
 getHieDbLoc dir = do
-  let db = dirHash++"-"++takeBaseName dir++"-"++VERSION_ghc <.> "hiedb"
+  let db = intercalate "-" [dirHash, takeBaseName dir, VERSION_ghc, hiedbDataVersion] <.> "hiedb"
       dirHash = B.unpack $ B16.encode $ H.hash $ B.pack dir
   cDir <- IO.getXdgDirectory IO.XdgCache cacheDir
   createDirectoryIfMissing True cDir

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -571,7 +571,7 @@ indexHieFile se mod_summary srcPath hash hf = atomically $ do
         LSP.sendNotification LSP.SProgress $ LSP.ProgressParams tok $
           LSP.Report $ LSP.WorkDoneProgressReportParams
             { _cancellable = Nothing
-            , _message = Just $ T.pack (show srcPath) <> progress
+            , _message = Just $ T.pack (fromNormalizedFilePath srcPath) <> progress
             , _percentage = Nothing
             }
 

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -842,7 +842,7 @@ getModIfaceFromDiskAndIndexRule = defineEarlyCutoff $ \GetModIfaceFromDiskAndInd
         Left err -> fail $ "failed to read .hie file " ++ show hie_loc ++ ": " ++ displayException err
         -- can just re-index the file we read from disk
         Right hf -> liftIO $ do
-          L.logDebug (logger se) $ "Re-indexing hie file for" <> T.pack (show f)
+          L.logDebug (logger se) $ "Re-indexing hie file for" <> T.pack (fromNormalizedFilePath f)
           indexHieFile se ms f hash hf
 
   let fp = hiFileFingerPrint x

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -142,7 +142,7 @@ defaultIdeOptions session = IdeOptions
     ,optCheckParents = pure CheckOnSaveAndClose
     ,optHaddockParse = HaddockParse
     ,optCustomDynFlags = id
-    ,optFakeUid = toInstalledUnitId (stringToUnitId "fake_uid")
+    ,optFakeUid = toInstalledUnitId (stringToUnitId "main")
     }
 
 

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -85,11 +85,6 @@ data IdeOptions = IdeOptions
     -- ^ Will be called right after setting up a new cradle,
     --   allowing to customize the Ghc options used
   , optShakeOptions       :: ShakeOptions
-  , optFakeUid            :: InstalledUnitId
-    -- ^ unit id used to tag the internal component built by ghcide
-    --   To reuse external interface files the unit ids must match,
-    --   thus make sure to build them with `--this-unit-id` set to the
-    --   same value as the ghcide fake uid
   }
 
 optShakeFiles :: IdeOptions -> Maybe FilePath
@@ -142,7 +137,6 @@ defaultIdeOptions session = IdeOptions
     ,optCheckParents = pure CheckOnSaveAndClose
     ,optHaddockParse = HaddockParse
     ,optCustomDynFlags = id
-    ,optFakeUid = toInstalledUnitId (stringToUnitId "main")
     }
 
 

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -87,6 +87,9 @@ data IdeOptions = IdeOptions
   , optShakeOptions       :: ShakeOptions
   , optFakeUid            :: InstalledUnitId
     -- ^ unit id used to tag the internal component built by ghcide
+    --   To reuse external interface files the unit ids must match,
+    --   thus make sure to build them with `--this-unit-id` set to the
+    --   same value as the ghcide fake uid
   }
 
 optShakeFiles :: IdeOptions -> Maybe FilePath

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -85,6 +85,8 @@ data IdeOptions = IdeOptions
     -- ^ Will be called right after setting up a new cradle,
     --   allowing to customize the Ghc options used
   , optShakeOptions       :: ShakeOptions
+  , optFakeUid            :: InstalledUnitId
+    -- ^ unit id used to tag the internal component built by ghcide
   }
 
 optShakeFiles :: IdeOptions -> Maybe FilePath
@@ -137,6 +139,7 @@ defaultIdeOptions session = IdeOptions
     ,optCheckParents = pure CheckOnSaveAndClose
     ,optHaddockParse = HaddockParse
     ,optCustomDynFlags = id
+    ,optFakeUid = toInstalledUnitId (stringToUnitId "fake_uid")
     }
 
 


### PR DESCRIPTION
ghcide sets a custom unit id for the internal component. While this is mostly an internal implementation detail, it leaks out when trying to reuse interface files produced by ghc, which will need to be configured with `--this-unit-id fake_uid`. This is fine, but what if in the future ghcide changes the fake uid string? 

This PR adds a flag to control the fake uid string which can be used to get some protection against future ghcide changes.

Additionally, we should probably change the default value to "main", which is the name ghc uses for the default component, in order to make the scenario above, reusing interface files produced by ghc, work out of the box in most cases. Thoughts @fendor @wz1000 ?
