### PR TITLE
Set TextDocumentEdit version to Nothing instead of Just 0

### DIFF
--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -127,7 +127,7 @@ diffText' supports (f,fText) f2Text withDeletions  =
     diff = diffTextEdit fText f2Text withDeletions
     h = H.singleton f diff
     docChanges = J.List [InL docEdit]
-    docEdit = J.TextDocumentEdit (J.VersionedTextDocumentIdentifier f (Just 0)) $ fmap InL diff
+    docEdit = J.TextDocumentEdit (J.VersionedTextDocumentIdentifier f Nothing) $ fmap InL diff
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
Clients like the one built into neovim reject edits where the version is
lower than the expected document version.

This was always the case with hls because the version is hardcoded to 0.
vscode seems to accept that, but based on the specification it is more
accurate to set the version to `null` if it is not know.

The `textDocument` of `TextDocumentEdit` has the type
`OptionalVersionedTextDocumentIdentifier`

---

Update: Figured out that in 3.15 the `textDocument` was a `VersionedTextDocumentIdentifier`. We merged a change in neovim to allow 0 versions as well so I guess this PR is obsolete.