### PR TITLE
Context-aware ExactPrint grafting for HsExpr

### DIFF
--- a/ghcide/src/Development/IDE/GHC/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/GHC/ExactPrint.hs
@@ -65,9 +65,9 @@ import Parser (parseIdentifier)
 import Data.Traversable (for)
 import Data.Foldable (Foldable(fold))
 import Data.Bool (bool)
+import Data.Monoid (All(All))
 #if __GLASGOW_HASKELL__ == 808
 import Control.Arrow
-import Data.Monoid (All(All))
 #endif
 #if __GLASGOW_HASKELL__ > 808
 import Bag (listToBag)

--- a/ghcide/src/Development/IDE/GHC/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/GHC/ExactPrint.hs
@@ -180,7 +180,11 @@ transformM dflags ccs uri f a = runExceptT $
         pure $ diffText ccs (uri, T.pack src) (T.pack res) IncludeDeletions
 
 
--- | Returns whether or not this node requires its immediate children to have a
+-- | Returns whether or not this node requires its immediate children to have
+-- be parenthesized and have a leading space.
+--
+-- A more natural type for this function would be to return @(Bool, Bool)@, but
+-- we use 'All' instead for its monoid instance.
 needsParensSpace ::
     HsExpr GhcPs ->
     -- | (Needs parens, needs space)

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -170,7 +170,7 @@ graftHole span rtr
       $ unLoc
       $ rtr_extract rtr
 graftHole span rtr
-  = graftExpr span
+  = graft span
   $ rtr_extract rtr
 
 

--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic.hs
@@ -170,9 +170,7 @@ graftHole span rtr
       $ unLoc
       $ rtr_extract rtr
 graftHole span rtr
-  = graftWithoutParentheses span
-    -- Parenthesize the extract iff we're not in a top level hole
-  $ bool maybeParensAST id (_jIsTopHole $ rtr_jdg rtr)
+  = graftExpr span
   $ rtr_extract rtr
 
 

--- a/plugins/hls-tactics-plugin/test/GoldenSpec.hs
+++ b/plugins/hls-tactics-plugin/test/GoldenSpec.hs
@@ -80,6 +80,7 @@ spec = do
     test Destruct "b" "LayoutBind.hs" 4 3
     test Destruct "b" "LayoutDollarApp.hs" 2 15
     test Destruct "b" "LayoutOpApp.hs" 2 18
+    test Destruct "b" "LayoutLam.hs" 2 14
 
   -- test via:
   -- stack test hls-tactics-plugin --test-arguments '--match "Golden/destruct all/"'

--- a/plugins/hls-tactics-plugin/test/GoldenSpec.hs
+++ b/plugins/hls-tactics-plugin/test/GoldenSpec.hs
@@ -74,6 +74,14 @@ spec = do
   let goldenTest = mkGoldenTest allFeatures
 
   -- test via:
+  -- stack test hls-tactics-plugin --test-arguments '--match "Golden/layout/"'
+  describe "layout" $ do
+    let test = mkGoldenTest allFeatures
+    test Destruct "b" "LayoutBind.hs" 4 3
+    test Destruct "b" "LayoutDollarApp.hs" 2 15
+    test Destruct "b" "LayoutOpApp.hs" 2 18
+
+  -- test via:
   -- stack test hls-tactics-plugin --test-arguments '--match "Golden/destruct all/"'
   describe "destruct all" $ do
     let destructAllTest = mkGoldenTest allFeatures DestructAll ""

--- a/plugins/hls-tactics-plugin/test/golden/LayoutBind.hs
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutBind.hs
@@ -1,0 +1,6 @@
+test :: Bool -> IO ()
+test b = do
+  putStrLn "hello"
+  _
+  pure ()
+

--- a/plugins/hls-tactics-plugin/test/golden/LayoutBind.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutBind.hs.expected
@@ -1,0 +1,8 @@
+test :: Bool -> IO ()
+test b = do
+  putStrLn "hello"
+  case b of
+    False -> _
+    True -> _
+  pure ()
+

--- a/plugins/hls-tactics-plugin/test/golden/LayoutDollarApp.hs
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutDollarApp.hs
@@ -1,0 +1,3 @@
+test :: Bool -> Bool
+test b = id $ _
+

--- a/plugins/hls-tactics-plugin/test/golden/LayoutDollarApp.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutDollarApp.hs.expected
@@ -1,0 +1,5 @@
+test :: Bool -> Bool
+test b = id $ (case b of
+   False -> _
+   True -> _)
+

--- a/plugins/hls-tactics-plugin/test/golden/LayoutLam.hs
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutLam.hs
@@ -1,0 +1,3 @@
+test :: Bool -> Bool
+test = \b -> _
+

--- a/plugins/hls-tactics-plugin/test/golden/LayoutLam.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutLam.hs.expected
@@ -1,0 +1,5 @@
+test :: Bool -> Bool
+test = \b -> case b of
+  False -> _
+  True -> _
+

--- a/plugins/hls-tactics-plugin/test/golden/LayoutOpApp.hs
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutOpApp.hs
@@ -1,0 +1,2 @@
+test :: Bool -> Bool
+test b = True && _

--- a/plugins/hls-tactics-plugin/test/golden/LayoutOpApp.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutOpApp.hs.expected
@@ -1,0 +1,4 @@
+test :: Bool -> Bool
+test b = True && (case b of
+   False -> _
+   True -> _)


### PR DESCRIPTION
In #1486, it's pointed out that always inserting a leading space when grafting trees will break layout (and thus the parse) if you're grafting into a `do` block. Yikes.

This PR adds a function `graftExpr` which tracks the tree context of the graft's destination. If the immediate parent of the destination is a function application, or a few other things, we need to insert that space.

And hey, while we're looking at context, let's use it to determine if we need parentheses!

Fixes #1486 