### PR TITLE
Use custom config for completions plugin

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -35,7 +35,7 @@ import           Development.Shake
 import           Development.Shake.Classes
 import           GHC.Exts                                     (toList)
 import           GHC.Generics
-import           Ide.Plugin.Config                            (Config (completionSnippetsOn))
+import           Ide.Plugin.Config                            (Config)
 import           Ide.Types
 import qualified Language.LSP.Server                          as LSP
 import           Language.LSP.Types
@@ -47,6 +47,7 @@ descriptor plId = (defaultPluginDescriptor plId)
   { pluginRules = produceCompletions
   , pluginHandlers = mkPluginHandler STextDocumentCompletion getCompletionsLSP
   , pluginCommands = [extendImportCommand]
+  , pluginCustomConfig = mkCustomConfig properties
   }
 
 produceCompletions :: Rules ()
@@ -135,9 +136,8 @@ getCompletionsLSP ide plId
                 -> return (InL $ List [])
               (Just pfix', _) -> do
                 let clientCaps = clientCapabilities $ shakeExtras ide
-                config <- getClientConfig $ shakeExtras ide
-                let snippets = WithSnippets . completionSnippetsOn $ config
-                allCompletions <- liftIO $ getCompletions plId ideOpts cci' parsedMod bindMap pfix' clientCaps snippets
+                config <- getCompletionsConfig plId
+                allCompletions <- liftIO $ getCompletions plId ideOpts cci' parsedMod bindMap pfix' clientCaps config
                 pure $ InL (List allCompletions)
               _ -> return (InL $ List [])
           _ -> return (InL $ List [])

--- a/hls-plugin-api/src/Ide/Plugin/Config.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Config.hs
@@ -54,7 +54,6 @@ data Config =
     , diagnosticsOnChange         :: !Bool
     , diagnosticsDebounceDuration :: !Int
     , liquidOn                    :: !Bool
-    , completionSnippetsOn        :: !Bool
     , formatOnImportOn            :: !Bool
     , formattingProvider          :: !T.Text
     , maxCompletions              :: !Int
@@ -69,7 +68,6 @@ instance Default Config where
     , diagnosticsOnChange         = True
     , diagnosticsDebounceDuration = 350000
     , liquidOn                    = False
-    , completionSnippetsOn        = True
     , formatOnImportOn            = True
     -- , formattingProvider          = "brittany"
     , formattingProvider          = "ormolu"
@@ -94,7 +92,6 @@ parseConfig defValue = A.withObject "Config" $ \v -> do
         <*> o .:? "diagnosticsOnChange"                     .!= diagnosticsOnChange defValue
         <*> o .:? "diagnosticsDebounceDuration"             .!= diagnosticsDebounceDuration defValue
         <*> o .:? "liquidOn"                                .!= liquidOn defValue
-        <*> o .:? "completionSnippetsOn"                    .!= completionSnippetsOn defValue
         <*> o .:? "formatOnImportOn"                        .!= formatOnImportOn defValue
         <*> o .:? "formattingProvider"                      .!= formattingProvider defValue
         <*> o .:? "maxCompletions"                          .!= maxCompletions defValue
@@ -110,7 +107,6 @@ instance A.ToJSON Config where
                  , "diagnosticsOnChange"         .= diagnosticsOnChange
                  , "diagnosticsDebounceDuration" .= diagnosticsDebounceDuration
                  , "liquidOn"                    .= liquidOn
-                 , "completionSnippetsOn"        .= completionSnippetsOn
                  , "formatOnImportOn"            .= formatOnImportOn
                  , "formattingProvider"          .= formattingProvider
                  , "maxCompletions"              .= maxCompletions

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -288,8 +288,6 @@ type CommandFunction ideState a
   -> a
   -> LspM Config (Either ResponseError Value)
 
-newtype WithSnippets = WithSnippets Bool
-
 -- ---------------------------------------------------------------------
 
 newtype PluginId = PluginId T.Text

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -328,7 +328,7 @@ snippetTests = testGroup "snippets" [
     , testCase "respects lsp configuration" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
         doc <- openDoc "Completion.hs" "haskell"
 
-        let config = object [ "haskell" .= object ["completionSnippetsOn" .= False]]
+        let config = object ["haskell" .= object ["plugin" .= object ["ghcide-completions" .= object ["config" .= object ["snippetsOn" .= False]]]]]
 
         sendNotification SWorkspaceDidChangeConfiguration
                         (DidChangeConfigurationParams config)


### PR DESCRIPTION
* Remove `haskell.completionSnippetsOn`
* Use `Properties` (#1576) to define the custom config, including switches of whether to enable snippets and auto extending import lists.

Clients now shoud provide JSON value like:
```json
"ghcide-completions":{
      "globalOn":true,
      "config":{
         "autoExtendOn":true,
         "snippetsOn":true
      },
      "completionOn":true
}
```

in the section `haskell.plugin` to control completions plugin.