### PR TITLE
Use ConLikes instead of DataCons

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
@@ -9,6 +9,8 @@ module Wingman.CodeGen
   ) where
 
 
+import PatSyn
+import           ConLike
 import           Control.Lens ((%~), (<>~), (&))
 import           Control.Monad.Except
 import           Control.Monad.State
@@ -36,7 +38,7 @@ import           Wingman.Types
 
 
 destructMatches
-    :: (DataCon -> Judgement -> Rule)
+    :: (ConLike -> Judgement -> Rule)
        -- ^ How to construct each match
     -> Maybe OccName
        -- ^ Scrutinee
@@ -54,47 +56,49 @@ destructMatches f scrut t jdg = do
       case dcs of
         [] -> throwError $ GoalMismatch "destruct" g
         _ -> fmap unzipTrace $ for dcs $ \dc -> do
-          let ev = mapMaybe mkEvidence $ dataConInstArgTys dc apps
+          let con = RealDataCon dc
+              ev = mapMaybe mkEvidence $ dataConInstArgTys dc apps
               -- We explicitly do not need to add the method hypothesis to
               -- #syn_scoped
               method_hy = foldMap evidenceToHypothesis ev
-              args = dataConInstOrigArgTys' dc apps
+              args = conLikeInstOrigArgTys' con apps
           modify $ appEndo $ foldMap (Endo . evidenceToSubst) ev
           subst <- gets ts_unifier
           names <- mkManyGoodNames (hyNamesInScope hy) args
-          let hy' = patternHypothesis scrut dc jdg
+          let hy' = patternHypothesis scrut con jdg
                   $ zip names
                   $ coerce args
               j = fmap (CType . substTyAddInScope subst . unCType)
                 $ introduce hy'
                 $ introduce method_hy
                 $ withNewGoal g jdg
-          ext <- f dc j
+          ext <- f con j
           pure $ ext
             & #syn_trace %~ rose ("match " <> show dc <> " {" <> intercalate ", " (fmap show names) <> "}")
                           . pure
             & #syn_scoped <>~ hy'
-            & #syn_val     %~ match [mkDestructPat dc names] . unLoc
+            & #syn_val     %~ match [mkDestructPat con names] . unLoc
 
 
 ------------------------------------------------------------------------------
 -- | Produces a pattern for a data con and the names of its fields.
-mkDestructPat :: DataCon -> [OccName] -> Pat GhcPs
-mkDestructPat dcon names
-  | isTupleDataCon dcon =
+mkDestructPat :: ConLike -> [OccName] -> Pat GhcPs
+mkDestructPat con names
+  | RealDataCon dcon <- con
+  , isTupleDataCon dcon =
       tuple pat_args
   | otherwise =
-      infixifyPatIfNecessary dcon $
+      infixifyPatIfNecessary con $
         conP
-          (coerceName $ dataConName dcon)
+          (coerceName $ conLikeName con)
           pat_args
   where
     pat_args = fmap bvar' names
 
 
-infixifyPatIfNecessary :: DataCon -> Pat GhcPs -> Pat GhcPs
+infixifyPatIfNecessary :: ConLike -> Pat GhcPs -> Pat GhcPs
 infixifyPatIfNecessary dcon x
-  | dataConIsInfix dcon =
+  | conLikeIsInfix dcon =
       case x of
         ConPatIn op (PrefixCon [lhs, rhs]) ->
           ConPatIn op $ InfixCon lhs rhs
@@ -113,8 +117,8 @@ unzipTrace = sequenceA
 --
 -- NOTE: The behaviour depends on GHC's 'dataConInstOrigArgTys'.
 --       We need some tweaks if the compiler changes the implementation.
-dataConInstOrigArgTys'
-  :: DataCon
+conLikeInstOrigArgTys'
+  :: ConLike
       -- ^ 'DataCon'structor
   -> [Type]
       -- ^ /Universally/ quantified type arguments to a result type.
@@ -123,21 +127,30 @@ dataConInstOrigArgTys'
       --   For example, for @MkMyGADT :: b -> MyGADT a c@, we
       --   must pass @[a, c]@ as this argument but not @b@, as @b@ is an existential.
   -> [Type]
-      -- ^ Types of arguments to the DataCon with returned type is instantiated with the second argument.
-dataConInstOrigArgTys' con uniTys =
-  let exvars = dataConExTys con
-   in dataConInstOrigArgTys con $
+      -- ^ Types of arguments to the ConLike with returned type is instantiated with the second argument.
+conLikeInstOrigArgTys' con uniTys =
+  let exvars = conLikeExTys con
+   in conLikeInstOrigArgTys con $
         uniTys ++ fmap mkTyVarTy exvars
       -- Rationale: At least in GHC <= 8.10, 'dataConInstOrigArgTys'
       -- unifies the second argument with DataCon's universals followed by existentials.
       -- If the definition of 'dataConInstOrigArgTys' changes,
       -- this place must be changed accordingly.
 
