### PR TITLE
Add new variables to the extract when doing intros

### DIFF
--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -12,7 +12,7 @@ module Ide.Plugin.Tactic.Tactics
   ) where
 
 import           Control.Applicative (Alternative(empty))
-import           Control.Lens ((&), (%~))
+import           Control.Lens ((&), (%~), (<>~))
 import           Control.Monad (unless)
 import           Control.Monad.Except (throwError)
 import           Control.Monad.Reader.Class (MonadReader (ask))
@@ -104,6 +104,7 @@ intros = rule $ \jdg -> do
         ext
           & #syn_trace %~ rose ("intros {" <> intercalate ", " (fmap show vs) <> "}")
                         . pure
+          & #syn_scoped <>~ hy'
           & #syn_val   %~ noLoc . lambda (fmap bvar' vs) . unLoc
 
 


### PR DESCRIPTION
#1453 introduced a slight bug where I forgot to update the extract's knowledge of introduced scoped variables when running `intros`. This made the scoring function reject lots of otherwise good programs, and a bunch of tests went red.

Found it this morning when seeing mysterious failures in an unrelated part of the codebase.

This makes it look like the tactics tests aren't being run as part of CI :scream: How do we get them to run?