### PR TITLE
Remove ignored paths

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -92,7 +92,6 @@ jobs:
   bench-example:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    needs: [bench-init]
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,18 +4,22 @@ on:
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - '**/docs/**'
-      - '**.md'
-      - '**/LICENSE'
-      - '.circleci/**'
-      - 'install/**'
-      - 'nix/**'
-      - 'test/**'
-      - 'ghcide/test/**'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: true
+          paths_ignore: '["**/docs/**", "**.md", "**/LICENSE", ".circleci/**", "install/**", "nix/**", "**/test/**"]'
+
   bench-init:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -86,6 +90,8 @@ jobs:
         path: ~/.cabal/cabal.tar.gz
 
   bench-example:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     needs: [bench-init]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,7 +90,7 @@ jobs:
         path: ~/.cabal/cabal.tar.gz
 
   bench-example:
-    needs: pre_job
+    needs: [pre_job, bench-init]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,15 +4,22 @@ on:
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - '**/docs/**'
-      - '**.md'
-      - '**/LICENSE'
-      - '.circleci/**'
-      - 'install/**'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: true
+          paths_ignore: '["**/docs/**", "**.md", "**/LICENSE", ".circleci/**", "install/**"]'
+
   nix:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,23 @@ on:
   pull_request:
     branches:
       - '**'
-    paths-ignore:
-      - '**/docs/**'
-      - '**.md'
-      - '**/LICENSE'
-      - '.circleci/**'
-      - 'install/**'
-      - 'nix/**'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: true
+          paths_ignore: '["**/docs/**", "**.md", "**/LICENSE", ".circleci/**", "install/**", "nix/**"]'
+
+
   test:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true


### PR DESCRIPTION
* `paths-ignore` doesnt work with required checks branch protection rules:  https://github.community/t/path-filtering-on-required-pull-request-checks/18402/3
* so we have to remove it, fortunately `skip-duplicate-actions` which was being already used can be used to get the same functionality: https://github.com/marketplace/actions/skip-duplicate-actions#option-1-skip-entire-jobs