+
+conLikeExTys :: ConLike -> [TyCoVar]
+conLikeExTys (RealDataCon d) = dataConExTys d
+conLikeExTys (PatSynCon p) = patSynExTys p
+
+patSynExTys :: PatSyn -> [TyCoVar]
+patSynExTys ps = patSynExTyVars ps
+
+
 ------------------------------------------------------------------------------
 -- | Combinator for performing case splitting, and running sub-rules on the
 -- resulting matches.
 
-destruct' :: (DataCon -> Judgement -> Rule) -> HyInfo CType -> Judgement -> Rule
+destruct' :: (ConLike -> Judgement -> Rule) -> HyInfo CType -> Judgement -> Rule
 destruct' f hi jdg = do
   when (isDestructBlacklisted jdg) $ throwError NoApplicableTactic
   let term = hi_name hi
@@ -156,7 +169,7 @@ destruct' f hi jdg = do
 ------------------------------------------------------------------------------
 -- | Combinator for performign case splitting, and running sub-rules on the
 -- resulting matches.
-destructLambdaCase' :: (DataCon -> Judgement -> Rule) -> Judgement -> Rule
+destructLambdaCase' :: (ConLike -> Judgement -> Rule) -> Judgement -> Rule
 destructLambdaCase' f jdg = do
   when (isDestructBlacklisted jdg) $ throwError NoApplicableTactic
   let g  = jGoal jdg
@@ -171,11 +184,11 @@ destructLambdaCase' f jdg = do
 -- | Construct a data con with subgoals for each field.
 buildDataCon
     :: Judgement
-    -> DataCon            -- ^ The data con to build
+    -> ConLike            -- ^ The data con to build
     -> [Type]             -- ^ Type arguments for the data con
     -> RuleM (Synthesized (LHsExpr GhcPs))
 buildDataCon jdg dc tyapps = do
-  let args = dataConInstOrigArgTys' dc tyapps
+  let args = conLikeInstOrigArgTys' dc tyapps
   ext
       <- fmap unzipTrace
        $ traverse ( \(arg, n) ->

--- a/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
@@ -9,7 +9,6 @@ module Wingman.CodeGen
   ) where
 
 
-import PatSyn
 import           ConLike
 import           Control.Lens ((%~), (<>~), (&))
 import           Control.Monad.Except
@@ -27,6 +26,7 @@ import           GHC.SourceGen.Binds
 import           GHC.SourceGen.Expr
 import           GHC.SourceGen.Overloaded
 import           GHC.SourceGen.Pat
+import           PatSyn
 import           Type hiding (Var)
 import           Wingman.CodeGen.Utils
 import           Wingman.GHC

--- a/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
@@ -3,6 +3,7 @@
 
 module Wingman.GHC where
 
+import           ConLike
 import           Control.Monad.State
 import           Data.Function (on)
 import           Data.Functor ((<&>))
@@ -24,7 +25,6 @@ import           TysWiredIn (charTyCon, doubleTyCon, floatTyCon, intTyCon)
 import           Unique
 import           Var
 import           Wingman.Types
-import ConLike
 
 
 tcTyVar_maybe :: Type -> Maybe Var

--- a/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
@@ -24,6 +24,7 @@ import           TysWiredIn (charTyCon, doubleTyCon, floatTyCon, intTyCon)
 import           Unique
 import           Var
 import           Wingman.Types
+import ConLike
 
 
 tcTyVar_maybe :: Type -> Maybe Var
@@ -106,12 +107,12 @@ freshTyvars t = do
 ------------------------------------------------------------------------------
 -- | Given a datacon, extract its record fields' names and types. Returns
 -- nothing if the datacon is not a record.
-getRecordFields :: DataCon -> Maybe [(OccName, CType)]
+getRecordFields :: ConLike -> Maybe [(OccName, CType)]
 getRecordFields dc =
-  case dataConFieldLabels dc of
+  case conLikeFieldLabels dc of
     [] -> Nothing
     lbls -> for lbls $ \lbl -> do
-      (_, ty) <- dataConFieldType_maybe dc $ flLabel lbl
+      let ty = conLikeFieldType dc $ flLabel lbl
       pure (mkVarOccFS $ flLabel lbl, CType ty)
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
@@ -1,17 +1,17 @@
 module Wingman.Judgements where
 
