### PR TITLE
Update nix

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,7 +10,7 @@ when added to the path.
 
 ## Minimal checklist
 
-* [ ] generate the list of pull requests finished since the last release using the [haskell script](https://github.com/haskell/haskell-language-server/blob/master/GenChangelogs.hs) in the project root.
+* [ ] generate the list of pull requests finished since the last release using the [haskell script](https://github.com/haskell/haskell-language-server/blob/master/GenChangelogs.hs) in the project root. Nix users should run command `genChangelogs` (a wrapper of the script) in nix-shell instead.
 * [ ] add that list to the actual [Changelog](https://github.com/haskell/haskell-language-server/blob/master/ChangeLog.md) with a description of the release.
 * [ ] bump up versions of changed packages. All are optional but [haskell-language-server itself](https://github.com/haskell/haskell-language-server/blob/master/haskell-language-server.cabal).
 * [ ] create the tag and make an initial prerelease to trigger the ci workflow (see details below)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,7 +10,8 @@ when added to the path.
 
 ## Minimal checklist
 
-* [ ] generate the list of pull requests finished since the last release using the [haskell script](https://github.com/haskell/haskell-language-server/blob/master/GenChangelogs.hs) in the project root. Nix users should run command `genChangelogs` (a wrapper of the script) in nix-shell instead.
+* [ ] generate the list of pull requests finished since the last release using the [haskell script](https://github.com/haskell/haskell-language-server/blob/master/GenChangelogs.hs) in the project root.
+  Nix users should run command `gen-hls-changelogs` (a wrapper of the script) in nix-shell instead.
 * [ ] add that list to the actual [Changelog](https://github.com/haskell/haskell-language-server/blob/master/ChangeLog.md) with a description of the release.
 * [ ] bump up versions of changed packages. All are optional but [haskell-language-server itself](https://github.com/haskell/haskell-language-server/blob/master/haskell-language-server.cabal).
 * [ ] create the tag and make an initial prerelease to trigger the ci workflow (see details below)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -48,15 +48,15 @@ let
         inherit gitignoreSource;
         inherit ourSources;
 
-        genChangelogs = with pkgs;
+        gen-hls-changelogs = with pkgs;
           let myGHC = haskellPackages.ghcWithPackages (p: with p; [ github ]);
-          in runCommand "genChangelogs" {
+          in runCommand "gen-hls-changelogs" {
               passAsFile = [ "text" ];
               preferLocalBuild = true;
               allowSubstitutes = false;
               buildInputs = [ git myGHC ];
             } ''
-              dest=$out/bin/genChangelogs
+              dest=$out/bin/gen-hls-changelogs
               mkdir -p $out/bin
               echo "#!${runtimeShell}" >> $dest
               echo "${myGHC}/bin/runghc ${../GenChangelogs.hs}" >> $dest

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5147860e23ed75ce9d40298c66b416c00be1167",
-        "sha256": "104mw4rfbzyrfkxq468dlk38drrjx92dgyvkazgci67a6cx3n6nx",
+        "rev": "6fc2b7ecc2a167ce6a6902d5417daf1fa5cac777",
+        "sha256": "0bcf8yr8scgk7kdjhbrvv7l1d1yv8fnb1d7k3vgnd9qrjnl2fbcf",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c5147860e23ed75ce9d40298c66b416c00be1167.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6fc2b7ecc2a167ce6a6902d5417daf1fa5cac777.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,7 @@ haskellPackagesForProject.shellFor {
     capstone
     tracy
 
-    genChangelogs
+    gen-hls-changelogs
 
     haskellPackages.cabal-install
     haskellPackages.hlint

--- a/shell.nix
+++ b/shell.nix
@@ -37,6 +37,8 @@ haskellPackagesForProject.shellFor {
     capstone
     tracy
 
+    genChangelogs
+
     haskellPackages.cabal-install
     haskellPackages.hlint
     haskellPackages.ormolu


### PR DESCRIPTION
* `tracy-0.7.7` is available with fix of the build on macOS
* ~~`lsp{,types}-1.2`, `lsp-test-0.14.0`~~ (UPDATE: it seems that nix doesn't update them), and other packages which may have updates can be used with nix

This PR also adds a command `gen-hls-changelogs` to nix shell, calling GenChangelogs.hs with dependencies resolved by nix -- maintainers who use nix now can invoke this script smoothly.