### PR TITLE
Wrap test suite of tactics plugin into tasty test tree

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,4 +166,4 @@ jobs:
 
       - if: ${{ needs.pre_job.outputs.should_skip != 'true' && matrix.test }}
         name: Test hls-tactics-plugin test suite
-        run: LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-tactics-plugin --test-options="-j1"
+        run: cabal test hls-tactics-plugin --test-options="-j1 --rerun-update" || cabal test hls-tactics-plugin --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-tactics-plugin --test-options="-j1 --rerun"

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -119,6 +119,7 @@ test-suite tests
     CodeAction.IntrosSpec
     CodeAction.UseDataConSpec
     ProviderSpec
+    Spec
     UnificationSpec
     Utils
   hs-source-dirs:
@@ -144,6 +145,7 @@ test-suite tests
     , text
     , deepseq
     , tasty-hunit
+    , tasty-hspec
   build-tool-depends:
       hspec-discover:hspec-discover
   default-language: Haskell2010

--- a/plugins/hls-tactics-plugin/test/Main.hs
+++ b/plugins/hls-tactics-plugin/test/Main.hs
@@ -1,1 +1,8 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Main #-}
+module Main where
+
+import qualified Spec
+import Test.Hls
+import Test.Tasty.Hspec
+
+main :: IO ()
+main = testSpecs Spec.spec >>= defaultTestRunner . testGroup "tactics"

--- a/plugins/hls-tactics-plugin/test/Spec.hs
+++ b/plugins/hls-tactics-plugin/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}


### PR DESCRIPTION
* tasty can show duration of each test case
* timeout set in `defaultTestRunner` can be applied
* cli options of the test executable are unified with others in our code base