### PR TITLE
Fix non-determinism in boot-def test

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4608,6 +4608,11 @@ bootTests = testCase "boot-def-test" $ runWithExtraFiles "boot" $ \dir -> do
   liftIO $ runInDir dir $ do
     cDoc <- createDoc cPath "haskell" cSource
     _ <- getHover cDoc $ Position 4 3
+    ~() <- skipManyTill anyMessage $ satisfyMaybe $ \case
+      FromServerMess (SCustomMethod "ghcide/reference/ready") (NotMess NotificationMessage{_params = fp}) -> do
+        A.Success fp' <- pure $ fromJSON fp
+        if equalFilePath fp' cPath then pure () else Nothing
+      _ -> Nothing
     closeDoc cDoc
 
   cdoc <- createDoc cPath "haskell" cSource


### PR DESCRIPTION
Earlier boot-def failed in ~1/20 runs on my machine.

After this fix, I ran the test 200 times and observed 0 failures.
