### PR TITLE
Set all plugin flags to manual

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -106,37 +106,37 @@ flag all-formatters
 flag class
   description: Enable class plugin
   default:     True
-  manual:      False
+  manual:      True
 
 flag haddockComments
   description: Enable haddockComments plugin
   default:     True
-  manual:      False
+  manual:      True
 
 flag eval
   description: Enable eval plugin
   default:     True
-  manual:      False
+  manual:      True
 
 flag importLens
   description: Enable importLens plugin
   default:     True
-  manual:      False
+  manual:      True
 
 flag retrie
   description: Enable retrie plugin
   default:     True
-  manual:      False
+  manual:      True
 
 flag tactic
   description: Enable tactic plugin
   default:     True
-  manual:      False
+  manual:      True
 
 flag hlint
   description: Enable hlint plugin
   default:     True
-  manual:      False
+  manual:      True
 
 flag moduleName
   description: Enable moduleName plugin
@@ -151,7 +151,7 @@ flag pragmas
 flag splice
   description: Enable splice plugin
   default:     True
-  manual:      False
+  manual:      True
 
 -- formatters
 


### PR DESCRIPTION
* I think that include plugins should be something cabal should not choose at its will, depending it they are buildable or not, but by the user explicitly (and fail if they are not buildable) 
* We are uploading all plugins before hls so all of them are available for now