+import           ConLike (ConLike)
 import           Control.Arrow
-import           Control.Lens                        hiding (Context)
+import           Control.Lens hiding (Context)
 import           Data.Bool
 import           Data.Char
 import           Data.Coerce
-import           Data.Generics.Product               (field)
-import           Data.Map                            (Map)
-import qualified Data.Map                            as M
+import           Data.Generics.Product (field)
+import           Data.Map (Map)
+import qualified Data.Map as M
 import           Data.Maybe
-import           Data.Set                            (Set)
-import qualified Data.Set                            as S
-import           DataCon                             (DataCon)
+import           Data.Set (Set)
+import qualified Data.Set as S
 import           Development.IDE.Spans.LocalBindings
 import           OccName
 import           SrcLoc
@@ -163,7 +163,7 @@ findPositionVal jdg defn pos = listToMaybe $ do
 ------------------------------------------------------------------------------
 -- | Helper function for determining the ancestry list for
 -- 'filterSameTypeFromOtherPositions'.
-findDconPositionVals :: Judgement' a -> DataCon -> Int -> [OccName]
+findDconPositionVals :: Judgement' a -> ConLike -> Int -> [OccName]
 findDconPositionVals jdg dcon pos = do
   (name, hi) <- M.toList $ hyByName $ jHypothesis jdg
   case hi_provenance hi of
@@ -178,7 +178,7 @@ findDconPositionVals jdg dcon pos = do
 -- given position for the datacon. Used to ensure recursive functions like
 -- 'fmap' preserve the relative ordering of their arguments by eliminating any
 -- other term which might match.
-filterSameTypeFromOtherPositions :: DataCon -> Int -> Judgement -> Judgement
+filterSameTypeFromOtherPositions :: ConLike -> Int -> Judgement -> Judgement
 filterSameTypeFromOtherPositions dcon pos jdg =
   let hy = hyByName
          . jHypothesis
@@ -230,7 +230,7 @@ extremelyStupid__definingFunction =
 
 patternHypothesis
     :: Maybe OccName
-    -> DataCon
+    -> ConLike
     -> Judgement' a
     -> [(OccName, a)]
     -> Hypothesis a
@@ -367,13 +367,6 @@ mkFirstJudgement hy top goal = Judgement
 isTopLevel :: Provenance -> Bool
 isTopLevel TopLevelArgPrv{} = True
 isTopLevel _                = False
-
-
-------------------------------------------------------------------------------
--- | Was this term defined by the user?
-isUserProv :: Provenance -> Bool
-isUserProv UserPrv{} = True
-isUserProv _         = False
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/KnownStrategies/QuickCheck.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/KnownStrategies/QuickCheck.hs
@@ -1,5 +1,6 @@
 module Wingman.KnownStrategies.QuickCheck where
 
+import ConLike (ConLike(RealDataCon))
 import Control.Monad.Except (MonadError (throwError))
 import Data.Bool (bool)
 import Data.Generics (everything, mkQ)
@@ -76,7 +77,7 @@ data Generator = Generator
 mkGenerator :: TyCon -> [Type] -> DataCon -> Generator
 mkGenerator tc apps dc = do
   let dc_expr   = var' $ occName $ dataConName dc
-      args = dataConInstOrigArgTys' dc apps
+      args = conLikeInstOrigArgTys' (RealDataCon dc) apps
       num_recursive_calls = sum $ fmap (bool 0 1 . doesTypeContain tc) args
       mkArbitrary = mkArbitraryCall tc num_recursive_calls
   Generator num_recursive_calls $ case args of

--- a/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
@@ -166,7 +166,7 @@ scoreSolution ext goal holes
     initial_scope = hyByName $ jEntireHypothesis goal
     intro_vals = M.keysSet $ hyByName $ syn_scoped ext
     used_vals = S.intersection intro_vals $ syn_used_vals ext
-    used_user_vals = filter (isUserProv . hi_provenance)
+    used_user_vals = filter (isLocalHypothesis . hi_provenance)
                    $ mapMaybe (flip M.lookup initial_scope)
                    $ S.toList
                    $ syn_used_vals ext

--- a/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
@@ -3,6 +3,7 @@ module Wingman.Tactics
   , runTactic
   ) where
 
+import           ConLike (ConLike(RealDataCon))
 import           Control.Applicative (Alternative(empty))
 import           Control.Lens ((&), (%~), (<>~))
 import           Control.Monad (unless)
@@ -231,18 +232,26 @@ requireNewHoles m = do
 
 
 ------------------------------------------------------------------------------
--- | Attempt to instantiate the given data constructor to solve the goal.
+-- | Attempt to instantiate the given ConLike to solve the goal.
 --
