### PR TITLE
Add an option to control progress reporting

### DIFF
--- a/ghcide/src/Development/IDE/Core/FileExists.hs
+++ b/ghcide/src/Development/IDE/Core/FileExists.hs
@@ -13,19 +13,17 @@ where
 import           Control.Concurrent.Extra
 import           Control.Exception
 import           Control.Monad.Extra
-import           Data.Binary
 import qualified Data.ByteString                       as BS
 import           Data.HashMap.Strict                   (HashMap)
 import qualified Data.HashMap.Strict                   as HashMap
 import           Data.Maybe
 import           Development.IDE.Core.FileStore
 import           Development.IDE.Core.IdeConfiguration
+import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
 import           Development.Shake
-import           Development.Shake.Classes
-import           GHC.Generics
 import           Language.LSP.Server                   hiding (getVirtualFile)
 import           Language.LSP.Types
 import           Language.LSP.Types.Capabilities
@@ -111,15 +109,6 @@ fromChange FcDeleted = Just True
 fromChange FcChanged = Nothing
 
 -------------------------------------------------------------------------------------
-
-type instance RuleResult GetFileExists = Bool
-
-data GetFileExists = GetFileExists
-    deriving (Eq, Show, Typeable, Generic)
-
-instance NFData   GetFileExists
-instance Hashable GetFileExists
-instance Binary   GetFileExists
 
 -- | Returns True if the file exists
 --   Note that a file is not considered to exist unless it is saved to disk.

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -939,8 +939,8 @@ defineEarlyCutoff'
     -> Action (RunResult (A (RuleResult k)))
 defineEarlyCutoff' doDiagnostics key file old mode action = do
     extras@ShakeExtras{state, inProgress} <- getShakeExtras
-    -- don't do progress for GetFileExists, as there are lots of non-nodes for just that one key
-    (if show key == "GetFileExists" then id else withProgressVar inProgress file) $ do
+    options <- getIdeOptions
+    (if optSkipProgress options key then id else withProgressVar inProgress file) $ do
         val <- case old of
             Just old | mode == RunDependenciesSame -> do
                 v <- liftIO $ getValues state key file

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -101,11 +101,11 @@ otTracedAction key file success act
             return res)
   | otherwise = act
 
-
+#if MIN_GHC_API_VERSION(8,8,0)
 otTracedProvider :: MonadUnliftIO m => PluginId -> ByteString -> m a -> m a
-
-
-
+#else
+otTracedProvider :: MonadUnliftIO m => PluginId -> String -> m a -> m a
+#endif
 otTracedProvider (PluginId pluginName) provider act = do
   runInIO <- askRunInIO
   liftIO $ withSpan (provider <> " provider") $ \sp -> do

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -36,6 +36,7 @@ import           Development.IDE.Types.Shake    (Key (..), Value,
                                                  Values)
 import           Development.Shake              (Action, actionBracket)
 import           Foreign.Storable               (Storable (sizeOf))
+import           GHC.RTS.Flags
 import           HeapSize                       (recursiveSize, runHeapsize)
 import           Ide.PluginUtils                (installSigUsr1Handler)
 import           Ide.Types                      (PluginId (..))
@@ -47,6 +48,7 @@ import           OpenTelemetry.Eventlog         (Instrument, SpanInFlight,
                                                  addEvent, beginSpan, endSpan,
                                                  mkValueObserver, observe,
                                                  setTag, withSpan, withSpan_)
+import           System.IO.Unsafe               (unsafePerformIO)
 
 -- | Trace a handler using OpenTelemetry. Adds various useful info into tags in the OpenTelemetry span.
 otTracedHandler
@@ -68,6 +70,14 @@ otTracedHandler requestType label act =
 otSetUri :: SpanInFlight -> Uri -> IO ()
 otSetUri sp (Uri t) = setTag sp "uri" (encodeUtf8 t)
 
+{-# NOINLINE isTracingEnabled #-}
+isTracingEnabled :: Bool
+isTracingEnabled = unsafePerformIO $ do
+    flags <- getTraceFlags
+    case tracing flags of
+        TraceNone -> return False
+        _         -> return True
+
 -- | Trace a Shake action using opentelemetry.
 otTracedAction
     :: Show k
@@ -76,23 +86,26 @@ otTracedAction
     -> (a -> Bool) -- ^ Did this action succeed?
     -> Action a -- ^ The action
     -> Action a
-otTracedAction key file success act = actionBracket
-    (do
-        sp <- beginSpan (fromString (show key))
-        setTag sp "File" (fromString $ fromNormalizedFilePath file)
-        return sp
-    )
-    endSpan
-    (\sp -> do
-        res <- act
-        unless (success res) $ setTag sp "error" "1"
-        return res)
+otTracedAction key file success act
+  | isTracingEnabled =
+    actionBracket
+        (do
+            sp <- beginSpan (fromString (show key))
+            setTag sp "File" (fromString $ fromNormalizedFilePath file)
+            return sp
+        )
+        endSpan
+        (\sp -> do
+            res <- act
+            unless (success res) $ setTag sp "error" "1"
+            return res)
+  | otherwise = act
 
-#if MIN_GHC_API_VERSION(8,8,0)
+
 otTracedProvider :: MonadUnliftIO m => PluginId -> ByteString -> m a -> m a
-#else
-otTracedProvider :: MonadUnliftIO m => PluginId -> String -> m a -> m a
-#endif
+
+
+
 otTracedProvider (PluginId pluginName) provider act = do
   runInIO <- askRunInIO
   liftIO $ withSpan (provider <> " provider") $ \sp -> do
@@ -220,3 +233,4 @@ repeatUntilJust nattempts action = do
     case res of
         Nothing -> repeatUntilJust (nattempts-1) action
         Just{}  -> return res
+

--- a/ghcide/src/Development/IDE/GHC/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/GHC/ExactPrint.hs
@@ -67,11 +67,6 @@ import Data.Monoid (All(All))
 #if __GLASGOW_HASKELL__ == 808
 import Control.Arrow
 #endif
-#if __GLASGOW_HASKELL__ > 808
-import Bag (listToBag)
-import ErrUtils (mkErrMsg)
-import Outputable (text, neverQualify)
-#endif
 
 
 ------------------------------------------------------------------------------

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -135,8 +135,13 @@ defaultIdeOptions session = IdeOptions
 
 defaultSkipProgress :: Typeable a => a -> Bool
 defaultSkipProgress key = case () of
+    -- don't do progress for GetFileContents as it's cheap
     _ | Just GetFileContents <- cast key        -> True
+    -- don't do progress for GetFileExists, as there are lots of redundant nodes
+    -- (normally there is one node per file, but this is not the case for GetFileExists)
     _ | Just GetFileExists <- cast key          -> True
+    -- don't do progress for GetModificationTime as there are lot of redundant nodes
+    -- (for the interface files)
     _ | Just GetModificationTime_{} <- cast key -> True
     _                                           -> False
 


### PR DESCRIPTION
The current implementation of progress reporting uses `actionBracket` which has O(logC) complexity in the number of registered Cleanups (https://github.com/ndmitchell/shake/issues/797).

Since we do progress reporting for every File and Rule updated, the worst case complexity is around O(F*R*logC) for all the files in the project. In large projects, this is quite expensive.

Since `otTracedAction` is implemented using `actionBracket` too, I have made it conditional on eventlogs being enabled.

For reviewers understanding: I had to move some types around to avoid cyclic module dependencies.