### PR TITLE
Try a homomorphic destruct before a standard destruct

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
@@ -224,6 +224,16 @@ unify goal inst = do
 
 
 ------------------------------------------------------------------------------
+-- | Prefer the first tactic to the second, if the bool is true. Otherwise, just run the second tactic.
+--
+-- This is useful when you have a clever pruning solution that isn't always
+-- applicable.
+attemptWhen :: TacticsM a -> TacticsM a -> Bool -> TacticsM a
+attemptWhen _  t2 False = t2
+attemptWhen t1 t2 True  = commit t1 t2
+
+
+------------------------------------------------------------------------------
 -- | Get the class methods of a 'PredType', correctly dealing with
 -- instantiation of quantified class types.
 methodHypothesis :: PredType -> Maybe [HyInfo CType]

--- a/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
@@ -272,7 +272,7 @@ requireConcreteHole m = do
   let vars = S.fromList $ tyCoVarsOfTypeWellScoped $ unCType $ jGoal jdg
   case S.size $ vars S.\\ skolems of
     0 -> m
-    _ -> throwError $ traceIdX "too polymorphic" TooPolymorphic
+    _ -> throwError TooPolymorphic
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
@@ -87,7 +87,7 @@ runTactic ctx jdg t =
               RunTacticResults
                 { rtr_trace = syn_trace syn
                 , rtr_extract = simplify $ syn_val syn
-                , rtr_other_solns = reverse . fmap fst $ take 5 sorted
+                , rtr_other_solns = reverse . fmap fst $ sorted
                 , rtr_jdg = jdg
                 , rtr_ctx = ctx
                 }
@@ -272,7 +272,7 @@ requireConcreteHole m = do
   let vars = S.fromList $ tyCoVarsOfTypeWellScoped $ unCType $ jGoal jdg
   case S.size $ vars S.\\ skolems of
     0 -> m
-    _ -> throwError TooPolymorphic
+    _ -> throwError $ traceIdX "too polymorphic" TooPolymorphic
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Plugin.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Plugin.hs
@@ -139,7 +139,7 @@ mkWorkspaceEdits
     -> Either UserFacingMessage WorkspaceEdit
 mkWorkspaceEdits span dflags ccs uri pm rtr = do
   for_ (rtr_other_solns rtr) $ \soln -> do
-    traceMX "other solution" soln
+    traceMX "other solution" $ syn_val soln
     traceMX "with score" $ scoreSolution soln (rtr_jdg rtr) []
   traceMX "solution" $ rtr_extract rtr
   let g = graftHole (RealSrcSpan span) rtr

--- a/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
@@ -108,7 +108,7 @@ intros = rule $ \jdg -> do
 destructAuto :: HyInfo CType -> TacticsM ()
 destructAuto hi = requireConcreteHole $ tracing "destruct(auto)" $ do
   jdg <- goal
-  let subtactic = rule $ destruct' (const subgoal) hi
+  let subtactic = destructOrHomoAuto hi
   case isPatternMatch $ hi_provenance hi of
     True ->
       pruning subtactic $ \jdgs ->
@@ -122,6 +122,26 @@ destructAuto hi = requireConcreteHole $ tracing "destruct(auto)" $ do
 
 
 ------------------------------------------------------------------------------
+-- | When running auto, in order to prune the auto search tree, we try
+-- a homomorphic destruct whenever possible. If that produces any results, we
+-- can probably just prune the other side.
+destructOrHomoAuto :: HyInfo CType -> TacticsM ()
+destructOrHomoAuto hi = tracing "destructOrHomoAuto" $ do
+  jdg <- goal
+  let g  = unCType $ jGoal jdg
+      ty = unCType $ hi_type hi
+
+  let do_destruct = rule $ destruct' (const subgoal) hi
+
+  case (splitTyConApp_maybe g, splitTyConApp_maybe ty) of
+    (Just (gtc, apps), Just (tytc, _)) | gtc == tytc ->
+      commit
+        (rule $ destruct' (\dc jdg -> buildDataCon False jdg dc apps) hi)
+        do_destruct
+    _ -> do_destruct
+
+
+------------------------------------------------------------------------------
 -- | Case split, and leave holes in the matches.
 destruct :: HyInfo CType -> TacticsM ()
 destruct hi = requireConcreteHole $ tracing "destruct(user)" $
@@ -132,7 +152,7 @@ destruct hi = requireConcreteHole $ tracing "destruct(user)" $
 -- | Case split, using the same data constructor in the matches.
 homo :: HyInfo CType -> TacticsM ()
 homo = requireConcreteHole . tracing "homo" . rule . destruct' (\dc jdg ->
-  buildDataCon jdg dc $ snd $ splitAppTys $ unCType $ jGoal jdg)
+  buildDataCon False jdg dc $ snd $ splitAppTys $ unCType $ jGoal jdg)
 
 
 ------------------------------------------------------------------------------
@@ -147,7 +167,7 @@ homoLambdaCase :: TacticsM ()
 homoLambdaCase =
   tracing "homoLambdaCase" $
     rule $ destructLambdaCase' $ \dc jdg ->
-      buildDataCon jdg dc
+      buildDataCon False jdg dc
         . snd
         . splitAppTys
         . unCType
@@ -242,7 +262,7 @@ splitConLike dc =
     let g = jGoal jdg
     case splitTyConApp_maybe $ unCType g of
       Just (_, apps) -> do
-        buildDataCon (unwhitelistingSplit jdg) dc apps
+        buildDataCon True (unwhitelistingSplit jdg) dc apps
       Nothing -> throwError $ GoalMismatch "splitDataCon" g
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
@@ -49,6 +49,7 @@ spec = do
     autoTest  9 12 "AutoEndo.hs"
     autoTest  2 16 "AutoEmptyString.hs"
     autoTest  7 35 "AutoPatSynUse.hs"
+    autoTest  2 28 "AutoZip.hs"
 
     failing "flaky in CI" $
       autoTest 2 11 "GoldenApplicativeThen.hs"

--- a/plugins/hls-tactics-plugin/test/golden/AutoZip.hs
+++ b/plugins/hls-tactics-plugin/test/golden/AutoZip.hs
@@ -1,0 +1,3 @@
+zip_it_up_and_zip_it_out :: [a] -> [b] -> [(a, b)]
+zip_it_up_and_zip_it_out = _
+

--- a/plugins/hls-tactics-plugin/test/golden/AutoZip.hs.expected
+++ b/plugins/hls-tactics-plugin/test/golden/AutoZip.hs.expected
@@ -1,0 +1,6 @@
+zip_it_up_and_zip_it_out :: [a] -> [b] -> [(a, b)]
+zip_it_up_and_zip_it_out _ [] = []
+zip_it_up_and_zip_it_out [] (_ : _) = []
+zip_it_up_and_zip_it_out (a : l_a5) (b : l_b3)
+  = (a, b) : zip_it_up_and_zip_it_out l_a5 l_b3
+


### PR DESCRIPTION
This is the first of three PRs cleaning up how Wingman approaches its proof search. It now attempts to synthesize homomorphic case splits if possible, and will only fall back to a regular split if the homomorphic one didn't lead to any solutions. This aggressively prunes the search tree in most cases, and means we have more auto gas to spend on harder proofs. As a result, we can now synthesize a solution to `zip`, which was previously too expensive to find.