### PR TITLE
Simplify tactics state structure

### DIFF
--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -50,6 +50,7 @@ import           Language.LSP.Types.Capabilities
 import           OccName
 import           Prelude                                          hiding (span)
 import           System.Timeout
+import Data.Foldable (for_)
 
 
 descriptor :: PluginId -> PluginDescriptor IdeState
@@ -144,7 +145,7 @@ mkWorkspaceEdits
     -> RunTacticResults
     -> Either ResponseError (Maybe WorkspaceEdit)
 mkWorkspaceEdits span dflags ccs uri pm rtr = do
-  traceMX "other solutions" $ rtr_other_solns rtr
+  for_ (rtr_other_solns rtr) $ traceMX "other solution"
   let g = graftHole (RealSrcSpan span) rtr
       response = transform dflags ccs uri g pm
    in case response of

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -23,6 +23,7 @@ import           Data.Aeson
 import           Data.Bifunctor                                   (Bifunctor (bimap))
 import           Data.Bool                                        (bool)
 import           Data.Data                                        (Data)
+import           Data.Foldable (for_)
 import           Data.Generics.Aliases                            (mkQ)
 import           Data.Generics.Schemes                            (everything)
 import           Data.Maybe
@@ -50,7 +51,6 @@ import           Language.LSP.Types.Capabilities
 import           OccName
 import           Prelude                                          hiding (span)
 import           System.Timeout
-import Data.Foldable (for_)
 
 
 descriptor :: PluginId -> PluginDescriptor IdeState

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -144,6 +144,7 @@ mkWorkspaceEdits
     -> RunTacticResults
     -> Either ResponseError (Maybe WorkspaceEdit)
 mkWorkspaceEdits span dflags ccs uri pm rtr = do
+  traceMX "other solutions" $ rtr_other_solns rtr
   let g = graftHole (RealSrcSpan span) rtr
       response = transform dflags ccs uri g pm
    in case response of

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -83,7 +83,6 @@ destructMatches f scrut t jdg = do
               j = introduce hy'
                 $ withNewGoal g jdg
           Synthesized tr sc sg <- f dc j
