### PR TITLE
Give a canonical ordering for destructing terms in Wingman

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
@@ -62,7 +62,10 @@ withNewGoal t = field @"_jGoal" .~ t
 
 
 introduce :: Hypothesis a -> Judgement' a -> Judgement' a
-introduce hy = field @"_jHypothesis" <>~ hy
+-- NOTE(sandy): It's important that we put the new hypothesis terms first,
+-- since 'jAcceptableDestructTargets' will never destruct a pattern that occurs
+-- after a previously-destructed term.
+introduce hy = field @"_jHypothesis" %~ mappend hy
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
@@ -339,9 +339,7 @@ overFunctions =
 
 overAlgebraicTerms :: (HyInfo CType -> TacticsM ()) -> TacticsM ()
 overAlgebraicTerms =
-  attemptOn $ filter (isJust . algebraicTyCon . unCType . hi_type)
-            . unHypothesis
-            . jHypothesis
+  attemptOn jAcceptableDestructTargets
 
 
 allNames :: Judgement -> Set OccName

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -261,6 +261,10 @@ instance Uniquable a => Ord (Uniquely a) where
   compare = nonDetCmpUnique `on` getUnique . getViaUnique
 
 
+-- NOTE(sandy): The usage of list here is mostly for convenience, but if it's
+-- ever changed, make sure to correspondingly update
+-- 'jAcceptableDestructTargets' so that it correctly identifies newly
+-- introduced terms.
 newtype Hypothesis a = Hypothesis
   { unHypothesis :: [HyInfo a]
   }


### PR DESCRIPTION
Today, Wingman tries to destruct terms in any order. For example, when trying to synthesize `zip`, it will try the following solutions:

```haskell

\ l_a l_b
  -> case l_b of
       []
         -> case l_a of
              [] -> _
              (a : l_a3) -> _
       (b : l_b3)
         -> case l_a of
              [] -> _
              (a : l_a5) -> _
```

and

```haskell
\ l_a l_b
  -> case l_a of
       []
         -> case l_b of
              [] -> _
              (b : l_b3) -> _
       (a : l_a3)
         -> case l_b of
              [] -> _
              (b : l_b5) -> _
```

These two solutions are equal modulo the order in which we did a pattern match. But it's stupid to explore both paths, since they _cannot_ produce different answers. 

Instead, this PR introduces a canonical ordering on the destructing on terms, using the natural ordering of introduction in the hypothesis. In particular, Wingman will not try to destruct anything that was introduced before something that has already been destructed.

This change has a remarkable `O(n!)` asymptotic increase _at each hole_ :star_struck: The search is still remains stupid, but at least it's no longer _factorially_ stupid.