### PR TITLE
Skip tracing unless eventlog is enabled

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -52,6 +52,7 @@ library
         filepath,
         fingertree,
         ghc-exactprint,
+        ghc-trace-events,
         Glob,
         haddock-library ^>= 1.10.0,
         hashable,

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -60,7 +60,7 @@ otTracedHandler
     -> String -- ^ Message label
     -> (SpanInFlight -> m a)
     -> m a
-otTracedHandler requestType label act =
+otTracedHandler requestType label act
   | isTracingEnabled = do
     let !name =
             if null label

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -46,7 +46,7 @@ import           Ide.Types                      (PluginId (..))
 import           Language.LSP.Types             (NormalizedFilePath,
                                                  fromNormalizedFilePath)
 import           Numeric.Natural                (Natural)
-import           OpenTelemetry.Eventlog         (Instrument, SpanInFlight,
+import           OpenTelemetry.Eventlog         (Instrument, SpanInFlight (..),
                                                  Synchronicity (Asynchronous),
                                                  addEvent, beginSpan, endSpan,
                                                  mkValueObserver, observe,
@@ -69,7 +69,7 @@ otTracedHandler requestType label act
     -- Add an event so all requests can be quickly seen in the viewer without searching
     runInIO <- askRunInIO
     liftIO $ withSpan (fromString name) (\sp -> addEvent sp "" (fromString $ name <> " received") >> runInIO (act sp))
-  | otherwise = act
+  | otherwise = act (SpanInFlight 0)
 
 otSetUri :: SpanInFlight -> Uri -> IO ()
 otSetUri sp (Uri t) = setTag sp "uri" (encodeUtf8 t)


### PR DESCRIPTION
This was done only for otTracedAction but not for otTracedHandler and otTracedProvider