-          modify $ withIntroducedVals $ mappend $ S.fromList names
           pure
             $ Synthesized
               ( rose ("match " <> show dc <> " {" <>

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/CodeGen.hs
@@ -77,8 +77,10 @@ destructMatches f scrut t jdg = do
         _ -> fmap unzipTrace $ for dcs $ \dc -> do
           let args = dataConInstOrigArgTys' dc apps
           names <- mkManyGoodNames (hyNamesInScope hy) args
-          let hy' = zip names $ coerce args
-              j = introducingPat scrut dc hy'
+          let hy' = patternHypothesis scrut dc jdg
+                  $ zip names
+                  $ coerce args
+              j = introduce hy'
                 $ withNewGoal g jdg
           Synthesized tr sg <- f dc j
           modify $ withIntroducedVals $ mappend $ S.fromList names

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
@@ -48,6 +48,7 @@ deriveArbitrary = do
               -- a bespoke binding "terminal", and a not-so-bespoke "n".
               -- But maybe it's fine for known rules?
               mempty
+              mempty
           $ noLoc $
               let' [valBind (fromString "terminal") $ list $ fmap genExpr terminal] $
                 appDollar (mkFunc "sized") $ lambda [bvar' (mkVarOcc "n")] $

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
@@ -43,8 +43,8 @@ deriveArbitrary = do
             terminal_expr = mkVal "terminal"
             oneof_expr = mkVal "oneof"
         pure
-          ( tracePrim "deriveArbitrary"
-          , noLoc $
+          $ Synthesized (tracePrim "deriveArbitrary")
+          $ noLoc $
               let' [valBind (fromString "terminal") $ list $ fmap genExpr terminal] $
                 appDollar (mkFunc "sized") $ lambda [bvar' (mkVarOcc "n")] $
                   case' (infixCall "<=" (mkVal "n") (int 1))
@@ -56,7 +56,6 @@ deriveArbitrary = do
                             (list $ fmap genExpr big)
                             terminal_expr
                     ]
-          )
     _ -> throwError $ GoalMismatch "deriveArbitrary" ty
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/KnownStrategies/QuickCheck.hs
@@ -44,6 +44,10 @@ deriveArbitrary = do
             oneof_expr = mkVal "oneof"
         pure
           $ Synthesized (tracePrim "deriveArbitrary")
+              -- TODO(sandy): This thing is not actually empty! We produced
+              -- a bespoke binding "terminal", and a not-so-bespoke "n".
+              -- But maybe it's fine for known rules?
+              mempty
           $ noLoc $
               let' [valBind (fromString "terminal") $ list $ fmap genExpr terminal] $
                 appDollar (mkFunc "sized") $ lambda [bvar' (mkVarOcc "n")] $

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/LanguageServer.hs
@@ -197,7 +197,8 @@ getRhsPosVals rss tcs
         , isHole $ occName hole  -- and the span is a hole
         -> First $ do
             patnames <- traverse getPatName ps
-            pure $ zip patnames $ [0..] <&> TopLevelArgPrv name
+            pure $ zip patnames $ [0..] <&> \n ->
+              TopLevelArgPrv name n (length patnames)
       _ -> mempty
   ) tcs
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
@@ -169,7 +169,7 @@ scoreSolution ext TacticState{..} holes
     , Reward   $ S.null $ intro_vals S.\\ used_vals
     , Penalize $ S.size unused_top_vals
     , Penalize $ S.size intro_vals
-    , Reward   $ S.size $ traceIdX "used vals" $ used_vals
+    , Reward   $ S.size used_vals
     , Penalize ts_recursion_count
     , Penalize $ solutionSize $ syn_val ext
     )

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Machinery.hs
@@ -93,14 +93,14 @@ runTactic ctx jdg t =
       (errs, []) -> Left $ take 50 errs
       (_, fmap assoc23 -> solns) -> do
         let sorted =
-              flip sortBy solns $ comparing $ \((_, ext), (jdg, holes)) ->
+              flip sortBy solns $ comparing $ \((syn_val -> ext), (jdg, holes)) ->
                 Down $ scoreSolution ext jdg holes
         case sorted of
-          (((tr, ext), _) : _) ->
+          ((syn, _) : _) ->
             Right $
               RunTacticResults
-                { rtr_trace = tr
-                , rtr_extract = simplify ext
+                { rtr_trace = syn_trace syn
+                , rtr_extract = simplify $ syn_val syn
                 , rtr_other_solns = reverse . fmap fst $ take 5 sorted
                 , rtr_jdg = jdg
                 , rtr_ctx = ctx
@@ -119,11 +119,11 @@ tracePrim = flip rose []
 tracing
     :: Functor m
     => String
-    -> TacticT jdg (Trace, ext) err s m a
-    -> TacticT jdg (Trace, ext) err s m a
+    -> TacticT jdg (Synthesized ext) err s m a
+    -> TacticT jdg (Synthesized ext) err s m a
 tracing s (TacticT m)
   = TacticT $ StateT $ \jdg ->
-      mapExtract' (first $ rose s . pure) $ runStateT m jdg
+      mapExtract' (mapTrace $ rose s . pure) $ runStateT m jdg
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -72,8 +72,6 @@ recursion = requireConcreteHole $ tracing "recursion" $ do
     modify $ pushRecursionStack .  countRecursiveCall
     ensure guardStructurallySmallerRecursion popRecursionStack $ do
       let hy' = recursiveHypothesis defs
-
-      -- TODO(sandy): do we need to add this to syn_scoped?
       localTactic (apply $ HyInfo name RecursivePrv ty) (introduce hy')
         <@> fmap (localTactic assumption . filterPosition name) [0..]
 
@@ -164,6 +162,7 @@ apply hi = requireConcreteHole $ tracing ("apply' " <> show (hi_name hi)) $ do
   let (_, _, args, ret) = tacticsSplitFunTy ty'
   -- TODO(sandy): Bug here! Prevents us from doing mono-map like things
   -- Don't require new holes for locally bound vars; only respect linearity
+  -- see https://github.com/haskell/haskell-language-server/issues/1447
   requireNewHoles $ rule $ \jdg -> do
     unify g (CType ret)
     Synthesized tr sc uv sgs

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -148,12 +148,14 @@ homoLambdaCase =
 apply :: HyInfo CType -> TacticsM ()
 apply hi = requireConcreteHole $ tracing ("apply' " <> show (hi_name hi)) $ do
   jdg <- goal
-  let hy = jHypothesis jdg
-      g  = jGoal jdg
+  let g  = jGoal jdg
       ty = unCType $ hi_type hi
       func = hi_name hi
   ty' <- freshTyvars ty
   let (_, _, args, ret) = tacticsSplitFunTy ty'
+  -- TODO(sandy): Bug here! Prevents us from doing mono-map like things
+  -- Don't require new holes for locally bound vars; only respect linearity
+  -- requireNewHoles $
   requireNewHoles $ rule $ \jdg -> do
     unify g (CType ret)
     useOccName jdg func

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -88,7 +88,6 @@ intros = rule $ \jdg -> do
           hy' = lambdaHypothesis top_hole $ zip vs $ coerce as
           jdg' = introduce hy'
                $ withNewGoal (CType b) jdg
-      modify $ withIntroducedVals $ mappend $ S.fromList vs
       when (isJust top_hole) $ addUnusedTopVals $ S.fromList vs
       Synthesized tr sc sg <- newSubgoal jdg'
       pure

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -65,6 +65,10 @@ recursion :: TacticsM ()
 recursion = requireConcreteHole $ tracing "recursion" $ do
   defs <- getCurrentDefinitions
   attemptOn (const defs) $ \(name, ty) -> do
+    -- TODO(sandy): When we can inspect the extract of a TacticsM bind
+    -- (requires refinery support), this recursion stack stuff is unnecessary.
+    -- We can just inspect the extract to see i we used any pattern vals, and
+    -- then be on our merry way.
     modify $ pushRecursionStack .  countRecursiveCall
     ensure guardStructurallySmallerRecursion popRecursionStack $ do
       let hy' = recursiveHypothesis defs

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
@@ -90,8 +90,6 @@ data TacticState = TacticState
       -- ^ The current substitution of univars.
     , ts_used_vals :: !(Set OccName)
       -- ^ Set of values used by tactics.
-    , ts_intro_vals :: !(Set OccName)
-      -- ^ Set of values introduced by tactics.
     , ts_unused_top_vals :: !(Set OccName)
       -- ^ Set of currently unused arguments to the function being defined.
     , ts_recursion_stack :: ![Maybe PatVal]
@@ -121,7 +119,6 @@ defaultTacticState =
     { ts_skolems         = mempty
     , ts_unifier         = emptyTCvSubst
     , ts_used_vals       = mempty
-    , ts_intro_vals      = mempty
     , ts_unused_top_vals = mempty
     , ts_recursion_stack = mempty
     , ts_recursion_count = 0
@@ -153,11 +150,6 @@ popRecursionStack = withRecursionStack tail
 withUsedVals :: (Set OccName -> Set OccName) -> TacticState -> TacticState
 withUsedVals f =
   field @"ts_used_vals" %~ f
-
-
-withIntroducedVals :: (Set OccName -> Set OccName) -> TacticState -> TacticState
-withIntroducedVals f =
-  field @"ts_intro_vals" %~ f
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Types.hs
@@ -165,6 +165,7 @@ data Provenance
     TopLevelArgPrv
       OccName   -- ^ Binding function
       Int       -- ^ Argument Position
+      Int       -- ^ of how many arguments total?
     -- | A binding created in a pattern match.
   | PatternMatchPrv PatVal
     -- | A class method from the given context.


### PR DESCRIPTION
Refinery implements the tactics search by growing a search tree and collapsing back the results of each branch. But this is a complicated thing to think about, because there is data moving in three different directions. The `Judgement` moves from root to leaves, while the "extract" moves from leaves to root --- and the `TacticState` moves sideways between branches, just to make things hard.

This PR formalizes the extract to as a dedicated type `Synthesized` (it corresponds to a synthesized attribute in the lingo of [attribute grammars](https://en.wikipedia.org/wiki/Attribute_grammar)). Having this new conceptual clarity made me realize that I used to be using the `TacticState` as a hacky way of passing information back up the search tree. So this PR chops out a lot of that complexity and is more principled about how it implements the same behavior.

Specifically, it does the following things:

* Separate the creation of a local hypothesis (newly created bindings) from the *introduction* of them in the judgment
* Pushes these new local hypotheses into the extract, so that we have provenance information when scoring generated solutions
* Pushes used variables into the extract as well
* Greatly simplifies the `TacticState` structure, and removes a lot of imperative statefulness around that

The `TacticState` still contains some should-be-extract data about recursion usage, but that can't be removed until there are some changes upstream to `refinery`.