### PR TITLE
Reformat all files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you don't want to use [nix](https://nixos.org/guides/install-nix.html), you c
       "hooks": [
         {
           "entry": "stylish-haskell --inplace",
-          "exclude": "(test/testdata/.*|hie-compat/.*)",
+          "exclude": "(^Setup.hs$|test/testdata/.*$|test/data/.*$|^hie-compat/.*$)",
           "files": "\\.l?hs$",
           "id": "stylish-haskell",
           "language": "system",

--- a/GenChangelogs.hs
+++ b/GenChangelogs.hs
@@ -3,16 +3,17 @@
 build-depends: base, process, text, github, time
 -}
 
-{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
-import Control.Monad
-import Data.List
-import Data.Maybe
-import qualified Data.Text as T
-import Data.Time.Format.ISO8601
-import Data.Time.LocalTime
-import System.Process
-import GitHub
+import           Control.Monad
+import           Data.List
+import           Data.Maybe
+import qualified Data.Text                as T
+import           Data.Time.Format.ISO8601
+import           Data.Time.LocalTime
+import           GitHub
+import           System.Process
 
 main = do
   callCommand "git fetch --tags"

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -4,11 +4,10 @@
 {-# LANGUAGE RecordWildCards   #-}
 module Main(main) where
 
-import           Ide.Arguments             (Arguments (..), LspArguments (..),
-                                            getArguments)
-import           Ide.Main                  (defaultMain)
+import           Ide.Arguments (Arguments (..), LspArguments (..), getArguments)
+import           Ide.Main      (defaultMain)
+import           Main.Utf8     (withUtf8)
 import           Plugins
-import Main.Utf8 (withUtf8)
 
 main :: IO ()
 main = withUtf8 $ do

--- a/exe/Plugins.hs
+++ b/exe/Plugins.hs
@@ -2,77 +2,77 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Plugins where
 
-import Ide.Types (IdePlugins)
-import           Ide.PluginUtils           (pluginDescToIdePlugins)
+import           Ide.PluginUtils                   (pluginDescToIdePlugins)
+import           Ide.Types                         (IdePlugins)
 
 -- fixed plugins
-import           Ide.Plugin.Example        as Example
-import           Ide.Plugin.Example2       as Example2
-import           Development.IDE           (IdeState)
-import Development.IDE.Plugin.HLS.GhcIde as GhcIde
+import           Development.IDE                   (IdeState)
+import           Development.IDE.Plugin.HLS.GhcIde as GhcIde
+import           Ide.Plugin.Example                as Example
+import           Ide.Plugin.Example2               as Example2
 
 -- haskell-language-server optional plugins
 
 #if class
-import           Ide.Plugin.Class          as Class
+import           Ide.Plugin.Class                  as Class
 #endif
 
 #if haddockComments
-import           Ide.Plugin.HaddockComments as HaddockComments
+import           Ide.Plugin.HaddockComments        as HaddockComments
 #endif
 
 #if eval
-import           Ide.Plugin.Eval           as Eval
+import           Ide.Plugin.Eval                   as Eval
 #endif
 
 #if importLens
-import           Ide.Plugin.ExplicitImports as ExplicitImports
+import           Ide.Plugin.ExplicitImports        as ExplicitImports
 #endif
 
 #if retrie
-import           Ide.Plugin.Retrie         as Retrie
+import           Ide.Plugin.Retrie                 as Retrie
 #endif
 
 #if tactic
-import           Ide.Plugin.Tactic         as Tactic
+import           Ide.Plugin.Tactic                 as Tactic
 #endif
 
 #if hlint
-import           Ide.Plugin.Hlint          as Hlint
+import           Ide.Plugin.Hlint                  as Hlint
 #endif
 
 #if moduleName
-import           Ide.Plugin.ModuleName     as ModuleName
+import           Ide.Plugin.ModuleName             as ModuleName
 #endif
 
 #if pragmas
-import           Ide.Plugin.Pragmas        as Pragmas
+import           Ide.Plugin.Pragmas                as Pragmas
 #endif
 
 #if splice
-import           Ide.Plugin.Splice        as Splice
+import           Ide.Plugin.Splice                 as Splice
 #endif
 
 -- formatters
 
 #if floskell
-import           Ide.Plugin.Floskell       as Floskell
+import           Ide.Plugin.Floskell               as Floskell
 #endif
 
 #if fourmolu
-import           Ide.Plugin.Fourmolu       as Fourmolu
+import           Ide.Plugin.Fourmolu               as Fourmolu
 #endif
 
 #if ormolu
-import           Ide.Plugin.Ormolu         as Ormolu
+import           Ide.Plugin.Ormolu                 as Ormolu
 #endif
 
 #if stylishHaskell
-import           Ide.Plugin.StylishHaskell as StylishHaskell
+import           Ide.Plugin.StylishHaskell         as StylishHaskell
 #endif
 
 #if AGPL && brittany
-import           Ide.Plugin.Brittany       as Brittany
+import           Ide.Plugin.Brittany               as Brittany
 #endif
 
 -- ---------------------------------------------------------------------

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -3,24 +3,24 @@
 -- https://github.com/alanz/vscode-hie-server
 module Main where
 
-import Control.Monad.Extra
-import Data.Default
-import Data.Foldable
-import Data.List
-import Data.Void
-import Development.IDE.Session (findCradle)
-import HIE.Bios hiding (findCradle)
-import HIE.Bios.Environment
-import HIE.Bios.Types
-import Ide.Arguments
-import Ide.Version
-import System.Directory
-import System.Environment
-import System.Exit
-import System.FilePath
-import System.IO
-import System.Info
-import System.Process
+import           Control.Monad.Extra
+import           Data.Default
+import           Data.Foldable
+import           Data.List
+import           Data.Void
+import           Development.IDE.Session (findCradle)
+import           HIE.Bios                hiding (findCradle)
+import           HIE.Bios.Environment
+import           HIE.Bios.Types
+import           Ide.Arguments
+import           Ide.Version
+import           System.Directory
+import           System.Environment
+import           System.Exit
+import           System.FilePath
+import           System.IO
+import           System.Info
+import           System.Process
 
 -- ---------------------------------------------------------------------
 
@@ -50,7 +50,7 @@ launchHaskellLanguageServer :: Arguments -> IO ()
 launchHaskellLanguageServer parsedArgs = do
   case parsedArgs of
     LspMode LspArguments{..} -> whenJust argsCwd setCurrentDirectory
-    _ -> pure ()
+    _                        -> pure ()
 
   d <- getCurrentDirectory
 

--- a/ghcide/bench/exe/Main.hs
+++ b/ghcide/bench/exe/Main.hs
@@ -34,11 +34,11 @@
 
 {-# LANGUAGE ImplicitParams #-}
 
-import Control.Exception.Safe
-import Experiments
-import Options.Applicative
-import System.IO
+import           Control.Exception.Safe
 import           Control.Monad
+import           Experiments
+import           Options.Applicative
+import           System.IO
 
 optsP :: Parser (Config, Bool)
 optsP = (,) <$> configP <*> switch (long "no-clean")

--- a/ghcide/bench/hist/Main.hs
+++ b/ghcide/bench/hist/Main.hs
@@ -38,24 +38,24 @@
    > cabal bench --benchmark-options "bench-results/HEAD/results.csv bench-results/HEAD/edit.diff.svg"
 
  -}
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DerivingStrategies#-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS -Wno-orphans #-}
 
-import Data.Foldable (find)
-import Data.Yaml (FromJSON (..), decodeFileThrow)
-import Development.Benchmark.Rules
-import Development.Shake
-import Experiments.Types (Example, exampleToOptions)
-import qualified Experiments.Types as E
-import GHC.Generics (Generic)
-import Numeric.Natural (Natural)
-import Development.Shake.Classes
-import System.Console.GetOpt
-import Data.Maybe
-import Control.Monad.Extra
-import System.FilePath
+import           Control.Monad.Extra
+import           Data.Foldable               (find)
+import           Data.Maybe
+import           Data.Yaml                   (FromJSON (..), decodeFileThrow)
+import           Development.Benchmark.Rules
+import           Development.Shake
+import           Development.Shake.Classes
+import           Experiments.Types           (Example, exampleToOptions)
+import qualified Experiments.Types           as E
+import           GHC.Generics                (Generic)
+import           Numeric.Natural             (Natural)
+import           System.Console.GetOpt
+import           System.FilePath
 
 
 configPath :: FilePath
@@ -82,7 +82,7 @@ main = shakeArgsWith shakeOpts [configOpt] $ \configs wants -> pure $ Just $ do
   _configStatic <- createBuildSystem config
   case wants of
       [] -> want ["all"]
-      _ -> want wants
+      _  -> want wants
 
 ghcideBuildRules :: MkBuildRules BuildSystem
 ghcideBuildRules = MkBuildRules findGhcForBuildSystem "ghcide" projectDepends buildGhcide
@@ -95,13 +95,13 @@ ghcideBuildRules = MkBuildRules findGhcForBuildSystem "ghcide" projectDepends bu
 --------------------------------------------------------------------------------
 
 data Config buildSystem = Config
-  { experiments :: [Unescaped String],
-    examples :: [Example],
-    samples :: Natural,
-    versions :: [GitCommit],
+  { experiments     :: [Unescaped String],
+    examples        :: [Example],
+    samples         :: Natural,
+    versions        :: [GitCommit],
     -- | Output folder ('foo' works, 'foo/bar' does not)
-    outputFolder :: String,
-    buildTool :: buildSystem,
+    outputFolder    :: String,
+    buildTool       :: buildSystem,
     profileInterval :: Maybe Double
   }
   deriving (Generic, Show)

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE ImplicitParams #-}
-{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE ImplicitParams            #-}
+{-# LANGUAGE ImpredicativeTypes        #-}
 {-# OPTIONS_GHC -Wno-deprecations -Wno-unticked-promoted-constructors #-}
 
 module Experiments
@@ -21,29 +21,30 @@ module Experiments
 , runBench
 , exampleToOptions
 ) where
-import Control.Applicative.Combinators (skipManyTill)
-import Control.Exception.Safe (IOException, handleAny, try)
-import Control.Monad.Extra
-import Control.Monad.IO.Class
-import Data.Aeson (Value(Null), toJSON)
-import Data.List
-import Data.Maybe
-import qualified Data.Text as T
-import Data.Version
-import Development.IDE.Plugin.Test
-import Experiments.Types
-import Language.LSP.Test
-import Language.LSP.Types
-import Language.LSP.Types.Capabilities
-import Numeric.Natural
-import Options.Applicative
-import System.Directory
-import System.Environment.Blank (getEnv)
-import System.FilePath ((</>), (<.>))
-import System.Process
-import System.Time.Extra
-import Text.ParserCombinators.ReadP (readP_to_S)
-import Development.Shake (cmd_, CmdOption (Cwd, FileStdout))
+import           Control.Applicative.Combinators (skipManyTill)
+import           Control.Exception.Safe          (IOException, handleAny, try)
+import           Control.Monad.Extra
+import           Control.Monad.IO.Class
+import           Data.Aeson                      (Value (Null), toJSON)
+import           Data.List
+import           Data.Maybe
+import qualified Data.Text                       as T
+import           Data.Version
+import           Development.IDE.Plugin.Test
+import           Development.Shake               (CmdOption (Cwd, FileStdout),
+                                                  cmd_)
+import           Experiments.Types
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Language.LSP.Types.Capabilities
+import           Numeric.Natural
+import           Options.Applicative
+import           System.Directory
+import           System.Environment.Blank        (getEnv)
+import           System.FilePath                 ((<.>), (</>))
+import           System.Process
+import           System.Time.Extra
+import           Text.ParserCombinators.ReadP    (readP_to_S)
 
 charEdit :: Position -> TextDocumentContentChangeEvent
 charEdit p =
@@ -54,9 +55,9 @@ charEdit p =
     }
 
 data DocumentPositions = DocumentPositions {
-    identifierP :: Maybe Position,
+    identifierP    :: Maybe Position,
     stringLiteralP :: !Position,
-    doc :: !TextDocumentIdentifier
+    doc            :: !TextDocumentIdentifier
 }
 
 allWithIdentifierPos :: Monad m => (DocumentPositions -> m Bool) -> [DocumentPositions] -> m Bool
@@ -225,9 +226,9 @@ type Experiment = [DocumentPositions] -> Session Bool
 
 data Bench =
   Bench
-  { name :: !String,
-    enabled :: !Bool,
-    samples :: !Natural,
+  { name       :: !String,
+    enabled    :: !Bool,
+    samples    :: !Natural,
     benchSetup :: [DocumentPositions] -> Session (),
     experiment :: Experiment
   }
@@ -344,12 +345,12 @@ runBenchmarksFun dir allBenchmarks = do
         }
 
 data BenchRun = BenchRun
-  { startup :: !Seconds,
-    runSetup :: !Seconds,
+  { startup       :: !Seconds,
+    runSetup      :: !Seconds,
     runExperiment :: !Seconds,
-    userWaits :: !Seconds,
-    delayedWork :: !Seconds,
-    success :: !Bool
+    userWaits     :: !Seconds,
+    delayedWork   :: !Seconds,
+    success       :: !Bool
   }
 
 badRun :: BenchRun
@@ -416,8 +417,8 @@ runBench runSess b = handleAny (\e -> print e >> return badRun)
 data SetupResult = SetupResult {
     runBenchmarks :: [Bench] -> IO (),
     -- | Path to the setup benchmark example
-    benchDir :: FilePath,
-    cleanUp :: IO ()
+    benchDir      :: FilePath,
+    cleanUp       :: IO ()
 }
 
 callCommandLogging :: HasConfig => String -> IO ()
@@ -456,9 +457,9 @@ setup = do
                     ""
             Stack -> do
                 let stackVerbosity = case verbosity ?config of
-                        Quiet -> "--silent"
+                        Quiet  -> "--silent"
                         Normal -> ""
-                        All -> "--verbose"
+                        All    -> "--verbose"
                 callCommandLogging $ "stack " <> stackVerbosity <> " unpack " <> package <> " --to " <> examplesPath
                 -- Generate the stack descriptor to match the one used to build ghcide
                 stack_yaml <- fromMaybe "stack.yaml" <$> getEnv "STACK_YAML"
@@ -526,8 +527,8 @@ findEndOfImports _ = Nothing
 --------------------------------------------------------------------------------------------
 
 pad :: Int -> String -> String
-pad n [] = replicate n ' '
-pad 0 _ = error "pad"
+pad n []     = replicate n ' '
+pad 0 _      = error "pad"
 pad n (x:xx) = x : pad (n-1) xx
 
 -- | Search for a position where:
@@ -568,6 +569,6 @@ searchSymbol doc@TextDocumentIdentifier{_uri} fileContents pos = do
         defs <- getDefinitions doc pos
         case defs of
             (InL [Location uri _]) -> return $ uri /= _uri
-            _ -> return False
+            _                      -> return False
       checkCompletions pos =
         not . null <$> getCompletions doc pos

--- a/ghcide/bench/lib/Experiments/Types.hs
+++ b/ghcide/bench/lib/Experiments/Types.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings  #-}
 module Experiments.Types (module Experiments.Types ) where
 
-import Data.Aeson
-import Data.Version
-import Numeric.Natural
-import System.FilePath (isPathSeparator)
-import Development.Shake.Classes
-import GHC.Generics
+import           Data.Aeson
+import           Data.Version
+import           Development.Shake.Classes
+import           GHC.Generics
+import           Numeric.Natural
+import           System.FilePath           (isPathSeparator)
 
 data CabalStack = Cabal | Stack
   deriving (Eq, Show)
@@ -16,18 +16,18 @@ data CabalStack = Cabal | Stack
 data Verbosity = Quiet | Normal | All
   deriving (Eq, Show)
 data Config = Config
-  { verbosity :: !Verbosity,
+  { verbosity         :: !Verbosity,
     -- For some reason, the Shake profile files are truncated and won't load
-    shakeProfiling :: !(Maybe FilePath),
+    shakeProfiling    :: !(Maybe FilePath),
     otMemoryProfiling :: !(Maybe FilePath),
-    outputCSV :: !FilePath,
-    buildTool :: !CabalStack,
-    ghcideOptions :: ![String],
-    matches :: ![String],
-    repetitions :: Maybe Natural,
-    ghcide :: FilePath,
-    timeoutLsp :: Int,
-    example :: Example
+    outputCSV         :: !FilePath,
+    buildTool         :: !CabalStack,
+    ghcideOptions     :: ![String],
+    matches           :: ![String],
+    repetitions       :: Maybe Natural,
+    ghcide            :: FilePath,
+    timeoutLsp        :: Int,
+    example           :: Example
   }
   deriving (Eq, Show)
 

--- a/ghcide/exe/Arguments.hs
+++ b/ghcide/exe/Arguments.hs
@@ -3,24 +3,24 @@
 
 module Arguments(Arguments, Arguments'(..), getArguments, IdeCmd(..)) where
 
-import Options.Applicative
-import HieDb.Run
+import           HieDb.Run
+import           Options.Applicative
 
 type Arguments = Arguments' IdeCmd
 
 data IdeCmd = Typecheck [FilePath] | DbCmd Options Command | LSP
 
 data Arguments' a = Arguments
-    {argLSP :: Bool
-    ,argsCwd :: Maybe FilePath
-    ,argsVersion :: Bool
-    ,argsShakeProfiling :: Maybe FilePath
+    {argLSP                :: Bool
+    ,argsCwd               :: Maybe FilePath
+    ,argsVersion           :: Bool
+    ,argsShakeProfiling    :: Maybe FilePath
     ,argsOTMemoryProfiling :: Bool
-    ,argsTesting :: Bool
-    ,argsDisableKick :: Bool
-    ,argsThreads :: Int
-    ,argsVerbose :: Bool
-    ,argFilesOrCmd :: a
+    ,argsTesting           :: Bool
+    ,argsDisableKick       :: Bool
+    ,argsThreads           :: Int
+    ,argsVerbose           :: Bool
+    ,argFilesOrCmd         :: a
     }
 
 getArguments :: IO Arguments

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -5,41 +5,45 @@
 
 module Main(main) where
 
-import Arguments ( Arguments'(..), IdeCmd(..), getArguments )
-import Control.Concurrent.Extra ( newLock, withLock )
-import Control.Monad.Extra ( unless, when, whenJust )
-import Data.Default ( Default(def) )
-import Data.List.Extra ( upper )
-import Data.Maybe (fromMaybe)
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
-import Data.Version ( showVersion )
-import Development.GitRev ( gitHash )
-import Development.IDE ( Logger(Logger), Priority(Info), action )
-import Development.IDE.Core.OfInterest (kick)
-import Development.IDE.Core.Rules (mainRule)
+import           Arguments                         (Arguments' (..),
+                                                    IdeCmd (..), getArguments)
+import           Control.Concurrent.Extra          (newLock, withLock)
+import           Control.Monad.Extra               (unless, when, whenJust)
+import           Data.Default                      (Default (def))
+import           Data.List.Extra                   (upper)
+import           Data.Maybe                        (fromMaybe)
+import qualified Data.Text                         as T
+import qualified Data.Text.IO                      as T
+import           Data.Version                      (showVersion)
+import           Development.GitRev                (gitHash)
+import           Development.IDE                   (Logger (Logger),
+                                                    Priority (Info), action)
+import           Development.IDE.Core.OfInterest   (kick)
+import           Development.IDE.Core.Rules        (mainRule)
+import qualified Development.IDE.Main              as Main
 import qualified Development.IDE.Plugin.HLS.GhcIde as GhcIde
-import qualified Development.IDE.Plugin.Test as Test
-import Development.IDE.Session (setInitialDynFlags, getHieDbLoc)
-import Development.IDE.Types.Options
-import qualified Development.IDE.Main as Main
-import Development.Shake (ShakeOptions(shakeThreads))
-import Ide.Plugin.Config (Config(checkParents, checkProject))
-import Ide.PluginUtils (pluginDescToIdePlugins)
-import HieDb.Run (Options(..), runCommand)
-import Paths_ghcide ( version )
-import qualified System.Directory.Extra as IO
-import System.Environment ( getExecutablePath )
-import System.Exit ( ExitCode(ExitFailure), exitSuccess, exitWith )
-import System.Info ( compilerVersion )
-import System.IO ( stderr, hPutStrLn )
+import qualified Development.IDE.Plugin.Test       as Test
+import           Development.IDE.Session           (getHieDbLoc,
+                                                    setInitialDynFlags)
+import           Development.IDE.Types.Options
+import           Development.Shake                 (ShakeOptions (shakeThreads))
+import           HieDb.Run                         (Options (..), runCommand)
+import           Ide.Plugin.Config                 (Config (checkParents, checkProject))
+import           Ide.PluginUtils                   (pluginDescToIdePlugins)
+import           Paths_ghcide                      (version)
+import qualified System.Directory.Extra            as IO
+import           System.Environment                (getExecutablePath)
+import           System.Exit                       (ExitCode (ExitFailure),
+                                                    exitSuccess, exitWith)
+import           System.IO                         (hPutStrLn, stderr)
+import           System.Info                       (compilerVersion)
 
 ghcideVersion :: IO String
 ghcideVersion = do
   path <- getExecutablePath
   let gitHashSection = case $(gitHash) of
         x | x == "UNKNOWN" -> ""
-        x -> " (GIT hash: " <> x <> ")"
+        x                  -> " (GIT hash: " <> x <> ")"
   return $ "ghcide version: " <> showVersion version
              <> " (GHC: " <> showVersion compilerVersion
              <> ") (PATH: " <> path <> ")"
@@ -68,7 +72,7 @@ main = do
         dbLoc <- getHieDbLoc dir
         mlibdir <- setInitialDynFlags def
         case mlibdir of
-          Nothing -> exitWith $ ExitFailure 1
+          Nothing     -> exitWith $ ExitFailure 1
           Just libdir -> runCommand libdir opts{database = dbLoc} cmd
 
       _ -> do
@@ -82,7 +86,7 @@ main = do
           Main.defaultMain def
             {Main.argFiles = case argFilesOrCmd of
                 Typecheck x | not argLSP -> Just x
-                _ -> Nothing
+                _                        -> Nothing
 
             ,Main.argsLogger = logger
 

--- a/ghcide/session-loader/Development/IDE/Session/VersionCheck.hs
+++ b/ghcide/session-loader/Development/IDE/Session/VersionCheck.hs
@@ -5,13 +5,13 @@
 -- See https://github.com/haskell/ghcide/pull/697
 module Development.IDE.Session.VersionCheck (ghcVersionChecker) where
 
-import Data.Maybe
-import GHC.Check
+import           Data.Maybe
+import           GHC.Check
 -- Only use this for checking against the compile time GHC libDir!
 -- Use getRuntimeGhcLibDir from hie-bios instead for everything else
 -- otherwise binaries will not be distributable since paths will be baked into them
 import qualified GHC.Paths
-import System.Environment
+import           System.Environment
 
 ghcVersionChecker :: GhcVersionChecker
 ghcVersionChecker = $$(makeGhcVersionChecker (fromMaybe GHC.Paths.libdir <$> lookupEnv "NIX_GHC_LIBDIR"))

--- a/ghcide/src/Development/IDE/Core/Debouncer.hs
+++ b/ghcide/src/Development/IDE/Core/Debouncer.hs
@@ -8,14 +8,14 @@ module Development.IDE.Core.Debouncer
     , noopDebouncer
     ) where
 
-import Control.Concurrent.Extra
-import Control.Concurrent.Async
-import Control.Exception
-import Control.Monad.Extra
-import Data.Hashable
-import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as Map
-import System.Time.Extra
+import           Control.Concurrent.Async
+import           Control.Concurrent.Extra
+import           Control.Exception
+import           Control.Monad.Extra
+import           Data.HashMap.Strict      (HashMap)
+import qualified Data.HashMap.Strict      as Map
+import           Data.Hashable
+import           System.Time.Extra
 
 -- | A debouncer can be used to avoid triggering many events
 -- (e.g. diagnostics) for the same key (e.g. the same file)

--- a/ghcide/src/Development/IDE/Core/FileExists.hs
+++ b/ghcide/src/Development/IDE/Core/FileExists.hs
@@ -14,9 +14,9 @@ import           Control.Concurrent.Extra
 import           Control.Exception
 import           Control.Monad.Extra
 import           Data.Binary
-import qualified Data.ByteString               as BS
-import           Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.ByteString                       as BS
+import           Data.HashMap.Strict                   (HashMap)
+import qualified Data.HashMap.Strict                   as HashMap
 import           Data.Maybe
 import           Development.IDE.Core.FileStore
 import           Development.IDE.Core.IdeConfiguration
@@ -26,11 +26,11 @@ import           Development.IDE.Types.Options
 import           Development.Shake
 import           Development.Shake.Classes
 import           GHC.Generics
-import           Language.LSP.Server hiding (getVirtualFile)
+import           Language.LSP.Server                   hiding (getVirtualFile)
 import           Language.LSP.Types
 import           Language.LSP.Types.Capabilities
-import qualified System.Directory as Dir
-import qualified System.FilePath.Glob as Glob
+import qualified System.Directory                      as Dir
+import qualified System.FilePath.Glob                  as Glob
 
 {- Note [File existence cache and LSP file watchers]
 Some LSP servers provide the ability to register file watches with the client, which will then notify
@@ -212,7 +212,7 @@ fileExistsFast vfs file = do
       Just exist -> pure exist
       -- We don't know about it: use the slow route.
       -- Note that we do *not* call 'fileExistsSlow', as that would trigger 'alwaysRerun'.
-      Nothing -> liftIO $ getFileExistsVFS vfs file
+      Nothing    -> liftIO $ getFileExistsVFS vfs file
     pure (summarizeExists exist, ([], Just exist))
 
 summarizeExists :: Bool -> Maybe BS.ByteString

--- a/ghcide/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/ghcide/src/Development/IDE/Core/IdeConfiguration.hs
@@ -14,20 +14,20 @@ where
 
 import           Control.Concurrent.Extra
 import           Control.Monad
-import           Data.Hashable                  (Hashed, hashed, unhashed)
-import           Data.HashSet                   (HashSet, singleton)
-import           Data.Text                      (Text, isPrefixOf)
 import           Data.Aeson.Types               (Value)
+import           Data.HashSet                   (HashSet, singleton)
+import           Data.Hashable                  (Hashed, hashed, unhashed)
+import           Data.Text                      (Text, isPrefixOf)
 import           Development.IDE.Core.Shake
 import           Development.IDE.Types.Location
 import           Development.Shake
 import           Language.LSP.Types
-import           System.FilePath (isRelative)
+import           System.FilePath                (isRelative)
 
 -- | Lsp client relevant configuration details
 data IdeConfiguration = IdeConfiguration
   { workspaceFolders :: HashSet NormalizedUri
-  , clientSettings :: Hashed (Maybe Value)
+  , clientSettings   :: Hashed (Maybe Value)
   }
   deriving (Show)
 

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -1,8 +1,8 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 -- | Utilities and state for the files of interest - those which are currently
 --   open in the editor. The useful function is 'getFilesOfInterest'.
@@ -12,32 +12,32 @@ module Development.IDE.Core.OfInterest(
     kick, FileOfInterestStatus(..)
     ) where
 
-import Control.Concurrent.Extra
-import Data.Binary
-import Data.Hashable
-import Control.DeepSeq
-import GHC.Generics
-import Data.Typeable
-import qualified Data.ByteString.UTF8 as BS
-import Control.Exception
-import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Text as T
-import Data.Tuple.Extra
-import Development.Shake
-import Control.Monad
+import           Control.Concurrent.Extra
+import           Control.DeepSeq
+import           Control.Exception
+import           Control.Monad
+import           Data.Binary
+import qualified Data.ByteString.UTF8                         as BS
+import           Data.HashMap.Strict                          (HashMap)
+import qualified Data.HashMap.Strict                          as HashMap
+import           Data.Hashable
+import qualified Data.Text                                    as T
+import           Data.Tuple.Extra
+import           Data.Typeable
+import           Development.Shake
+import           GHC.Generics
 
-import Development.IDE.Types.Exports
-import Development.IDE.Types.Location
-import Development.IDE.Types.Logger
-import Development.IDE.Core.RuleTypes
-import Development.IDE.Core.Shake
-import Data.Maybe (catMaybes)
-import Data.List.Extra (nubOrd)
-import Development.IDE.Import.DependencyInformation
-import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.Class
-import Development.IDE.Types.Options
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Maybe
+import           Data.List.Extra                              (nubOrd)
+import           Data.Maybe                                   (catMaybes)
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Shake
+import           Development.IDE.Import.DependencyInformation
+import           Development.IDE.Types.Exports
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Logger
+import           Development.IDE.Types.Options
 
 newtype OfInterestVar = OfInterestVar (Var (HashMap NormalizedFilePath FileOfInterestStatus))
 instance IsIdeGlobal OfInterestVar

--- a/ghcide/src/Development/IDE/Core/PositionMapping.hs
+++ b/ghcide/src/Development/IDE/Core/PositionMapping.hs
@@ -22,14 +22,14 @@ module Development.IDE.Core.PositionMapping
   , fromCurrent
   ) where
 
-import Control.Monad
-import qualified Data.Text as T
-import Language.LSP.Types
-import Data.List
-import Data.Algorithm.Diff
-import Data.Bifunctor
-import Control.DeepSeq
+import           Control.DeepSeq
+import           Control.Monad
+import           Data.Algorithm.Diff
+import           Data.Bifunctor
+import           Data.List
+import qualified Data.Text           as T
 import qualified Data.Vector.Unboxed as V
+import           Language.LSP.Types
 
 -- | Either an exact position, or the range of text that was substituted
 data PositionResult a
@@ -40,16 +40,16 @@ data PositionResult a
   deriving (Eq,Ord,Show,Functor)
 
 lowerRange :: PositionResult a -> a
-lowerRange (PositionExact a) = a
+lowerRange (PositionExact a)       = a
 lowerRange (PositionRange lower _) = lower
 
 upperRange :: PositionResult a -> a
-upperRange (PositionExact a) = a
+upperRange (PositionExact a)       = a
 upperRange (PositionRange _ upper) = upper
 
 positionResultToMaybe :: PositionResult a -> Maybe a
 positionResultToMaybe (PositionExact a) = Just a
-positionResultToMaybe _ = Nothing
+positionResultToMaybe _                 = Nothing
 
 instance Applicative PositionResult where
   pure = PositionExact
@@ -66,7 +66,7 @@ instance Monad PositionResult where
 
 -- The position delta is the difference between two versions
 data PositionDelta = PositionDelta
-  { toDelta :: !(Position -> PositionResult Position)
+  { toDelta   :: !(Position -> PositionResult Position)
   , fromDelta :: !(Position -> PositionResult Position)
   }
 

--- a/ghcide/src/Development/IDE/Core/Preprocessor.hs
+++ b/ghcide/src/Development/IDE/Core/Preprocessor.hs
@@ -5,32 +5,34 @@ module Development.IDE.Core.Preprocessor
   ( preprocessor
   ) where
 
-import Development.IDE.GHC.CPP
-import Development.IDE.GHC.Orphans()
-import Development.IDE.GHC.Compat
-import GhcMonad
-import StringBuffer as SB
+import           Development.IDE.GHC.CPP
+import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Orphans       ()
+import           GhcMonad
+import           StringBuffer                      as SB
 
-import Data.List.Extra
-import System.FilePath
-import System.IO.Extra
-import Data.Char
-import qualified HeaderInfo as Hdr
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Location
-import Development.IDE.GHC.Error
-import SysTools (Option (..), runUnlit, runPp)
-import Control.Monad.Trans.Except
-import qualified GHC.LanguageExtensions as LangExt
-import Data.Maybe
-import Control.Exception.Safe (catch, throw)
-import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
-import Data.Text (Text)
-import qualified Data.Text as T
-import Outputable (showSDoc)
-import Control.DeepSeq (NFData(rnf))
-import Control.Exception (evaluate)
-import HscTypes (HscEnv(hsc_dflags))
+import           Control.DeepSeq                   (NFData (rnf))
+import           Control.Exception                 (evaluate)
+import           Control.Exception.Safe            (catch, throw)
+import           Control.Monad.Trans.Except
+import           Data.Char
+import           Data.IORef                        (IORef, modifyIORef,
+                                                    newIORef, readIORef)
+import           Data.List.Extra
+import           Data.Maybe
+import           Data.Text                         (Text)
+import qualified Data.Text                         as T
+import           Development.IDE.GHC.Error
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
+import qualified GHC.LanguageExtensions            as LangExt
+import qualified HeaderInfo                        as Hdr
+import           HscTypes                          (HscEnv (hsc_dflags))
+import           Outputable                        (showSDoc)
+import           SysTools                          (Option (..), runPp,
+                                                    runUnlit)
+import           System.FilePath
+import           System.IO.Extra
 
 
 -- | Given a file and some contents, apply any necessary preprocessors,
@@ -62,7 +64,7 @@ preprocessor env filename mbContents = do
                             ( \(e :: GhcException) -> do
                                 logs <- readIORef cppLogs
                                 case diagsFromCPPLogs filename (reverse logs) of
-                                  [] -> throw e
+                                  []    -> throw e
                                   diags -> return $ Left diags
                             )
             dflags <- ExceptT $ parsePragmasIntoDynFlags env filename contents
@@ -88,9 +90,9 @@ data CPPLog = CPPLog Severity SrcSpan Text
 
 data CPPDiag
   = CPPDiag
-      { cdRange :: Range,
+      { cdRange    :: Range,
         cdSeverity :: Maybe DiagnosticSeverity,
-        cdMessage :: [Text]
+        cdMessage  :: [Text]
       }
   deriving (Show)
 

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -1,12 +1,12 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 -- | A Shake implementation of the compiler service, built
 --   using the "Shaker" abstraction layer for in-memory use.
@@ -16,33 +16,37 @@ module Development.IDE.Core.RuleTypes(
     ) where
 
 import           Control.DeepSeq
-import Control.Lens
-import Data.Aeson.Types (Value)
-import Data.Binary
-import           Development.IDE.Import.DependencyInformation
-import Development.IDE.GHC.Compat hiding (HieFileResult)
-import Development.IDE.GHC.Util
-import Development.IDE.Types.HscEnvEq (HscEnvEq)
-import Development.IDE.Types.KnownTargets
+import           Control.Lens
+import           Data.Aeson.Types                             (Value)
+import           Data.Binary
 import           Data.Hashable
+import qualified Data.Map                                     as M
 import           Data.Typeable
-import qualified Data.Map as M
+import           Development.IDE.GHC.Compat                   hiding
+                                                              (HieFileResult)
+import           Development.IDE.GHC.Util
+import           Development.IDE.Import.DependencyInformation
+import           Development.IDE.Types.HscEnvEq               (HscEnvEq)
+import           Development.IDE.Types.KnownTargets
 import           Development.Shake
-import           GHC.Generics                             (Generic)
+import           GHC.Generics                                 (Generic)
 
-import HscTypes (ModGuts, hm_iface, HomeModInfo, hm_linkable)
+import           HscTypes                                     (HomeModInfo,
+                                                               ModGuts,
+                                                               hm_iface,
+                                                               hm_linkable)
 
+import           Data.ByteString                              (ByteString)
+import qualified Data.ByteString.Char8                        as BS
+import           Data.Int                                     (Int64)
+import           Data.Text                                    (Text)
+import           Development.IDE.Import.FindImports           (ArtifactsLocation)
 import           Development.IDE.Spans.Common
 import           Development.IDE.Spans.LocalBindings
-import           Development.IDE.Import.FindImports (ArtifactsLocation)
-import Data.ByteString (ByteString)
-import Language.LSP.Types (NormalizedFilePath)
-import TcRnMonad (TcGblEnv)
-import qualified Data.ByteString.Char8 as BS
-import Development.IDE.Types.Options (IdeGhcSession)
-import Data.Text (Text)
-import Data.Int (Int64)
-import GHC.Serialized (Serialized)
+import           Development.IDE.Types.Options                (IdeGhcSession)
+import           GHC.Serialized                               (Serialized)
+import           Language.LSP.Types                           (NormalizedFilePath)
+import           TcRnMonad                                    (TcGblEnv)
 
 data LinkableType = ObjectLinkable | BCOLinkable
   deriving (Eq,Ord,Show, Generic)
@@ -101,10 +105,10 @@ newtype ImportMap = ImportMap
 
 data Splices = Splices
     { exprSplices :: [(LHsExpr GhcTc, LHsExpr GhcPs)]
-    , patSplices :: [(LHsExpr GhcTc, LPat GhcPs)]
+    , patSplices  :: [(LHsExpr GhcTc, LPat GhcPs)]
     , typeSplices :: [(LHsExpr GhcTc, LHsType GhcPs)]
     , declSplices :: [(LHsExpr GhcTc, [LHsDecl GhcPs])]
-    , awSplices :: [(LHsExpr GhcTc, Serialized)]
+    , awSplices   :: [(LHsExpr GhcTc, Serialized)]
     }
 
 instance Semigroup Splices where
@@ -128,12 +132,12 @@ instance NFData Splices where
 -- | Contains the typechecked module and the OrigNameCache entry for
 -- that module.
 data TcModuleResult = TcModuleResult
-    { tmrParsed :: ParsedModule
-    , tmrRenamed :: RenamedSource
-    , tmrTypechecked :: TcGblEnv
+    { tmrParsed          :: ParsedModule
+    , tmrRenamed         :: RenamedSource
+    , tmrTypechecked     :: TcGblEnv
     , tmrTopLevelSplices :: Splices
     -- ^ Typechecked splice information
-    , tmrDeferedError :: !Bool
+    , tmrDeferedError    :: !Bool
     -- ^ Did we defer any type errors for this module?
     }
 instance Show TcModuleResult where
@@ -149,7 +153,7 @@ data HiFileResult = HiFileResult
     { hirModSummary :: !ModSummary
     -- Bang patterns here are important to stop the result retaining
     -- a reference to a typechecked module
-    , hirHomeMod :: !HomeModInfo
+    , hirHomeMod    :: !HomeModInfo
     -- ^ Includes the Linkable iff we need object files
     }
 
@@ -159,7 +163,7 @@ hiFileFingerPrint hfr = ifaceBS <> linkableBS
     ifaceBS = fingerprintToBS . getModuleHash . hirModIface $ hfr -- will always be two bytes
     linkableBS = case hm_linkable $ hirHomeMod hfr of
       Nothing -> ""
-      Just l -> BS.pack $ show $ linkableTime l
+      Just l  -> BS.pack $ show $ linkableTime l
 
 hirModIface :: HiFileResult -> ModIface
 hirModIface = hm_iface . hirHomeMod
@@ -174,14 +178,14 @@ instance Show HiFileResult where
 data HieAstResult
   = forall a. HAR
   { hieModule :: Module
-  , hieAst :: !(HieASTs a)
-  , refMap :: RefMap a
+  , hieAst    :: !(HieASTs a)
+  , refMap    :: RefMap a
   -- ^ Lazy because its value only depends on the hieAst, which is bundled in this type
   -- Lazyness can't cause leaks here because the lifetime of `refMap` will be the same
   -- as that of `hieAst`
-  , typeRefs :: M.Map Name [RealSrcSpan]
+  , typeRefs  :: M.Map Name [RealSrcSpan]
   -- ^ type references in this file
-  , hieKind :: !(HieKind a)
+  , hieKind   :: !(HieKind a)
   -- ^ Is this hie file loaded from the disk, or freshly computed?
   }
 
@@ -191,7 +195,7 @@ data HieKind a where
 
 instance NFData (HieKind a) where
     rnf (HieFromDisk hf) = rnf hf
-    rnf HieFresh = ()
+    rnf HieFresh         = ()
 
 instance NFData HieAstResult where
     rnf (HAR m hf _rm _tr kind) = rnf m `seq` rwhnf hf `seq` rnf kind
@@ -285,7 +289,7 @@ data FileVersion
 instance NFData FileVersion
 
 vfsVersion :: FileVersion -> Maybe Int
-vfsVersion (VFSVersion i) = Just i
+vfsVersion (VFSVersion i)     = Just i
 vfsVersion ModificationTime{} = Nothing
 
 data GetFileContents = GetFileContents

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -13,35 +13,40 @@ import           Control.Concurrent.Async       (Async, async)
 import           Control.Concurrent.Extra       (Var, modifyVar_, newVar,
                                                  readVar, threadDelay)
 import           Control.Exception              (evaluate)
-import           Control.Exception.Safe         (catch, SomeException)
-import           Control.Monad                  (void, when, unless, forM_, forever, (>=>))
+import           Control.Exception.Safe         (SomeException, catch)
+import           Control.Monad                  (forM_, forever, unless, void,
+                                                 when, (>=>))
 import           Control.Monad.Extra            (whenJust)
+import           Control.Monad.IO.Unlift
 import           Control.Seq                    (r0, seqList, seqTuple2, using)
+import           Data.ByteString                (ByteString)
 import           Data.Dynamic                   (Dynamic)
 import qualified Data.HashMap.Strict            as HMap
 import           Data.IORef                     (modifyIORef', newIORef,
                                                  readIORef, writeIORef)
 import           Data.String                    (IsString (fromString))
+import           Data.Text.Encoding             (encodeUtf8)
 import           Development.IDE.Core.RuleTypes (GhcSession (GhcSession),
                                                  GhcSessionDeps (GhcSessionDeps),
                                                  GhcSessionIO (GhcSessionIO))
-import           Development.IDE.Types.Logger   (logInfo, Logger, logDebug)
-import           Development.IDE.Types.Shake    (ValueWithDiagnostics(..), Key (..), Value, Values)
+import           Development.IDE.Types.Location (Uri (..))
+import           Development.IDE.Types.Logger   (Logger, logDebug, logInfo)
+import           Development.IDE.Types.Shake    (Key (..), Value,
+                                                 ValueWithDiagnostics (..),
+                                                 Values)
 import           Development.Shake              (Action, actionBracket)
-import           Ide.PluginUtils                (installSigUsr1Handler)
 import           Foreign.Storable               (Storable (sizeOf))
 import           HeapSize                       (recursiveSize, runHeapsize)
+import           Ide.PluginUtils                (installSigUsr1Handler)
+import           Ide.Types                      (PluginId (..))
 import           Language.LSP.Types             (NormalizedFilePath,
                                                  fromNormalizedFilePath)
 import           Numeric.Natural                (Natural)
-import           OpenTelemetry.Eventlog         (SpanInFlight, Synchronicity(Asynchronous), Instrument, addEvent, beginSpan, endSpan,
+import           OpenTelemetry.Eventlog         (Instrument, SpanInFlight,
+                                                 Synchronicity (Asynchronous),
+                                                 addEvent, beginSpan, endSpan,
                                                  mkValueObserver, observe,
                                                  setTag, withSpan, withSpan_)
-import Data.ByteString (ByteString)
-import Data.Text.Encoding (encodeUtf8)
-import Ide.Types (PluginId (..))
-import Development.IDE.Types.Location (Uri (..))
-import Control.Monad.IO.Unlift
 
 -- | Trace a handler using OpenTelemetry. Adds various useful info into tags in the OpenTelemetry span.
 otTracedHandler

--- a/ghcide/src/Development/IDE/GHC/CPP.hs
+++ b/ghcide/src/Development/IDE/GHC/CPP.hs
@@ -7,7 +7,10 @@
 
 {- HLINT ignore -} -- since copied from upstream
 
-{-# LANGUAGE CPP, NamedFieldPuns, NondecreasingIndentation, BangPatterns, MultiWayIf #-}
+{-# LANGUAGE CPP                      #-}
+{-# LANGUAGE MultiWayIf               #-}
+{-# LANGUAGE NamedFieldPuns           #-}
+{-# LANGUAGE NondecreasingIndentation #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 #include "ghc-api-version.h"
 
@@ -22,29 +25,29 @@
 module Development.IDE.GHC.CPP(doCpp, addOptP)
 where
 
-import Development.IDE.GHC.Compat
-import Packages
-import SysTools
-import Module
-import Panic
-import FileCleanup
+import           Development.IDE.GHC.Compat
+import           FileCleanup
+import           Module
+import           Packages
+import           Panic
+import           SysTools
 #if MIN_GHC_API_VERSION(8,8,2)
-import LlvmCodeGen (llvmVersionList)
+import           LlvmCodeGen                (llvmVersionList)
 #elif MIN_GHC_API_VERSION(8,8,0)
-import LlvmCodeGen (LlvmVersion (..))
+import           LlvmCodeGen                (LlvmVersion (..))
 #endif
 #if MIN_GHC_API_VERSION (8,10,0)
-import Fingerprint
-import ToolSettings
+import           Fingerprint
+import           ToolSettings
 #endif
 
-import System.Directory
-import System.FilePath
-import Control.Monad
-import System.Info
-import Data.List        ( intercalate )
-import Data.Maybe
-import Data.Version
+import           Control.Monad
+import           Data.List                  (intercalate)
+import           Data.Maybe
+import           Data.Version
+import           System.Directory
+import           System.FilePath
+import           System.Info
 
 
 

--- a/ghcide/src/Development/IDE/GHC/Error.hs
+++ b/ghcide/src/Development/IDE/GHC/Error.hs
@@ -29,20 +29,20 @@ module Development.IDE.GHC.Error
   , toDSeverity
   ) where
 
-import                     Development.IDE.Types.Diagnostics as D
-import qualified           Data.Text as T
-import Data.Maybe
-import Development.IDE.Types.Location
-import Development.IDE.GHC.Orphans()
-import qualified FastString as FS
-import           GHC
 import           Bag
-import HscTypes
-import Panic
+import           Data.Maybe
+import           Data.String                       (fromString)
+import qualified Data.Text                         as T
+import           Development.IDE.GHC.Orphans       ()
+import           Development.IDE.Types.Diagnostics as D
+import           Development.IDE.Types.Location
 import           ErrUtils
+import qualified FastString                        as FS
+import           GHC
+import           HscTypes
+import qualified Outputable                        as Out
+import           Panic
 import           SrcLoc
-import qualified Outputable                 as Out
-import Data.String (fromString)
 
 
 
@@ -92,7 +92,7 @@ realSrcLocToPosition real =
 -- | Extract a file name from a GHC SrcSpan (use message for unhelpful ones)
 -- FIXME This may not be an _absolute_ file name, needs fixing.
 srcSpanToFilename :: SrcSpan -> Maybe FilePath
-srcSpanToFilename (UnhelpfulSpan _) = Nothing
+srcSpanToFilename (UnhelpfulSpan _)  = Nothing
 srcSpanToFilename (RealSrcSpan real) = Just $ FS.unpackFS $ srcSpanFile real
 
 realSrcSpanToLocation :: RealSrcSpan -> Location
@@ -123,7 +123,7 @@ positionToRealSrcLoc nfp (Position l c)=
 isInsideSrcSpan :: Position -> SrcSpan -> Bool
 p `isInsideSrcSpan` r = case srcSpanToRange r of
   Just (Range sp ep) -> sp <= p && p <= ep
-  _ -> False
+  _                  -> False
 
 -- | Convert a GHC severity to a DAML compiler Severity. Severities below
 -- "Warning" level are dropped (returning Nothing).
@@ -160,7 +160,7 @@ zeroSpan file = realSrcLocSpan (mkRealSrcLoc file 1 1)
 realSpan :: SrcSpan
          -> Maybe RealSrcSpan
 realSpan = \case
-  RealSrcSpan r -> Just r
+  RealSrcSpan r   -> Just r
   UnhelpfulSpan _ -> Nothing
 
 

--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -12,16 +12,16 @@ module Development.IDE.GHC.Orphans() where
 
 import           Bag
 import           Control.DeepSeq
-import Data.Aeson
+import           Data.Aeson
 import           Data.Hashable
+import           Data.String                (IsString (fromString))
+import           Data.Text                  (Text)
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Util
 import           GHC                        ()
 import           GhcPlugins
+import           Retrie.ExactPrint          (Annotated)
 import qualified StringBuffer               as SB
-import Data.Text (Text)
-import Data.String (IsString(fromString))
-import Retrie.ExactPrint (Annotated)
 
 
 -- Orphan instances for types from the GHC API.

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP #-}
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -28,46 +28,53 @@ module Development.IDE.GHC.Util(
     disableWarningsAsErrors,
     ) where
 
-import Control.Concurrent
-import Data.List.Extra
-import Data.ByteString.Internal (ByteString(..))
-import Data.Maybe
-import Data.Typeable
-import qualified Data.ByteString.Internal as BS
-import Fingerprint
-import GhcMonad
-import DynFlags
-import Control.Exception
-import Data.IORef
-import FileCleanup
-import Foreign.Ptr
-import Foreign.ForeignPtr
-import Foreign.Storable
-import GHC.IO.BufferedIO (BufferedIO)
-import GHC.IO.Device as IODevice
-import GHC.IO.Encoding
-import GHC.IO.Exception
-import GHC.IO.Handle.Types
-import GHC.IO.Handle.Internals
-import qualified Data.Text                as T
-import qualified Data.Text.Encoding       as T
-import qualified Data.Text.Encoding.Error as T
-import qualified Data.ByteString          as BS
-import Lexer
-import StringBuffer
-import System.FilePath
-import HscTypes (cg_binds, md_types, cg_module, ModDetails, CgGuts, ic_dflags, hsc_IC, HscEnv(hsc_dflags))
-import PackageConfig (PackageConfig)
-import Outputable (SDoc, showSDocUnsafe, ppr, Outputable, mkUserStyle, renderWithStyle, neverQualify, Depth(..))
-import Packages (getPackageConfigMap, lookupPackage')
-import SrcLoc (mkRealSrcLoc)
-import FastString (mkFastString)
-import Module (moduleNameSlashes)
-import OccName (parenSymOcc)
-import RdrName (nameRdrName, rdrNameOcc)
+import           Control.Concurrent
+import           Control.Exception
+import qualified Data.ByteString                as BS
+import           Data.ByteString.Internal       (ByteString (..))
+import qualified Data.ByteString.Internal       as BS
+import           Data.IORef
+import           Data.List.Extra
+import           Data.Maybe
+import qualified Data.Text                      as T
+import qualified Data.Text.Encoding             as T
+import qualified Data.Text.Encoding.Error       as T
+import           Data.Typeable
+import           DynFlags
+import           FastString                     (mkFastString)
+import           FileCleanup
+import           Fingerprint
+import           Foreign.ForeignPtr
+import           Foreign.Ptr
+import           Foreign.Storable
+import           GHC.IO.BufferedIO              (BufferedIO)
+import           GHC.IO.Device                  as IODevice
+import           GHC.IO.Encoding
+import           GHC.IO.Exception
+import           GHC.IO.Handle.Internals
+import           GHC.IO.Handle.Types
+import           GhcMonad
+import           HscTypes                       (CgGuts, HscEnv (hsc_dflags),
+                                                 ModDetails, cg_binds,
+                                                 cg_module, hsc_IC, ic_dflags,
+                                                 md_types)
+import           Lexer
+import           Module                         (moduleNameSlashes)
+import           OccName                        (parenSymOcc)
+import           Outputable                     (Depth (..), Outputable, SDoc,
+                                                 mkUserStyle, neverQualify, ppr,
+                                                 renderWithStyle,
+                                                 showSDocUnsafe)
+import           PackageConfig                  (PackageConfig)
+import           Packages                       (getPackageConfigMap,
+                                                 lookupPackage')
+import           RdrName                        (nameRdrName, rdrNameOcc)
+import           SrcLoc                         (mkRealSrcLoc)
+import           StringBuffer
+import           System.FilePath
 
-import Development.IDE.GHC.Compat as GHC
-import Development.IDE.Types.Location
+import           Development.IDE.GHC.Compat     as GHC
+import           Development.IDE.Types.Location
 
 
 ----------------------------------------------------------------------

--- a/ghcide/src/Development/IDE/GHC/Warnings.hs
+++ b/ghcide/src/Development/IDE/GHC/Warnings.hs
@@ -4,16 +4,16 @@
 
 module Development.IDE.GHC.Warnings(withWarnings) where
 
-import Data.List
-import ErrUtils
-import GhcPlugins as GHC hiding (Var, (<>))
+import           Data.List
+import           ErrUtils
+import           GhcPlugins                        as GHC hiding (Var, (<>))
 
 import           Control.Concurrent.Extra
-import qualified           Data.Text as T
+import qualified Data.Text                         as T
 
-import           Development.IDE.Types.Diagnostics
 import           Development.IDE.GHC.Error
-import           Language.LSP.Types (type (|?)(..))
+import           Development.IDE.Types.Diagnostics
+import           Language.LSP.Types                (type (|?) (..))
 
 
 -- | Take a GHC monadic action (e.g. @typecheckModule pm@ for some
@@ -40,8 +40,8 @@ attachReason :: WarnReason -> Diagnostic -> Diagnostic
 attachReason wr d = d{_code = InR <$> showReason wr}
  where
   showReason = \case
-    NoReason -> Nothing
-    Reason flag -> showFlag flag
+    NoReason       -> Nothing
+    Reason flag    -> showFlag flag
     ErrReason flag -> showFlag =<< flag
 
 showFlag :: WarningFlag -> Maybe T.Text

--- a/ghcide/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/ghcide/src/Development/IDE/LSP/HoverDefinition.hs
@@ -1,7 +1,7 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GADTs      #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- | Display information on hover.
 module Development.IDE.LSP.HoverDefinition
@@ -12,16 +12,16 @@ module Development.IDE.LSP.HoverDefinition
     , gotoTypeDefinition
     ) where
 
-import Control.Monad.IO.Class
+import           Control.Monad.IO.Class
 import           Development.IDE.Core.Rules
 import           Development.IDE.Core.Shake
 import           Development.IDE.LSP.Server
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger
-import qualified Language.LSP.Server as LSP
+import qualified Language.LSP.Server            as LSP
 import           Language.LSP.Types
 
-import qualified Data.Text as T
+import qualified Data.Text                      as T
 
 gotoDefinition :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (ResponseResult TextDocumentDefinition))
 hover          :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (Maybe Hover))

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -2,39 +2,42 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE RankNTypes            #-}
 
 module Development.IDE.LSP.Notifications
     ( setHandlersNotifications
     ) where
 
-import qualified Language.LSP.Server      as LSP
+import qualified Language.LSP.Server                   as LSP
 import           Language.LSP.Types
-import qualified Language.LSP.Types       as LSP
-import qualified Language.LSP.Types.Capabilities as LSP
+import qualified Language.LSP.Types                    as LSP
+import qualified Language.LSP.Types.Capabilities       as LSP
 
 import           Development.IDE.Core.IdeConfiguration
 import           Development.IDE.Core.Service
-import           Development.IDE.LSP.Server
 import           Development.IDE.Core.Shake
+import           Development.IDE.LSP.Server
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger
 import           Development.IDE.Types.Options
 
 import           Control.Monad.Extra
-import           Data.Foldable                    as F
+import           Data.Foldable                         as F
+import qualified Data.HashMap.Strict                   as M
+import qualified Data.HashSet                          as S
 import           Data.Maybe
-import qualified Data.HashMap.Strict              as M
-import qualified Data.HashSet                     as S
-import qualified Data.Text                        as Text
+import qualified Data.Text                             as Text
 
-import           Development.IDE.Core.FileStore   (setSomethingModified, setFileModified, typecheckParents)
-import           Development.IDE.Core.FileExists  (modifyFileExists, watchedGlobs)
+import           Control.Monad.IO.Class
+import           Development.IDE.Core.FileExists       (modifyFileExists,
+                                                        watchedGlobs)
+import           Development.IDE.Core.FileStore        (setFileModified,
+                                                        setSomethingModified,
+                                                        typecheckParents)
 import           Development.IDE.Core.OfInterest
-import Ide.Plugin.Config (CheckParents(CheckOnClose))
-import Control.Monad.IO.Class
+import           Ide.Plugin.Config                     (CheckParents (CheckOnClose))
 
 
 whenUriFile :: Uri -> (NormalizedFilePath -> IO ()) -> IO ()

--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                   #-}
 
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE RankNTypes            #-}
 #include "ghc-api-version.h"
 
 module Development.IDE.LSP.Outline
@@ -10,25 +10,21 @@ module Development.IDE.LSP.Outline
   )
 where
 
-import           Language.LSP.Types
-import           Language.LSP.Server (LspM)
 import           Control.Monad.IO.Class
 import           Data.Functor
 import           Data.Generics
 import           Data.Maybe
-import           Data.Text                      ( Text
-                                                , pack
-                                                )
-import qualified Data.Text                     as T
+import           Data.Text                      (Text, pack)
+import qualified Data.Text                      as T
 import           Development.IDE.Core.Rules
 import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Compat
-import           Development.IDE.GHC.Error      ( realSrcSpanToRange )
+import           Development.IDE.GHC.Error      (realSrcSpanToRange)
 import           Development.IDE.Types.Location
-import           Outputable                     ( Outputable
-                                                , ppr
-                                                , showSDocUnsafe
-                                                )
+import           Language.LSP.Server            (LspM)
+import           Language.LSP.Types
+import           Outputable                     (Outputable, ppr,
+                                                 showSDocUnsafe)
 
 moduleOutline
   :: IdeState -> DocumentSymbolParams -> LspM c (Either ResponseError (List DocumentSymbol |? List SymbolInformation))

--- a/ghcide/src/Development/IDE/LSP/Server.hs
+++ b/ghcide/src/Development/IDE/LSP/Server.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE UndecidableInstances  #-}
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE RankNTypes            #-}
 module Development.IDE.LSP.Server
   ( ReactorMessage(..)
   , ReactorChan
@@ -15,14 +15,14 @@ module Development.IDE.LSP.Server
   , notificationHandler
   ) where
 
-import Language.LSP.Server (LspM, Handlers)
-import Language.LSP.Types
-import qualified Language.LSP.Server as LSP
-import Development.IDE.Core.Shake
-import UnliftIO.Chan
-import Control.Monad.Reader
-import Ide.Types (HasTracing, traceWithSpan)
-import Development.IDE.Core.Tracing
+import           Control.Monad.Reader
+import           Development.IDE.Core.Shake
+import           Development.IDE.Core.Tracing
+import           Ide.Types                    (HasTracing, traceWithSpan)
+import           Language.LSP.Server          (Handlers, LspM)
+import qualified Language.LSP.Server          as LSP
+import           Language.LSP.Types
+import           UnliftIO.Chan
 
 data ReactorMessage
   = ReactorNotification (IO ())

--- a/ghcide/src/Development/IDE/Plugin.hs
+++ b/ghcide/src/Development/IDE/Plugin.hs
@@ -1,13 +1,13 @@
 module Development.IDE.Plugin ( Plugin(..) ) where
 
-import Data.Default
-import Development.Shake
+import           Data.Default
+import           Development.Shake
 
-import Development.IDE.LSP.Server
-import qualified Language.LSP.Server as LSP
+import           Development.IDE.LSP.Server
+import qualified Language.LSP.Server        as LSP
 
 data Plugin c = Plugin
-    {pluginRules :: Rules ()
+    {pluginRules    :: Rules ()
     ,pluginHandlers :: LSP.Handlers (ServerM c)
     }
 

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RankNTypes         #-}
 
 module Development.IDE.Plugin.CodeAction.ExactPrint
   ( Rewrite (..),
@@ -18,31 +18,37 @@ module Development.IDE.Plugin.CodeAction.ExactPrint
   )
 where
 
-import Control.Applicative
-import Control.Monad
-import Control.Monad.Trans
-import Data.Char (isAlphaNum)
-import Data.Data (Data)
-import Data.Functor
-import qualified Data.Map.Strict as Map
-import Data.Maybe (fromJust, isNothing, mapMaybe)
-import qualified Data.Text as T
-import Development.IDE.GHC.Compat hiding (parseExpr)
-import Development.IDE.GHC.ExactPrint
-    ( Annotate, ASTElement(parseAST) )
-import FieldLabel (flLabel)
-import GhcPlugins (sigPrec, mkRealSrcLoc)
-import Language.Haskell.GHC.ExactPrint
-import Language.Haskell.GHC.ExactPrint.Types (DeltaPos (DP), KeywordId (G), mkAnnKey)
-import Language.LSP.Types
-import OccName
-import Outputable (ppr, showSDocUnsafe, showSDoc)
-import Retrie.GHC (rdrNameOcc, unpackFS, mkRealSrcSpan, realSrcSpanEnd)
-import Development.IDE.Spans.Common
-import Development.IDE.GHC.Error
-import Data.Generics (listify)
-import GHC.Exts (IsList (fromList))
-import Control.Monad.Extra (whenJust)
+import           Control.Applicative
+import           Control.Monad
+import           Control.Monad.Extra                   (whenJust)
+import           Control.Monad.Trans
+import           Data.Char                             (isAlphaNum)
+import           Data.Data                             (Data)
+import           Data.Functor
+import           Data.Generics                         (listify)
+import qualified Data.Map.Strict                       as Map
+import           Data.Maybe                            (fromJust, isNothing,
+                                                        mapMaybe)
+import qualified Data.Text                             as T
+import           Development.IDE.GHC.Compat            hiding (parseExpr)
+import           Development.IDE.GHC.Error
+import           Development.IDE.GHC.ExactPrint        (ASTElement (parseAST),
+                                                        Annotate)
+import           Development.IDE.Spans.Common
+import           FieldLabel                            (flLabel)
+import           GHC.Exts                              (IsList (fromList))
+import           GhcPlugins                            (mkRealSrcLoc, sigPrec)
+import           Language.Haskell.GHC.ExactPrint
+import           Language.Haskell.GHC.ExactPrint.Types (DeltaPos (DP),
+                                                        KeywordId (G), mkAnnKey)
+import           Language.LSP.Types
+import           OccName
+import           Outputable                            (ppr, showSDoc,
+                                                        showSDocUnsafe)
+import           Retrie.GHC                            (mkRealSrcSpan,
+                                                        rdrNameOcc,
+                                                        realSrcSpanEnd,
+                                                        unpackFS)
 
 ------------------------------------------------------------------------------
 
@@ -115,7 +121,7 @@ fixParens openDP closeDP ctxt@(L _ elems) = do
 
     dropHsParTy :: LHsType pass -> LHsType pass
     dropHsParTy (L _ (HsParTy _ ty)) = ty
-    dropHsParTy other = other
+    dropHsParTy other                = other
 
 -- | Append a constraint at the end of a type context.
 --   If no context is present, a new one will be created.
@@ -161,7 +167,7 @@ appendConstraint constraintT = go
 liftParseAST :: ASTElement ast => DynFlags -> String -> TransformT (Either String) (Located ast)
 liftParseAST df s = case parseAST df "" s of
   Right (anns, x) -> modifyAnnsT (anns <>) $> x
-  Left _ -> lift $ Left $ "No parse: " <> s
+  Left _          -> lift $ Left $ "No parse: " <> s
 
 lookupAnn :: (Data a, Monad m) => KeywordId -> Located a -> TransformT m (Maybe DeltaPos)
 lookupAnn comment la = do
@@ -172,16 +178,16 @@ dp00 :: DeltaPos
 dp00 = DP (0, 0)
 
 headMaybe :: [a] -> Maybe a
-headMaybe [] = Nothing
+headMaybe []      = Nothing
 headMaybe (a : _) = Just a
 
 lastMaybe :: [a] -> Maybe a
-lastMaybe [] = Nothing
+lastMaybe []    = Nothing
 lastMaybe other = Just $ last other
 
 liftMaybe :: String -> Maybe a -> TransformT (Either String) a
 liftMaybe _ (Just x) = return x
-liftMaybe s _ = lift $ Left s
+liftMaybe s _        = lift $ Left s
 
 -- | Copy anns attached to a into b with modification, then delete anns of a
 transferAnn :: (Data a, Data b) => Located a -> Located b -> (Annotation -> Annotation) -> TransformT (Either String) ()
@@ -198,7 +204,7 @@ extendImport mparent identifier lDecl@(L l _) =
   Rewrite l $ \df -> do
     case mparent of
       Just parent -> extendImportViaParent df parent identifier lDecl
-      _ -> extendImportTopLevel df identifier lDecl
+      _           -> extendImportTopLevel df identifier lDecl
 
 -- | Add an identifier to import list
 --
@@ -311,7 +317,7 @@ unIEWrappedName (occName -> occ) = showSDocUnsafe $ parenSymOcc occ (ppr occ)
 
 hasParen :: String -> Bool
 hasParen ('(' : _) = True
-hasParen _ = False
+hasParen _         = False
 
 unqalDP :: Bool -> [(KeywordId, DeltaPos)]
 unqalDP paren =

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/PositionIndexed.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/PositionIndexed.hs
@@ -126,7 +126,7 @@ extendToIncludePreviousNewlineIfPossible indexedString range
   | Just (before, _, _) <- unconsRange range indexedString
   , maybeFirstSpacePos <- lastSpacePos $ reverse before
   = case maybeFirstSpacePos of
-      Nothing -> range
+      Nothing  -> range
       Just pos -> range { _start = pos }
   | otherwise = range
   where
@@ -137,4 +137,4 @@ extendToIncludePreviousNewlineIfPossible indexedString range
       then Nothing -- didn't find any space
       else case xs of
               (y:ys) | isSpace $ snd y -> lastSpacePos (y:ys)
-              _ -> Just pos
+              _                        -> Just pos

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/RuleTypes.hs
@@ -4,14 +4,14 @@ module Development.IDE.Plugin.CodeAction.RuleTypes
     ,IdentInfo(..)
     ) where
 
-import Data.Hashable (Hashable)
-import Control.DeepSeq (NFData)
-import Data.Binary (Binary)
-import Development.IDE.Types.HscEnvEq (HscEnvEq)
-import Development.IDE.Types.Exports
-import Development.Shake (RuleResult)
-import Data.Typeable (Typeable)
-import GHC.Generics (Generic)
+import           Control.DeepSeq                (NFData)
+import           Data.Binary                    (Binary)
+import           Data.Hashable                  (Hashable)
+import           Data.Typeable                  (Typeable)
+import           Development.IDE.Types.Exports
+import           Development.IDE.Types.HscEnvEq (HscEnvEq)
+import           Development.Shake              (RuleResult)
+import           GHC.Generics                   (Generic)
 
 -- Rule type for caching Package Exports
 type instance RuleResult PackageExports = ExportsMap

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE GADTs      #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE GADTs#-}
 
 #include "ghc-api-version.h"
 
@@ -13,52 +13,55 @@ module Development.IDE.Plugin.Completions.Logic (
 , getCompletions
 ) where
 
-import Control.Applicative
-import Data.Char (isUpper)
-import Data.Generics
-import Data.List.Extra as List hiding (stripPrefix)
-import qualified Data.Map  as Map
+import           Control.Applicative
+import           Data.Char                                (isUpper)
+import           Data.Generics
+import           Data.List.Extra                          as List hiding
+                                                                  (stripPrefix)
+import qualified Data.Map                                 as Map
 
-import Data.Maybe (fromMaybe, isJust, listToMaybe, mapMaybe)
-import qualified Data.Text as T
-import qualified Text.Fuzzy as Fuzzy
+import           Data.Maybe                               (fromMaybe, isJust,
+                                                           listToMaybe,
+                                                           mapMaybe)
+import qualified Data.Text                                as T
+import qualified Text.Fuzzy                               as Fuzzy
 
-import HscTypes
-import Name
-import RdrName
-import Type
+import           HscTypes
+import           Name
+import           RdrName
+import           Type
 #if MIN_GHC_API_VERSION(8,10,0)
-import Predicate (isDictTy)
-import Pair
-import Coercion
+import           Coercion
+import           Pair
+import           Predicate                                (isDictTy)
 #endif
 
-import Language.LSP.Types
-import Language.LSP.Types.Capabilities
-import qualified Language.LSP.VFS as VFS
-import Development.IDE.Core.Compile
-import Development.IDE.Core.PositionMapping
-import Development.IDE.Plugin.Completions.Types
-import Development.IDE.Spans.Documentation
-import Development.IDE.Spans.LocalBindings
-import Development.IDE.GHC.Compat as GHC
-import Development.IDE.GHC.Error
-import Development.IDE.Types.Options
-import Development.IDE.Spans.Common
-import Development.IDE.GHC.Util
-import Outputable (Outputable)
-import qualified Data.Set as Set
-import ConLike
-import GhcPlugins (
-    flLabel,
-    unpackFS)
-import Data.Either (fromRight)
-import Data.Aeson (ToJSON (toJSON))
-import Data.Functor
-import Ide.PluginUtils (mkLspCommand)
-import Ide.Types (CommandId (..), PluginId, WithSnippets (..))
-import Control.Monad
-import Development.IDE.Types.HscEnvEq
+import           ConLike
+import           Control.Monad
+import           Data.Aeson                               (ToJSON (toJSON))
+import           Data.Either                              (fromRight)
+import           Data.Functor
+import qualified Data.Set                                 as Set
+import           Development.IDE.Core.Compile
+import           Development.IDE.Core.PositionMapping
+import           Development.IDE.GHC.Compat               as GHC
+import           Development.IDE.GHC.Error
+import           Development.IDE.GHC.Util
+import           Development.IDE.Plugin.Completions.Types
+import           Development.IDE.Spans.Common
+import           Development.IDE.Spans.Documentation
+import           Development.IDE.Spans.LocalBindings
+import           Development.IDE.Types.HscEnvEq
+import           Development.IDE.Types.Options
+import           GhcPlugins                               (flLabel, unpackFS)
+import           Ide.PluginUtils                          (mkLspCommand)
+import           Ide.Types                                (CommandId (..),
+                                                           PluginId,
+                                                           WithSnippets (..))
+import           Language.LSP.Types
+import           Language.LSP.Types.Capabilities
+import qualified Language.LSP.VFS                         as VFS
+import           Outputable                               (Outputable)
 
 -- From haskell-ide-engine/hie-plugin-api/Haskell/Ide/Engine/Context.hs
 
@@ -195,7 +198,7 @@ mkCompl
   where kind = Just compKind
         docs' = imported : spanDocToMarkdown docs
         imported = case importedFrom of
-          Left pos -> "*Defined at '" <> ppr pos <> "'*\n'"
+          Left pos  -> "*Defined at '" <> ppr pos <> "'*\n'"
           Right mod -> "*Defined in '" <> mod <> "'*\n"
         colon = if optNewColonConvention then ": " else ":: "
         documentation = Just $ CompletionDocMarkup $
@@ -215,7 +218,7 @@ mkNameCompItem doc thingParent origName origMod thingType isInfix docs !imp = CI
     label = stripPrefix $ showGhc origName
     insertText = case isInfix of
             Nothing -> case getArgText <$> thingType of
-                            Nothing -> label
+                            Nothing      -> label
                             Just argText -> label <> " " <> argText
             Just LeftSide -> label <> "`"
 
@@ -447,9 +450,9 @@ findRecordCompl uri pmod mn DataDecl {tcdLName, tcdDataDefn} = result
 
         getFlds :: HsConDetails arg (Located [LConDeclField GhcPs]) -> Maybe [ConDeclField GhcPs]
         getFlds conArg = case conArg of
-                             RecCon rec -> Just $ unLoc <$> unLoc rec
+                             RecCon rec  -> Just $ unLoc <$> unLoc rec
                              PrefixCon _ -> Just []
-                             _ -> Nothing
+                             _           -> Nothing
 
         extract ConDeclField{..}
              -- TODO: Why is cd_fld_names a list?
@@ -522,10 +525,10 @@ getCompletions plId ideOpts CC {allModNamesAsNS, unqualCompls, qualCompls, impor
 
           -- completions specific to the current context
           ctxCompls' = case mcc of
-                        Nothing -> compls
-                        Just TypeContext -> filter isTypeCompl compls
+                        Nothing           -> compls
+                        Just TypeContext  -> filter isTypeCompl compls
                         Just ValueContext -> filter (not . isTypeCompl) compls
-                        Just _ -> filter (not . isTypeCompl) compls
+                        Just _            -> filter (not . isTypeCompl) compls
           -- Add whether the text to insert has backticks
           ctxCompls = map (\comp -> comp { isInfix = infixCompls }) ctxCompls'
 
@@ -546,7 +549,7 @@ getCompletions plId ideOpts CC {allModNamesAsNS, unqualCompls, qualCompls, impor
               ty = ppr <$> typ
               thisModName = case nameModule_maybe name of
                 Nothing -> Left $ nameSrcSpan name
-                Just m -> Right $ ppr m
+                Just m  -> Right $ ppr m
 
           compls = if T.null prefixModule
             then localCompls ++ unqualCompls

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 module Development.IDE.Plugin.Completions.Types (
   module Development.IDE.Plugin.Completions.Types
 ) where
 
 import           Control.DeepSeq
-import qualified Data.Map  as Map
-import qualified Data.Text as T
-import SrcLoc
+import qualified Data.Map                     as Map
+import qualified Data.Text                    as T
+import           SrcLoc
 
-import Development.IDE.Spans.Common
-import Data.Aeson (FromJSON, ToJSON)
-import Data.Text (Text)
-import GHC.Generics (Generic)
-import Language.LSP.Types (CompletionItemKind, Uri)
+import           Data.Aeson                   (FromJSON, ToJSON)
+import           Data.Text                    (Text)
+import           Development.IDE.Spans.Common
+import           GHC.Generics                 (Generic)
+import           Language.LSP.Types           (CompletionItemKind, Uri)
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/LSP/Completions.hs
 
@@ -24,25 +24,25 @@ extendImportCommandId :: Text
 extendImportCommandId = "extendImport"
 
 data ExtendImport = ExtendImport
-  { doc :: !Uri,
-    newThing :: !T.Text,
+  { doc         :: !Uri,
+    newThing    :: !T.Text,
     thingParent :: !(Maybe T.Text),
-    importName :: !T.Text,
-    importQual :: !(Maybe T.Text)
+    importName  :: !T.Text,
+    importQual  :: !(Maybe T.Text)
   }
   deriving (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 data CompItem = CI
-  { compKind     :: CompletionItemKind
-  , insertText   :: T.Text         -- ^ Snippet for the completion
-  , importedFrom :: Either SrcSpan T.Text         -- ^ From where this item is imported from.
-  , typeText     :: Maybe T.Text   -- ^ Available type information.
-  , label        :: T.Text         -- ^ Label to display to the user.
-  , isInfix      :: Maybe Backtick -- ^ Did the completion happen
+  { compKind            :: CompletionItemKind
+  , insertText          :: T.Text         -- ^ Snippet for the completion
+  , importedFrom        :: Either SrcSpan T.Text         -- ^ From where this item is imported from.
+  , typeText            :: Maybe T.Text   -- ^ Available type information.
+  , label               :: T.Text         -- ^ Label to display to the user.
+  , isInfix             :: Maybe Backtick -- ^ Did the completion happen
                                    -- in the context of an infix notation.
-  , docs         :: SpanDoc        -- ^ Available documentation.
-  , isTypeCompl  :: Bool
+  , docs                :: SpanDoc        -- ^ Available documentation.
+  , isTypeCompl         :: Bool
   , additionalTextEdits :: Maybe ExtendImport
   }
   deriving (Eq, Show)
@@ -59,10 +59,10 @@ instance Monoid QualCompls where
 
 -- | End result of the completions
 data CachedCompletions = CC
-  { allModNamesAsNS :: [T.Text] -- ^ All module names in scope.
+  { allModNamesAsNS   :: [T.Text] -- ^ All module names in scope.
                                 -- Prelude is a single module
-  , unqualCompls :: [CompItem]  -- ^ All Possible completion items
-  , qualCompls :: QualCompls    -- ^ Completion items associated to
+  , unqualCompls      :: [CompItem]  -- ^ All Possible completion items
+  , qualCompls        :: QualCompls    -- ^ Completion items associated to
                                 -- to a specific module name.
   , importableModules :: [T.Text] -- ^ All modules that may be imported.
   } deriving Show

--- a/ghcide/src/Development/IDE/Plugin/Test.hs
+++ b/ghcide/src/Development/IDE/Plugin/Test.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs              #-}
 -- | A plugin that adds custom messages for use in tests
 module Development.IDE.Plugin.Test
   ( TestRequest(..)
@@ -10,33 +10,33 @@ module Development.IDE.Plugin.Test
   , blockCommandId
   ) where
 
-import Control.Monad.STM
-import Control.Monad.IO.Class
-import Data.Aeson
-import Data.Aeson.Types
-import Data.CaseInsensitive (CI, original)
-import Development.IDE.Core.Service
-import Development.IDE.Core.Shake
-import Development.IDE.GHC.Compat
-import Development.IDE.Types.HscEnvEq (HscEnvEq(hscEnv))
-import Development.IDE.Plugin
-import Development.IDE.LSP.Server
-import Development.IDE.Types.Action
-import GHC.Generics (Generic)
-import GhcPlugins (HscEnv(hsc_dflags))
-import Language.LSP.Types
-import System.Time.Extra
-import Development.IDE.Core.RuleTypes
-import Control.Monad
-import Development.Shake (Action)
-import Data.Maybe (isJust)
-import Data.Bifunctor
-import Data.Text (pack, Text)
-import Data.String
-import Development.IDE.Types.Location (fromUri)
-import Control.Concurrent (threadDelay)
-import Ide.Types
-import qualified Language.LSP.Server as LSP
+import           Control.Concurrent             (threadDelay)
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Control.Monad.STM
+import           Data.Aeson
+import           Data.Aeson.Types
+import           Data.Bifunctor
+import           Data.CaseInsensitive           (CI, original)
+import           Data.Maybe                     (isJust)
+import           Data.String
+import           Data.Text                      (Text, pack)
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Service
+import           Development.IDE.Core.Shake
+import           Development.IDE.GHC.Compat
+import           Development.IDE.LSP.Server
+import           Development.IDE.Plugin
+import           Development.IDE.Types.Action
+import           Development.IDE.Types.HscEnvEq (HscEnvEq (hscEnv))
+import           Development.IDE.Types.Location (fromUri)
+import           Development.Shake              (Action)
+import           GHC.Generics                   (Generic)
+import           GhcPlugins                     (HscEnv (hsc_dflags))
+import           Ide.Types
+import qualified Language.LSP.Server            as LSP
+import           Language.LSP.Types
+import           System.Time.Extra
 
 data TestRequest
     = BlockSeconds Seconds           -- ^ :: Null

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -6,44 +6,36 @@ module Development.IDE.Plugin.TypeLenses
   )
 where
 
-import Control.Monad.IO.Class
-import Data.Aeson.Types (Value (..), toJSON)
-import qualified Data.HashMap.Strict as Map
-import qualified Data.Text as T
-import Development.IDE.Core.RuleTypes (TypeCheck (TypeCheck))
-import Development.IDE.Core.Rules (IdeState, runAction)
-import Development.IDE.Core.Service (getDiagnostics)
-import Development.IDE.Core.Shake (getHiddenDiagnostics, use)
-import Development.IDE.Types.Location
-  ( Position (Position, _character, _line),
-    Range (Range, _end, _start),
-    toNormalizedFilePath',
-    uriToFilePath',
-  )
-import Ide.PluginUtils (mkLspCommand)
-import Ide.Types
-  ( CommandFunction,
-    CommandId (CommandId),
-    PluginCommand (PluginCommand),
-    PluginDescriptor(..),
-    PluginId,
-    defaultPluginDescriptor,
-    mkPluginHandler
-  )
-import qualified Language.LSP.Server as LSP
-import Language.LSP.Types
-  ( ApplyWorkspaceEditParams (ApplyWorkspaceEditParams),
-    CodeLens (CodeLens),
-    CodeLensParams (CodeLensParams, _textDocument),
-    Diagnostic (..),
-    List (..),
-    ResponseError,
-    TextDocumentIdentifier (TextDocumentIdentifier),
-    TextEdit (TextEdit),
-    WorkspaceEdit (WorkspaceEdit),
-    SMethod(..)
-  )
-import Text.Regex.TDFA ((=~))
+import           Control.Monad.IO.Class
+import           Data.Aeson.Types               (Value (..), toJSON)
+import qualified Data.HashMap.Strict            as Map
+import qualified Data.Text                      as T
+import           Development.IDE.Core.RuleTypes (TypeCheck (TypeCheck))
+import           Development.IDE.Core.Rules     (IdeState, runAction)
+import           Development.IDE.Core.Service   (getDiagnostics)
+import           Development.IDE.Core.Shake     (getHiddenDiagnostics, use)
+import           Development.IDE.Types.Location (Position (Position, _character, _line),
+                                                 Range (Range, _end, _start),
+                                                 toNormalizedFilePath',
+                                                 uriToFilePath')
+import           Ide.PluginUtils                (mkLspCommand)
+import           Ide.Types                      (CommandFunction,
+                                                 CommandId (CommandId),
+                                                 PluginCommand (PluginCommand),
+                                                 PluginDescriptor (..),
+                                                 PluginId,
+                                                 defaultPluginDescriptor,
+                                                 mkPluginHandler)
+import qualified Language.LSP.Server            as LSP
+import           Language.LSP.Types             (ApplyWorkspaceEditParams (ApplyWorkspaceEditParams),
+                                                 CodeLens (CodeLens),
+                                                 CodeLensParams (CodeLensParams, _textDocument),
+                                                 Diagnostic (..), List (..),
+                                                 ResponseError, SMethod (..),
+                                                 TextDocumentIdentifier (TextDocumentIdentifier),
+                                                 TextEdit (TextEdit),
+                                                 WorkspaceEdit (WorkspaceEdit))
+import           Text.Regex.TDFA                ((=~))
 
 typeLensCommandId :: T.Text
 typeLensCommandId = "typesignature.add"

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -1,8 +1,8 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE CPP   #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE CPP #-}
 #include "ghc-api-version.h"
 
 -- | Gives information about symbols at a given point in DAML files.
@@ -19,45 +19,45 @@ module Development.IDE.Spans.AtPoint (
   , defRowToSymbolInfo
   ) where
 
-import Development.IDE.GHC.Error
-import Development.IDE.GHC.Orphans()
-import Development.IDE.Types.Location
+import           Development.IDE.GHC.Error
+import           Development.IDE.GHC.Orphans          ()
+import           Development.IDE.Types.Location
 import           Language.LSP.Types
 
 -- compiler and infrastructure
-import Development.IDE.GHC.Compat
-import Development.IDE.Types.Options
-import Development.IDE.Spans.Common
-import Development.IDE.Core.RuleTypes
-import Development.IDE.Core.PositionMapping
+import           Development.IDE.Core.PositionMapping
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.GHC.Compat
+import           Development.IDE.Spans.Common
+import           Development.IDE.Types.Options
 
 -- GHC API imports
-import Name
-import Outputable hiding ((<>))
-import SrcLoc
-import TyCoRep hiding (FunTy)
-import TyCon
+import           FastString                           (unpackFS)
+import           IfaceType
+import           Name
+import           NameEnv
+import           Outputable                           hiding ((<>))
+import           SrcLoc
+import           TyCoRep                              hiding (FunTy)
+import           TyCon
 import qualified Var
-import NameEnv
-import IfaceType
-import FastString (unpackFS)
 
-import Control.Applicative
-import Control.Monad.Extra
-import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.Class
-import Control.Monad.IO.Class
+import           Control.Applicative
+import           Control.Monad.Extra
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Maybe
+import qualified Data.HashMap.Strict                  as HM
+import qualified Data.Map.Strict                      as M
 import           Data.Maybe
-import qualified Data.Text as T
-import qualified Data.Map.Strict as M
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Text                            as T
 
-import qualified Data.Array as A
-import Data.Either
-import Data.List.Extra (nubOrd, dropEnd1)
-import Data.List (isSuffixOf)
+import qualified Data.Array                           as A
+import           Data.Either
+import           Data.List                            (isSuffixOf)
+import           Data.List.Extra                      (dropEnd1, nubOrd)
 
-import HieDb hiding (pointCommand)
+import           HieDb                                hiding (pointCommand)
 
 -- | Gives a Uri for the module, given the .hie file location and the the module info
 -- The Bool denotes if it is a boot module
@@ -135,7 +135,7 @@ rowToLoc (row:.info) = flip Location range <$> mfile
     start = Position (refSLine row - 1) (refSCol row -1)
     end = Position (refELine row - 1) (refECol row -1)
     mfile = case modInfoSrcFile info of
-      Just f -> Just $ toUri f
+      Just f  -> Just $ toUri f
       Nothing -> Nothing
 
 typeRowToLoc :: Res TypeRef -> Maybe Location
@@ -362,7 +362,7 @@ pointCommand :: HieASTs t -> Position -> (HieAST t -> a) -> [a]
 pointCommand hf pos k =
     catMaybes $ M.elems $ flip M.mapWithKey (getAsts hf) $ \fs ast ->
       case selectSmallestContaining (sp fs) ast of
-        Nothing -> Nothing
+        Nothing   -> Nothing
         Just ast' -> Just $ k ast'
  where
    sloc fs = mkRealSrcLoc fs (line+1) (cha+1)

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DerivingStrategies #-}
 #include "ghc-api-version.h"
 
 module Development.IDE.Spans.Common (
@@ -18,25 +18,25 @@ module Development.IDE.Spans.Common (
 , KindMap
 ) where
 
-import Data.Maybe
-import qualified Data.Text as T
-import Data.List.Extra
-import Control.DeepSeq
-import GHC.Generics
+import           Control.DeepSeq
+import           Data.List.Extra
+import           Data.Maybe
+import qualified Data.Text                    as T
+import           GHC.Generics
 
-import GHC
-import Outputable hiding ((<>))
-import ConLike
-import DataCon
-import Var
-import NameEnv
-import DynFlags
+import           ConLike
+import           DataCon
+import           DynFlags
+import           GHC
+import           NameEnv
+import           Outputable                   hiding ((<>))
+import           Var
 
+import           Development.IDE.GHC.Orphans  ()
+import           Development.IDE.GHC.Util
 import qualified Documentation.Haddock.Parser as H
-import qualified Documentation.Haddock.Types as H
-import Development.IDE.GHC.Orphans ()
-import Development.IDE.GHC.Util
-import RdrName (rdrNameOcc)
+import qualified Documentation.Haddock.Types  as H
+import           RdrName                      (rdrNameOcc)
 
 type DocMap = NameEnv SpanDoc
 type KindMap = NameEnv TyThing
@@ -174,19 +174,19 @@ haddockToMarkdown (H.DocProperty _)
   = ""  -- don't really know what to do
 
 escapeBackticks :: String -> String
-escapeBackticks "" = ""
+escapeBackticks ""       = ""
 escapeBackticks ('`':ss) = '\\':'`':escapeBackticks ss
 escapeBackticks (s  :ss) = s:escapeBackticks ss
 
 removeUnescapedBackticks :: String -> String
 removeUnescapedBackticks = \case
   '\\' : '`' : ss -> '\\' : '`' : removeUnescapedBackticks ss
-  '`' : ss -> removeUnescapedBackticks ss
-  "" -> ""
-  s : ss -> s : removeUnescapedBackticks ss
+  '`' : ss        -> removeUnescapedBackticks ss
+  ""              -> ""
+  s : ss          -> s : removeUnescapedBackticks ss
 
 splitForList :: String -> String
 splitForList s
   = case lines s of
-      [] -> ""
+      []           -> ""
       (first:rest) -> unlines $ first : map (("  " ++) . trimStart) rest

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -2,7 +2,7 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP        #-}
 #include "ghc-api-version.h"
 
 module Development.IDE.Spans.Documentation (
@@ -14,32 +14,32 @@ module Development.IDE.Spans.Documentation (
   ) where
 
 import           Control.Monad
-import           Control.Monad.Extra (findM)
+import           Control.Monad.Extra            (findM)
 import           Data.Either
 import           Data.Foldable
 import           Data.List.Extra
-import qualified Data.Map as M
-import qualified Data.Set as S
+import qualified Data.Map                       as M
 import           Data.Maybe
-import qualified Data.Text as T
+import qualified Data.Set                       as S
+import qualified Data.Text                      as T
 import           Development.IDE.Core.Compile
+import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error
 import           Development.IDE.Spans.Common
-import           Development.IDE.Core.RuleTypes
 import           System.Directory
 import           System.FilePath
 
-import           FastString
-import           SrcLoc (RealLocated)
-import           GhcMonad
-import           Packages
-import           Name
-import           Language.LSP.Types (getUri, filePathToUri)
-import           TcRnTypes
 import           ExtractDocs
+import           FastString
+import           GhcMonad
+import           HscTypes                       (HscEnv (hsc_dflags))
+import           Language.LSP.Types             (filePathToUri, getUri)
+import           Name
 import           NameEnv
-import HscTypes (HscEnv(hsc_dflags))
+import           Packages
+import           SrcLoc                         (RealLocated)
+import           TcRnTypes
 
 mkDocMap
   :: HscEnv
@@ -77,11 +77,11 @@ getDocumentationsTryGhc :: HscEnv -> Module -> [Name] -> IO [SpanDoc]
 getDocumentationsTryGhc env mod names = do
   res <- catchSrcErrors (hsc_dflags env) "docs" $ getDocsBatch env mod names
   case res of
-      Left _ -> return []
+      Left _    -> return []
       Right res -> zipWithM unwrap res names
   where
     unwrap (Right (Just docs, _)) n = SpanDocString docs <$> getUris n
-    unwrap _ n = mkSpanDocText n
+    unwrap _ n                      = mkSpanDocText n
 
     mkSpanDocText name =
       SpanDocText [] <$> getUris name
@@ -152,7 +152,7 @@ getDocumentation sources targetName = fromMaybe [] $ do
     -- @FunBind@ (which covers functions and variables).
     name_of_bind :: HsBind GhcPs -> Maybe (Located RdrName)
     name_of_bind FunBind {fun_id} = Just fun_id
-    name_of_bind _ = Nothing
+    name_of_bind _                = Nothing
     -- Get source spans from names, discard unhelpful spans, remove
     -- duplicates and sort.
     sortedNameSpans :: [Located RdrName] -> [RealSrcSpan]

--- a/ghcide/src/Development/IDE/Types/Action.hs
+++ b/ghcide/src/Development/IDE/Types/Action.hs
@@ -11,9 +11,9 @@ module Development.IDE.Types.Action
 where
 
 import           Control.Concurrent.STM
-import           Data.Hashable                (Hashable (..))
 import           Data.HashSet                 (HashSet)
 import qualified Data.HashSet                 as Set
+import           Data.Hashable                (Hashable (..))
 import           Data.Unique                  (Unique)
 import           Development.IDE.Types.Logger
 import           Development.Shake            (Action)

--- a/ghcide/src/Development/IDE/Types/Diagnostics.hs
+++ b/ghcide/src/Development/IDE/Types/Diagnostics.hs
@@ -16,21 +16,20 @@ module Development.IDE.Types.Diagnostics (
   showDiagnosticsColored,
   ) where
 
-import Control.DeepSeq
-import Data.Maybe as Maybe
-import qualified Data.Text as T
-import Data.Text.Prettyprint.Doc
-import Language.LSP.Types as LSP (DiagnosticSource,
-    DiagnosticSeverity(..)
-  , Diagnostic(..)
-  , List(..)
-  )
-import Language.LSP.Diagnostics
-import Data.Text.Prettyprint.Doc.Render.Text
+import           Control.DeepSeq
+import           Data.Maybe                                as Maybe
+import qualified Data.Text                                 as T
+import           Data.Text.Prettyprint.Doc
+import           Data.Text.Prettyprint.Doc.Render.Terminal (Color (..), color)
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Terminal
-import Data.Text.Prettyprint.Doc.Render.Terminal (Color(..), color)
+import           Data.Text.Prettyprint.Doc.Render.Text
+import           Language.LSP.Diagnostics
+import           Language.LSP.Types                        as LSP (Diagnostic (..),
+                                                                   DiagnosticSeverity (..),
+                                                                   DiagnosticSource,
+                                                                   List (..))
 
-import Development.IDE.Types.Location
+import           Development.IDE.Types.Location
 
 
 -- | The result of an IDE operation. Warnings and errors are in the Diagnostic,
@@ -114,10 +113,10 @@ prettyDiagnostic (fp, sh, LSP.Diagnostic{..}) =
         , slabel_ "Severity:" $ pretty $ show sev
         , slabel_ "Message: "
             $ case sev of
-              LSP.DsError -> annotate $ color Red
+              LSP.DsError   -> annotate $ color Red
               LSP.DsWarning -> annotate $ color Yellow
-              LSP.DsInfo -> annotate $ color Blue
-              LSP.DsHint -> annotate $ color Magenta
+              LSP.DsInfo    -> annotate $ color Blue
+              LSP.DsHint    -> annotate $ color Magenta
             $ stringParagraphs _message
         ]
     where

--- a/ghcide/src/Development/IDE/Types/Exports.hs
+++ b/ghcide/src/Development/IDE/Types/Exports.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 module Development.IDE.Types.Exports
 (
@@ -9,22 +9,22 @@ module Development.IDE.Types.Exports
     createExportsMapTc
 ) where
 
-import Avail (AvailInfo(..))
-import Control.DeepSeq (NFData(..))
-import Data.Text (pack, Text)
-import Development.IDE.GHC.Compat
-import Development.IDE.GHC.Util
-import Data.HashMap.Strict (HashMap)
-import GHC.Generics (Generic)
-import Name
-import FieldLabel (flSelector)
-import qualified Data.HashMap.Strict as Map
-import GhcPlugins (IfaceExport, ModGuts(..))
-import Data.HashSet (HashSet)
-import qualified Data.HashSet as Set
-import Data.Bifunctor (Bifunctor(second))
-import Data.Hashable (Hashable)
-import TcRnTypes(TcGblEnv(..))
+import           Avail                      (AvailInfo (..))
+import           Control.DeepSeq            (NFData (..))
+import           Data.Bifunctor             (Bifunctor (second))
+import           Data.HashMap.Strict        (HashMap)
+import qualified Data.HashMap.Strict        as Map
+import           Data.HashSet               (HashSet)
+import qualified Data.HashSet               as Set
+import           Data.Hashable              (Hashable)
+import           Data.Text                  (Text, pack)
+import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Util
+import           FieldLabel                 (flSelector)
+import           GHC.Generics               (Generic)
+import           GhcPlugins                 (IfaceExport, ModGuts (..))
+import           Name
+import           TcRnTypes                  (TcGblEnv (..))
 
 newtype ExportsMap = ExportsMap
     {getExportsMap :: HashMap IdentifierText (HashSet IdentInfo)}
@@ -36,10 +36,10 @@ instance Semigroup ExportsMap where
 type IdentifierText = Text
 
 data IdentInfo = IdentInfo
-    { name :: !Text
-    , rendered :: Text
-    , parent :: !(Maybe Text)
-    , isDatacon :: !Bool
+    { name           :: !Text
+    , rendered       :: Text
+    , parent         :: !(Maybe Text)
+    , isDatacon      :: !Bool
     , moduleNameText :: !Text
     }
     deriving (Generic, Show)

--- a/ghcide/src/Development/IDE/Types/KnownTargets.hs
+++ b/ghcide/src/Development/IDE/Types/KnownTargets.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 module Development.IDE.Types.KnownTargets (KnownTargets, Target(..), toKnownFiles) where
 
-import Data.HashMap.Strict
-import Development.IDE.Types.Location
-import Development.IDE.GHC.Compat (ModuleName)
-import Development.IDE.GHC.Orphans ()
-import Data.Hashable
-import GHC.Generics
-import Control.DeepSeq
-import Data.HashSet
-import qualified Data.HashSet as HSet
-import qualified Data.HashMap.Strict as HMap
+import           Control.DeepSeq
+import           Data.HashMap.Strict
+import qualified Data.HashMap.Strict            as HMap
+import           Data.HashSet
+import qualified Data.HashSet                   as HSet
+import           Data.Hashable
+import           Development.IDE.GHC.Compat     (ModuleName)
+import           Development.IDE.GHC.Orphans    ()
+import           Development.IDE.Types.Location
+import           GHC.Generics
 
 -- | A mapping of module name to known files
 type KnownTargets = HashMap Target [NormalizedFilePath]

--- a/ghcide/src/Development/IDE/Types/Location.hs
+++ b/ghcide/src/Development/IDE/Types/Location.hs
@@ -25,16 +25,17 @@ module Development.IDE.Types.Location
     , readSrcSpan
     ) where
 
-import Control.Applicative
-import Language.LSP.Types (Location(..), Range(..), Position(..))
-import Control.Monad
-import Data.Hashable (Hashable(hash))
-import Data.String
-import FastString
-import qualified Language.LSP.Types as LSP
-import SrcLoc as GHC
-import Text.ParserCombinators.ReadP as ReadP
-import Data.Maybe (fromMaybe)
+import           Control.Applicative
+import           Control.Monad
+import           Data.Hashable                (Hashable (hash))
+import           Data.Maybe                   (fromMaybe)
+import           Data.String
+import           FastString
+import           Language.LSP.Types           (Location (..), Position (..),
+                                               Range (..))
+import qualified Language.LSP.Types           as LSP
+import           SrcLoc                       as GHC
+import           Text.ParserCombinators.ReadP as ReadP
 
 toNormalizedFilePath' :: FilePath -> LSP.NormalizedFilePath
 -- We want to keep empty paths instead of normalising them to "."

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -17,15 +17,16 @@ module Development.IDE.Types.Options
   , OptHaddockParse(..)
   ,optShakeFiles) where
 
-import Development.Shake
-import Development.IDE.Types.HscEnvEq (HscEnvEq)
-import           GHC hiding (parseModule, typecheckModule)
-import           GhcPlugins                     as GHC hiding (fst3, (<>))
-import qualified Language.LSP.Types.Capabilities as LSP
-import qualified Data.Text as T
-import Development.IDE.Types.Diagnostics
-import Control.DeepSeq (NFData(..))
-import Ide.Plugin.Config
+import           Control.DeepSeq                   (NFData (..))
+import qualified Data.Text                         as T
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.HscEnvEq    (HscEnvEq)
+import           Development.Shake
+import           GHC                               hiding (parseModule,
+                                                    typecheckModule)
+import           GhcPlugins                        as GHC hiding (fst3, (<>))
+import           Ide.Plugin.Config
+import qualified Language.LSP.Types.Capabilities   as LSP
 
 data IdeGhcSession = IdeGhcSession
   { loadSessionFun :: FilePath -> IO (IdeResult HscEnvEq, [FilePath])
@@ -38,52 +39,52 @@ instance Show IdeGhcSession where show _ = "IdeGhcSession"
 instance NFData IdeGhcSession where rnf !_ = ()
 
 data IdeOptions = IdeOptions
-  { optPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
+  { optPreprocessor       :: GHC.ParsedSource -> IdePreprocessedSource
     -- ^ Preprocessor to run over all parsed source trees, generating a list of warnings
     --   and a list of errors, along with a new parse tree.
-  , optGhcSession :: Action IdeGhcSession
+  , optGhcSession         :: Action IdeGhcSession
     -- ^ Setup a GHC session for a given file, e.g. @Foo.hs@.
     --   For the same 'ComponentOptions' from hie-bios, the resulting function will be applied once per file.
     --   It is desirable that many files get the same 'HscEnvEq', so that more IDE features work.
-  , optPkgLocationOpts :: IdePkgLocationOptions
+  , optPkgLocationOpts    :: IdePkgLocationOptions
     -- ^ How to locate source and @.hie@ files given a module name.
-  , optExtensions :: [String]
+  , optExtensions         :: [String]
     -- ^ File extensions to search for code, defaults to Haskell sources (including @.hs@)
-  , optShakeProfiling :: Maybe FilePath
+  , optShakeProfiling     :: Maybe FilePath
     -- ^ Set to 'Just' to create a directory of profiling reports.
-  , optOTMemoryProfiling :: IdeOTMemoryProfiling
+  , optOTMemoryProfiling  :: IdeOTMemoryProfiling
     -- ^ Whether to record profiling information with OpenTelemetry. You must
     --   also enable the -l RTS flag for this to have any effect
-  , optTesting :: IdeTesting
+  , optTesting            :: IdeTesting
     -- ^ Whether to enable additional lsp messages used by the test suite for checking invariants
-  , optReportProgress :: IdeReportProgress
+  , optReportProgress     :: IdeReportProgress
     -- ^ Whether to report progress during long operations.
-  , optLanguageSyntax :: String
+  , optLanguageSyntax     :: String
     -- ^ the ```language to use
   , optNewColonConvention :: Bool
     -- ^ whether to use new colon convention
-  , optKeywords :: [T.Text]
+  , optKeywords           :: [T.Text]
     -- ^ keywords used for completions. These are customizable
     -- since DAML has a different set of keywords than Haskell.
-  , optDefer :: IdeDefer
+  , optDefer              :: IdeDefer
     -- ^ Whether to defer type errors, typed holes and out of scope
     --   variables. Deferral allows the IDE to continue to provide
     --   features such as diagnostics and go-to-definition, in
     --   situations in which they would become unavailable because of
     --   the presence of type errors, holes or unbound variables.
-  , optCheckProject :: IO Bool
+  , optCheckProject       :: IO Bool
     -- ^ Whether to typecheck the entire project on load
-  , optCheckParents :: IO CheckParents
+  , optCheckParents       :: IO CheckParents
     -- ^ When to typecheck reverse dependencies of a file
-  , optHaddockParse :: OptHaddockParse
+  , optHaddockParse       :: OptHaddockParse
     -- ^ Whether to return result of parsing module with Opt_Haddock.
     --   Otherwise, return the result of parsing without Opt_Haddock, so
     --   that the parsed module contains the result of Opt_KeepRawTokenStream,
     --   which might be necessary for hlint.
-  , optCustomDynFlags :: DynFlags -> DynFlags
+  , optCustomDynFlags     :: DynFlags -> DynFlags
     -- ^ Will be called right after setting up a new cradle,
     --   allowing to customize the Ghc options used
-  , optShakeOptions :: ShakeOptions
+  , optShakeOptions       :: ShakeOptions
   }
 
 optShakeFiles :: IdeOptions -> Maybe FilePath
@@ -99,9 +100,9 @@ data OptHaddockParse = HaddockParse | NoHaddockParse
 data IdePreprocessedSource = IdePreprocessedSource
   { preprocWarnings :: [(GHC.SrcSpan, String)]
     -- ^ Warnings emitted by the preprocessor.
-  , preprocErrors :: [(GHC.SrcSpan, String)]
+  , preprocErrors   :: [(GHC.SrcSpan, String)]
     -- ^ Errors emitted by the preprocessor.
-  , preprocSource :: GHC.ParsedSource
+  , preprocSource   :: GHC.ParsedSource
     -- ^ New parse tree emitted by the preprocessor.
   }
 

--- a/ghcide/src/Development/IDE/Types/Shake.hs
+++ b/ghcide/src/Development/IDE/Types/Shake.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DerivingStrategies        #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE TypeFamilies              #-}
 module Development.IDE.Types.Shake
   ( Q (..),
     A (..),
@@ -15,21 +15,22 @@ module Development.IDE.Types.Shake
   toShakeValue,encodeShakeValue,decodeShakeValue)
 where
 
-import Control.DeepSeq
-import Control.Exception
-import qualified Data.ByteString.Char8 as BS
-import Data.Dynamic
-import Data.Hashable
-import Data.HashMap.Strict
-import Data.Vector (Vector)
-import Data.Typeable
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Location
-import Development.Shake (RuleResult, ShakeException (shakeExceptionInner))
-import Development.Shake.Classes
-import GHC.Generics
-import Language.LSP.Types
-import Development.IDE.Core.PositionMapping
+import           Control.DeepSeq
+import           Control.Exception
+import qualified Data.ByteString.Char8                as BS
+import           Data.Dynamic
+import           Data.HashMap.Strict
+import           Data.Hashable
+import           Data.Typeable
+import           Data.Vector                          (Vector)
+import           Development.IDE.Core.PositionMapping
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
+import           Development.Shake                    (RuleResult,
+                                                       ShakeException (shakeExceptionInner))
+import           Development.Shake.Classes
+import           GHC.Generics
+import           Language.LSP.Types
 
 data Value v
     = Succeeded TextDocumentVersion v
@@ -43,8 +44,8 @@ instance NFData v => NFData (Value v)
 -- up2date results not for stale values.
 currentValue :: Value v -> Maybe v
 currentValue (Succeeded _ v) = Just v
-currentValue (Stale _ _ _) = Nothing
-currentValue Failed{} = Nothing
+currentValue (Stale _ _ _)   = Nothing
+currentValue Failed{}        = Nothing
 
 data ValueWithDiagnostics
   = ValueWithDiagnostics !(Value Dynamic) !(Vector FileDiagnostic)
@@ -122,7 +123,7 @@ encodeShakeValue :: ShakeValue -> BS.ByteString
 encodeShakeValue = \case
   ShakeNoCutoff -> BS.empty
   ShakeResult r -> BS.cons 'r' r
-  ShakeStale r -> BS.cons 's' r
+  ShakeStale r  -> BS.cons 's' r
 
 decodeShakeValue :: BS.ByteString -> ShakeValue
 decodeShakeValue bs = case BS.uncons bs of

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -2,86 +2,96 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE ImplicitParams  #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE ImplicitParams        #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# OPTIONS_GHC -Wno-deprecations -Wno-unticked-promoted-constructors #-}
 #include "ghc-api-version.h"
 
 module Main (main) where
 
-import Control.Applicative.Combinators
-import Control.Exception (bracket_, catch)
-import qualified Control.Lens as Lens
-import Control.Monad
-import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Aeson (toJSON,fromJSON)
-import qualified Data.Aeson as A
-import qualified Data.Binary as Binary
-import Data.Default
-import Data.Foldable
-import Data.List.Extra
-import Data.Maybe
-import Data.Rope.UTF16 (Rope)
-import qualified Data.Rope.UTF16 as Rope
-import qualified Data.Set as Set
-import Development.IDE.Core.PositionMapping (fromCurrent, toCurrent, PositionResult(..), positionResultToMaybe)
-import Development.IDE.Core.Shake (Q(..))
-import Development.IDE.GHC.Util
-import qualified Data.Text as T
-import Development.IDE.Plugin.Completions.Types (extendImportCommandId)
-import Development.IDE.Plugin.TypeLenses (typeLensCommandId)
-import Development.IDE.Spans.Common
-import Development.IDE.Test
-    ( canonicalizeUri,
-      diagnostic,
-      expectCurrentDiagnostics,
-      expectDiagnostics,
-      expectDiagnosticsWithTags,
-      expectNoMoreDiagnostics,
-      flushMessages,
-      standardizeQuotes,
-      waitForAction,
-      Cursor, expectMessages )
-import Development.IDE.Test.Runfiles
-import qualified Development.IDE.Types.Diagnostics as Diagnostics
-import Development.IDE.Types.Location
-import Development.Shake (getDirectoryFilesIO)
-import Ide.Plugin.Config
-import qualified Experiments as Bench
-import Language.LSP.Test
-import Language.LSP.Types hiding (mkRange)
-import Language.LSP.Types.Capabilities
-import qualified Language.LSP.Types.Lens as Lsp (diagnostics, params, message)
-import Language.LSP.VFS (applyChange)
-import Network.URI
-import System.Environment.Blank (unsetEnv, getEnv, setEnv)
-import System.FilePath
-import System.IO.Extra hiding (withTempDir)
+import           Control.Applicative.Combinators
+import           Control.Exception                        (bracket_, catch)
+import qualified Control.Lens                             as Lens
+import           Control.Monad
+import           Control.Monad.IO.Class                   (MonadIO, liftIO)
+import           Data.Aeson                               (fromJSON, toJSON)
+import qualified Data.Aeson                               as A
+import qualified Data.Binary                              as Binary
+import           Data.Default
+import           Data.Foldable
+import           Data.List.Extra
+import           Data.Maybe
+import           Data.Rope.UTF16                          (Rope)
+import qualified Data.Rope.UTF16                          as Rope
+import qualified Data.Set                                 as Set
+import qualified Data.Text                                as T
+import           Development.IDE.Core.PositionMapping     (PositionResult (..),
+                                                           fromCurrent,
+                                                           positionResultToMaybe,
+                                                           toCurrent)
+import           Development.IDE.Core.Shake               (Q (..))
+import           Development.IDE.GHC.Util
+import           Development.IDE.Plugin.Completions.Types (extendImportCommandId)
+import           Development.IDE.Plugin.TypeLenses        (typeLensCommandId)
+import           Development.IDE.Spans.Common
+import           Development.IDE.Test                     (Cursor,
+                                                           canonicalizeUri,
+                                                           diagnostic,
+                                                           expectCurrentDiagnostics,
+                                                           expectDiagnostics,
+                                                           expectDiagnosticsWithTags,
+                                                           expectMessages,
+                                                           expectNoMoreDiagnostics,
+                                                           flushMessages,
+                                                           standardizeQuotes,
+                                                           waitForAction)
+import           Development.IDE.Test.Runfiles
+import qualified Development.IDE.Types.Diagnostics        as Diagnostics
+import           Development.IDE.Types.Location
+import           Development.Shake                        (getDirectoryFilesIO)
+import qualified Experiments                              as Bench
+import           Ide.Plugin.Config
+import           Language.LSP.Test
+import           Language.LSP.Types                       hiding (mkRange)
+import           Language.LSP.Types.Capabilities
+import qualified Language.LSP.Types.Lens                  as Lsp (diagnostics,
+                                                                  message,
+                                                                  params)
+import           Language.LSP.VFS                         (applyChange)
+import           Network.URI
+import           System.Directory
+import           System.Environment.Blank                 (getEnv, setEnv,
+                                                           unsetEnv)
+import           System.Exit                              (ExitCode (ExitSuccess))
+import           System.FilePath
+import           System.IO.Extra                          hiding (withTempDir)
 import qualified System.IO.Extra
-import System.Directory
-import System.Exit (ExitCode(ExitSuccess))
-import System.Process.Extra (readCreateProcessWithExitCode, CreateProcess(cwd), proc)
-import System.Info.Extra (isWindows)
-import Test.QuickCheck
+import           System.Info.Extra                        (isWindows)
+import           System.Process.Extra                     (CreateProcess (cwd),
+                                                           proc,
+                                                           readCreateProcessWithExitCode)
+import           Test.QuickCheck
 -- import Test.QuickCheck.Instances ()
-import Test.Tasty
-import Test.Tasty.ExpectedFailure
-import Test.Tasty.Ingredients.Rerun
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck
-import System.Time.Extra
-import Development.IDE.Plugin.CodeAction (matchRegExMultipleImports)
-import Development.IDE.Plugin.Test (TestRequest (BlockSeconds, GetInterfaceFilesDir), WaitForIdeRuleResult (..), blockCommandId)
-import Control.Monad.Extra (whenJust)
-import qualified Language.LSP.Types.Lens as L
-import Control.Lens ((^.))
-import Data.Tuple.Extra
+import           Control.Lens                             ((^.))
+import           Control.Monad.Extra                      (whenJust)
+import           Data.Tuple.Extra
+import           Development.IDE.Plugin.CodeAction        (matchRegExMultipleImports)
+import           Development.IDE.Plugin.Test              (TestRequest (BlockSeconds, GetInterfaceFilesDir),
+                                                           WaitForIdeRuleResult (..),
+                                                           blockCommandId)
+import qualified Language.LSP.Types.Lens                  as L
+import           System.Time.Extra
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure
+import           Test.Tasty.HUnit
+import           Test.Tasty.Ingredients.Rerun
+import           Test.Tasty.QuickCheck
 
 waitForProgressBegin :: Session ()
 waitForProgressBegin = skipManyTill anyMessage $ satisfyMaybe $ \case
@@ -2473,7 +2483,7 @@ addImplicitParamsConstraintTests =
         ]
     ]
   where
-    mkContext "" = ""
+    mkContext ""       = ""
     mkContext contents = "(" <> contents <> ") => "
 
     exampleCode bodyBase contextBase contextCaller =
@@ -2858,7 +2868,7 @@ exportTemplate mRange initialContent expectedAction expectedContents = do
   doc <- createDoc "A.hs" "haskell" initialContent
   _ <- waitForDiagnostics
   actions <- case mRange of
-    Nothing -> getAllCodeActions doc
+    Nothing    -> getAllCodeActions doc
     Just range -> getCodeActions doc range
   case expectedContents of
     Just content -> do
@@ -3593,7 +3603,7 @@ completionCommandTest name src pos wanted expected = testSession name $ do
   compls <- skipManyTill anyMessage (getCompletions docId pos)
   let wantedC = find ( \case
             CompletionItem {_insertText = Just x} -> wanted `T.isPrefixOf` x
-            _ -> False
+            _                                     -> False
             ) compls
   case wantedC of
     Nothing ->
@@ -3622,7 +3632,7 @@ completionNoCommandTest name src pos wanted = testSession name $ do
   compls <- getCompletions docId pos
   let wantedC = find ( \case
             CompletionItem {_insertText = Just x} -> wanted `T.isPrefixOf` x
-            _ -> False
+            _                                     -> False
             ) compls
   case wantedC of
     Nothing ->
@@ -4402,7 +4412,7 @@ dependentFileTest = testGroup "addDependentFile"
 cradleLoadedMessage :: Session FromServerMessage
 cradleLoadedMessage = satisfy $ \case
         FromServerMess (SCustomMethod m) (NotMess _) -> m == cradleLoadedMethod
-        _ -> False
+        _                                            -> False
 
 cradleLoadedMethod :: T.Text
 cradleLoadedMethod = "ghcide/cradle/loaded"
@@ -4891,7 +4901,7 @@ getReferences' (file, l, c) includeDeclaration = do
     doc <- openDoc file "haskell"
     getReferences doc (Position l c) $ toBool includeDeclaration
     where toBool YesIncludeDeclaration = True
-          toBool NoExcludeDeclaration = False
+          toBool NoExcludeDeclaration  = False
 
 referenceTestSession :: String -> FilePath -> [FilePath] -> (FilePath -> Session ()) -> TestTree
 referenceTestSession name thisDoc docs' f = testSessionWithExtraFiles "references" name $ \dir -> do
@@ -5034,7 +5044,7 @@ runInDir' dir startExeIn startSessionIn extraOptions s = do
     checkEnv :: String -> IO (Maybe Bool)
     checkEnv s = fmap convertVal <$> getEnv s
     convertVal "0" = False
-    convertVal _ = True
+    convertVal _   = True
 
 openTestDataDoc :: FilePath -> Session TextDocumentIdentifier
 openTestDataDoc path = do
@@ -5064,7 +5074,7 @@ findCodeActions' op errMsg doc range expectedTitles = do
             ++ show expectedTitles
   liftIO $ case matches of
     Nothing -> assertFailure msg
-    Just _ -> pure ()
+    Just _  -> pure ()
   return (fromJust matches)
 
 findCodeAction :: TextDocumentIdentifier -> Range -> T.Text -> Session CodeAction
@@ -5295,4 +5305,4 @@ withTempDir f = System.IO.Extra.withTempDir $ \dir -> do
 assertJust :: MonadIO m => String -> Maybe a -> m a
 assertJust s = \case
   Nothing -> liftIO $ assertFailure s
-  Just x -> pure x
+  Just x  -> pure x

--- a/ghcide/test/manual/lhs/Main.hs
+++ b/ghcide/test/manual/lhs/Main.hs
@@ -6,7 +6,7 @@ module Main
     main
   ) where
 
-import Test (main)
+import           Test (main)
 
 
 

--- a/ghcide/test/preprocessor/Main.hs
+++ b/ghcide/test/preprocessor/Main.hs
@@ -1,7 +1,7 @@
 
 module Main(main) where
 
-import System.Environment
+import           System.Environment
 
 main :: IO ()
 main = do

--- a/ghcide/test/src/Development/IDE/Test.hs
+++ b/ghcide/test/src/Development/IDE/Test.hs
@@ -1,9 +1,9 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE PolyKinds             #-}
 
 module Development.IDE.Test
   ( Cursor
@@ -22,23 +22,24 @@ module Development.IDE.Test
   , waitForAction
   ) where
 
-import qualified Data.Aeson as A
-import Control.Applicative.Combinators
-import Control.Lens hiding (List)
-import Control.Monad
-import Control.Monad.IO.Class
-import Data.Bifunctor (second)
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
-import Language.LSP.Test hiding (message)
-import qualified Language.LSP.Test as LspTest
-import Language.LSP.Types
-import Language.LSP.Types.Lens as Lsp
-import System.Time.Extra
-import Test.Tasty.HUnit
-import System.Directory (canonicalizePath)
-import Data.Maybe (fromJust)
-import Development.IDE.Plugin.Test (WaitForIdeRuleResult, TestRequest(..))
+import           Control.Applicative.Combinators
+import           Control.Lens                    hiding (List)
+import           Control.Monad
+import           Control.Monad.IO.Class
+import qualified Data.Aeson                      as A
+import           Data.Bifunctor                  (second)
+import qualified Data.Map.Strict                 as Map
+import           Data.Maybe                      (fromJust)
+import qualified Data.Text                       as T
+import           Development.IDE.Plugin.Test     (TestRequest (..),
+                                                  WaitForIdeRuleResult)
+import           Language.LSP.Test               hiding (message)
+import qualified Language.LSP.Test               as LspTest
+import           Language.LSP.Types
+import           Language.LSP.Types.Lens         as Lsp
+import           System.Directory                (canonicalizePath)
+import           System.Time.Extra
+import           Test.Tasty.HUnit
 
 -- | (0-based line number, 0-based column number)
 type Cursor = (Int, Int)
@@ -62,8 +63,8 @@ requireDiagnostic actuals expected@(severity, cursor, expectedMsg, expectedTag) 
         && hasTag expectedTag (d ^. tags)
 
     hasTag :: Maybe DiagnosticTag -> Maybe (List DiagnosticTag) -> Bool
-    hasTag Nothing  _       = True
-    hasTag (Just _) Nothing = False
+    hasTag Nothing  _                          = True
+    hasTag (Just _) Nothing                    = False
     hasTag (Just actualTag) (Just (List tags)) = actualTag `elem` tags
 
 -- |wait for @timeout@ seconds and report an assertion failure
@@ -186,7 +187,7 @@ standardizeQuotes msg = let
         repl '‘' = '\''
         repl '’' = '\''
         repl '`' = '\''
-        repl  c   = c
+        repl  c  = c
     in  T.map repl msg
 
 waitForAction :: String -> TextDocumentIdentifier -> Session (Either ResponseError WaitForIdeRuleResult)
@@ -197,5 +198,5 @@ waitForAction key TextDocumentIdentifier{_uri} = do
     return $ do
       e <- _result
       case A.fromJSON e of
-        A.Error e -> Left $ ResponseError InternalError (T.pack e) Nothing
+        A.Error e   -> Left $ ResponseError InternalError (T.pack e) Nothing
         A.Success a -> pure a

--- a/hls-plugin-api/src/Ide/Plugin/Config.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Config.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE TypeFamilies       #-}
 module Ide.Plugin.Config
     ( getConfigFromNotification
     , Config(..)
@@ -14,13 +14,13 @@ module Ide.Plugin.Config
     ) where
 
 import           Control.Applicative
-import qualified Data.Aeson                    as A
-import qualified Data.Aeson.Types              as A
-import           Data.Aeson              hiding ( Error )
+import           Data.Aeson          hiding (Error)
+import qualified Data.Aeson          as A
+import qualified Data.Aeson.Types    as A
 import           Data.Default
-import qualified Data.Text                     as T
-import qualified Data.Map as Map
-import GHC.Generics (Generic)
+import qualified Data.Map            as Map
+import qualified Data.Text           as T
+import           GHC.Generics        (Generic)
 
 -- ---------------------------------------------------------------------
 

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -1,54 +1,54 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE BangPatterns         #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DefaultSignatures    #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns         #-}
 
 module Ide.Types
     where
 
 #ifdef mingw32_HOST_OS
-import qualified System.Win32.Process                    as P (getCurrentProcessId)
+import qualified System.Win32.Process            as P (getCurrentProcessId)
 #else
+import qualified System.Posix.Process            as P (getProcessID)
 import           System.Posix.Signals
-import qualified System.Posix.Process                    as P (getProcessID)
 #endif
-import           Data.Aeson                    hiding (defaultOptions)
-import           GHC.Generics
-import qualified Data.Map  as Map
-import           Data.String
-import qualified Data.Text                     as T
-import           Development.Shake hiding (command)
-import           Ide.Plugin.Config
-import           Language.LSP.Types
-import           Language.LSP.VFS
-import           Language.LSP.Types.Lens as J hiding (id)
-import           Language.LSP.Types.Capabilities
-import           Language.LSP.Server (LspM, getVirtualFile)
-import           Text.Regex.TDFA.Text()
-import           Data.Dependent.Map (DMap)
-import qualified Data.Dependent.Map as DMap
-import Data.List.NonEmpty (NonEmpty(..), toList)
-import Data.GADT.Compare
-import Data.Maybe
-import Data.Semigroup
-import Control.Lens ((^.))
-import qualified Data.DList as DList
+import           Control.Lens                    ((^.))
+import           Control.Monad
+import           Data.Aeson                      hiding (defaultOptions)
+import qualified Data.DList                      as DList
 import qualified Data.Default
-import System.IO.Unsafe
-import Control.Monad
-import OpenTelemetry.Eventlog
-import Data.Text.Encoding (encodeUtf8)
+import           Data.Dependent.Map              (DMap)
+import qualified Data.Dependent.Map              as DMap
+import           Data.GADT.Compare
+import           Data.List.NonEmpty              (NonEmpty (..), toList)
+import qualified Data.Map                        as Map
+import           Data.Maybe
+import           Data.Semigroup
+import           Data.String
+import qualified Data.Text                       as T
+import           Data.Text.Encoding              (encodeUtf8)
+import           Development.Shake               hiding (command)
+import           GHC.Generics
+import           Ide.Plugin.Config
+import           Language.LSP.Server             (LspM, getVirtualFile)
+import           Language.LSP.Types
+import           Language.LSP.Types.Capabilities
+import           Language.LSP.Types.Lens         as J hiding (id)
+import           Language.LSP.VFS
+import           OpenTelemetry.Eventlog
+import           System.IO.Unsafe
+import           Text.Regex.TDFA.Text            ()
 
 -- ---------------------------------------------------------------------
 
@@ -58,10 +58,10 @@ newtype IdePlugins ideState = IdePlugins
 -- ---------------------------------------------------------------------
 
 data PluginDescriptor ideState =
-  PluginDescriptor { pluginId          :: !PluginId
-                   , pluginRules       :: !(Rules ())
-                   , pluginCommands    :: ![PluginCommand ideState]
-                   , pluginHandlers    :: PluginHandlers ideState
+  PluginDescriptor { pluginId       :: !PluginId
+                   , pluginRules    :: !(Rules ())
+                   , pluginCommands :: ![PluginCommand ideState]
+                   , pluginHandlers :: PluginHandlers ideState
                    }
 
 -- | Methods that can be handled by plugins.

--- a/install.hs
+++ b/install.hs
@@ -16,6 +16,6 @@ build-depends:
 -- TODO: set `shake.project` in cabal-config above, when supported
 -- (see https://github.com/haskell/cabal/issues/6353)
 
-import HlsInstall (defaultMain)
+import           HlsInstall (defaultMain)
 
 main = defaultMain

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE CPP #-}
 module Cabal where
 
+import           Control.Monad
 import           Development.Shake
 import           Development.Shake.FilePath
-import           Control.Monad
-import           System.Directory                         ( copyFile )
-import           System.Info                              ( os )
+import           System.Directory           (copyFile)
+import           System.Info                (os)
 
-import           Version
-import           Print
 import           Env
+import           Print
+import           Version
 #if RUN_FROM_STACK
-import           Control.Exception                        ( throwIO )
+import           Control.Exception          (throwIO)
 #else
 import           Cabal.Config
 import           Data.Functor.Identity
@@ -131,16 +131,16 @@ requiredCabalVersionForWindows = [3, 0, 0, 0]
 getVerbosityArg :: Verbosity -> String
 getVerbosityArg v = "-v" ++ cabalVerbosity
   where cabalVerbosity = case v of
-          Silent ->     "0"
+          Silent     ->     "0"
 #if MIN_VERSION_shake(0,18,4)
-          Error ->      "0"
-          Warn ->       "1"
-          Info ->       "1"
-          Verbose ->    "2"
+          Error      ->      "0"
+          Warn       ->       "1"
+          Info       ->       "1"
+          Verbose    ->    "2"
 #else
-          Quiet ->      "0"
-          Normal ->     "1"
-          Loud ->       "2"
-          Chatty ->     "2"
+          Quiet      ->      "0"
+          Normal     ->     "1"
+          Loud       ->       "2"
+          Chatty     ->     "2"
 #endif
           Diagnostic -> "3"

--- a/install/src/Env.hs
+++ b/install/src/Env.hs
@@ -1,34 +1,23 @@
 module Env where
 
-import           Development.Shake
-import           Control.Monad.IO.Class
 import           Control.Monad
+import           Control.Monad.Extra        (mapMaybeM)
+import           Control.Monad.IO.Class
+import           Data.Function              (on, (&))
+import           Data.List                  (isInfixOf, sort, sortBy)
+import           Data.List.Extra            (nubOrdBy, trim)
+import           Data.Maybe                 (isJust, mapMaybe)
+import           Data.Ord                   (comparing)
+import           Development.Shake
 import           Development.Shake.FilePath
-import           System.Info                              ( os )
-import           Data.Maybe                               ( isJust
-                                                          , mapMaybe
-                                                          )
-import           System.Directory                         ( findExecutable
-                                                          , findExecutables
-                                                          , listDirectory
-                                                          )
-import           Data.Function                            ( (&)
-                                                          , on
-                                                          )
-import           Data.List                                ( sort
-                                                          , sortBy
-                                                          , isInfixOf
-                                                          )
-import           Data.List.Extra                          ( nubOrdBy
-                                                          , trim
-                                                          )
-import           Data.Ord                                 ( comparing )
-import           Control.Monad.Extra                      ( mapMaybeM )
+import           System.Directory           (findExecutable, findExecutables,
+                                             listDirectory)
+import           System.Info                (os)
 
-import qualified Data.Text                     as T
+import qualified Data.Text                  as T
 
-import           Version
 import           Print
+import           Version
 
 
 type GhcPath = String
@@ -86,7 +75,7 @@ getGhcPathOf :: MonadIO m => VersionNumber -> m (Maybe GhcPath)
 getGhcPathOf ghcVersion =
   liftIO $ findExecutable ("ghc-" ++ ghcVersion <.> exe) >>= \case
     Nothing -> lookup ghcVersion <$> getGhcPaths
-    path -> return path
+    path    -> return path
 
 -- | Get a list of GHCs that are available in $PATH
 getGhcPaths :: MonadIO m => m [(VersionNumber, GhcPath)]

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -1,13 +1,13 @@
 -- |Module for Help messages and traget descriptions
 module Help where
 
+import           Data.List         (intercalate)
 import           Development.Shake
-import           Data.List                                ( intercalate )
 
+import           BuildSystem
 import           Env
 import           Print
 import           Version
-import           BuildSystem
 
 stackCommand :: TargetDescription -> String
 stackCommand target = "stack install.hs " ++ fst target ++ " [options]"

--- a/install/src/HlsInstall.hs
+++ b/install/src/HlsInstall.hs
@@ -1,15 +1,15 @@
 module HlsInstall where
 
-import           Development.Shake
 import           Control.Monad
-import           System.Environment                       ( unsetEnv )
+import           Development.Shake
+import           System.Environment (unsetEnv)
 
 import           BuildSystem
-import           Stack
 import           Cabal
-import           Version
 import           Env
 import           Help
+import           Stack
+import           Version
 
 defaultMain :: IO ()
 defaultMain = do

--- a/install/src/Print.hs
+++ b/install/src/Print.hs
@@ -1,10 +1,10 @@
 module Print where
 
-import           Development.Shake
 import           Control.Monad.IO.Class
-import           Data.List                                ( dropWhileEnd )
-import           Data.List.Extra                          ( trim )
-import           Data.Char                                ( isSpace )
+import           Data.Char              (isSpace)
+import           Data.List              (dropWhileEnd)
+import           Data.List.Extra        (trim)
+import           Development.Shake
 
 -- | lift putStrLn to MonadIO
 printLine :: MonadIO m => String -> m ()

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE CPP #-}
 module Stack where
 
-import           Data.List.Extra                          ( trim )
+import           Control.Monad
+import           Data.List.Extra            (trim)
 import           Development.Shake
 import           Development.Shake.FilePath
-import           Control.Monad
-import           System.Directory                         ( copyFile )
+import           System.Directory           (copyFile)
 -- import           System.FilePath                          ( (</>) )
-import           System.Info                              ( os )
-import           Version
 import           Print
+import           System.Info                (os)
+import           Version
 
 stackInstallHlsWithErrMsg :: Maybe VersionNumber -> [String] -> Action ()
 stackInstallHlsWithErrMsg mbVersionNumber args =
@@ -123,17 +123,17 @@ stackBuildFailMsg =
 getVerbosityArg :: Verbosity -> String
 getVerbosityArg v = "--verbosity=" ++ stackVerbosity
   where stackVerbosity = case v of
-          Silent ->     "silent"
+          Silent     ->     "silent"
 #if MIN_VERSION_shake(0,18,4)
-          Error ->      "error"
-          Warn ->       "warn"
-          Info ->       "info"
-          Verbose ->    "info"
+          Error      ->      "error"
+          Warn       ->       "warn"
+          Info       ->       "info"
+          Verbose    ->    "info"
 #else
-          Quiet ->      "error"
-          Normal ->     "warn"
-          Loud ->       "info"
-          Chatty ->     "info"
+          Quiet      ->      "error"
+          Normal     ->     "warn"
+          Loud       ->       "info"
+          Chatty     ->     "info"
 #endif
 
           Diagnostic -> "debug"

--- a/install/src/Version.hs
+++ b/install/src/Version.hs
@@ -1,11 +1,8 @@
 module Version where
 
-import           Data.Version                             ( Version
-                                                          , parseVersion
-                                                          , makeVersion
-                                                          , showVersion
-                                                          )
-import           Text.ParserCombinators.ReadP             ( readP_to_S )
+import           Data.Version                 (Version, makeVersion,
+                                               parseVersion, showVersion)
+import           Text.ParserCombinators.ReadP (readP_to_S)
 
 
 type VersionNumber = String

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -54,7 +54,7 @@ in (import sources.nixpkgs
       # default_stages = ["manual" "push"];
       hooks = {
         stylish-haskell.enable = true;
-        stylish-haskell.excludes = [ "test/testdata/.*" "hie-compat/.*" ];
+        stylish-haskell.excludes = [ "^Setup.hs$" "test/testdata/.*$" "test/data/.*$" "^hie-compat/.*$" ];
       };
     };
   }

--- a/plugins/default/src/Ide/Plugin/Brittany.hs
+++ b/plugins/default/src/Ide/Plugin/Brittany.hs
@@ -1,28 +1,28 @@
-{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE PolyKinds    #-}
 {-# LANGUAGE TypeFamilies #-}
 module Ide.Plugin.Brittany where
-  
-import           Control.Exception (bracket_)
+
+import           Control.Exception           (bracket_)
 import           Control.Lens
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Maybe (MaybeT, runMaybeT)
+import           Control.Monad.Trans.Maybe   (MaybeT, runMaybeT)
 import           Data.Coerce
-import           Data.Maybe (mapMaybe, maybeToList)
+import           Data.Maybe                  (mapMaybe, maybeToList)
 import           Data.Semigroup
-import           Data.Text                             (Text)
-import qualified Data.Text                             as T
-import           Development.IDE hiding (pluginHandlers)
-import           Development.IDE.GHC.Compat (topDir, ModSummary(ms_hspp_opts))
-import qualified DynFlags                          as D
-import qualified EnumSet                           as S
+import           Data.Text                   (Text)
+import qualified Data.Text                   as T
+import           Development.IDE             hiding (pluginHandlers)
+import           Development.IDE.GHC.Compat  (ModSummary (ms_hspp_opts), topDir)
+import qualified DynFlags                    as D
+import qualified EnumSet                     as S
 import           GHC.LanguageExtensions.Type
-import           Language.Haskell.Brittany
-import           Language.LSP.Types            as J
-import qualified Language.LSP.Types.Lens       as J
 import           Ide.PluginUtils
 import           Ide.Types
+import           Language.Haskell.Brittany
+import           Language.LSP.Types          as J
+import qualified Language.LSP.Types.Lens     as J
+import           System.Environment          (setEnv, unsetEnv)
 import           System.FilePath
-import           System.Environment (setEnv, unsetEnv)
 
 descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId = (defaultPluginDescriptor plId)
@@ -108,11 +108,11 @@ showErr (ErrorUnknownNode s _)  = s
 showErr ErrorOutputCheck        = "Brittany error - invalid output"
 
 showExtension :: Extension -> Maybe String
-showExtension Cpp = Just "-XCPP"
+showExtension Cpp              = Just "-XCPP"
 -- Brittany chokes on parsing extensions that produce warnings
 showExtension DatatypeContexts = Nothing
-showExtension RecordPuns = Just "-XNamedFieldPuns"
-showExtension other = Just $ "-X" ++ show other
+showExtension RecordPuns       = Just "-XNamedFieldPuns"
+showExtension other            = Just $ "-X" ++ show other
 
 getExtensions :: D.DynFlags -> [String]
 getExtensions = mapMaybe showExtension . S.toList . D.extensionFlags

--- a/plugins/default/src/Ide/Plugin/Example.hs
+++ b/plugins/default/src/Ide/Plugin/Example.hs
@@ -1,39 +1,40 @@
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE TypeFamilies      #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ViewPatterns          #-}
 
 module Ide.Plugin.Example
   (
     descriptor
   ) where
 
-import Control.DeepSeq ( NFData )
-import Control.Monad.Trans.Maybe
-import Data.Aeson
-import Data.Binary
-import Data.Functor
-import qualified Data.HashMap.Strict as Map
-import Data.Hashable
-import qualified Data.Text as T
-import Data.Typeable
-import Development.IDE as D
-import Development.IDE.GHC.Compat (ParsedModule(ParsedModule))
-import Development.IDE.Core.Rules (useE)
-import Development.IDE.Core.Shake (getDiagnostics, getHiddenDiagnostics)
-import GHC.Generics
-import Ide.PluginUtils
-import Ide.Types
-import Language.LSP.Types
-import Language.LSP.Server
-import Text.Regex.TDFA.Text()
-import Control.Monad.IO.Class
+import           Control.DeepSeq            (NFData)
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Maybe
+import           Data.Aeson
+import           Data.Binary
+import           Data.Functor
+import qualified Data.HashMap.Strict        as Map
+import           Data.Hashable
+import qualified Data.Text                  as T
+import           Data.Typeable
+import           Development.IDE            as D
+import           Development.IDE.Core.Rules (useE)
+import           Development.IDE.Core.Shake (getDiagnostics,
+                                             getHiddenDiagnostics)
+import           Development.IDE.GHC.Compat (ParsedModule (ParsedModule))
+import           GHC.Generics
+import           Ide.PluginUtils
+import           Ide.Types
+import           Language.LSP.Server
+import           Language.LSP.Types
+import           Text.Regex.TDFA.Text       ()
 
 -- ---------------------------------------------------------------------
 
@@ -138,7 +139,7 @@ codeLens ideState plId CodeLensParams{_textDocument=TextDocumentIdentifier uri} 
 -- ---------------------------------------------------------------------
 -- | Parameters for the addTodo PluginCommand.
 data AddTodoParams = AddTodoParams
-  { file   :: Uri  -- ^ Uri of the file to add the pragma to
+  { file     :: Uri  -- ^ Uri of the file to add the pragma to
   , todoText :: T.Text
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)

--- a/plugins/default/src/Ide/Plugin/Floskell.hs
+++ b/plugins/default/src/Ide/Plugin/Floskell.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ide.Plugin.Floskell
@@ -8,16 +8,16 @@ module Ide.Plugin.Floskell
   )
 where
 
-import qualified Data.ByteString.Lazy           as BS
-import qualified Data.Text as T
-import qualified Data.Text.Encoding             as T
-import           Development.IDE as D           hiding (pluginHandlers)
+import           Control.Monad.IO.Class
+import qualified Data.ByteString.Lazy   as BS
+import qualified Data.Text              as T
+import qualified Data.Text.Encoding     as T
+import           Development.IDE        as D hiding (pluginHandlers)
 import           Floskell
 import           Ide.PluginUtils
 import           Ide.Types
 import           Language.LSP.Types
-import           Text.Regex.TDFA.Text()
-import Control.Monad.IO.Class
+import           Text.Regex.TDFA.Text   ()
 
 -- ---------------------------------------------------------------------
 

--- a/plugins/default/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/default/src/Ide/Plugin/Fourmolu.hs
@@ -1,34 +1,34 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PackageImports #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE PackageImports           #-}
+{-# LANGUAGE TypeApplications         #-}
 
 module Ide.Plugin.Fourmolu (
     descriptor,
     provider,
 ) where
 
-import Control.Exception
-import Data.Either.Extra
-import System.FilePath
+import           Control.Exception
+import           Data.Either.Extra
+import           System.FilePath
 
-import Control.Lens ((^.))
-import qualified Data.Text as T
-import Development.IDE as D hiding (pluginHandlers)
-import qualified DynFlags as D
-import qualified EnumSet as S
-import GHC (DynFlags, moduleNameString)
-import GHC.LanguageExtensions.Type (Extension (Cpp))
-import GhcPlugins (HscEnv (hsc_dflags))
-import Ide.PluginUtils (makeDiffTextEdit)
+import           Control.Lens                ((^.))
+import qualified Data.Text                   as T
+import           Development.IDE             as D hiding (pluginHandlers)
+import qualified DynFlags                    as D
+import qualified EnumSet                     as S
+import           GHC                         (DynFlags, moduleNameString)
+import           GHC.LanguageExtensions.Type (Extension (Cpp))
+import           GhcPlugins                  (HscEnv (hsc_dflags))
+import           Ide.PluginUtils             (makeDiffTextEdit)
 
-import Ide.Types
-import Language.LSP.Server
-import Language.LSP.Types
-import Language.LSP.Types.Lens
-import "fourmolu" Ormolu
-import Control.Monad.IO.Class
+import           Control.Monad.IO.Class
+import           Ide.Types
+import           Language.LSP.Server
+import           Language.LSP.Types
+import           Language.LSP.Types.Lens
+import           "fourmolu" Ormolu
 
 -- ---------------------------------------------------------------------
 
@@ -99,5 +99,5 @@ convertDynFlags df =
         ex = map showExtension $ S.toList $ D.extensionFlags df
         showExtension = \case
             Cpp -> "-XCPP"
-            x -> "-X" ++ show x
+            x   -> "-X" ++ show x
      in return $ map DynOption $ pp <> pm <> ex

--- a/plugins/default/src/Ide/Plugin/ModuleName.hs
+++ b/plugins/default/src/Ide/Plugin/ModuleName.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
 {-# OPTIONS_GHC -Wall -Wwarn -fno-warn-type-defaults -fno-warn-unused-binds -fno-warn-unused-imports -Wno-unticked-promoted-constructors #-}
 
 {- | Keep the module name in sync with its file path.
@@ -14,60 +14,39 @@ module Ide.Plugin.ModuleName (
     descriptor,
 ) where
 
-import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Monad
-import Data.Aeson (
-    ToJSON (toJSON),
-    Value (Null),
- )
-import Data.Char (isLower)
-import qualified Data.HashMap.Strict as Map
-import Data.List (find, intercalate, isPrefixOf)
-import Data.Maybe (maybeToList)
-import Data.String (IsString)
-import Data.Text (Text, pack)
-import qualified Data.Text as T
+import           Control.Monad
+import           Control.Monad.IO.Class (MonadIO (liftIO))
+import           Data.Aeson             (ToJSON (toJSON), Value (Null))
+import           Data.Char              (isLower)
+import qualified Data.HashMap.Strict    as Map
+import           Data.List              (find, intercalate, isPrefixOf)
+import           Data.Maybe             (maybeToList)
+import           Data.String            (IsString)
+import           Data.Text              (Text, pack)
+import qualified Data.Text              as T
 -- import Debug.Trace (trace)
-import Development.IDE (
-    GetParsedModule (
-        GetParsedModule
-    ),
-    GhcSession (GhcSession),
-    HscEnvEq,
-    IdeState,
-    List (..),
-    NormalizedFilePath,
-    Position (Position),
-    Range (Range),
-    evalGhcEnv,
-    hscEnvWithImportPaths,
-    realSrcSpanToRange,
-    runAction,
-    toNormalizedUri,
-    uriToFilePath',
-    use,
-    use_,
- )
-import GHC (
-    DynFlags (importPaths),
-    GenLocated (L),
-    HsModule (hsmodName),
-    ParsedModule (pm_parsed_source),
-    SrcSpan (RealSrcSpan),
-    getSessionDynFlags,
-    unLoc,
- )
-import Ide.PluginUtils (mkLspCmdId, getProcessID)
-import Ide.Types
-import Language.LSP.Server
-import Language.LSP.Types
-import Language.LSP.VFS (virtualFileText)
-import System.Directory (canonicalizePath)
-import System.FilePath (
-    dropExtension,
-    splitDirectories,
-    takeFileName,
- )
+import           Development.IDE        (GetParsedModule (GetParsedModule),
+                                         GhcSession (GhcSession), HscEnvEq,
+                                         IdeState, List (..),
+                                         NormalizedFilePath,
+                                         Position (Position), Range (Range),
+                                         evalGhcEnv, hscEnvWithImportPaths,
+                                         realSrcSpanToRange, runAction,
+                                         toNormalizedUri, uriToFilePath', use,
+                                         use_)
+import           GHC                    (DynFlags (importPaths), GenLocated (L),
+                                         HsModule (hsmodName),
+                                         ParsedModule (pm_parsed_source),
+                                         SrcSpan (RealSrcSpan),
+                                         getSessionDynFlags, unLoc)
+import           Ide.PluginUtils        (getProcessID, mkLspCmdId)
+import           Ide.Types
+import           Language.LSP.Server
+import           Language.LSP.Types
+import           Language.LSP.VFS       (virtualFileText)
+import           System.Directory       (canonicalizePath)
+import           System.FilePath        (dropExtension, splitDirectories,
+                                         takeFileName)
 
 -- |Plugin descriptor
 descriptor :: PluginId -> PluginDescriptor IdeState

--- a/plugins/default/src/Ide/Plugin/Ormolu.hs
+++ b/plugins/default/src/Ide/Plugin/Ormolu.hs
@@ -11,21 +11,21 @@ module Ide.Plugin.Ormolu
 where
 
 import           Control.Exception
-import qualified Data.Text                         as T
-import           Development.IDE hiding (pluginHandlers)
-import qualified DynFlags                          as D
-import qualified EnumSet                           as S
+import           Control.Monad.IO.Class
+import qualified Data.Text                   as T
+import           Development.IDE             hiding (pluginHandlers)
+import qualified DynFlags                    as D
+import qualified EnumSet                     as S
 import           GHC
 import           GHC.LanguageExtensions.Type
-import           GhcPlugins                        (HscEnv (hsc_dflags))
+import           GhcPlugins                  (HscEnv (hsc_dflags))
 import           Ide.PluginUtils
 import           Ide.Types
 import           Language.LSP.Server
 import           Language.LSP.Types
-import "ormolu"  Ormolu
-import           System.FilePath                   (takeFileName)
-import           Text.Regex.TDFA.Text              ()
-import Control.Monad.IO.Class
+import           "ormolu" Ormolu
+import           System.FilePath             (takeFileName)
+import           Text.Regex.TDFA.Text        ()
 
 -- ---------------------------------------------------------------------
 

--- a/plugins/default/src/Ide/Plugin/StylishHaskell.hs
+++ b/plugins/default/src/Ide/Plugin/StylishHaskell.hs
@@ -18,7 +18,7 @@ import           GHC.LanguageExtensions.Type
 import           Ide.PluginUtils
 import           Ide.Types
 import           Language.Haskell.Stylish
-import           Language.LSP.Types            as J
+import           Language.LSP.Types          as J
 
 import           System.Directory
 import           System.FilePath

--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class.hs
@@ -12,30 +12,32 @@ import           BooleanFormula
 import           Class
 import           ConLike
 import           Control.Applicative
-import           Control.Lens hiding (List, use)
+import           Control.Lens                            hiding (List, use)
 import           Control.Monad
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
 import           Data.Aeson
 import           Data.Char
 import           Data.List
-import qualified Data.Map.Strict as Map
+import qualified Data.Map.Strict                         as Map
 import           Data.Maybe
-import qualified Data.Text as T
-import           Development.IDE hiding (pluginHandlers)
-import           Development.IDE.Core.PositionMapping (fromCurrentRange, toCurrentRange)
-import           Development.IDE.GHC.Compat hiding (getLoc)
+import qualified Data.Text                               as T
+import           Development.IDE                         hiding (pluginHandlers)
+import           Development.IDE.Core.PositionMapping    (fromCurrentRange,
+                                                          toCurrentRange)
+import           Development.IDE.GHC.Compat              hiding (getLoc)
 import           Development.IDE.Spans.AtPoint
-import qualified GHC.Generics as Generics
-import           GhcPlugins hiding (Var, getLoc, (<>))
+import qualified GHC.Generics                            as Generics
+import           GhcPlugins                              hiding (Var, getLoc,
+                                                          (<>))
 import           Ide.PluginUtils
 import           Ide.Types
 import           Language.Haskell.GHC.ExactPrint
 import           Language.Haskell.GHC.ExactPrint.Parsers (parseDecl)
-import           Language.Haskell.GHC.ExactPrint.Types hiding (GhcPs, Parens)
+import           Language.Haskell.GHC.ExactPrint.Types   hiding (GhcPs, Parens)
 import           Language.LSP.Server
 import           Language.LSP.Types
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Types.Lens                 as J
 import           SrcLoc
 import           TcEnv
 import           TcRnMonad
@@ -87,7 +89,7 @@ addMethodPlaceholders state AddMinimalMethodsParams{..} = do
     makeMethodDecl df mName =
       case parseDecl df (T.unpack mName) . T.unpack $ toMethodName mName <> " = _" of
         Right (ann, d) -> Just (setPrecedingLines d 1 indent ann, d)
-        Left _ -> Nothing
+        Left _         -> Nothing
 
     addMethodDecls :: ParsedSource -> [LHsDecl GhcPs] -> Transform (Located (HsModule GhcPs))
     addMethodDecls ps mDecls = do
@@ -203,7 +205,7 @@ isClassMethodWarning = T.isPrefixOf "• No explicit implementation for"
 minDefToMethodGroups :: BooleanFormula Name -> [[T.Text]]
 minDefToMethodGroups = go
   where
-    go (Var mn) = [[T.pack . occNameString . occName $ mn]]
-    go (Or ms) = concatMap (go . unLoc) ms
-    go (And ms) = foldr (liftA2 (<>)) [[]] (fmap (go . unLoc) ms)
+    go (Var mn)   = [[T.pack . occNameString . occName $ mn]]
+    go (Or ms)    = concatMap (go . unLoc) ms
+    go (And ms)   = foldr (liftA2 (<>)) [[]] (fmap (go . unLoc) ms)
     go (Parens m) = go (unLoc m)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
@@ -4,27 +4,23 @@
 -- | Expression execution
 module Ide.Plugin.Eval.Code (Statement, testRanges, resultRange, evalExtensions, evalSetup, evalExpr, propSetup, testCheck, asStatements) where
 
-import Data.Algorithm.Diff (Diff, PolyDiff (..), getDiff)
-import qualified Data.List.NonEmpty as NE
-import Data.String (IsString)
-import qualified Data.Text as T
-import Development.IDE.Types.Location (Position (..), Range (..))
-import GHC (compileExpr)
-import GHC.LanguageExtensions.Type (Extension (..))
-import GhcMonad (Ghc, GhcMonad, liftIO)
-import Ide.Plugin.Eval.Types (
-    Language (Plain),
-    Loc,
-    Section (sectionLanguage),
-    Test (..),
-    Txt,
-    locate,
-    locate0, Located(..)
- )
-import InteractiveEval (runDecls)
-import Unsafe.Coerce (unsafeCoerce)
-import Control.Lens ((^.))
-import Language.LSP.Types.Lens (start, line)
+import           Control.Lens                   ((^.))
+import           Data.Algorithm.Diff            (Diff, PolyDiff (..), getDiff)
+import qualified Data.List.NonEmpty             as NE
+import           Data.String                    (IsString)
+import qualified Data.Text                      as T
+import           Development.IDE.Types.Location (Position (..), Range (..))
+import           GHC                            (compileExpr)
+import           GHC.LanguageExtensions.Type    (Extension (..))
+import           GhcMonad                       (Ghc, GhcMonad, liftIO)
+import           Ide.Plugin.Eval.Types          (Language (Plain), Loc,
+                                                 Located (..),
+                                                 Section (sectionLanguage),
+                                                 Test (..), Txt, locate,
+                                                 locate0)
+import           InteractiveEval                (runDecls)
+import           Language.LSP.Types.Lens        (line, start)
+import           Unsafe.Coerce                  (unsafeCoerce)
 
 -- | Return the ranges of the expression and result parts of the given test
 testRanges :: Test -> (Range, Range)
@@ -57,7 +53,7 @@ showDiffs :: (Semigroup a, IsString a) => [Diff a] -> [a]
 showDiffs = map showDiff
 
 showDiff :: (Semigroup a, IsString a) => Diff a -> a
-showDiff (First w) = "WAS " <> w
+showDiff (First w)  = "WAS " <> w
 showDiff (Second w) = "NOW " <> w
 showDiff (Both w _) = w
 
@@ -67,7 +63,7 @@ testCheck (section, test) out
     | otherwise = showDiffs $ getDiff (map T.pack $ testOutput test) out
 
 testLenghts :: Test -> (Int, Int)
-testLenghts (Example e r _) = (NE.length e, length r)
+testLenghts (Example e r _)  = (NE.length e, length r)
 testLenghts (Property _ r _) = (1, length r)
 
 -- |A one-line Haskell statement

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneDeriving  #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports -Wno-orphans #-}
 
 -- |GHC API utilities
@@ -14,29 +14,25 @@ module Ide.Plugin.Eval.GHC (
     showDynFlags,
 ) where
 
-import Data.List (isPrefixOf)
-import Data.Maybe (mapMaybe)
-import Development.IDE.GHC.Compat
+import           Data.List                   (isPrefixOf)
+import           Data.Maybe                  (mapMaybe)
+import           Data.String                 (fromString)
+import           Development.IDE.GHC.Compat
 import qualified EnumSet
-import GHC.LanguageExtensions.Type (Extension (..))
-import GhcMonad (modifySession)
-import GhcPlugins (DefUnitId (..), InstalledUnitId (..), fsLit, hsc_IC, pprHsString)
-import HscTypes (InteractiveContext (ic_dflags))
-import Ide.Plugin.Eval.Util (asS, gStrictTry)
+import           GHC.LanguageExtensions.Type (Extension (..))
+import           GhcMonad                    (modifySession)
+import           GhcPlugins                  (DefUnitId (..),
+                                              InstalledUnitId (..), fsLit,
+                                              hsc_IC, pprHsString)
+import           HscTypes                    (InteractiveContext (ic_dflags))
+import           Ide.Plugin.Eval.Util        (asS, gStrictTry)
 import qualified Lexer
-import Module (UnitId (DefiniteUnitId))
-import Outputable (
-    Outputable (ppr),
-    SDoc,
-    showSDocUnsafe,
-    text,
-    vcat,
-    (<+>),
- )
+import           Module                      (UnitId (DefiniteUnitId))
+import           Outputable                  (Outputable (ppr), SDoc,
+                                              showSDocUnsafe, text, vcat, (<+>))
 import qualified Parser
-import SrcLoc (mkRealSrcLoc)
-import StringBuffer (stringToStringBuffer)
-import Data.String (fromString)
+import           SrcLoc                      (mkRealSrcLoc)
+import           StringBuffer                (stringToStringBuffer)
 
 {- $setup
 >>> import GHC
@@ -63,7 +59,7 @@ False
 -}
 isExpr :: DynFlags -> String -> Bool
 isExpr df stmt = case parseThing Parser.parseExpression df stmt of
-    Lexer.POk _ _ -> True
+    Lexer.POk _ _   -> True
     Lexer.PFailed{} -> False
 
 parseThing :: Lexer.P thing -> DynFlags -> String -> Lexer.ParseResult thing
@@ -107,9 +103,9 @@ pkgNames_ :: [PackageFlag] -> [String]
 pkgNames_ =
     mapMaybe
         ( \case
-            ExposePackage _ (PackageArg n) _ -> Just n
+            ExposePackage _ (PackageArg n) _                 -> Just n
             ExposePackage _ (UnitIdArg (DefiniteUnitId n)) _ -> Just $ asS n
-            _ -> Nothing
+            _                                                -> Nothing
         )
 
 {- | Expose a list of packages.

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Parse/Option.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Parse/Option.hs
@@ -6,10 +6,10 @@ module Ide.Plugin.Eval.Parse.Option (
     parseSetFlags,
 ) where
 
-import Text.Megaparsec.Char
-import Text.Megaparsec
-import Data.Void (Void)
-import Control.Arrow (left)
+import           Control.Arrow        (left)
+import           Data.Void            (Void)
+import           Text.Megaparsec
+import           Text.Megaparsec.Char
 
 {- |
 >>> langOptions ":set   -XBinaryLiterals  -XOverloadedStrings "

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableInstances       #-}
 {-# OPTIONS_GHC -Wwarn #-}
 
 module Ide.Plugin.Eval.Types
@@ -29,16 +29,16 @@ module Ide.Plugin.Eval.Types
     )
 where
 
-import Control.DeepSeq (NFData (rnf), deepseq)
-import Data.Aeson (FromJSON, ToJSON)
-import Data.List (partition)
-import Data.List.NonEmpty (NonEmpty)
-import Data.Map.Strict (Map)
-import Data.String (IsString (..))
-import Development.IDE (Range)
-import GHC.Generics (Generic)
-import qualified Text.Megaparsec as P
-import Language.LSP.Types (TextDocumentIdentifier)
+import           Control.DeepSeq    (NFData (rnf), deepseq)
+import           Data.Aeson         (FromJSON, ToJSON)
+import           Data.List          (partition)
+import           Data.List.NonEmpty (NonEmpty)
+import           Data.Map.Strict    (Map)
+import           Data.String        (IsString (..))
+import           Development.IDE    (Range)
+import           GHC.Generics       (Generic)
+import           Language.LSP.Types (TextDocumentIdentifier)
+import qualified Text.Megaparsec    as P
 
 -- | A thing with a location attached.
 data Located l a = Located {location :: l, located :: a}
@@ -65,15 +65,15 @@ type Txt = String
 
 data Sections = Sections
     { nonSetupSections :: [Section]
-    , setupSections :: [Section]
+    , setupSections    :: [Section]
     }
     deriving (Show, Eq, Generic)
 
 data Section = Section
-    { sectionName :: Txt
-    , sectionTests :: [Test]
+    { sectionName     :: Txt
+    , sectionTests    :: [Test]
     , sectionLanguage :: Language
-    , sectionFormat :: Format
+    , sectionFormat   :: Format
     }
     deriving (Eq, Show, Generic, FromJSON, ToJSON, NFData)
 
@@ -93,7 +93,7 @@ data Test
     deriving (Eq, Show, Generic, FromJSON, ToJSON, NFData)
 
 data Comments = Comments
-    { lineComments :: Map Range RawLineComment
+    { lineComments  :: Map Range RawLineComment
     , blockComments :: Map Range RawBlockComment
     }
     deriving (Show, Eq, Ord, Generic)
@@ -128,7 +128,7 @@ instance Monoid Comments where
 
 isProperty :: Test -> Bool
 isProperty Property {} = True
-isProperty _ = False
+isProperty _           = False
 
 data Format
     = SingleLine
@@ -156,7 +156,7 @@ type EvalId = Int
 -- | Specify the test section to execute
 data EvalParams = EvalParams
     { sections :: [Section]
-    , module_ :: !TextDocumentIdentifier
-    , evalId :: !EvalId -- ^ unique group id; for test uses
+    , module_  :: !TextDocumentIdentifier
+    , evalId   :: !EvalId -- ^ unique group id; for test uses
     }
     deriving (Eq, Show, Generic, FromJSON, ToJSON)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- |Debug utilities
@@ -15,40 +15,29 @@ module Ide.Plugin.Eval.Util (
     logWith,
 ) where
 
-import Control.Monad.Extra (maybeM)
-import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Except (
-    ExceptT (..),
-    runExceptT,
-    throwE,
- )
-import Data.Aeson (Value (Null))
-import Data.Bifunctor (first)
-import Data.String (IsString (fromString))
-import qualified Data.Text as T
-import Development.IDE (
-    IdeState,
-    Priority (..),
-    ideLogger,
-    logPriority,
- )
-import Exception (ExceptionMonad, SomeException (..), evaluate, gcatch)
-import GHC.Exts (toList)
-import GHC.Stack (HasCallStack, callStack, srcLocFile, srcLocStartCol, srcLocStartLine)
-import Language.LSP.Server
-import Language.LSP.Types
-import Outputable (
-    Outputable (ppr),
-    ppr,
-    showSDocUnsafe,
- )
-import System.FilePath (takeExtension)
-import System.Time.Extra (
-    duration,
-    showDuration,
- )
-import UnliftIO.Exception (catchAny)
+import           Control.Monad.Extra        (maybeM)
+import           Control.Monad.IO.Class     (MonadIO (liftIO))
+import           Control.Monad.Trans.Class  (lift)
+import           Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
+import           Data.Aeson                 (Value (Null))
+import           Data.Bifunctor             (first)
+import           Data.String                (IsString (fromString))
+import qualified Data.Text                  as T
+import           Development.IDE            (IdeState, Priority (..), ideLogger,
+                                             logPriority)
+import           Exception                  (ExceptionMonad, SomeException (..),
+                                             evaluate, gcatch)
+import           GHC.Exts                   (toList)
+import           GHC.Stack                  (HasCallStack, callStack,
+                                             srcLocFile, srcLocStartCol,
+                                             srcLocStartLine)
+import           Language.LSP.Server
+import           Language.LSP.Types
+import           Outputable                 (Outputable (ppr), ppr,
+                                             showSDocUnsafe)
+import           System.FilePath            (takeExtension)
+import           System.Time.Extra          (duration, showDuration)
+import           UnliftIO.Exception         (catchAny)
 
 asS :: Outputable a => a -> String
 asS = showSDocUnsafe . ppr

--- a/plugins/hls-eval-plugin/test/Eval.hs
+++ b/plugins/hls-eval-plugin/test/Eval.hs
@@ -1,45 +1,36 @@
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE ViewPatterns          #-}
 
 module Eval (
     tests,
 ) where
 
-import Control.Applicative.Combinators (
-    skipManyTill
- )
-import Control.Monad (when)
-import Control.Monad.IO.Class (MonadIO (liftIO))
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
-import Language.LSP.Test
-import Language.LSP.Types
-import Language.LSP.Types.Lens (command, title, range)
-import Control.Lens (view, _Just, preview)
-import System.Directory (doesFileExist)
-import System.FilePath (
-    (<.>),
-    (</>),
- )
-import Test.Hls.Util (hlsCommand, GhcVersion (GHC84, GHC86), knownBrokenForGhcVersions, knownBrokenInEnv, EnvSpec (HostOS, GhcVer), OS (Windows))
-import Test.Tasty (
-    TestTree,
-    testGroup,
- )
-import Test.Tasty.ExpectedFailure (
-    expectFailBecause,
- )
-import Test.Tasty.HUnit (
-    testCase,
-    (@?=),
- )
-import Data.List.Extra (nubOrdOn)
-import Ide.Plugin.Eval.Types (EvalParams(..))
-import Data.Aeson (fromJSON)
-import Data.Aeson.Types (Result(Success))
+import           Control.Applicative.Combinators (skipManyTill)
+import           Control.Lens                    (_Just, preview, view)
+import           Control.Monad                   (when)
+import           Control.Monad.IO.Class          (MonadIO (liftIO))
+import           Data.Aeson                      (fromJSON)
+import           Data.Aeson.Types                (Result (Success))
+import           Data.List.Extra                 (nubOrdOn)
+import qualified Data.Text                       as T
+import qualified Data.Text.IO                    as T
+import           Ide.Plugin.Eval.Types           (EvalParams (..))
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Language.LSP.Types.Lens         (command, range, title)
+import           System.Directory                (doesFileExist)
+import           System.FilePath                 ((<.>), (</>))
+import           Test.Hls.Util                   (EnvSpec (GhcVer, HostOS),
+                                                  GhcVersion (GHC84, GHC86),
+                                                  OS (Windows), hlsCommand,
+                                                  knownBrokenForGhcVersions,
+                                                  knownBrokenInEnv)
+import           Test.Tasty                      (TestTree, testGroup)
+import           Test.Tasty.ExpectedFailure      (expectFailBecause)
+import           Test.Tasty.HUnit                (testCase, (@?=))
 
 tests :: TestTree
 tests =

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -1,43 +1,42 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 #include "ghc-api-version.h"
 
 module Ide.Plugin.ExplicitImports (descriptor) where
 
-import Control.DeepSeq
-import Control.Monad.IO.Class
-import Data.Aeson (ToJSON (toJSON), Value (Null))
-import Data.Aeson.Types (FromJSON)
-import qualified Data.HashMap.Strict as HashMap
-import Data.IORef (readIORef)
-import qualified Data.Map.Strict as Map
-import Data.Maybe (catMaybes, fromMaybe)
-import qualified Data.Text as T
-import Development.IDE
-import Development.IDE.Core.PositionMapping
-import Development.IDE.GHC.Compat
-import Development.Shake.Classes
-import GHC.Generics (Generic)
-import Ide.PluginUtils ( mkLspCommand )
-import Ide.Types
-import Language.LSP.Types
-import Language.LSP.Server
-import PrelNames (pRELUDE)
-import RnNames
-  ( findImportUsage,
-    getMinimalImports,
-  )
-import TcRnMonad (initTcWithGbl)
-import TcRnTypes (TcGblEnv (tcg_used_gres))
+import           Control.DeepSeq
+import           Control.Monad.IO.Class
+import           Data.Aeson                           (ToJSON (toJSON),
+                                                       Value (Null))
+import           Data.Aeson.Types                     (FromJSON)
+import qualified Data.HashMap.Strict                  as HashMap
+import           Data.IORef                           (readIORef)
+import qualified Data.Map.Strict                      as Map
+import           Data.Maybe                           (catMaybes, fromMaybe)
+import qualified Data.Text                            as T
+import           Development.IDE
+import           Development.IDE.Core.PositionMapping
+import           Development.IDE.GHC.Compat
+import           Development.Shake.Classes
+import           GHC.Generics                         (Generic)
+import           Ide.PluginUtils                      (mkLspCommand)
+import           Ide.Types
+import           Language.LSP.Server
+import           Language.LSP.Types
+import           PrelNames                            (pRELUDE)
+import           RnNames                              (findImportUsage,
+                                                       getMinimalImports)
+import           TcRnMonad                            (initTcWithGbl)
+import           TcRnTypes                            (TcGblEnv (tcg_used_gres))
 
 importCommandId :: CommandId
 importCommandId = "ImportLensCommand"
@@ -46,7 +45,7 @@ importCommandId = "ImportLensCommand"
 descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId =
   (defaultPluginDescriptor plId)
-    { 
+    {
       -- This plugin provides a command handler
       pluginCommands = [importLensCommand],
       -- This plugin defines a new rule

--- a/plugins/hls-haddock-comments-plugin/src/Ide/Plugin/HaddockComments.hs
+++ b/plugins/hls-haddock-comments-plugin/src/Ide/Plugin/HaddockComments.hs
@@ -1,25 +1,26 @@
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 module Ide.Plugin.HaddockComments (descriptor) where
 
-import Control.Monad (join)
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Map as Map
-import qualified Data.Text as T
-import Development.IDE hiding (pluginHandlers)
-import Development.IDE.GHC.Compat
-import Development.IDE.GHC.ExactPrint (GetAnnotatedParsedSource (..), annsA, astA)
-import Ide.Types
-import Language.Haskell.GHC.ExactPrint
-import Language.Haskell.GHC.ExactPrint.Types hiding (GhcPs)
-import Language.Haskell.GHC.ExactPrint.Utils
-import Language.LSP.Types
-import Control.Monad.IO.Class
+import           Control.Monad                         (join)
+import           Control.Monad.IO.Class
+import qualified Data.HashMap.Strict                   as HashMap
+import qualified Data.Map                              as Map
+import qualified Data.Text                             as T
+import           Development.IDE                       hiding (pluginHandlers)
+import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.ExactPrint        (GetAnnotatedParsedSource (..),
+                                                        annsA, astA)
+import           Ide.Types
+import           Language.Haskell.GHC.ExactPrint
+import           Language.Haskell.GHC.ExactPrint.Types hiding (GhcPs)
+import           Language.Haskell.GHC.ExactPrint.Utils
+import           Language.LSP.Types
 
 -----------------------------------------------------------------------------
 descriptor :: PluginId -> PluginDescriptor IdeState
@@ -50,11 +51,11 @@ genList =
 -- | Defines how to generate haddock comments by tweaking annotations of AST
 data GenComments = forall a.
   GenComments
-  { title :: T.Text,
-    fromDecl :: HsDecl GhcPs -> Maybe a,
-    collectKeys :: a -> [AnnKey],
-    isFresh :: Annotation -> Bool,
-    updateAnn :: Annotation -> Annotation,
+  { title         :: T.Text,
+    fromDecl      :: HsDecl GhcPs -> Maybe a,
+    collectKeys   :: a -> [AnnKey],
+    isFresh       :: Annotation -> Bool,
+    updateAnn     :: Annotation -> Annotation,
     updateDeclAnn :: Annotation -> Annotation
   }
 
@@ -81,7 +82,7 @@ genForSig = GenComments {..}
     title = "Generate signature comments"
 
     fromDecl (SigD _ (TypeSig _ _ (HsWC _ (HsIB _ x)))) = Just x
-    fromDecl _ = Nothing
+    fromDecl _                                          = Nothing
 
     updateAnn x = x {annEntryDelta = DP (0, 1), annsDP = dp}
     updateDeclAnn = cleanPriorComments

--- a/plugins/hls-splice-plugin/src/Ide/Plugin/Splice/Types.hs
+++ b/plugins/hls-splice-plugin/src/Ide/Plugin/Splice/Types.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings  #-}
 
 module Ide.Plugin.Splice.Types where
 
-import Data.Aeson (FromJSON, ToJSON)
-import Development.IDE (Uri)
-import GHC.Generics (Generic)
-import Development.IDE.GHC.Compat (RealSrcSpan)
-import qualified Data.Text as T
-import Ide.Types ( CommandId )
+import           Data.Aeson                 (FromJSON, ToJSON)
+import qualified Data.Text                  as T
+import           Development.IDE            (Uri)
+import           Development.IDE.GHC.Compat (RealSrcSpan)
+import           GHC.Generics               (Generic)
+import           Ide.Types                  (CommandId)
 
 -- | Parameter for the addMethods PluginCommand.
 data ExpandSpliceParams = ExpandSpliceParams
-    { uri :: Uri
-    , spliceSpan :: RealSrcSpan
+    { uri           :: Uri
+    , spliceSpan    :: RealSrcSpan
     , spliceContext :: SpliceContext
     }
     deriving (Show, Eq, Generic)
@@ -36,11 +36,11 @@ expandStyles =
     ]
 
 toExpandCmdTitle :: ExpandStyle -> T.Text
-toExpandCmdTitle Inplace = inplaceCmdName
+toExpandCmdTitle Inplace   = inplaceCmdName
 toExpandCmdTitle Commented = commentedCmdName
 
 toCommandId :: ExpandStyle -> CommandId
-toCommandId Inplace = expandInplaceId
+toCommandId Inplace   = expandInplaceId
 toCommandId Commented = expandCommentedId
 
 expandInplaceId, expandCommentedId :: CommandId

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Auto.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Auto.hs
@@ -1,13 +1,13 @@
 module Ide.Plugin.Tactic.Auto where
 
-import Control.Monad.State (gets)
-import Ide.Plugin.Tactic.Context
-import Ide.Plugin.Tactic.Judgements
-import Ide.Plugin.Tactic.KnownStrategies
-import Ide.Plugin.Tactic.Machinery (tracing)
-import Ide.Plugin.Tactic.Tactics
-import Ide.Plugin.Tactic.Types
-import Refinery.Tactic
+import           Control.Monad.State               (gets)
+import           Ide.Plugin.Tactic.Context
+import           Ide.Plugin.Tactic.Judgements
+import           Ide.Plugin.Tactic.KnownStrategies
+import           Ide.Plugin.Tactic.Machinery       (tracing)
+import           Ide.Plugin.Tactic.Tactics
+import           Ide.Plugin.Tactic.Types
+import           Refinery.Tactic
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CaseSplit.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CaseSplit.hs
@@ -9,14 +9,14 @@ module Ide.Plugin.Tactic.CaseSplit
   , splitToDecl
   ) where
 
-import           Data.Bool (bool)
+import           Data.Bool                  (bool)
 import           Data.Data
 import           Data.Generics
-import           Data.Set (Set)
-import qualified Data.Set as S
+import           Data.Set                   (Set)
+import qualified Data.Set                   as S
 import           Development.IDE.GHC.Compat
-import           GHC.Exts (IsString(fromString))
-import           GHC.SourceGen (funBinds, match, wildP)
+import           GHC.Exts                   (IsString (fromString))
+import           GHC.SourceGen              (funBinds, match, wildP)
 import           Ide.Plugin.Tactic.GHC
 import           Ide.Plugin.Tactic.Types
 import           OccName
@@ -28,7 +28,7 @@ import           OccName
 -- match) and a body.
 mkFirstAgda :: [Pat GhcPs] -> HsExpr GhcPs -> AgdaMatch
 mkFirstAgda pats (Lambda pats' body) = mkFirstAgda (pats <> pats') body
-mkFirstAgda pats body = AgdaMatch pats body
+mkFirstAgda pats body                = AgdaMatch pats body
 
 
 ------------------------------------------------------------------------------
@@ -55,7 +55,7 @@ wildify (AgdaMatch pats body) =
 wildifyT :: Data a => Set OccName -> a -> a
 wildifyT (S.map occNameString -> used) = everywhere $ mkT $ \case
   VarPat _ (L _ var) | S.notMember (occNameString $ occName var) used -> wildP
-  (x :: Pat GhcPs) -> x
+  (x :: Pat GhcPs)                                                    -> x
 
 
 ------------------------------------------------------------------------------
@@ -63,7 +63,7 @@ wildifyT (S.map occNameString -> used) = everywhere $ mkT $ \case
 rewriteVarPat :: Data a => RdrName -> Pat GhcPs -> a -> a
 rewriteVarPat name rep = everywhere $ mkT $ \case
   VarPat _ (L _ var) | eqRdrName name var -> rep
-  (x :: Pat GhcPs) -> x
+  (x :: Pat GhcPs)                        -> x
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -1,21 +1,20 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections    #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns     #-}
 
 module Ide.Plugin.Tactic.CodeGen
   ( module Ide.Plugin.Tactic.CodeGen
   , module Ide.Plugin.Tactic.CodeGen.Utils
   ) where
 
-import           Control.Lens ((+~), (%~), (<>~))
+import           Control.Lens                    ((%~), (+~), (<>~))
 import           Control.Monad.Except
-import           Control.Monad.State (MonadState)
-import           Control.Monad.State.Class (modify)
-import           Data.Generics.Product (field)
+import           Control.Monad.State             (MonadState)
+import           Control.Monad.State.Class       (modify)
+import           Data.Generics.Product           (field)
 import           Data.List
-import qualified Data.Map as M
-import qualified Data.Set as S
+import qualified Data.Map                        as M
+import qualified Data.Set                        as S
 import           Data.Traversable
 import           DataCon
 import           Development.IDE.GHC.Compat
@@ -24,13 +23,13 @@ import           GHC.SourceGen.Binds
 import           GHC.SourceGen.Expr
 import           GHC.SourceGen.Overloaded
 import           GHC.SourceGen.Pat
+import           Ide.Plugin.Tactic.CodeGen.Utils
 import           Ide.Plugin.Tactic.GHC
 import           Ide.Plugin.Tactic.Judgements
 import           Ide.Plugin.Tactic.Machinery
 import           Ide.Plugin.Tactic.Naming
 import           Ide.Plugin.Tactic.Types
-import           Ide.Plugin.Tactic.CodeGen.Utils
-import           Type hiding (Var)
+import           Type                            hiding (Var)
 
 
 useOccName :: MonadState TacticState m => Judgement -> OccName -> m ()

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen/Utils.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen/Utils.hs
@@ -2,14 +2,14 @@
 
 module Ide.Plugin.Tactic.CodeGen.Utils where
 
-import Data.List
-import DataCon
-import Development.IDE.GHC.Compat
-import GHC.Exts
-import GHC.SourceGen (recordConE, RdrNameStr)
-import GHC.SourceGen.Overloaded
-import Ide.Plugin.Tactic.GHC (getRecordFields)
-import Name
+import           Data.List
+import           DataCon
+import           Development.IDE.GHC.Compat
+import           GHC.Exts
+import           GHC.SourceGen              (RdrNameStr, recordConE)
+import           GHC.SourceGen.Overloaded
+import           Ide.Plugin.Tactic.GHC      (getRecordFields)
+import           Name
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Context.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Context.hs
@@ -7,18 +7,18 @@ import           Bag
 import           Control.Arrow
 import           Control.Monad.Reader
 import           Data.List
-import           Data.Maybe (mapMaybe)
-import           Data.Set (Set)
-import qualified Data.Set as S
+import           Data.Maybe                   (mapMaybe)
+import           Data.Set                     (Set)
+import qualified Data.Set                     as S
 import           Development.IDE.GHC.Compat
-import           Ide.Plugin.Tactic.GHC (tacticsThetaTy)
-import           Ide.Plugin.Tactic.Machinery (methodHypothesis)
+import           Ide.Plugin.Tactic.FeatureSet (FeatureSet)
+import           Ide.Plugin.Tactic.GHC        (tacticsThetaTy)
+import           Ide.Plugin.Tactic.Machinery  (methodHypothesis)
 import           Ide.Plugin.Tactic.Types
 import           OccName
 import           TcRnTypes
-import           TcType (substTy, tcSplitSigmaTy)
-import           Unify (tcUnifyTy)
-import Ide.Plugin.Tactic.FeatureSet (FeatureSet)
+import           TcType                       (substTy, tcSplitSigmaTy)
+import           Unify                        (tcUnifyTy)
 
 
 mkContext :: FeatureSet -> [(OccName, CType)] -> TcGblEnv -> Context
@@ -84,7 +84,7 @@ getFunBindId :: HsBindLR GhcTc GhcTc -> [Id]
 getFunBindId (AbsBinds _ _ _ abes _ _ _)
   = abes >>= \case
       ABE _ poly _ _ _ -> pure poly
-      _ -> []
+      _                -> []
 getFunBindId _ = []
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Debug.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Debug.hs
@@ -14,18 +14,18 @@ module Ide.Plugin.Tactic.Debug
   , traceFX
   ) where
 
-import Control.DeepSeq
-import Control.Exception
-import Debug.Trace
-import DynFlags (unsafeGlobalDynFlags)
-import Outputable hiding ((<>))
-import System.IO.Unsafe (unsafePerformIO)
+import           Control.DeepSeq
+import           Control.Exception
+import           Debug.Trace
+import           DynFlags          (unsafeGlobalDynFlags)
+import           Outputable        hiding ((<>))
+import           System.IO.Unsafe  (unsafePerformIO)
 
 #if __GLASGOW_HASKELL__ >= 808
-import PlainPanic (PlainGhcException)
+import           PlainPanic        (PlainGhcException)
 type GHC_EXCEPTION = PlainGhcException
 #else
-import Panic (GhcException)
+import           Panic             (GhcException)
 type GHC_EXCEPTION = GhcException
 #endif
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/FeatureSet.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/FeatureSet.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Ide.Plugin.Tactic.FeatureSet
   ( Feature (..)
@@ -12,11 +11,11 @@ module Ide.Plugin.Tactic.FeatureSet
   , prettyFeatureSet
   ) where
 
-import           Data.List (intercalate)
-import           Data.Maybe (mapMaybe, listToMaybe)
-import           Data.Set (Set)
-import qualified Data.Set as S
-import qualified Data.Text as T
+import           Data.List  (intercalate)
+import           Data.Maybe (listToMaybe, mapMaybe)
+import           Data.Set   (Set)
+import qualified Data.Set   as S
+import qualified Data.Text  as T
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/GHC.hs
@@ -10,23 +10,25 @@
 module Ide.Plugin.Tactic.GHC where
 
 import           Control.Monad.State
-import           Data.Function (on)
-import           Data.List (isPrefixOf)
-import qualified Data.Map as M
-import           Data.Maybe (isJust)
-import           Data.Set (Set)
-import qualified Data.Set as S
+import           Data.Function              (on)
+import           Data.List                  (isPrefixOf)
+import qualified Data.Map                   as M
+import           Data.Maybe                 (isJust)
+import           Data.Set                   (Set)
+import qualified Data.Set                   as S
 import           Data.Traversable
 import           DataCon
 import           Development.IDE.GHC.Compat
-import           GHC.SourceGen (match, case', lambda)
-import           Generics.SYB (mkQ, everything, listify, Data, mkT, everywhere)
+import           GHC.SourceGen              (case', lambda, match)
+import           Generics.SYB               (Data, everything, everywhere,
+                                             listify, mkQ, mkT)
 import           Ide.Plugin.Tactic.Types
 import           OccName
 import           TcType
 import           TyCoRep
 import           Type
-import           TysWiredIn (intTyCon, floatTyCon, doubleTyCon, charTyCon)
+import           TysWiredIn                 (charTyCon, doubleTyCon, floatTyCon,
+                                             intTyCon)
 import           Unique
 import           Var
 
@@ -60,7 +62,7 @@ cloneTyVar t =
 -- | Is this a function type?
 isFunction :: Type -> Bool
 isFunction (tacticsSplitFunTy -> (_, _, [], _)) = False
-isFunction _ = True
+isFunction _                                    = True
 
 
 ------------------------------------------------------------------------------
@@ -94,7 +96,7 @@ freshTyvars t = do
       (mkT $ \tv ->
         case M.lookup tv reps of
           Just tv' -> tv'
-          Nothing -> tv
+          Nothing  -> tv
       ) t
 
 
@@ -137,7 +139,7 @@ containsHsVar :: Data a => RdrName -> a -> Bool
 containsHsVar name x = not $ null $ listify (
   \case
     ((HsVar _ (L _ a)) :: HsExpr GhcPs) | eqRdrName a name -> True
-    _ -> False
+    _                                                      -> False
   ) x
 
 
@@ -147,7 +149,7 @@ containsHole :: Data a => a -> Bool
 containsHole x = not $ null $ listify (
   \case
     ((HsVar _ (L _ name)) :: HsExpr GhcPs) -> isHole $ occName name
-    _ -> False
+    _                                      -> False
   ) x
 
 
@@ -288,5 +290,5 @@ unXPat :: Pat GhcPs -> Pat GhcPs
 #if __GLASGOW_HASKELL__ == 808
 unXPat (XPat (L _ pat)) = unXPat pat
 #endif
-unXPat pat = pat
+unXPat pat              = pat
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Judgements.hs
@@ -30,17 +30,17 @@ module Ide.Plugin.Tactic.Judgements
   ) where
 
 import           Control.Arrow
-import           Control.Lens hiding (Context)
+import           Control.Lens                        hiding (Context)
 import           Data.Bool
 import           Data.Char
 import           Data.Coerce
-import           Data.Generics.Product (field)
-import           Data.Map (Map)
-import qualified Data.Map as M
+import           Data.Generics.Product               (field)
+import           Data.Map                            (Map)
+import qualified Data.Map                            as M
 import           Data.Maybe
-import           Data.Set (Set)
-import qualified Data.Set as S
-import           DataCon (DataCon)
+import           Data.Set                            (Set)
+import qualified Data.Set                            as S
+import           DataCon                             (DataCon)
 import           Development.IDE.Spans.LocalBindings
 import           Ide.Plugin.Tactic.Types
 import           OccName
@@ -272,7 +272,7 @@ disallowing :: DisallowReason -> [OccName] -> Judgement' a -> Judgement' a
 disallowing reason (S.fromList -> ns) =
   field @"_jHypothesis" %~ (\z -> Hypothesis . flip fmap (unHypothesis z) $ \hi ->
     case S.member (hi_name hi) ns of
-      True -> overProvenance (DisallowedPrv reason) hi
+      True  -> overProvenance (DisallowedPrv reason) hi
       False -> hi
                            )
 
@@ -404,4 +404,4 @@ isDisallowed _               = False
 -- | Eliminates 'DisallowedPrv' provenances.
 expandDisallowed :: Provenance -> Provenance
 expandDisallowed (DisallowedPrv _ prv) = expandDisallowed prv
-expandDisallowed prv = prv
+expandDisallowed prv                   = prv

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies.hs
@@ -2,14 +2,14 @@
 
 module Ide.Plugin.Tactic.KnownStrategies where
 
-import Control.Monad.Error.Class
-import Ide.Plugin.Tactic.Context (getCurrentDefinitions)
-import Ide.Plugin.Tactic.Tactics
-import Ide.Plugin.Tactic.Types
-import OccName (mkVarOcc)
-import Refinery.Tactic
-import Ide.Plugin.Tactic.Machinery (tracing)
-import Ide.Plugin.Tactic.KnownStrategies.QuickCheck (deriveArbitrary)
+import           Control.Monad.Error.Class
+import           Ide.Plugin.Tactic.Context                    (getCurrentDefinitions)
+import           Ide.Plugin.Tactic.KnownStrategies.QuickCheck (deriveArbitrary)
+import           Ide.Plugin.Tactic.Machinery                  (tracing)
+import           Ide.Plugin.Tactic.Tactics
+import           Ide.Plugin.Tactic.Types
+import           OccName                                      (mkVarOcc)
+import           Refinery.Tactic
 
 
 knownStrategies :: TacticsM ()

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
@@ -2,27 +2,28 @@
 
 module Ide.Plugin.Tactic.KnownStrategies.QuickCheck where
 
-import Control.Monad.Except (MonadError(throwError))
-import Data.Bool (bool)
-import Data.List (partition)
-import DataCon ( DataCon, dataConName )
-import Development.IDE.GHC.Compat (HsExpr, GhcPs, noLoc)
-import GHC.Exts ( IsString(fromString) )
-import GHC.List ( foldl' )
-import GHC.SourceGen (int)
-import GHC.SourceGen.Binds ( match, valBind )
-import GHC.SourceGen.Expr ( case', lambda, let' )
-import GHC.SourceGen.Overloaded ( App((@@)), HasList(list) )
-import GHC.SourceGen.Pat ( conP )
-import Ide.Plugin.Tactic.CodeGen
-import Ide.Plugin.Tactic.Judgements (jGoal)
-import Ide.Plugin.Tactic.Machinery (tracePrim)
-import Ide.Plugin.Tactic.Types
-import OccName (occNameString,  mkVarOcc, HasOccName(occName) )
-import Refinery.Tactic (goal,  rule )
-import TyCon (tyConName,  TyCon, tyConDataCons )
-import Type ( splitTyConApp_maybe )
-import Data.Generics (mkQ, everything)
+import           Control.Monad.Except         (MonadError (throwError))
+import           Data.Bool                    (bool)
+import           Data.Generics                (everything, mkQ)
+import           Data.List                    (partition)
+import           DataCon                      (DataCon, dataConName)
+import           Development.IDE.GHC.Compat   (GhcPs, HsExpr, noLoc)
+import           GHC.Exts                     (IsString (fromString))
+import           GHC.List                     (foldl')
+import           GHC.SourceGen                (int)
+import           GHC.SourceGen.Binds          (match, valBind)
+import           GHC.SourceGen.Expr           (case', lambda, let')
+import           GHC.SourceGen.Overloaded     (App ((@@)), HasList (list))
+import           GHC.SourceGen.Pat            (conP)
+import           Ide.Plugin.Tactic.CodeGen
+import           Ide.Plugin.Tactic.Judgements (jGoal)
+import           Ide.Plugin.Tactic.Machinery  (tracePrim)
+import           Ide.Plugin.Tactic.Types
+import           OccName                      (HasOccName (occName), mkVarOcc,
+                                               occNameString)
+import           Refinery.Tactic              (goal, rule)
+import           TyCon                        (TyCon, tyConDataCons, tyConName)
+import           Type                         (splitTyConApp_maybe)
 
 
 ------------------------------------------------------------------------------
@@ -64,7 +65,7 @@ deriveArbitrary = do
 -- | Helper data type for the generator of a specific data con.
 data Generator = Generator
   { genRecursiveCount :: Integer
-  , genExpr :: HsExpr GhcPs
+  , genExpr           :: HsExpr GhcPs
   }
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/LanguageServer/TacticProviders.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/LanguageServer/TacticProviders.hs
@@ -12,17 +12,17 @@ module Ide.Plugin.Tactic.LanguageServer.TacticProviders
   ) where
 
 import           Control.Monad
-import           Control.Monad.Error.Class (MonadError(throwError))
+import           Control.Monad.Error.Class    (MonadError (throwError))
 import           Data.Aeson
 import           Data.Coerce
-import qualified Data.Map as M
+import qualified Data.Map                     as M
 import           Data.Maybe
 import           Data.Monoid
-import qualified Data.Text as T
+import qualified Data.Text                    as T
 import           Data.Traversable
 import           Development.IDE.GHC.Compat
 import           GHC.Generics
-import           GHC.LanguageExtensions.Type (Extension (LambdaCase))
+import           GHC.LanguageExtensions.Type  (Extension (LambdaCase))
 import           Ide.Plugin.Tactic.Auto
 import           Ide.Plugin.Tactic.FeatureSet
 import           Ide.Plugin.Tactic.GHC
@@ -34,17 +34,17 @@ import           Ide.PluginUtils
 import           Ide.Types
 import           Language.LSP.Types
 import           OccName
-import           Prelude hiding (span)
-import           Refinery.Tactic (goal)
+import           Prelude                      hiding (span)
+import           Refinery.Tactic              (goal)
 
 
 ------------------------------------------------------------------------------
 -- | A mapping from tactic commands to actual tactics for refinery.
 commandTactic :: TacticCommand -> OccName -> TacticsM ()
-commandTactic Auto         = const auto
-commandTactic Intros       = const intros
-commandTactic Destruct     = useNameFromHypothesis destruct
-commandTactic Homomorphism = useNameFromHypothesis homo
+commandTactic Auto                   = const auto
+commandTactic Intros                 = const intros
+commandTactic Destruct               = useNameFromHypothesis destruct
+commandTactic Homomorphism           = useNameFromHypothesis homo
 commandTactic DestructLambdaCase     = const destructLambdaCase
 commandTactic HomomorphismLambdaCase = const homoLambdaCase
 
@@ -180,7 +180,7 @@ tcCommandId c = coerce $ T.pack $ "tactics" <> show c <> "Command"
 -- type, and that both are usual algebraic types.
 homoFilter :: Type -> Type -> Bool
 homoFilter (algebraicTyCon -> Just t1) (algebraicTyCon -> Just t2) = t1 == t2
-homoFilter _ _ = False
+homoFilter _ _                                                     = False
 
 
 ------------------------------------------------------------------------------
@@ -188,5 +188,5 @@ homoFilter _ _ = False
 -- algebraic types.
 destructFilter :: Type -> Type -> Bool
 destructFilter _ (algebraicTyCon -> Just _) = True
-destructFilter _ _ = False
+destructFilter _ _                          = False
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
@@ -6,6 +5,7 @@
 {-# LANGUAGE MonoLocalBinds        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE ViewPatterns          #-}
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 
@@ -13,29 +13,29 @@ module Ide.Plugin.Tactic.Machinery
   ( module Ide.Plugin.Tactic.Machinery
   ) where
 
-import           Class (Class(classTyVars))
+import           Class                        (Class (classTyVars))
 import           Control.Arrow
 import           Control.Monad.Error.Class
 import           Control.Monad.Reader
-import           Control.Monad.State (MonadState(..))
-import           Control.Monad.State.Class (gets, modify)
-import           Control.Monad.State.Strict (StateT (..))
-import           Data.Bool (bool)
+import           Control.Monad.State          (MonadState (..))
+import           Control.Monad.State.Class    (gets, modify)
+import           Control.Monad.State.Strict   (StateT (..))
+import           Data.Bool                    (bool)
 import           Data.Coerce
 import           Data.Either
 import           Data.Foldable
-import           Data.Functor ((<&>))
-import           Data.Generics (mkQ, everything, gcount)
-import           Data.List (sortBy)
-import qualified Data.Map as M
-import           Data.Ord (comparing, Down(..))
-import           Data.Set (Set)
-import qualified Data.Set as S
+import           Data.Functor                 ((<&>))
+import           Data.Generics                (everything, gcount, mkQ)
+import           Data.List                    (sortBy)
+import qualified Data.Map                     as M
+import           Data.Ord                     (Down (..), comparing)
+import           Data.Set                     (Set)
+import qualified Data.Set                     as S
 import           Development.IDE.GHC.Compat
 import           Ide.Plugin.Tactic.Judgements
-import           Ide.Plugin.Tactic.Simplify (simplify)
+import           Ide.Plugin.Tactic.Simplify   (simplify)
 import           Ide.Plugin.Tactic.Types
-import           OccName (HasOccName(occName))
+import           OccName                      (HasOccName (occName))
 import           Refinery.ProofState
 import           Refinery.Tactic
 import           Refinery.Tactic.Internal
@@ -204,7 +204,7 @@ tryUnifyUnivarsButNotSkolems skolems goal inst =
          [unCType inst]
          [unCType goal] of
     Unifiable subst -> pure subst
-    _ -> Nothing
+    _               -> Nothing
 
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Naming.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Naming.hs
@@ -3,18 +3,18 @@
 module Ide.Plugin.Tactic.Naming where
 
 import           Control.Monad.State.Strict
-import           Data.Bool (bool)
+import           Data.Bool                  (bool)
 import           Data.Char
-import           Data.Map (Map)
-import qualified Data.Map as M
-import           Data.Set (Set)
-import qualified Data.Set as S
+import           Data.Map                   (Map)
+import qualified Data.Map                   as M
+import           Data.Set                   (Set)
+import qualified Data.Set                   as S
 import           Data.Traversable
 import           Name
 import           TcType
 import           TyCon
 import           Type
-import           TysWiredIn (listTyCon, pairTyCon, unitTyCon)
+import           TysWiredIn                 (listTyCon, pairTyCon, unitTyCon)
 
 
 ------------------------------------------------------------------------------
@@ -72,7 +72,7 @@ mkGoodName
 mkGoodName in_scope t =
   let tn = mkTyName t
    in mkVarOcc $ case S.member (mkVarOcc tn) in_scope of
-        True -> tn ++ show (length in_scope)
+        True  -> tn ++ show (length in_scope)
         False -> tn
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Range.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Range.hs
@@ -1,7 +1,7 @@
 module Ide.Plugin.Tactic.Range where
 
-import qualified FastString as FS
 import           Development.IDE.Types.Location
+import qualified FastString                     as FS
 import           SrcLoc
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Simplify.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Simplify.hs
@@ -8,14 +8,15 @@ module Ide.Plugin.Tactic.Simplify
   ( simplify
   ) where
 
-import Data.Generics (everywhere, mkT, GenericT)
-import Data.List.Extra (unsnoc)
-import Data.Monoid (Endo (..))
-import Development.IDE.GHC.Compat
-import GHC.SourceGen (var)
-import GHC.SourceGen.Expr (lambda)
-import Ide.Plugin.Tactic.CodeGen.Utils
-import Ide.Plugin.Tactic.GHC (fromPatCompatPs, containsHsVar)
+import           Data.Generics                   (GenericT, everywhere, mkT)
+import           Data.List.Extra                 (unsnoc)
+import           Data.Monoid                     (Endo (..))
+import           Development.IDE.GHC.Compat
+import           GHC.SourceGen                   (var)
+import           GHC.SourceGen.Expr              (lambda)
+import           Ide.Plugin.Tactic.CodeGen.Utils
+import           Ide.Plugin.Tactic.GHC           (containsHsVar,
+                                                  fromPatCompatPs)
 
 
 ------------------------------------------------------------------------------
@@ -93,7 +94,7 @@ simplifyCompose = mkT $ \case
 simplifyRemoveParens :: GenericT
 simplifyRemoveParens = mkT $ \case
   HsPar _ (L _ x) | isAtomicHsExpr x -> x
-  (x :: HsExpr GhcPs) -> x
+  (x :: HsExpr GhcPs)                -> x
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE ViewPatterns          #-}
 
 module Ide.Plugin.Tactic.Tactics
@@ -9,18 +9,18 @@ module Ide.Plugin.Tactic.Tactics
   , runTactic
   ) where
 
-import           Control.Monad (when)
-import           Control.Monad.Except (throwError)
-import           Control.Monad.Reader.Class (MonadReader(ask))
+import           Control.Monad                (when)
+import           Control.Monad.Except         (throwError)
+import           Control.Monad.Reader.Class   (MonadReader (ask))
 import           Control.Monad.State.Class
-import           Control.Monad.State.Strict (StateT(..), runStateT)
-import           Data.Bool (bool)
+import           Control.Monad.State.Strict   (StateT (..), runStateT)
+import           Data.Bool                    (bool)
 import           Data.Foldable
 import           Data.List
-import qualified Data.Map as M
+import qualified Data.Map                     as M
 import           Data.Maybe
-import           Data.Set (Set)
-import qualified Data.Set as S
+import           Data.Set                     (Set)
+import qualified Data.Set                     as S
 import           DataCon
 import           Development.IDE.GHC.Compat
 import           GHC.Exts
@@ -33,11 +33,11 @@ import           Ide.Plugin.Tactic.Judgements
 import           Ide.Plugin.Tactic.Machinery
 import           Ide.Plugin.Tactic.Naming
 import           Ide.Plugin.Tactic.Types
-import           Name (occNameString)
+import           Name                         (occNameString)
 import           Refinery.Tactic
 import           Refinery.Tactic.Internal
 import           TcType
-import           Type hiding (Var)
+import           Type                         hiding (Var)
 
 
 ------------------------------------------------------------------------------
@@ -224,7 +224,7 @@ splitDataCon dc =
     case splitTyConApp_maybe $ unCType g of
       Just (tc, apps) -> do
         case elem dc $ tyConDataCons tc of
-          True -> buildDataCon (unwhitelistingSplit jdg) dc apps
+          True  -> buildDataCon (unwhitelistingSplit jdg) dc apps
           False -> throwError $ IncorrectDataCon dc
       Nothing -> throwError $ GoalMismatch "splitDataCon" g
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/TestTypes.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/TestTypes.hs
@@ -2,9 +2,9 @@
 
 module Ide.Plugin.Tactic.TestTypes where
 
-import qualified Data.Text as T
-import Data.Aeson
-import Ide.Plugin.Tactic.FeatureSet
+import           Data.Aeson
+import qualified Data.Text                    as T
+import           Ide.Plugin.Tactic.FeatureSet
 
 ------------------------------------------------------------------------------
 -- | The list of tactics exposed to the outside world. These are attached to
@@ -21,11 +21,11 @@ data TacticCommand
 
 -- | Generate a title for the command.
 tacticTitle :: TacticCommand -> T.Text -> T.Text
-tacticTitle Auto _ = "Attempt to fill hole"
-tacticTitle Intros _ = "Introduce lambda"
-tacticTitle Destruct var = "Case split on " <> var
-tacticTitle Homomorphism var = "Homomorphic case split on " <> var
-tacticTitle DestructLambdaCase _ = "Lambda case split"
+tacticTitle Auto _                   = "Attempt to fill hole"
+tacticTitle Intros _                 = "Introduce lambda"
+tacticTitle Destruct var             = "Case split on " <> var
+tacticTitle Homomorphism var         = "Homomorphic case split on " <> var
+tacticTitle DestructLambdaCase _     = "Lambda case split"
 tacticTitle HomomorphismLambdaCase _ = "Homomorphic lambda case split"
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
@@ -20,26 +20,28 @@ module Ide.Plugin.Tactic.Types
   , Range
   ) where
 
-import Control.Lens hiding (Context, (.=))
-import Control.Monad.Reader
-import Control.Monad.State
-import Data.Coerce
-import Data.Function
-import Data.Generics.Product (field)
-import Data.Set (Set)
-import Data.Tree
-import Development.IDE.GHC.Compat hiding (Node)
-import Development.IDE.GHC.Orphans ()
-import Development.IDE.Types.Location
-import GHC.Generics
-import Ide.Plugin.Tactic.Debug
-import Ide.Plugin.Tactic.FeatureSet (FeatureSet)
-import OccName
-import Refinery.Tactic
-import System.IO.Unsafe (unsafePerformIO)
-import Type
-import UniqSupply (takeUniqFromSupply, mkSplitUniqSupply, UniqSupply)
-import Unique (nonDetCmpUnique, Uniquable, getUnique, Unique)
+import           Control.Lens                   hiding (Context, (.=))
+import           Control.Monad.Reader
+import           Control.Monad.State
+import           Data.Coerce
+import           Data.Function
+import           Data.Generics.Product          (field)
+import           Data.Set                       (Set)
+import           Data.Tree
+import           Development.IDE.GHC.Compat     hiding (Node)
+import           Development.IDE.GHC.Orphans    ()
+import           Development.IDE.Types.Location
+import           GHC.Generics
+import           Ide.Plugin.Tactic.Debug
+import           Ide.Plugin.Tactic.FeatureSet   (FeatureSet)
+import           OccName
+import           Refinery.Tactic
+import           System.IO.Unsafe               (unsafePerformIO)
+import           Type
+import           UniqSupply                     (UniqSupply, mkSplitUniqSupply,
+                                                 takeUniqFromSupply)
+import           Unique                         (Uniquable, Unique, getUnique,
+                                                 nonDetCmpUnique)
 
 
 ------------------------------------------------------------------------------
@@ -79,13 +81,13 @@ instance Show (Pat GhcPs) where
 
 ------------------------------------------------------------------------------
 data TacticState = TacticState
-    { ts_skolems   :: !(Set TyVar)
+    { ts_skolems         :: !(Set TyVar)
       -- ^ The known skolems.
-    , ts_unifier   :: !TCvSubst
+    , ts_unifier         :: !TCvSubst
       -- ^ The current substitution of univars.
-    , ts_used_vals :: !(Set OccName)
+    , ts_used_vals       :: !(Set OccName)
       -- ^ Set of values used by tactics.
-    , ts_intro_vals :: !(Set OccName)
+    , ts_intro_vals      :: !(Set OccName)
       -- ^ Set of values introduced by tactics.
     , ts_unused_top_vals :: !(Set OccName)
       -- ^ Set of currently unused arguments to the function being defined.
@@ -95,7 +97,7 @@ data TacticState = TacticState
       -- value is 'False' are guaranteed to loop, and must be pruned.
     , ts_recursion_count :: !Int
       -- ^ Number of calls to recursion. We penalize each.
-    , ts_unique_gen :: !UniqSupply
+    , ts_unique_gen      :: !UniqSupply
     } deriving stock (Show, Generic)
 
 instance Show UniqSupply where
@@ -247,11 +249,11 @@ overProvenance f (HyInfo name prv ty) = HyInfo name (f prv) ty
 ------------------------------------------------------------------------------
 -- | The current bindings and goal for a hole to be filled by refinery.
 data Judgement' a = Judgement
-  { _jHypothesis :: !(Hypothesis a)
+  { _jHypothesis        :: !(Hypothesis a)
   , _jBlacklistDestruct :: !Bool
-  , _jWhitelistSplit :: !Bool
-  , _jIsTopHole    :: !Bool
-  , _jGoal         :: !a
+  , _jWhitelistSplit    :: !Bool
+  , _jIsTopHole         :: !Bool
+  , _jGoal              :: !a
   }
   deriving stock (Eq, Generic, Functor, Show)
 
@@ -335,9 +337,9 @@ type Trace = Rose String
 data Context = Context
   { ctxDefiningFuncs :: [(OccName, CType)]
     -- ^ The functions currently being defined
-  , ctxModuleFuncs :: [(OccName, CType)]
+  , ctxModuleFuncs   :: [(OccName, CType)]
     -- ^ Everything defined in the current module
-  , ctxFeatureSet :: FeatureSet
+  , ctxFeatureSet    :: FeatureSet
   }
   deriving stock (Eq, Ord, Show)
 

--- a/plugins/hls-tactics-plugin/test/AutoTupleSpec.hs
+++ b/plugins/hls-tactics-plugin/test/AutoTupleSpec.hs
@@ -2,17 +2,17 @@
 
 module AutoTupleSpec where
 
-import Data.Either (isRight)
-import Ide.Plugin.Tactic.Judgements (mkFirstJudgement)
-import Ide.Plugin.Tactic.Machinery
-import Ide.Plugin.Tactic.Tactics (auto')
-import Ide.Plugin.Tactic.Types
-import OccName (mkVarOcc)
-import Test.Hspec
-import Test.QuickCheck
-import Type (mkTyVarTy)
-import TysPrim (alphaTyVars)
-import TysWiredIn (mkBoxedTupleTy)
+import           Data.Either                  (isRight)
+import           Ide.Plugin.Tactic.Judgements (mkFirstJudgement)
+import           Ide.Plugin.Tactic.Machinery
+import           Ide.Plugin.Tactic.Tactics    (auto')
+import           Ide.Plugin.Tactic.Types
+import           OccName                      (mkVarOcc)
+import           Test.Hspec
+import           Test.QuickCheck
+import           Type                         (mkTyVarTy)
+import           TysPrim                      (alphaTyVars)
+import           TysWiredIn                   (mkBoxedTupleTy)
 
 
 spec :: Spec

--- a/plugins/hls-tactics-plugin/test/GoldenSpec.hs
+++ b/plugins/hls-tactics-plugin/test/GoldenSpec.hs
@@ -7,24 +7,27 @@
 
 module GoldenSpec where
 
-import           Control.Applicative.Combinators ( skipManyTill )
-import           Control.Lens hiding ((<.>), failing)
-import           Control.Monad (unless)
+import           Control.Applicative.Combinators (skipManyTill)
+import           Control.Lens                    hiding (failing, (<.>))
+import           Control.Monad                   (unless)
 import           Control.Monad.IO.Class
 import           Data.Aeson
-import           Data.Default (Default(def))
+import           Data.Default                    (Default (def))
 import           Data.Foldable
-import qualified Data.Map as M
+import qualified Data.Map                        as M
 import           Data.Maybe
-import           Data.Text (Text)
-import qualified Data.Text.IO as T
-import qualified Ide.Plugin.Config as Plugin
-import           Ide.Plugin.Tactic.FeatureSet (FeatureSet, allFeatures)
+import           Data.Text                       (Text)
+import qualified Data.Text.IO                    as T
+import qualified Ide.Plugin.Config               as Plugin
+import           Ide.Plugin.Tactic.FeatureSet    (FeatureSet, allFeatures)
 import           Ide.Plugin.Tactic.TestTypes
 import           Language.LSP.Test
 import           Language.LSP.Types
-import           Language.LSP.Types.Lens hiding (id, capabilities, message, executeCommand, applyEdit, rename, line, title, name, actions)
-import           System.Directory (doesFileExist)
+import           Language.LSP.Types.Lens         hiding (actions, applyEdit,
+                                                  capabilities, executeCommand,
+                                                  id, line, message, name,
+                                                  rename, title)
+import           System.Directory                (doesFileExist)
 import           System.FilePath
 import           Test.Hspec
 
@@ -128,7 +131,7 @@ pointRange
 ------------------------------------------------------------------------------
 -- | Get the title of a code action.
 codeActionTitle :: (Command |? CodeAction) -> Maybe Text
-codeActionTitle InL{} = Nothing
+codeActionTitle InL{}                               = Nothing
 codeActionTitle (InR(CodeAction title _ _ _ _ _ _)) = Just title
 
 
@@ -160,7 +163,7 @@ mkTest name fp line col ts = it name $ do
 setFeatureSet :: FeatureSet -> Session ()
 setFeatureSet features = do
   let unObject (Object obj) = obj
-      unObject _ = undefined
+      unObject _            = undefined
       def_config = def :: Plugin.Config
       config =
         def_config

--- a/plugins/hls-tactics-plugin/test/Server.hs
+++ b/plugins/hls-tactics-plugin/test/Server.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Main(main) where
 
 import           Data.Default
 import           Development.IDE.Main
 import qualified Development.IDE.Plugin.HLS.GhcIde as Ghcide
-import           Ide.Plugin.Tactic as T
+import           Ide.Plugin.Tactic                 as T
 import           Ide.PluginUtils
 
 main :: IO ()

--- a/plugins/hls-tactics-plugin/test/UnificationSpec.hs
+++ b/plugins/hls-tactics-plugin/test/UnificationSpec.hs
@@ -4,21 +4,21 @@
 module UnificationSpec where
 
 import           Control.Arrow
-import           Data.Bool (bool)
-import           Data.Functor ((<&>))
-import           Data.Maybe (mapMaybe)
-import qualified Data.Set as S
+import           Data.Bool                   (bool)
+import           Data.Functor                ((<&>))
+import           Data.Maybe                  (mapMaybe)
+import qualified Data.Set                    as S
 import           Data.Traversable
-import           Data.Tuple (swap)
+import           Data.Tuple                  (swap)
 import           Ide.Plugin.Tactic.Debug
 import           Ide.Plugin.Tactic.Machinery
 import           Ide.Plugin.Tactic.Types
-import           TcType (tcGetTyVar_maybe, substTy)
+import           TcType                      (substTy, tcGetTyVar_maybe)
 import           Test.Hspec
 import           Test.QuickCheck
-import           Type (mkTyVarTy)
-import           TysPrim (alphaTyVars)
-import           TysWiredIn (mkBoxedTupleTy)
+import           Type                        (mkTyVarTy)
+import           TysPrim                     (alphaTyVars)
+import           TysWiredIn                  (mkBoxedTupleTy)
 
 
 instance Show Type where

--- a/plugins/hls-tactics-plugin/test/golden/SplitPattern.hs
+++ b/plugins/hls-tactics-plugin/test/golden/SplitPattern.hs
@@ -1,8 +1,8 @@
 data ADT = One | Two Int | Three | Four Bool ADT | Five
 
 case_split :: ADT -> Int
-case_split One = _
-case_split (Two i) = _
-case_split Three = _
+case_split One        = _
+case_split (Two i)    = _
+case_split Three      = _
 case_split (Four b a) = _
-case_split Five = _
+case_split Five       = _

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -1,13 +1,13 @@
+{-# LANGUAGE AllowAmbiguousTypes       #-}
+{-# LANGUAGE ApplicativeDo             #-}
+{-# LANGUAGE ConstraintKinds           #-}
+{-# LANGUAGE DeriveAnyClass            #-}
+{-# LANGUAGE DerivingStrategies        #-}
+{-# LANGUAGE DuplicateRecordFields     #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ApplicativeDo     #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE TypeFamilies              #-}
 
 {- |
     This module provides a bunch of Shake rules to build multiple revisions of a
@@ -72,9 +72,12 @@ import           Data.Aeson                                (FromJSON (..),
                                                             ToJSON (..),
                                                             Value (..), (.!=),
                                                             (.:?))
-import Data.List (find, isInfixOf, stripPrefix, transpose)
+import           Data.Char                                 (isDigit)
+import           Data.List                                 (find, isInfixOf,
+                                                            stripPrefix,
+                                                            transpose)
 import           Data.List.Extra                           (lower)
-import Data.Maybe (fromMaybe)
+import           Data.Maybe                                (fromMaybe)
 import           Data.Text                                 (Text)
 import qualified Data.Text                                 as T
 import           Development.Shake
@@ -87,15 +90,16 @@ import           GHC.Stack                                 (HasCallStack)
 import qualified Graphics.Rendering.Chart.Backend.Diagrams as E
 import           Graphics.Rendering.Chart.Easy             ((.=))
 import qualified Graphics.Rendering.Chart.Easy             as E
-import           System.Directory (createDirectoryIfMissing, findExecutable, renameFile)
+import           System.Directory                          (createDirectoryIfMissing,
+                                                            findExecutable,
+                                                            renameFile)
 import           System.FilePath
+import           System.Time.Extra                         (Seconds)
 import qualified Text.ParserCombinators.ReadP              as P
+import           Text.Printf
 import           Text.Read                                 (Read (..), get,
                                                             readMaybe,
                                                             readP_to_Prec)
-import Text.Printf
-import Data.Char (isDigit)
-import System.Time.Extra (Seconds)
 
 newtype GetExperiments = GetExperiments () deriving newtype (Binary, Eq, Hashable, NFData, Show)
 newtype GetVersions = GetVersions () deriving newtype (Binary, Eq, Hashable, NFData, Show)
@@ -257,7 +261,7 @@ profilingP inp | Just delay <- stripPrefix "profiled-" inp, Just i <- readMaybe 
 profilingP _ = Nothing
 
 profilingPath :: ProfilingMode -> FilePath
-profilingPath NoProfiling = "unprofiled"
+profilingPath NoProfiling            = "unprofiled"
 profilingPath (CheapHeapProfiling i) = "profiled-" <> show i
 
 -- TODO generalize BuildSystem
@@ -328,7 +332,7 @@ benchRules build MkBenchRules{..} = do
         liftIO $ renameFile "ghcide.eventlog" outEventlog
         liftIO $ case prof of
             CheapHeapProfiling{} -> renameFile "ghcide.hp" outHp
-            NoProfiling -> writeFile outHp dummyHp
+            NoProfiling          -> writeFile outHp dummyHp
 
         -- extend csv output with allocation data
         csvContents <- liftIO $ lines <$> readFile outcsv
@@ -352,7 +356,7 @@ parseMaxResidencyAndAllocations input =
   where
     inps = reverse $ lines input
     f label = case find (label `isInfixOf`) inps of
-        Just l -> read $ filter isDigit $ head $ words l
+        Just l  -> read $ filter isDigit $ head $ words l
         Nothing -> -1
 
 
@@ -550,9 +554,9 @@ instance Read Frame where
 
 -- | A file path containing the output of -S for a given run
 data RunLog = RunLog
-  { runVersion     :: !String,
-    runFrames      :: ![Frame],
-    runSuccess     :: !Bool
+  { runVersion :: !String,
+    runFrames  :: ![Frame],
+    runSuccess :: !Bool
   }
 
 loadRunLog :: HasCallStack => Escaped FilePath -> String -> Action RunLog

--- a/src/Ide/Arguments.hs
+++ b/src/Ide/Arguments.hs
@@ -1,10 +1,9 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE CPP #-} -- To get precise GHC version
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TupleSections   #-}
 {-# OPTIONS_GHC -Wno-dodgy-imports #-} -- GHC no longer exports def in GHC 8.6 and above
 
 module Ide.Arguments
@@ -16,12 +15,12 @@ module Ide.Arguments
   , haskellLanguageServerNumericVersion
   ) where
 
-import Data.Version
-import Development.GitRev
-import Options.Applicative
-import Paths_haskell_language_server
-import System.Environment
-import HieDb.Run
+import           Data.Version
+import           Development.GitRev
+import           HieDb.Run
+import           Options.Applicative
+import           Paths_haskell_language_server
+import           System.Environment
 
 -- ---------------------------------------------------------------------
 
@@ -32,17 +31,17 @@ data Arguments
   | LspMode LspArguments
 
 data LspArguments = LspArguments
-    {argLSP :: Bool
-    ,argsCwd :: Maybe FilePath
-    ,argFiles :: [FilePath]
-    ,argsShakeProfiling :: Maybe FilePath
-    ,argsTesting :: Bool
-    ,argsExamplePlugin :: Bool
+    {argLSP                 :: Bool
+    ,argsCwd                :: Maybe FilePath
+    ,argFiles               :: [FilePath]
+    ,argsShakeProfiling     :: Maybe FilePath
+    ,argsTesting            :: Bool
+    ,argsExamplePlugin      :: Bool
     -- These next two are for compatibility with existing hie clients, allowing
     -- them to just change the name of the exe and still work.
-    , argsDebugOn       :: Bool
-    , argsLogFile       :: Maybe String
-    , argsThreads       :: Int
+    , argsDebugOn           :: Bool
+    , argsLogFile           :: Maybe String
+    , argsThreads           :: Int
     , argsProjectGhcVersion :: Bool
     } deriving Show
 
@@ -122,7 +121,7 @@ haskellLanguageServerVersion = do
   path <- getExecutablePath
   let gitHashSection = case $(gitHash) of
         x | x == "UNKNOWN" -> ""
-        x -> " (GIT hash: " <> x <> ")"
+        x                  -> " (GIT hash: " <> x <> ")"
   return $ "haskell-language-server version: " <> haskellLanguageServerNumericVersion
              <> " (GHC: " <> VERSION_ghc
              <> ") (PATH: " <> path <> ")"

--- a/src/Ide/Version.hs
+++ b/src/Ide/Version.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
 -- | Information and display strings for HIE's version
 -- and the current project's version
 module Ide.Version where
 
+import           Data.Maybe                    (listToMaybe)
+import           Data.Version
 import           Development.GitRev            (gitCommitCount)
 import           Options.Applicative.Simple    (simpleVersion)
 import qualified Paths_haskell_language_server as Meta
-import           System.Info
-import           Data.Version
-import           Data.Maybe (listToMaybe)
 import           System.Directory
-import           System.Process
 import           System.Exit
+import           System.Info
+import           System.Process
 import           Text.ParserCombinators.ReadP
 
 -- >>> hlsVersion
@@ -37,7 +37,7 @@ hlsVersion =
 data ProgramsOfInterest = ProgramsOfInterest
   { cabalVersion :: Maybe Version
   , stackVersion :: Maybe Version
-  , ghcVersion :: Maybe Version
+  , ghcVersion   :: Maybe Version
   }
 
 showProgramVersionOfInterest :: ProgramsOfInterest -> String
@@ -67,7 +67,7 @@ findVersionOf tool =
     Just path ->
       readProcessWithExitCode path ["--numeric-version"] "" >>= \case
         (ExitSuccess, sout, _) -> pure $ consumeParser myVersionParser sout
-        _ -> pure Nothing
+        _                      -> pure Nothing
   where
     myVersionParser = do
       skipSpaces

--- a/test/functional/Command.hs
+++ b/test/functional/Command.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Command (tests) where
 
-import Control.Lens hiding (List)
-import Control.Monad.IO.Class
-import qualified Data.Text as T
-import Data.Char
-import Language.LSP.Test
-import Language.LSP.Types as LSP
-import Language.LSP.Types.Lens as LSP
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Control.Lens            hiding (List)
+import           Control.Monad.IO.Class
+import           Data.Char
+import qualified Data.Text               as T
+import           Language.LSP.Test
+import           Language.LSP.Types      as LSP
+import           Language.LSP.Types.Lens as LSP
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "commands" [

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -2,19 +2,19 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Completion(tests) where
 
-import Control.Monad.IO.Class
-import Control.Lens hiding ((.=))
-import Data.Aeson (object, (.=))
-import Language.LSP.Test
-import Language.LSP.Types
-import Language.LSP.Types.Lens hiding (applyEdit)
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
-import Test.Tasty.HUnit
-import qualified Data.Text as T
-import Data.Default (def)
-import Ide.Plugin.Config (Config (maxCompletions))
+import           Control.Lens               hiding ((.=))
+import           Control.Monad.IO.Class
+import           Data.Aeson                 (object, (.=))
+import           Data.Default               (def)
+import qualified Data.Text                  as T
+import           Ide.Plugin.Config          (Config (maxCompletions))
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Language.LSP.Types.Lens    hiding (applyEdit)
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure (ignoreTestBecause)
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "completions" [

--- a/test/functional/Config.hs
+++ b/test/functional/Config.hs
@@ -2,19 +2,19 @@
 
 module Config (tests) where
 
-import           Control.Lens hiding (List)
 import           Control.Applicative.Combinators (skipManyTill)
+import           Control.Lens                    hiding (List)
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Data.Default
-import qualified Data.Map as Map
-import qualified Data.Text as T
+import qualified Data.Map                        as Map
+import qualified Data.Text                       as T
 import           Ide.Plugin.Config
-import           Language.LSP.Test as Test
+import           Language.LSP.Test               as Test
 import           Language.LSP.Types
-import qualified Language.LSP.Types.Lens as L
-import           System.FilePath ((</>))
+import qualified Language.LSP.Types.Lens         as L
+import           System.FilePath                 ((</>))
 import           Test.Hls.Util
 import           Test.Tasty
 import           Test.Tasty.HUnit

--- a/test/functional/Deferred.hs
+++ b/test/functional/Deferred.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings     #-}
 module Deferred(tests) where
 
-import Control.Applicative.Combinators
-import Control.Monad.IO.Class
-import Control.Lens hiding (List)
+import           Control.Applicative.Combinators
+import           Control.Lens                    hiding (List)
+import           Control.Monad.IO.Class
 -- import Control.Monad
 -- import Data.Maybe
-import Language.LSP.Test
-import Language.LSP.Types
-import Language.LSP.Types.Lens hiding (id, message)
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Language.LSP.Types.Lens         hiding (id, message)
 -- import qualified Language.LSP.Types.Lens as LSP
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
-import Test.Tasty.HUnit
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure      (ignoreTestBecause)
+import           Test.Tasty.HUnit
 
 
 tests :: TestTree

--- a/test/functional/Definition.hs
+++ b/test/functional/Definition.hs
@@ -1,15 +1,15 @@
 module Definition (tests) where
 
-import Control.Lens
-import Control.Monad.IO.Class
-import Language.LSP.Test
-import Language.LSP.Types
-import Language.LSP.Types.Lens
-import System.Directory
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
-import Test.Tasty.HUnit
+import           Control.Lens
+import           Control.Monad.IO.Class
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Language.LSP.Types.Lens
+import           System.Directory
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure (ignoreTestBecause)
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "definitions" [

--- a/test/functional/Diagnostic.hs
+++ b/test/functional/Diagnostic.hs
@@ -2,18 +2,18 @@
 
 module Diagnostic (tests) where
 
-import Control.Applicative.Combinators
-import           Control.Lens hiding (List)
+import           Control.Applicative.Combinators
+import           Control.Lens                    hiding (List)
 import           Control.Monad.IO.Class
-import           Data.Aeson (toJSON)
+import           Data.Aeson                      (toJSON)
 import qualified Data.Default
 import           Ide.Plugin.Config
-import           Language.LSP.Test hiding (message)
+import           Language.LSP.Test               hiding (message)
 import           Language.LSP.Types
-import qualified Language.LSP.Types.Lens as LSP
+import qualified Language.LSP.Types.Lens         as LSP
 import           Test.Hls.Util
 import           Test.Tasty
-import           Test.Tasty.ExpectedFailure (ignoreTestBecause)
+import           Test.Tasty.ExpectedFailure      (ignoreTestBecause)
 import           Test.Tasty.HUnit
 
 -- ---------------------------------------------------------------------

--- a/test/functional/Format.hs
+++ b/test/functional/Format.hs
@@ -1,21 +1,22 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Format (tests) where
 
-import Control.Monad.IO.Class
-import Data.Aeson
-import qualified Data.ByteString.Lazy as BS
-import qualified Data.Text.Encoding as T
-import Language.LSP.Test
-import Language.LSP.Types
+import           Control.Lens            ((^.))
+import           Control.Monad.IO.Class
+import           Data.Aeson
+import qualified Data.ByteString.Lazy    as BS
+import qualified Data.Text.Encoding      as T
+import           Language.LSP.Test
+import           Language.LSP.Types
 import qualified Language.LSP.Types.Lens as LSP
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.Golden
-import Test.Tasty.HUnit
-import Control.Lens ((^.))
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.Golden
+import           Test.Tasty.HUnit
 
 #if AGPL
-import qualified Data.Text.IO as T
+import qualified Data.Text.IO            as T
 #endif
 
 tests :: TestTree

--- a/test/functional/FunctionalBadProject.hs
+++ b/test/functional/FunctionalBadProject.hs
@@ -9,8 +9,8 @@ module FunctionalBadProject (tests) where
 -- import           Language.LSP.Types as LSP
 -- import           Language.LSP.Types.Lens as LSP hiding (contents, error )
 -- import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 -- ---------------------------------------------------------------------
 -- TODO: Currently this can not succeed, since such an error is thrown in "runActionWithContext" which

--- a/test/functional/FunctionalLiquid.hs
+++ b/test/functional/FunctionalLiquid.hs
@@ -2,14 +2,14 @@
 
 module FunctionalLiquid (tests) where
 
-import           Control.Lens hiding (List)
+import           Control.Lens               hiding (List)
 import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Data.Default
-import           Language.LSP.Test hiding (message)
-import           Language.LSP.Types as LSP
-import           Language.LSP.Types.Lens as LSP hiding (contents)
 import           Ide.Plugin.Config
+import           Language.LSP.Test          hiding (message)
+import           Language.LSP.Types         as LSP
+import           Language.LSP.Types.Lens    as LSP hiding (contents)
 import           Test.Hls.Util
 import           Test.Tasty
 import           Test.Tasty.ExpectedFailure (ignoreTestBecause)

--- a/test/functional/HaddockComments.hs
+++ b/test/functional/HaddockComments.hs
@@ -1,29 +1,29 @@
+{-# LANGUAGE DataKinds                #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE NamedFieldPuns           #-}
+{-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE ViewPatterns             #-}
 
 module HaddockComments
   ( tests,
   )
 where
 
-import Control.Monad.IO.Class (liftIO)
-import qualified Data.ByteString.Lazy as LBS
-import Data.Foldable (find)
-import Data.Maybe (mapMaybe)
-import Data.Text (Text)
-import Data.Text.Encoding (encodeUtf8)
-import Language.LSP.Test
-import Language.LSP.Types
-import System.FilePath ((<.>), (</>))
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.Golden
-import Test.Tasty.HUnit
+import           Control.Monad.IO.Class (liftIO)
+import qualified Data.ByteString.Lazy   as LBS
+import           Data.Foldable          (find)
+import           Data.Maybe             (mapMaybe)
+import           Data.Text              (Text)
+import           Data.Text.Encoding     (encodeUtf8)
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           System.FilePath        ((<.>), (</>))
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.Golden
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests =
@@ -66,11 +66,11 @@ data GenCommentsType = Signature | Record
 
 toTitle :: GenCommentsType -> Text
 toTitle Signature = "Generate signature comments"
-toTitle Record = "Generate fields comments"
+toTitle Record    = "Generate fields comments"
 
 caTitle :: (Command |? CodeAction) -> Maybe Text
 caTitle (InR CodeAction {_title}) = Just _title
-caTitle _ = Nothing
+caTitle _                         = Nothing
 
 haddockCommentsPath :: String
 haddockCommentsPath = "test" </> "testdata" </> "haddockComments"

--- a/test/functional/HieBios.hs
+++ b/test/functional/HieBios.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 module HieBios (tests) where
 
-import Control.Lens ((^.))
-import Control.Monad.IO.Class
-import qualified Data.Text as T
-import Language.LSP.Test
-import Language.LSP.Types
+import           Control.Lens            ((^.))
+import           Control.Monad.IO.Class
+import qualified Data.Text               as T
+import           Language.LSP.Test
+import           Language.LSP.Types
 import qualified Language.LSP.Types.Lens as L
-import System.FilePath ((</>))
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.HUnit
+import           System.FilePath         ((</>))
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "hie-bios" [

--- a/test/functional/Highlight.hs
+++ b/test/functional/Highlight.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Highlight (tests) where
 
-import Control.Monad.IO.Class
-import Language.LSP.Test
-import Language.LSP.Types
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Control.Monad.IO.Class
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "highlight" [

--- a/test/functional/Main.hs
+++ b/test/functional/Main.hs
@@ -1,34 +1,32 @@
 module Main where
 
-import Class
-import Command
-import Completion
-import Config
-import Deferred
-import Definition
-import Diagnostic
-import Eval
-import Format
-import FunctionalBadProject
-import FunctionalCodeAction
-import FunctionalLiquid
-import HaddockComments
-import HieBios
-import Highlight
-import ModuleName
-import Progress
-import Reference
-import Rename
-import Symbol
-import Splice
-import Test.Tasty
-import Test.Tasty.Ingredients.Rerun
-import Test.Tasty.Runners (
-    consoleTestReporter,
-    listingTests,
- )
-import Test.Tasty.Runners.AntXML
-import TypeDefinition
+import           Class
+import           Command
+import           Completion
+import           Config
+import           Deferred
+import           Definition
+import           Diagnostic
+import           Eval
+import           Format
+import           FunctionalBadProject
+import           FunctionalCodeAction
+import           FunctionalLiquid
+import           HaddockComments
+import           HieBios
+import           Highlight
+import           ModuleName
+import           Progress
+import           Reference
+import           Rename
+import           Splice
+import           Symbol
+import           Test.Tasty
+import           Test.Tasty.Ingredients.Rerun
+import           Test.Tasty.Runners           (consoleTestReporter,
+                                               listingTests)
+import           Test.Tasty.Runners.AntXML
+import           TypeDefinition
 
 main :: IO ()
 main =

--- a/test/functional/Progress.hs
+++ b/test/functional/Progress.hs
@@ -1,30 +1,31 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE OverloadedStrings     #-}
 
 module Progress (tests) where
 
-import Control.Applicative.Combinators
-import Control.Lens hiding ((.=))
-import Control.Monad.IO.Class
-import Data.Aeson (Value, decode, encode, object, toJSON, (.=))
-import Data.Default
-import Data.List (delete)
-import Data.Maybe (fromJust)
-import Data.Text (Text, pack)
-import Ide.Plugin.Config
-import Language.LSP.Test
-import Language.LSP.Types
-import Language.LSP.Types.Capabilities
-import qualified Language.LSP.Types.Lens as L
-import System.FilePath ((</>))
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
-import Test.Tasty.HUnit
+import           Control.Applicative.Combinators
+import           Control.Lens                    hiding ((.=))
+import           Control.Monad.IO.Class
+import           Data.Aeson                      (Value, decode, encode, object,
+                                                  toJSON, (.=))
+import           Data.Default
+import           Data.List                       (delete)
+import           Data.Maybe                      (fromJust)
+import           Data.Text                       (Text, pack)
+import           Ide.Plugin.Config
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Language.LSP.Types.Capabilities
+import qualified Language.LSP.Types.Lens         as L
+import           System.FilePath                 ((</>))
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure      (ignoreTestBecause)
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests =

--- a/test/functional/Reference.hs
+++ b/test/functional/Reference.hs
@@ -1,16 +1,16 @@
 module Reference (tests) where
 
-import Control.Lens
-import Control.Monad.IO.Class
-import Data.List
-import Language.LSP.Test
-import Language.LSP.Types
-import Language.LSP.Types.Lens
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
-import Test.Tasty.HUnit
-import Data.Coerce
+import           Control.Lens
+import           Control.Monad.IO.Class
+import           Data.Coerce
+import           Data.List
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Language.LSP.Types.Lens
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure (ignoreTestBecause)
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "references" [

--- a/test/functional/Rename.hs
+++ b/test/functional/Rename.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Rename (tests) where
 
-import Control.Monad.IO.Class (liftIO)
-import Language.LSP.Test
-import Language.LSP.Types
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.HUnit
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
+import           Control.Monad.IO.Class     (liftIO)
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure (ignoreTestBecause)
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "rename" [

--- a/test/functional/Splice.hs
+++ b/test/functional/Splice.hs
@@ -1,29 +1,29 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE ViewPatterns          #-}
 
 module Splice (tests) where
 
-import Control.Applicative.Combinators
-import Control.Monad
-import Control.Monad.IO.Class
-import Data.List (find)
-import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
-import Ide.Plugin.Splice.Types
-import Language.LSP.Test
-import Language.LSP.Types
-import System.Directory
-import System.FilePath
-import System.Time.Extra (sleep)
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Control.Applicative.Combinators
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Data.List                       (find)
+import           Data.Text                       (Text)
+import qualified Data.Text                       as T
+import qualified Data.Text.IO                    as T
+import           Ide.Plugin.Splice.Types
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           System.Directory
+import           System.FilePath
+import           System.Time.Extra               (sleep)
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests =
@@ -130,5 +130,5 @@ pointRange
 
 -- | Get the title of a code action.
 codeActionTitle :: (Command |? CodeAction) -> Maybe Text
-codeActionTitle InL{} = Nothing
+codeActionTitle InL{}                               = Nothing
 codeActionTitle (InR(CodeAction title _ _ _ _ _ _)) = Just title

--- a/test/functional/Symbol.hs
+++ b/test/functional/Symbol.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Symbol (tests) where
 
-import Control.Lens (to, ix, (^?), _Just)
-import Control.Monad.IO.Class
-import Data.List
-import Language.LSP.Test as Test
-import Language.LSP.Types
-import qualified Language.LSP.Types.Lens as L
-import Language.LSP.Types.Capabilities
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
-import Test.Tasty.HUnit
+import           Control.Lens                    (_Just, ix, to, (^?))
+import           Control.Monad.IO.Class
+import           Data.List
+import           Language.LSP.Test               as Test
+import           Language.LSP.Types
+import           Language.LSP.Types.Capabilities
+import qualified Language.LSP.Types.Lens         as L
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure      (ignoreTestBecause)
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "document symbols" [

--- a/test/functional/TypeDefinition.hs
+++ b/test/functional/TypeDefinition.hs
@@ -1,13 +1,13 @@
 module TypeDefinition (tests) where
 
-import Control.Monad.IO.Class
-import Data.Tuple.Extra (first3)
-import Language.LSP.Test
-import Language.LSP.Types
-import System.FilePath ((</>))
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Control.Monad.IO.Class
+import           Data.Tuple.Extra       (first3)
+import           Language.LSP.Test
+import           Language.LSP.Types
+import           System.FilePath        ((</>))
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "type definitions" [

--- a/test/wrapper/Main.hs
+++ b/test/wrapper/Main.hs
@@ -1,12 +1,13 @@
-import Data.List.Extra (trimEnd)
-import Data.Maybe
-import Test.Hls.Util
-import Test.Tasty
-import Test.Tasty.HUnit
-import Test.Tasty.Ingredients.Rerun
-import Test.Tasty.Runners ( listingTests, consoleTestReporter)
-import System.Process
-import System.Environment
+import           Data.List.Extra              (trimEnd)
+import           Data.Maybe
+import           System.Environment
+import           System.Process
+import           Test.Hls.Util
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.Ingredients.Rerun
+import           Test.Tasty.Runners           (consoleTestReporter,
+                                               listingTests)
 
 main :: IO ()
 main = do


### PR DESCRIPTION
This is a successor of #1384.

However, some CPP modules do not work with any formatters (including `stylish-haskell`, `ormolu`, `brittany`), so I format them by manually removing and then re-adding CPP parts.