### PR TITLE
Fix ghcide and HLS enter lsp mode by default

### DIFF
--- a/ghcide/exe/Arguments.hs
+++ b/ghcide/exe/Arguments.hs
@@ -42,4 +42,4 @@ arguments = Arguments
       <*> (commandP <|> lspCommand <|> checkCommand)
       where
           checkCommand = Check <$> many (argument str (metavar "FILES/DIRS..."))
-          lspCommand = LSP <$ switch (long "lsp" <> help "Start talking to an LSP client")
+          lspCommand = LSP <$ flag' True (long "lsp" <> help "Start talking to an LSP client")

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -22,7 +22,6 @@ import           Development.IDE                   (Logger (Logger),
                                                     Priority (Info), action)
 import           Development.IDE.Core.OfInterest   (kick)
 import           Development.IDE.Core.Rules        (mainRule)
-import           Development.IDE.Main              (Command (LSP))
 import qualified Development.IDE.Main              as Main
 import qualified Development.IDE.Plugin.HLS.GhcIde as GhcIde
 import qualified Development.IDE.Plugin.Test       as Test
@@ -76,12 +75,6 @@ main = do
     let logger = Logger $ \pri msg -> when (pri >= logLevel) $ withLock lock $
             T.putStrLn $ T.pack ("[" ++ upper (show pri) ++ "] ") <> msg
         logLevel = if argsVerbose then minBound else Info
-
-    case argsCommand of
-        LSP -> do
-            hPutStrLn stderr "Starting LSP server..."
-            hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcide WITHOUT the --lsp option!"
-        _ -> return ()
 
     Main.defaultMain def
         {Main.argCommand = argsCommand

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -199,7 +199,7 @@ defaultMain Arguments{..} = do
         LSP -> do
             t <- offsetTime
             hPutStrLn stderr "Starting LSP server..."
-            hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcide WITHOUT the --lsp option!"
+            hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run WITHOUT the --lsp option!"
             runLanguageServer options inH outH argsGetHieDbLoc argsDefaultHlsConfig argsOnConfigChange (pluginHandlers plugins) $ \env vfs rootPath hiedb hieChan -> do
                 t <- t
                 hPutStrLn stderr $ "Started LSP server in " ++ showDuration t

--- a/src/Ide/Arguments.hs
+++ b/src/Ide/Arguments.hs
@@ -120,7 +120,7 @@ arguments = GhcideArguments
       <*> switch (long "project-ghc-version"
                   <> help "Work out the project GHC version and print it")
     where
-        lspCommand = LSP <$ switch (long "lsp" <> help "Start talking to an LSP server")
+        lspCommand = LSP <$ flag' True (long "lsp" <> help "Start talking to an LSP server")
         checkCommand = Check <$> many (argument str (metavar "FILES/DIRS..."))
 
 -- ---------------------------------------------------------------------

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -86,7 +86,6 @@ runLspMode ghcideArgs@GhcideArguments{..} idePlugins = do
         hPutStrLn stderr $ "  with arguments: " <> show ghcideArgs
         hPutStrLn stderr $ "  with plugins: " <> show (map fst $ ipMap idePlugins)
         hPutStrLn stderr $ "  in directory: " <> dir
-        hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run ghcide WITHOUT the --lsp option!"
 
     Main.defaultMain def
       { Main.argCommand = argsCommand


### PR DESCRIPTION
We can't use `switch` with alternative combinators, since it never fails.