### PR TITLE
Introduce strict versions of modifyVar to improve contention

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -136,6 +136,7 @@ library
     include-dirs:
         include
     exposed-modules:
+        Control.Concurrent.Strict
         Development.IDE
         Development.IDE.Main
         Development.IDE.Core.Debouncer

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -20,7 +20,7 @@ module Development.IDE.Session
 -- building with ghc-lib we need to make this Haskell agnostic, so no hie-bios!
 
 import           Control.Concurrent.Async
-import           Control.Concurrent.Extra
+import           Control.Concurrent.Strict
 import           Control.Exception.Safe
 import           Control.Monad
 import           Control.Monad.Extra
@@ -213,7 +213,7 @@ loadSessionWithOptions SessionLoadingOptions{..} dir = do
   version <- newVar 0
   let returnWithVersion fun = IdeGhcSession fun <$> liftIO (readVar version)
   let invalidateShakeCache = do
-        modifyVar_ version (return . succ)
+        void $ modifyVar' version succ
   -- This caches the mapping from Mod.hs -> hie.yaml
   cradleLoc <- liftIO $ memoIO $ \v -> do
       res <- findCradle v
@@ -246,12 +246,12 @@ loadSessionWithOptions SessionLoadingOptions{..} dir = do
               TargetModule _ -> do
                 found <- filterM (IO.doesFileExist . fromNormalizedFilePath) targetLocations
                 return (targetTarget, found)
-          modifyVar_ knownTargetsVar $ traverseHashed $ \known -> do
+          modifyVarIO' knownTargetsVar $ traverseHashed $ \known -> do
             let known' = HM.unionWith (<>) known $ HM.fromList knownTargets
             when (known /= known') $
                 logDebug logger $ "Known files updated: " <>
                     T.pack(show $ (HM.map . map) fromNormalizedFilePath known')
-            evaluate known'
+            pure known'
 
     -- Create a new HscEnv from a hieYaml root and a set of options
     -- If the hieYaml file already has an HscEnv, the new component is
@@ -364,12 +364,12 @@ loadSessionWithOptions SessionLoadingOptions{..} dir = do
 
           let all_targets = cs ++ cached_targets
 
-          modifyVar_ fileToFlags $ \var -> do
-              pure $ Map.insert hieYaml (HM.fromList (concatMap toFlagsMap all_targets)) var
-          modifyVar_ filesMap $ \var -> do
-              evaluate $ HM.union var (HM.fromList (zip (map fst $ concatMap toFlagsMap all_targets) (repeat hieYaml)))
+          void $ modifyVar' fileToFlags $
+              Map.insert hieYaml (HM.fromList (concatMap toFlagsMap all_targets))
+          void $ modifyVar' filesMap $
+              flip HM.union (HM.fromList (zip (map fst $ concatMap toFlagsMap all_targets) (repeat hieYaml)))
 
-          extendKnownTargets all_targets
+          void $ extendKnownTargets all_targets
 
           -- Invalidate all the existing GhcSession build nodes by restarting the Shake session
           invalidateShakeCache
@@ -427,10 +427,9 @@ loadSessionWithOptions SessionLoadingOptions{..} dir = do
                dep_info <- getDependencyInfo (maybeToList hieYaml)
                let ncfp = toNormalizedFilePath' cfp
                let res = (map (renderCradleError ncfp) err, Nothing)
-               modifyVar_ fileToFlags $ \var -> do
-                 pure $ Map.insertWith HM.union hieYaml (HM.singleton ncfp (res, dep_info)) var
-               modifyVar_ filesMap $ \var -> do
-                 evaluate $ HM.insert ncfp hieYaml var
+               void $ modifyVar' fileToFlags $
+                    Map.insertWith HM.union hieYaml (HM.singleton ncfp (res, dep_info))
+               void $ modifyVar' filesMap $ HM.insert ncfp hieYaml
                return (res, maybe [] pure hieYaml ++ concatMap cradleErrorDependencies err)
 
     -- This caches the mapping from hie.yaml + Mod.hs -> [String]

--- a/ghcide/src/Control/Concurrent/Strict.hs
+++ b/ghcide/src/Control/Concurrent/Strict.hs
@@ -1,0 +1,34 @@
+module Control.Concurrent.Strict
+    (modifyVar', modifyVarIO'
+    ,modifyVar, modifyVar_
+    ,module Control.Concurrent.Extra
+    ) where
+
+import Control.Concurrent.Extra hiding (modifyVar, modifyVar_)
+import qualified Control.Concurrent.Extra as Extra
+import Control.Exception (evaluate)
+import Data.Tuple.Extra (dupe)
+import Control.Monad (void)
+
+-- | Strict modification that returns the new value
+modifyVar' :: Var a -> (a -> a) -> IO a
+modifyVar' var upd = modifyVarIO' var (pure . upd)
+
+-- | Strict modification that returns the new value
+modifyVarIO' :: Var a -> (a -> IO a) -> IO a
+modifyVarIO' var upd = do
+    res <- Extra.modifyVar var $ \v -> do
+        v' <- upd v
+        pure $ dupe v'
+    evaluate res
+
+modifyVar :: Var a -> (a -> IO (a, b)) -> IO b
+modifyVar var upd = do
+    (new, res) <- Extra.modifyVar var $ \old -> do
+        (new,res) <- upd old
+        return (new, (new, res))
+    void $ evaluate new
+    return res
+
+modifyVar_ :: Var a -> (a -> IO a) -> IO ()
+modifyVar_ var upd = void $ modifyVarIO' var upd

--- a/ghcide/src/Development/IDE/Core/Debouncer.hs
+++ b/ghcide/src/Development/IDE/Core/Debouncer.hs
@@ -9,7 +9,7 @@ module Development.IDE.Core.Debouncer
     ) where
 
 import           Control.Concurrent.Async
-import           Control.Concurrent.Extra
+import           Control.Concurrent.Strict
 import           Control.Exception
 import           Control.Monad            (join)
 import           Data.Foldable            (traverse_)

--- a/ghcide/src/Development/IDE/Core/FileExists.hs
+++ b/ghcide/src/Development/IDE/Core/FileExists.hs
@@ -10,7 +10,7 @@ module Development.IDE.Core.FileExists
   )
 where
 
