### PR TITLE
Avoid duplicating known targets and import paths

### DIFF
--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -83,6 +83,7 @@ import           Packages
 
 import           Control.Concurrent.STM               (atomically)
 import           Control.Concurrent.STM.TQueue
+import qualified Data.HashSet                         as Set
 import           Database.SQLite.Simple
 import           HIE.Bios.Cradle                      (yamlConfig)
 import           HieDb.Create
@@ -247,10 +248,10 @@ loadSessionWithOptions SessionLoadingOptions{..} dir = do
                 found <- filterM (IO.doesFileExist . fromNormalizedFilePath) targetLocations
                 return (targetTarget, found)
           modifyVarIO' knownTargetsVar $ traverseHashed $ \known -> do
-            let known' = HM.unionWith (<>) known $ HM.fromList knownTargets
+            let known' = HM.unionWith (<>) known $ HM.fromList $ map (second Set.fromList) knownTargets
             when (known /= known') $
                 logDebug logger $ "Known files updated: " <>
-                    T.pack(show $ (HM.map . map) fromNormalizedFilePath known')
+                    T.pack(show $ (HM.map . Set.map) fromNormalizedFilePath known')
             pure known'
 
     -- Create a new HscEnv from a hieYaml root and a set of options

--- a/ghcide/src/Development/IDE/Types/KnownTargets.hs
+++ b/ghcide/src/Development/IDE/Types/KnownTargets.hs
@@ -14,11 +14,11 @@ import           Development.IDE.Types.Location
 import           GHC.Generics
 
 -- | A mapping of module name to known files
-type KnownTargets = HashMap Target [NormalizedFilePath]
+type KnownTargets = HashMap Target (HashSet NormalizedFilePath)
 
 data Target = TargetModule ModuleName | TargetFile NormalizedFilePath
   deriving ( Eq, Generic, Show )
   deriving anyclass (Hashable, NFData)
 
 toKnownFiles :: KnownTargets -> HashSet NormalizedFilePath
-toKnownFiles = HSet.fromList . concat . HMap.elems
+toKnownFiles = HSet.unions . HMap.elems


### PR DESCRIPTION
We currently duplicate all the known targets on every cradle reload, which leaks space and leads to slower performance in `GetLocatedImports`. 
The trivial fix is to use a `Set` instead of a list, since the order doesn't matter here.