### PR TITLE
Relax ghcides upper bound on base16-bytestring

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -101,7 +101,7 @@ library
         cryptohash-sha1 >=0.11.100 && <0.12,
         hie-bios >= 0.7.1 && < 0.8.0,
         implicit-hie-cradle >= 0.3.0.2 && < 0.4,
-        base16-bytestring >=0.1.1 && <0.2
+        base16-bytestring >=0.1.1 && <1.1
     if os(windows)
       build-depends:
         Win32


### PR DESCRIPTION
base16-bytestring 1.0.1.0 has recently entered stackage nightly.
I have build haskell-language-server with that version and it seems to work fine.

Note: As of now implicit-hie-cradle and retrie also need this bump.