### PR TITLE
Use CiInterface/SkInterface for typeclass symbols

### DIFF
--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -69,7 +69,7 @@ documentSymbolForDecl (L (RealSrcSpan l) (TyClD _ FamDecl { tcdFam = FamilyDecl 
                        t  -> " " <> t
                      )
     , _detail = Just $ pprText fdInfo
-    , _kind   = SkClass
+    , _kind   = SkFunction
     }
 documentSymbolForDecl (L (RealSrcSpan l) (TyClD _ ClassDecl { tcdLName = L _ name, tcdSigs, tcdTyVars }))
   = Just (defDocumentSymbol l :: DocumentSymbol)

--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -69,7 +69,7 @@ documentSymbolForDecl (L (RealSrcSpan l) (TyClD _ FamDecl { tcdFam = FamilyDecl 
                        t  -> " " <> t
                      )
     , _detail = Just $ pprText fdInfo
-    , _kind   = SkClass
+    , _kind   = SkInterface
     }
 documentSymbolForDecl (L (RealSrcSpan l) (TyClD _ ClassDecl { tcdLName = L _ name, tcdSigs, tcdTyVars }))
   = Just (defDocumentSymbol l :: DocumentSymbol)
@@ -78,7 +78,7 @@ documentSymbolForDecl (L (RealSrcSpan l) (TyClD _ ClassDecl { tcdLName = L _ nam
                          "" -> ""
                          t  -> " " <> t
                        )
-    , _kind     = SkClass
+    , _kind     = SkInterface
     , _detail   = Just "class"
     , _children =
       Just $ List

--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -69,7 +69,7 @@ documentSymbolForDecl (L (RealSrcSpan l) (TyClD _ FamDecl { tcdFam = FamilyDecl 
                        t  -> " " <> t
                      )
     , _detail = Just $ pprText fdInfo
-    , _kind   = SkInterface
+    , _kind   = SkClass
     }
 documentSymbolForDecl (L (RealSrcSpan l) (TyClD _ ClassDecl { tcdLName = L _ name, tcdSigs, tcdTyVars }))
   = Just (defDocumentSymbol l :: DocumentSymbol)

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -145,7 +145,7 @@ occNameToComKind ty oc
   | isTcOcc   oc = case ty of
                      Just t
                        | "Constraint" `T.isSuffixOf` t
-                       -> CiClass
+                       -> CiInterface
                      _ -> CiStruct
   | isDataOcc oc = CiConstructor
   | otherwise    = CiVariable
@@ -406,7 +406,7 @@ localCompletionsForParsedModule uri pm@ParsedModule{pm_parsed_source = L _ HsMod
                 [mkComp id CiVariable Nothing
                 | VarPat _ id <- listify (\(_ :: Pat GhcPs) -> True) pat_lhs]
             TyClD _ ClassDecl{tcdLName, tcdSigs} ->
-                mkComp tcdLName CiClass Nothing :
+                mkComp tcdLName CiInterface Nothing :
                 [ mkComp id CiFunction (Just $ ppr typ)
                 | L _ (TypeSig _ ids typ) <- tcdSigs
                 , id <- ids]
@@ -428,7 +428,7 @@ localCompletionsForParsedModule uri pm@ParsedModule{pm_parsed_source = L _ HsMod
         ]
 
     mkComp n ctyp ty =
-        CI ctyp pn (Right thisModName) ty pn Nothing doc (ctyp `elem` [CiStruct, CiClass]) Nothing
+        CI ctyp pn (Right thisModName) ty pn Nothing doc (ctyp `elem` [CiStruct, CiInterface]) Nothing
       where
         pn = ppr n
         doc = SpanDocText (getDocumentation [pm] n) (SpanDocUris Nothing Nothing)

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -3768,7 +3768,7 @@ topLevelCompletionTests = [
         "class"
         ["bar :: Xx", "xxx = ()", "-- | haddock", "class Xxx a"]
         (Position 0 9)
-        [("Xxx", CiClass, "Xxx", False, True, Nothing)],
+        [("Xxx", CiInterface, "Xxx", False, True, Nothing)],
     completionTest
         "records"
         ["data Person = Person { _personName:: String, _personAge:: Int}", "bar = Person { _pers }" ]
@@ -3862,7 +3862,7 @@ nonLocalCompletionTests =
       "type"
       ["{-# OPTIONS_GHC -Wall #-}", "module A () where", "f :: Bo", "f = True"]
       (Position 2 7)
-      [ ("Bounded", CiClass, "Bounded ${1:*}", True, True, Nothing),
+      [ ("Bounded", CiInterface, "Bounded ${1:*}", True, True, Nothing),
         ("Bool", CiStruct, "Bool ", True, True, Nothing)
       ],
     completionTest

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4163,7 +4163,7 @@ outlineTests = testGroup
     let source = T.unlines ["{-# language TypeFamilies #-}", "type family A"]
     docId   <- createDoc "A.hs" "haskell" source
     symbols <- getDocumentSymbols docId
-    liftIO $ symbols @?= Left [docSymbolD "A" "type family" SkClass (R 1 0 1 13)]
+    liftIO $ symbols @?= Left [docSymbolD "A" "type family" SkFunction (R 1 0 1 13)]
   , testSessionWait "type family instance " $ do
     let source = T.unlines
           [ "{-# language TypeFamilies #-}"
@@ -4173,14 +4173,14 @@ outlineTests = testGroup
     docId   <- createDoc "A.hs" "haskell" source
     symbols <- getDocumentSymbols docId
     liftIO $ symbols @?= Left
-      [ docSymbolD "A a"   "type family" SkClass     (R 1 0 1 15)
+      [ docSymbolD "A a"   "type family" SkFunction     (R 1 0 1 15)
       , docSymbol "A ()" SkInterface (R 2 0 2 23)
       ]
   , testSessionWait "data family" $ do
     let source = T.unlines ["{-# language TypeFamilies #-}", "data family A"]
     docId   <- createDoc "A.hs" "haskell" source
     symbols <- getDocumentSymbols docId
-    liftIO $ symbols @?= Left [docSymbolD "A" "data family" SkClass (R 1 0 1 11)]
+    liftIO $ symbols @?= Left [docSymbolD "A" "data family" SkFunction (R 1 0 1 11)]
   , testSessionWait "data family instance " $ do
     let source = T.unlines
           [ "{-# language TypeFamilies #-}"
@@ -4190,7 +4190,7 @@ outlineTests = testGroup
     docId   <- createDoc "A.hs" "haskell" source
     symbols <- getDocumentSymbols docId
     liftIO $ symbols @?= Left
-      [ docSymbolD "A a"   "data family" SkClass     (R 1 0 1 11)
+      [ docSymbolD "A a"   "data family" SkFunction     (R 1 0 1 11)
       , docSymbol "A ()" SkInterface (R 2 0 2 25)
       ]
   , testSessionWait "constant" $ do

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4304,7 +4304,7 @@ outlineTests = testGroup
                                             (Just $ List cc)
   classSymbol name loc cc = DocumentSymbol name
                                            (Just "class")
-                                           SkClass
+                                           SkInterface
                                            Nothing
                                            loc
                                            loc


### PR DESCRIPTION
### Fixes #1581

This branch replaces the `CiClass`/`SkClass` item kinds for completions and document symbols with `CiInterface`/`SkInterface` (see the linked issue for the motivation behind this change).

Additionally, the symbol icons for type families which were previously `SkClass` have been replaced with `SkFunction`.