### PR TITLE
Ensure eval plugin Print class doesn't rely on Prelude being in scope

### DIFF
--- a/plugins/hls-eval-plugin/test/Eval.hs
+++ b/plugins/hls-eval-plugin/test/Eval.hs
@@ -155,6 +155,8 @@ tests =
                 $ testCase "Literate Haskell Bird Style" $ goldenTest "TLHS.lhs"
             -- , testCase "Literate Haskell LaTeX Style" $ goldenTest "TLHSLateX.lhs"
             ]
+        , testCase "Works with NoImplicitPrelude"
+            $ goldenTest "TNoImplicitPrelude.hs"
         ]
 
 goldenTest :: FilePath -> IO ()

--- a/plugins/hls-eval-plugin/test/testdata/TNoImplicitPrelude.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TNoImplicitPrelude.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TNoImplicitPrelude where
+
+import Data.List (unwords)
+import Data.String (String)
+
+-- >>> unwords example
+example :: [String]
+example = ["This","is","an","example","of","evaluation"]

--- a/plugins/hls-eval-plugin/test/testdata/TNoImplicitPrelude.hs.expected
+++ b/plugins/hls-eval-plugin/test/testdata/TNoImplicitPrelude.hs.expected
@@ -1,0 +1,11 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TNoImplicitPrelude where
+
+import Data.List (unwords)
+import Data.String (String)
+
+-- >>> unwords example
+-- "This is an example of evaluation"
+example :: [String]
+example = ["This","is","an","example","of","evaluation"]


### PR DESCRIPTION
Hi,

This PR is pretty much what it says on the tin :)

The reason I need this is because the codebase at work uses `{-# NoImplicitPrelude #-}`, together with a custom prelude that includes `show :: Show a => a -> Text`, which doesn't play well with the Eval plugin. Currently, we get errors like:

```
Request workspace/executeCommand failed.
  Message: Couldn't match type ‘Text’ with ‘[Char]’
Expected type: IO String
  Actual type: IO Text

  Code: -32603 
```

This is because the `Print` class, as defined on `Ide.Plugin.Eval.Code`, uses whatever `show` is in scope. Having a qualified Prelude in scope when `Print` is defined should be enough to avoid that, and I can't think of any drawbacks.

Thanks for your consideration and for all the great work on HLS so far!