--- INVARIANT: Assumes the give datacon is appropriate to construct the type
+-- INVARIANT: Assumes the given ConLike is appropriate to construct the type
 -- with.
-splitDataCon :: DataCon -> TacticsM ()
-splitDataCon dc =
+splitConLike :: ConLike -> TacticsM ()
+splitConLike dc =
   requireConcreteHole $ tracing ("splitDataCon:" <> show dc) $ rule $ \jdg -> do
     let g = jGoal jdg
     case splitTyConApp_maybe $ unCType g of
       Just (_, apps) -> do
         buildDataCon (unwhitelistingSplit jdg) dc apps
       Nothing -> throwError $ GoalMismatch "splitDataCon" g
+
+------------------------------------------------------------------------------
+-- | Attempt to instantiate the given data constructor to solve the goal.
+--
+-- INVARIANT: Assumes the given datacon is appropriate to construct the type
+-- with.
+splitDataCon :: DataCon -> TacticsM ()
+splitDataCon = splitConLike . RealDataCon
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -14,6 +14,7 @@ module Wingman.Types
   , Range
   ) where
 
+import           ConLike (ConLike)
 import           Control.Lens hiding (Context, (.=))
 import           Control.Monad.Reader
 import           Control.Monad.State
@@ -149,6 +150,9 @@ instance Show (LHsSigType GhcPs) where
 instance Show TyCon where
   show  = unsafeRender
 
+instance Show ConLike where
+  show  = unsafeRender
+
 
 ------------------------------------------------------------------------------
 -- | The state that should be shared between subgoals. Extracts move towards
@@ -237,7 +241,7 @@ data PatVal = PatVal
   , pv_ancestry  :: Set OccName
     -- ^ The set of values which had to be destructed to discover this term.
     -- Always contains the scrutinee.
-  , pv_datacon   :: Uniquely DataCon
+  , pv_datacon   :: Uniquely ConLike
     -- ^ The datacon which introduced this term.
   , pv_position  :: Int
     -- ^ The position of this binding in the datacon's arguments.

--- a/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
@@ -48,6 +48,7 @@ spec = do
     autoTest  4 19 "FmapJoinInLet.hs"
     autoTest  9 12 "AutoEndo.hs"
     autoTest  2 16 "AutoEmptyString.hs"
+    autoTest  7 35 "AutoPatSynUse.hs"
 
     failing "flaky in CI" $
       autoTest 2 11 "GoldenApplicativeThen.hs"

--- a/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
@@ -33,4 +33,5 @@ spec = do
     destructTest "a"  4  7 "LayoutSplitIn.hs"
     destructTest "a"  4 31 "LayoutSplitViewPat.hs"
     destructTest "a"  7 17 "LayoutSplitPattern.hs"
+    destructTest "a"  8 26 "LayoutSplitPatSyn.hs"
 

--- a/plugins/hls-tactics-plugin/test/golden/AutoPatSynUse.hs
+++ b/plugins/hls-tactics-plugin/test/golden/AutoPatSynUse.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+pattern JustSingleton :: a -> Maybe [a]
+pattern JustSingleton a <- Just [a]
+
+amIASingleton :: Maybe [a] -> Maybe a
+amIASingleton (JustSingleton a) = _
+

--- a/plugins/hls-tactics-plugin/test/golden/AutoPatSynUse.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/AutoPatSynUse.hs.expected
@@ -1,0 +1,8 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+pattern JustSingleton :: a -> Maybe [a]
+pattern JustSingleton a <- Just [a]
+
+amIASingleton :: Maybe [a] -> Maybe a
+amIASingleton (JustSingleton a) = Just a
+

--- a/plugins/hls-tactics-plugin/test/golden/LayoutSplitPatSyn.hs
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutSplitPatSyn.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+pattern JustSingleton :: a -> Maybe [a]
+pattern JustSingleton a <- Just [a]
+
+
+test :: Maybe [Bool] -> Maybe Bool
+test (JustSingleton a) = _
+
+

--- a/plugins/hls-tactics-plugin/test/golden/LayoutSplitPatSyn.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/LayoutSplitPatSyn.hs.expected
@@ -1,0 +1,11 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+pattern JustSingleton :: a -> Maybe [a]
+pattern JustSingleton a <- Just [a]
+
+
+test :: Maybe [Bool] -> Maybe Bool
+test (JustSingleton False) = _
+test (JustSingleton True) = _
+
+


### PR DESCRIPTION
Wingman was overly-specialized to `DataCon` in its provenance and splitting. This is unnecessary, and lead to some bugs where pattern synonyms wouldn't behave properly.