### PR TITLE
Fix cpp flags of brittany plugin and stylish haskell plugin

### DIFF
--- a/exe/Plugins.hs
+++ b/exe/Plugins.hs
@@ -110,7 +110,7 @@ idePlugins includeExamples = pluginDescToIdePlugins allPlugins
 #if retrie
       Retrie.descriptor "retrie" :
 #endif
-#if AGPL && brittany
+#if brittany
       Brittany.descriptor "brittany" :
 #endif
 #if class

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -264,10 +264,12 @@ common ormolu
 common stylishHaskell
   if flag(stylishHaskell) || flag(all-formatters)
     build-depends: hls-stylish-haskell-plugin ^>= 1.0.0.0
+    cpp-options: -DstylishHaskell
 
 common brittany
-  if (flag(brittany) || flag(all-formatters))
+  if flag(brittany) || flag(all-formatters)
     build-depends: hls-brittany-plugin ^>= 1.0.0.0
+    cpp-options: -Dbrittany
 
 executable haskell-language-server
   import:             common-deps


### PR DESCRIPTION
#1422 and #1604 extracted the two plugins into standalone packages respectively, whereas they missed setting corresponding cpp flags.