### PR TITLE
Let Wingman's apply tactic run endomorphisms

### DIFF
--- a/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Ide/Plugin/Tactic/Tactics.hs
@@ -167,10 +167,7 @@ apply hi = requireConcreteHole $ tracing ("apply' " <> show (hi_name hi)) $ do
       func = hi_name hi
   ty' <- freshTyvars ty
   let (_, _, args, ret) = tacticsSplitFunTy ty'
-  -- TODO(sandy): Bug here! Prevents us from doing mono-map like things
-  -- Don't require new holes for locally bound vars; only respect linearity
-  -- see https://github.com/haskell/haskell-language-server/issues/1447
-  requireNewHoles $ rule $ \jdg -> do
+  rule $ \jdg -> do
     unify g (CType ret)
     ext
         <- fmap unzipTrace

--- a/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
@@ -45,6 +45,7 @@ spec = do
     autoTest  2 14 "FmapJoin.hs"
     autoTest  2  9 "Fgmap.hs"
     autoTest  4 19 "FmapJoinInLet.hs"
+    autoTest  9 12 "AutoEndo.hs"
 
     failing "flaky in CI" $
       autoTest 2 11 "GoldenApplicativeThen.hs"

--- a/plugins/hls-tactics-plugin/test/golden/AutoEndo.hs
+++ b/plugins/hls-tactics-plugin/test/golden/AutoEndo.hs
@@ -1,0 +1,10 @@
+data Synthesized b a = Synthesized
+  { syn_trace :: b
+  , syn_val   :: a
+  }
+  deriving (Eq, Show)
+
+
+mapTrace :: (b -> b) -> Synthesized b a -> Synthesized b a
+mapTrace = _
+

--- a/plugins/hls-tactics-plugin/test/golden/AutoEndo.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/AutoEndo.hs.expected
@@ -1,0 +1,11 @@
+data Synthesized b a = Synthesized
+  { syn_trace :: b
+  , syn_val   :: a
+  }
+  deriving (Eq, Show)
+
+
+mapTrace :: (b -> b) -> Synthesized b a -> Synthesized b a
+mapTrace fbb (Synthesized b a)
+  = Synthesized {syn_trace = fbb b, syn_val = a}
+


### PR DESCRIPTION
Tactics was afraid of running endomorphisms in an attempt to cut down on the size of generated trees. But it doesn't seem to be an issue in practice, so why not.

Fixes #1447 