### PR TITLE
Add executable stanza in hls-install.cabal.

### DIFF
--- a/install/hls-install.cabal
+++ b/install/hls-install.cabal
@@ -45,3 +45,8 @@ flag run-from-stack
   description: Inform the application that it is run from stack
   default:     False
   manual:      True
+
+executable hls-install
+  main-is: ../install.hs
+  build-depends: base
+    , hls-install


### PR DESCRIPTION
This helps packaging on FreeBSD where we build installer executable as a
separate package.