### PR TITLE
Avoid reordering plugins

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -315,6 +315,7 @@ test-suite ghcide-tests
         implicit-hie:gen-hie
     build-depends:
         aeson,
+        async,
         base,
         binary,
         bytestring,

--- a/ghcide/src/Development/IDE/Plugin/HLS.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS.hs
@@ -44,13 +44,12 @@ import           UnliftIO.Exception           (catchAny)
 
 -- | Map a set of plugins to the underlying ghcide engine.
 asGhcIdePlugin :: IdePlugins IdeState -> Plugin Config
-asGhcIdePlugin mp =
+asGhcIdePlugin (IdePlugins ls) =
     mkPlugin rulesPlugins HLS.pluginRules <>
     mkPlugin executeCommandPlugins HLS.pluginCommands <>
     mkPlugin extensiblePlugins HLS.pluginHandlers <>
     mkPlugin extensibleNotificationPlugins HLS.pluginNotificationHandlers
     where
-        ls = Map.toList (ipMap mp)
 
         mkPlugin :: ([(PluginId, b)] -> Plugin Config) -> (PluginDescriptor IdeState -> b) -> Plugin Config
         mkPlugin maker selector =

--- a/hls-plugin-api/src/Ide/Plugin/ConfigUtils.hs
+++ b/hls-plugin-api/src/Ide/Plugin/ConfigUtils.hs
@@ -11,7 +11,6 @@ import           Data.Default          (def)
 import qualified Data.Dependent.Map    as DMap
 import qualified Data.Dependent.Sum    as DSum
 import qualified Data.HashMap.Lazy     as HMap
-import qualified Data.Map              as Map
 import           Ide.Plugin.Config
 import           Ide.Plugin.Properties (toDefaultJSON, toVSCodeExtensionSchema)
 import           Ide.Types
@@ -36,7 +35,7 @@ pluginsToDefaultConfig IdePlugins {..} =
     defaultConfig@Config {} = def
     unsafeValueToObject (A.Object o) = o
     unsafeValueToObject _            = error "impossible"
-    elems = A.object $ mconcat $ singlePlugin <$> Map.elems ipMap
+    elems = A.object $ mconcat $ singlePlugin <$> map snd ipMap
     -- Splice genericDefaultConfig and dedicatedDefaultConfig
     -- Example:
     --
@@ -100,7 +99,7 @@ pluginsToDefaultConfig IdePlugins {..} =
 -- | Generates json schema used in haskell vscode extension
 -- Similar to 'pluginsToDefaultConfig' but simpler, since schema has a flatten structure
 pluginsToVSCodeExtensionSchema :: IdePlugins a -> A.Value
-pluginsToVSCodeExtensionSchema IdePlugins {..} = A.object $ mconcat $ singlePlugin <$> Map.elems ipMap
+pluginsToVSCodeExtensionSchema IdePlugins {..} = A.object $ mconcat $ singlePlugin <$> map snd ipMap
   where
     singlePlugin PluginDescriptor {..} = genericSchema <> dedicatedSchema
       where

--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -37,7 +37,6 @@ import           Language.LSP.Types
 import qualified Language.LSP.Types              as J
 import           Language.LSP.Types.Capabilities
 
-import qualified Data.Map.Strict                 as Map
 import           Ide.Plugin.Config
 import           Ide.Plugin.Properties
 import           Language.LSP.Server
@@ -144,7 +143,7 @@ clientSupportsDocumentChanges caps =
 -- ---------------------------------------------------------------------
 
 pluginDescToIdePlugins :: [PluginDescriptor ideState] -> IdePlugins ideState
-pluginDescToIdePlugins plugins = IdePlugins $ Map.fromList $ map (\p -> (pluginId p, p)) plugins
+pluginDescToIdePlugins plugins = IdePlugins $ map (\p -> (pluginId p, p)) plugins
 
 
 -- ---------------------------------------------------------------------
@@ -214,12 +213,11 @@ positionInRange (Position pl po) (Range (Position sl so) (Position el eo)) =
 -- ---------------------------------------------------------------------
 
 allLspCmdIds' :: T.Text -> IdePlugins ideState -> [T.Text]
-allLspCmdIds' pid mp = mkPlugin (allLspCmdIds pid) (Just . pluginCommands)
+allLspCmdIds' pid (IdePlugins ls) = mkPlugin (allLspCmdIds pid) (Just . pluginCommands)
     where
         justs (p, Just x)  = [(p, x)]
         justs (_, Nothing) = []
 
-        ls = Map.toList (ipMap mp)
 
         mkPlugin maker selector
             = maker $ concatMap (\(pid, p) -> justs (pid, selector p)) ls

--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -37,6 +37,7 @@ import           Language.LSP.Types
 import qualified Language.LSP.Types              as J
 import           Language.LSP.Types.Capabilities
 
+import           Data.Containers.ListUtils       (nubOrdOn)
 import           Ide.Plugin.Config
 import           Ide.Plugin.Properties
 import           Language.LSP.Server
@@ -143,7 +144,8 @@ clientSupportsDocumentChanges caps =
 -- ---------------------------------------------------------------------
 
 pluginDescToIdePlugins :: [PluginDescriptor ideState] -> IdePlugins ideState
-pluginDescToIdePlugins plugins = IdePlugins $ map (\p -> (pluginId p, p)) plugins
+pluginDescToIdePlugins plugins =
+    IdePlugins $ map (\p -> (pluginId p, p)) $ nubOrdOn pluginId plugins
 
 
 -- ---------------------------------------------------------------------

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -54,7 +54,7 @@ import           Text.Regex.TDFA.Text            ()
 -- ---------------------------------------------------------------------
 
 newtype IdePlugins ideState = IdePlugins
-  { ipMap :: Map.Map PluginId (PluginDescriptor ideState)}
+  { ipMap :: [(PluginId, PluginDescriptor ideState)]}
 
 -- ---------------------------------------------------------------------
 

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -13,7 +13,6 @@ import           Control.Monad.Extra
 import qualified Data.Aeson.Encode.Pretty      as A
 import qualified Data.ByteString.Lazy.Char8    as LBS
 import           Data.Default
-import qualified Data.Map.Strict               as Map
 import qualified Data.Text                     as T
 import           Development.IDE.Core.Rules
 import qualified Development.IDE.Main          as Main
@@ -97,7 +96,7 @@ runLspMode lspArgs@LspArguments{..} idePlugins = do
     when argLSP $ do
         hPutStrLn stderr "Starting (haskell-language-server)LSP server..."
         hPutStrLn stderr $ "  with arguments: " <> show lspArgs
-        hPutStrLn stderr $ "  with plugins: " <> show (Map.keys $ ipMap idePlugins)
+        hPutStrLn stderr $ "  with plugins: " <> show (map fst $ ipMap idePlugins)
         hPutStrLn stderr $ "  in directory: " <> dir
         hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcide WITHOUT the --lsp option!"
 


### PR DESCRIPTION
Order of execution matters for notification plugins, so best to avoid unnecessary reorderings