### PR TITLE
Improve thread contention around diagnostics

### DIFF
--- a/ghcide/src/Development/IDE/Core/Debouncer.hs
+++ b/ghcide/src/Development/IDE/Core/Debouncer.hs
@@ -45,12 +45,12 @@ asyncRegisterEvent d 0 k fire = do
         (cancel, !m') <- evaluate $ Map.alterF (\prev -> (traverse_ cancel prev, Nothing)) k m
         return (m', cancel)
     fire
-asyncRegisterEvent d delay k fire = do
+asyncRegisterEvent d delay k fire = mask_ $ do
     a <- asyncWithUnmask $ \unmask -> unmask $ do
         sleep delay
         fire
         modifyVar_ d (evaluate . Map.delete k)
-    join $ modifyVar d $ \m -> mask_ $ do
+    join $ modifyVar d $ \m -> do
         (cancel, !m') <- evaluate $ Map.alterF (\prev -> (traverse_ cancel prev, Just a)) k m
         return (m', cancel)
 

--- a/ghcide/src/Development/IDE/Core/Debouncer.hs
+++ b/ghcide/src/Development/IDE/Core/Debouncer.hs
@@ -44,13 +44,14 @@ asyncRegisterEvent d 0 k fire = do
         whenJust (Map.lookup k m) cancel
         pure $ Map.delete k m
     fire
-asyncRegisterEvent d delay k fire = modifyVar_ d $ \m -> mask_ $ do
-    whenJust (Map.lookup k m) cancel
+asyncRegisterEvent d delay k fire = do
     a <- asyncWithUnmask $ \unmask -> unmask $ do
         sleep delay
         fire
         modifyVar_ d (pure . Map.delete k)
-    pure $ Map.insert k a m
+    modifyVar_ d $ \m -> mask_ $ do
+        whenJust (Map.lookup k m) cancel
+        pure $ Map.insert k a m
 
 -- | Debouncer used in the DAML CLI compiler that emits events immediately.
 noopDebouncer :: Debouncer k

--- a/ghcide/src/Development/IDE/Core/Debouncer.hs
+++ b/ghcide/src/Development/IDE/Core/Debouncer.hs
@@ -11,7 +11,8 @@ module Development.IDE.Core.Debouncer
 import           Control.Concurrent.Async
 import           Control.Concurrent.Extra
 import           Control.Exception
-import           Control.Monad.Extra
+import           Control.Monad            (join)
+import           Data.Foldable            (traverse_)
 import           Data.HashMap.Strict      (HashMap)
 import qualified Data.HashMap.Strict      as Map
 import           Data.Hashable
@@ -40,18 +41,18 @@ newAsyncDebouncer = Debouncer . asyncRegisterEvent <$> newVar Map.empty
 -- to mask if required.
 asyncRegisterEvent :: (Eq k, Hashable k) => Var (HashMap k (Async ())) -> Seconds -> k -> IO () -> IO ()
 asyncRegisterEvent d 0 k fire = do
-    modifyVar_ d $ \m -> mask_ $ do
-        whenJust (Map.lookup k m) cancel
-        pure $ Map.delete k m
+    join $ modifyVar d $ \m -> do
+        (cancel, !m') <- evaluate $ Map.alterF (\prev -> (traverse_ cancel prev, Nothing)) k m
+        return (m', cancel)
     fire
 asyncRegisterEvent d delay k fire = do
     a <- asyncWithUnmask $ \unmask -> unmask $ do
         sleep delay
         fire
-        modifyVar_ d (pure . Map.delete k)
-    modifyVar_ d $ \m -> mask_ $ do
-        whenJust (Map.lookup k m) cancel
-        pure $ Map.insert k a m
+        modifyVar_ d (evaluate . Map.delete k)
+    join $ modifyVar d $ \m -> mask_ $ do
+        (cancel, !m') <- evaluate $ Map.alterF (\prev -> (traverse_ cancel prev, Just a)) k m
+        return (m', cancel)
 
 -- | Debouncer used in the DAML CLI compiler that emits events immediately.
 noopDebouncer :: Debouncer k


### PR DESCRIPTION
These shared locks introduce contention and resulting in decreasing performance as the core count increases.

## 1. Debouncer

The async debouncer that we use in ghcide to deduplicate diagnostics is backed by a single lock containing  a Hashmap indexed by rule key used to store all the pending actions. We then grab this lock for every rule execution, for rules with diagnostics. In total, a rule execution grabs the lock twice: 

1. To enqueue the diagnostics update in the debouncer
2. When the update fires, to clean up

We then hold the lock for as long as it takes to update the map and cancel the previous async, if any. There is a bit of room for improvement here, by combining HashMap accesses as well as executing the cancel outside the lock.

Moreover, I have added an option to install a different Debouncer, e.g. the `noopDebouncer`, if desired.

## 2. Diagnostics lock

We store all the published diagnostics in a HashMap indexed by NFP behind a single lock. We then grab this lock once for every rule execution, for rules with diagnostics, and hold it for the whole publish loop. We can do better by executing the publish loop out of the lock

Fixes #1545 