### PR TITLE
Use runtime ghc libdir for ghc-exactprint and ghc-8.10

### DIFF
--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -53,13 +53,13 @@ library
     , transformers
     , unordered-containers
 
-  if ((!flag(ghc-lib) && impl(ghc >=8.10.1)) && impl(ghc <8.11.0))
+  if (!flag(ghc-lib) && impl(ghc >=8.10.1) && impl(ghc <9.0.0))
     build-depends: ghc ^>= 8.10
 
   else
     build-depends:
       , ghc
-      , ghc-lib            ^>= 8.10.2.20200916
+      , ghc-lib            ^>= 8.10.4.20210206
       , ghc-lib-parser-ex  ^>= 8.10
 
     cpp-options:   -DHLINT_ON_GHC_LIB

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -27,8 +27,8 @@ extra-deps:
   - floskell-0.10.4
   - fourmolu-0.3.0.0
   - ghc-exactprint-0.6.3.4
-  - ghc-lib-8.10.3.20201220
-  - ghc-lib-parser-8.10.3.20201220
+  - ghc-lib-8.10.4.20210206
+  - ghc-lib-parser-8.10.4.20210206
   - lsp-1.1.1.0
   - lsp-types-1.1.0.0
   - lsp-test-0.13.0.0

--- a/stack-8.10.3.yaml
+++ b/stack-8.10.3.yaml
@@ -25,6 +25,8 @@ extra-deps:
   - data-tree-print-0.1.0.2@rev:2
   - floskell-0.10.4
   - fourmolu-0.3.0.0
+  - ghc-lib-8.10.4.20210206
+  - ghc-lib-parser-8.10.4.20210206
   - heapsize-0.3.0
   - hie-bios-0.7.4
   - implicit-hie-cradle-0.3.0.2

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -36,8 +36,8 @@ extra-deps:
   - ghc-check-0.5.0.1
   - ghc-events-0.13.0
   - ghc-exactprint-0.6.3.4
-  - ghc-lib-8.10.3.20201220
-  - ghc-lib-parser-8.10.3.20201220
+  - ghc-lib-8.10.4.20210206
+  - ghc-lib-parser-8.10.4.20210206
   - ghc-lib-parser-ex-8.10.0.17
   - ghc-source-gen-0.4.0.0
   - ghc-trace-events-0.1.2.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -35,8 +35,8 @@ extra-deps:
   - ghc-check-0.5.0.1
   - ghc-events-0.13.0
   - ghc-exactprint-0.6.3.4
-  - ghc-lib-8.10.3.20201220
-  - ghc-lib-parser-8.10.3.20201220
+  - ghc-lib-8.10.4.20210206
+  - ghc-lib-parser-8.10.4.20210206
   - ghc-lib-parser-ex-8.10.0.17
   - ghc-source-gen-0.4.0.0
   - ghc-trace-events-0.1.2.1

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -31,8 +31,8 @@ extra-deps:
   - ghc-check-0.5.0.1
   - ghc-events-0.13.0
   - ghc-exactprint-0.6.3.4
-  - ghc-lib-8.10.3.20201220
-  - ghc-lib-parser-8.10.3.20201220
+  - ghc-lib-8.10.4.20210206
+  - ghc-lib-parser-8.10.4.20210206
   - ghc-lib-parser-ex-8.10.0.17
   - ghc-trace-events-0.1.2.1
   - haddock-library-1.8.0

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -29,8 +29,8 @@ extra-deps:
   - floskell-0.10.4
   - fourmolu-0.3.0.0
   - ghc-exactprint-0.6.3.4
-  - ghc-lib-8.10.3.20201220
-  - ghc-lib-parser-8.10.3.20201220
+  - ghc-lib-8.10.4.20210206
+  - ghc-lib-parser-8.10.4.20210206
   - ghc-trace-events-0.1.2.1
   - haskell-src-exts-1.21.1
   - heapsize-0.3.0

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -29,6 +29,8 @@ extra-deps:
   - floskell-0.10.4
   - fourmolu-0.3.0.0
   - ghc-exactprint-0.6.3.4
+  - ghc-lib-8.10.4.20210206
+  - ghc-lib-parser-8.10.4.20210206
   - ghc-trace-events-0.1.2.1
   - haskell-src-exts-1.21.1
   - heapsize-0.3.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,8 +37,8 @@ extra-deps:
   - ghc-check-0.5.0.1
   - ghc-events-0.13.0
   - ghc-exactprint-0.6.3.4
-  - ghc-lib-8.10.3.20201220
-  - ghc-lib-parser-8.10.3.20201220
+  - ghc-lib-8.10.4.20210206
+  - ghc-lib-parser-8.10.4.20210206
   - ghc-lib-parser-ex-8.10.0.17
   - ghc-source-gen-0.4.0.0
   - ghc-trace-events-0.1.2.1


### PR DESCRIPTION
* We were using it only in the code path for ghc < 8.10
* But I guess some change in either `ghc-exacprint` or `apply-refact` has exposed the ghc-wrapper  for the code path used in ghc-8.10 here (`applyRefact'`)
* Fixes #591