### PR TITLE
Use string literals to synthesize the empty string

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
@@ -187,5 +187,5 @@ buildDataCon jdg dc tyapps = do
                   ) $ zip args [0..]
   pure $ ext
     & #syn_trace %~ rose (show dc) . pure
-    & #syn_val   %~ mkCon dc
+    & #syn_val   %~ mkCon dc tyapps
 

--- a/plugins/hls-tactics-plugin/src/Wingman/CodeGen/Utils.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CodeGen/Utils.hs
@@ -1,19 +1,23 @@
 module Wingman.CodeGen.Utils where
 
-import           Data.List
-import           DataCon
-import           Development.IDE.GHC.Compat
-import           GHC.Exts
-import           GHC.SourceGen              (RdrNameStr, recordConE)
-import           GHC.SourceGen.Overloaded
-import           Wingman.GHC      (getRecordFields)
-import           Name
+import Data.List
+import DataCon
+import Development.IDE.GHC.Compat
+import GHC.Exts
+import GHC.SourceGen (RdrNameStr, recordConE, string)
+import GHC.SourceGen.Overloaded
+import GhcPlugins (nilDataCon, charTy, eqType)
+import Name
+import Wingman.GHC (getRecordFields)
 
 
 ------------------------------------------------------------------------------
 -- | Make a data constructor with the given arguments.
-mkCon :: DataCon -> [LHsExpr GhcPs] -> LHsExpr GhcPs
-mkCon dcon (fmap unLoc -> args)
+mkCon :: DataCon -> [Type] -> [LHsExpr GhcPs] -> LHsExpr GhcPs
+mkCon dcon apps (fmap unLoc -> args)
+  | dcon == nilDataCon
+  , [ty] <- apps
+  , ty `eqType` charTy = noLoc $ string ""
   | isTupleDataCon dcon =
       noLoc $ tuple args
   | dataConIsInfix dcon

--- a/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
@@ -47,6 +47,7 @@ spec = do
     autoTest  2  9 "Fgmap.hs"
     autoTest  4 19 "FmapJoinInLet.hs"
     autoTest  9 12 "AutoEndo.hs"
+    autoTest  2 16 "AutoEmptyString.hs"
 
     failing "flaky in CI" $
       autoTest 2 11 "GoldenApplicativeThen.hs"

--- a/plugins/hls-tactics-plugin/test/golden/AutoEmptyString.hs
+++ b/plugins/hls-tactics-plugin/test/golden/AutoEmptyString.hs
@@ -1,0 +1,2 @@
+empty_string :: String
+empty_string = _

--- a/plugins/hls-tactics-plugin/test/golden/AutoEmptyString.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/AutoEmptyString.hs.expected
@@ -1,0 +1,2 @@
+empty_string :: String
+empty_string = ""


### PR DESCRIPTION
When synthesizing `[] :: String`, Wingman will now produce `""` instead of `[]`