-import           Control.Concurrent.Extra
+import           Control.Concurrent.Strict
 import           Control.Exception
 import           Control.Monad.Extra
 import qualified Data.ByteString                       as BS
@@ -98,7 +98,7 @@ modifyFileExists state changes = do
   -- Masked to ensure that the previous values are flushed together with the map update
   mask $ \_ -> do
     -- update the map
-    modifyVar_ var $ evaluate . HashMap.union changesMap
+    void $ modifyVar' var $ HashMap.union changesMap
     -- See Note [Invalidating file existence results]
     -- flush previous values
     mapM_ (deleteValue (shakeExtras state) GetFileExists) (HashMap.keys changesMap)

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -22,9 +22,9 @@ module Development.IDE.Core.FileStore(
     getFileContentsImpl
     ) where
 
-import           Control.Concurrent.Extra
 import           Control.Concurrent.STM                       (atomically)
 import           Control.Concurrent.STM.TQueue                (writeTQueue)
+import           Control.Concurrent.Strict
 import           Control.Exception
 import           Control.Monad.Extra
 import qualified Data.ByteString                              as BS
@@ -85,7 +85,7 @@ makeVFSHandle = do
               (_nextVersion, vfs) <- readVar vfsVar
               pure $ Map.lookup uri vfs
         , setVirtualFileContents = Just $ \uri content ->
-              modifyVar_ vfsVar $ \(nextVersion, vfs) -> pure $ (nextVersion + 1, ) $
+              void $ modifyVar' vfsVar $ \(nextVersion, vfs) -> (nextVersion + 1, ) $
                   case content of
                     Nothing -> Map.delete uri vfs
                     -- The second version number is only used in persistFileVFS which we do not use so we set it to 0.

--- a/ghcide/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/ghcide/src/Development/IDE/Core/IdeConfiguration.hs
@@ -12,7 +12,7 @@ module Development.IDE.Core.IdeConfiguration
   )
 where
 
-import           Control.Concurrent.Extra
+import           Control.Concurrent.Strict
 import           Control.Monad
 import           Data.Aeson.Types               (Value)
 import           Data.HashSet                   (HashSet, singleton)
@@ -73,7 +73,7 @@ modifyIdeConfiguration
   :: IdeState -> (IdeConfiguration -> IdeConfiguration) -> IO ()
 modifyIdeConfiguration ide f = do
   IdeConfigurationVar var <- getIdeGlobalState ide
-  modifyVar_ var (pure . f)
+  void $ modifyVar' var f
 
 isWorkspaceFile :: NormalizedFilePath -> Action Bool
 isWorkspaceFile file =

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -133,7 +133,7 @@ import qualified Development.IDE.Spans.AtPoint                as AtPoint
 import           Development.IDE.Types.HscEnvEq
 import           Development.Shake.Classes                    hiding (get, put)
 
-import           Control.Concurrent.Extra
+import           Control.Concurrent.Strict
 import           Control.Monad.State
 import           Data.ByteString.Encoding                     as T
 import           Data.Coerce
@@ -947,7 +947,7 @@ getModIfaceRule = defineEarlyCutoff $ Rule $ \GetModIface f -> do
   -- Record the linkable so we know not to unload it
   whenJust (hm_linkable . hirHomeMod =<< mhmi) $ \(LM time mod _) -> do
       compiledLinkables <- getCompiledLinkables <$> getIdeGlobalAction
-      liftIO $ modifyVar_ compiledLinkables $ \old -> pure $ extendModuleEnv old mod time
+      liftIO $ void $ modifyVar' compiledLinkables $ \old -> extendModuleEnv old mod time
   pure res
 
 getModIfaceWithoutLinkableRule :: Rules ()

--- a/ghcide/src/Development/IDE/GHC/Warnings.hs
+++ b/ghcide/src/Development/IDE/GHC/Warnings.hs
@@ -8,7 +8,7 @@ import           Data.List
 import           ErrUtils
 import           GhcPlugins                        as GHC hiding (Var, (<>))
 
-import           Control.Concurrent.Extra
+import           Control.Concurrent.Strict
 import qualified Data.Text                         as T
 
 import           Development.IDE.GHC.Error

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -12,7 +12,7 @@ module Development.IDE.Types.HscEnvEq
 
 
 import           Control.Concurrent.Async      (Async, async, waitCatch)
-import           Control.Concurrent.Extra      (modifyVar, newVar)
+import           Control.Concurrent.Strict     (modifyVar, newVar)
 import           Control.DeepSeq               (force)
 import           Control.Exception             (evaluate, mask, throwIO)
 import           Control.Monad.Extra           (eitherM, join, mapMaybeM)


### PR DESCRIPTION
These strict versions enforce a new pattern: evaluate outside the lock
This is to minimize the time the lock is held and should help with contention

Eventually, it might make sense to upstream these primitives /cc @ndmitchell 