### PR TITLE
Correct megaparsec lower bound

### DIFF
--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -55,7 +55,7 @@ library
     , lsp-types
     , hls-plugin-api        ^>= 1.0.0.0
     , lens
-    , megaparsec            >=0.9
+    , megaparsec            >=9.0
     , mtl
     , parser-combinators
     , pretty-simple


### PR DESCRIPTION
Closes #1436

The config intent was set 9.0 but 0.9 was used