### PR TITLE
Prepare ghcide 1.2.0.2 and HLS 1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc: ['8.10.4', '8.10.3', '8.10.2', '8.8.4', '8.8.3', '8.8.2', '8.6.5', '8.6.4']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-18.04, macOS-latest, windows-latest]
         exclude:
           - os: windows-latest
             ghc: '8.10.2' # broken due to https://gitlab.haskell.org/ghc/ghc/-/issues/18550
@@ -58,7 +58,7 @@ jobs:
         echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
 
     - name: Set some linux specific things
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-18.04'
       env:
         GHC_VER: ${{ matrix.ghc }}
       run: |
@@ -156,7 +156,7 @@ jobs:
   # macOS and Linux, used by ghcup
   tar:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         os: [Linux, macOS]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,12 +34,18 @@ As always, there are many internal bug fixes and performance improvements in ghc
 * test suite of plugins are reorganized, which no longer need to be run with `test-server` executable
 * two new packages `hls-test-utils` and `hls-stylish-haskell-plugin` are extracted
 
-This version uses `lsp-1.2.0`, `hls-plugin-api-1.1.0`, and `ghcide-1.2.0`.
+This version uses `lsp-1.2.0`, `hls-plugin-api-1.1.0`, and `ghcide-1.2.0.2`.
 
 ### Pull requests merged for 1.1.0
 
+- Restore compat. with haddock-library 1.8
+([#1717](https://github.com/haskell/haskell-language-server/pull/1717)) by @pepeiborra
+- Don't suggest destruct actions for already-destructed terms
+([#1715](https://github.com/haskell/haskell-language-server/pull/1715)) by @isovector
 - Add keybindings and jump to hole to the Wingman README
 ([#1712](https://github.com/haskell/haskell-language-server/pull/1712)) by @isovector
+- Bracketing for snippet completions
+([#1709](https://github.com/haskell/haskell-language-server/pull/1709)) by @OliverMadine
 - Prepare ghcide 1.2.0
 ([#1707](https://github.com/haskell/haskell-language-server/pull/1707)) by @berberman
 - Adjust bounds

--- a/ghcide/CHANGELOG.md
+++ b/ghcide/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.2.0.2 (2021-04-13)
+* Bracketing for snippet completions (#1709) - Oliver Madine
+* Don't suggest destruct actions for already-destructed terms (#1715) - Sandy Maguire
+
+### 1.2.0.1 (2021-04-12)
+* restore compat. with haddock-library 1.8 (#1717) - Pepe Iborra
+
 ### 1.2.0 (2021-04-11)
 * Emit holes as diagnostics (#1653) - Sandy Maguire
 * Fix ghcide and HLS enter lsp mode by default (#1692) - Potato Hatsue

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.2.0.1
+version:            1.2.0.2
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -63,7 +63,7 @@ library
     , cryptohash-sha1
     , data-default
     , ghc
-    , ghcide                ^>= 1.2.0.0
+    , ghcide                ^>= 1.2.0.2
     , gitrev
     , lsp
     , hie-bios

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -43,7 +43,7 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  ^>=1.2.0.0
+    , ghcide                  ^>=1.2.0.2
     , hls-plugin-api          ^>=1.1.0.0
     , hspec
     , hspec-core

--- a/plugins/hls-brittany-plugin/hls-brittany-plugin.cabal
+++ b/plugins/hls-brittany-plugin/hls-brittany-plugin.cabal
@@ -25,8 +25,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          ^>=1.2.0.0
-    , hls-plugin-api  ^>=1.1
+    , ghcide          ^>=1.2.0.2
+    , hls-plugin-api  ^>=1.1.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -29,8 +29,8 @@ library
     , containers
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.2.0.0
-    , hls-plugin-api        ^>=1.1
+    , ghcide                ^>=1.2.0.2
+    , hls-plugin-api        ^>=1.1.0.0
     , lens
     , lsp
     , shake

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -61,9 +61,9 @@ library
     , ghc
     , ghc-boot-th
     , ghc-paths
-    , ghcide                ^>=1.2.0.0
+    , ghcide                ^>=1.2.0.2
     , hashable
-    , hls-plugin-api        ^>=1.1
+    , hls-plugin-api        ^>=1.1.0.0
     , lens
     , lsp
     , lsp-types

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -21,8 +21,8 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                ^>=1.2.0.0
-    , hls-plugin-api        ^>=1.1
+    , ghcide                ^>=1.2.0.2
+    , hls-plugin-api        ^>=1.1.0.0
     , lsp
     , lsp-types
     , shake

--- a/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
+++ b/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
@@ -29,8 +29,8 @@ library
     , containers
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.2.0.0
-    , hls-plugin-api        ^>=1.1
+    , ghcide                ^>=1.2.0.2
+    , hls-plugin-api        ^>=1.1.0.0
     , lsp-types
     , text
     , unordered-containers

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -41,10 +41,10 @@ library
     , extra
     , filepath
     , ghc-exactprint        >=0.6.3.4
-    , ghcide                ^>=1.2.0.0
+    , ghcide                ^>=1.2.0.2
     , hashable
     , hlint                 >=3.2
-    , hls-plugin-api        ^>=1.1
+    , hls-plugin-api        ^>=1.1.0.0
     , hslogger
     , lens
     , lsp

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -23,9 +23,9 @@ library
     , directory
     , extra
     , ghc
-    , ghcide                ^>=1.2
+    , ghcide                ^>=1.2.0.2
     , hashable
-    , hls-plugin-api        ^>=1.1
+    , hls-plugin-api        ^>=1.1.0.0
     , lsp
     , lsp-types
     , retrie                >=0.1.1.0

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -40,8 +40,8 @@ library
     , foldl
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.2.0.0
-    , hls-plugin-api        ^>=1.1
+    , ghcide                ^>=1.2.0.2
+    , hls-plugin-api        ^>=1.1.0.0
     , lens
     , lsp
     , retrie

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -22,8 +22,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide           ^>=1.2.0.0
-    , hls-plugin-api   ^>=1.1
+    , ghcide           ^>=1.2.0.2
+    , hls-plugin-api   ^>=1.1.0.0
     , lsp-types
     , mtl
     , stylish-haskell  ^>=0.12

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -72,8 +72,8 @@ library
     , ghc-boot-th
     , ghc-exactprint
     , ghc-source-gen
-    , ghcide                ^>=1.2.0.0
-    , hls-plugin-api        ^>=1.1
+    , ghcide                ^>=1.2.0.2
+    , hls-plugin-api        ^>=1.1.0.0
     , lens
     , lsp
     , mtl


### PR DESCRIPTION
Closes #1681

This will be the final preparation for 1.1.0 release. We should create tag `ghcide-v1.2.0.2` and `1.1.0` on the squashed commit of this PR, and upload `ghcide-1.2.0.2` to hackage.