### PR TITLE
Improve vscode extension schema generation

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -47,7 +47,7 @@ descriptor plId = (defaultPluginDescriptor plId)
   { pluginRules = produceCompletions
   , pluginHandlers = mkPluginHandler STextDocumentCompletion getCompletionsLSP
   , pluginCommands = [extendImportCommand]
-  , pluginCustomConfig = mkCustomConfig properties
+  , pluginConfigDescriptor = defaultConfigDescriptor {configCustomConfig = mkCustomConfig properties}
   }
 
 produceCompletions :: Rules ()

--- a/ghcide/src/Development/IDE/Plugin/HLS/GhcIde.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS/GhcIde.hs
@@ -33,7 +33,8 @@ descriptors =
 descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId = (defaultPluginDescriptor plId)
   { pluginHandlers = mkPluginHandler STextDocumentHover hover'
-                  <> mkPluginHandler STextDocumentDocumentSymbol symbolsProvider
+                  <> mkPluginHandler STextDocumentDocumentSymbol symbolsProvider,
+    pluginConfigDescriptor = defaultConfigDescriptor {configEnableGenericConfig = False}
   }
 
 -- ---------------------------------------------------------------------

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -17,8 +17,8 @@ import           Control.DeepSeq                     (rwhnf)
 import           Control.Monad                       (mzero)
 import           Control.Monad.Extra                 (whenMaybe)
 import           Control.Monad.IO.Class              (MonadIO (liftIO))
-import qualified Data.Aeson.Types                    as A
 import           Data.Aeson.Types                    (Value (..), toJSON)
+import qualified Data.Aeson.Types                    as A
 import qualified Data.HashMap.Strict                 as Map
 import           Data.List                           (find)
 import           Data.Maybe                          (catMaybes, fromJust)
@@ -60,6 +60,8 @@ import           Ide.Types                           (CommandFunction,
                                                       PluginCommand (PluginCommand),
                                                       PluginDescriptor (..),
                                                       PluginId,
+                                                      configCustomConfig,
+                                                      defaultConfigDescriptor,
                                                       defaultPluginDescriptor,
                                                       mkCustomConfig,
                                                       mkPluginHandler)
@@ -90,7 +92,7 @@ descriptor plId =
     { pluginHandlers = mkPluginHandler STextDocumentCodeLens codeLensProvider
     , pluginCommands = [PluginCommand (CommandId typeLensCommandId) "adds a signature" commandHandler]
     , pluginRules = rules
-    , pluginCustomConfig = mkCustomConfig properties
+    , pluginConfigDescriptor = defaultConfigDescriptor {configCustomConfig = mkCustomConfig properties}
     }
 
 properties :: Properties '[ 'PropertyKey "mode" ('TEnum Mode)]
@@ -212,8 +214,8 @@ data Mode
   deriving (Eq, Ord, Show, Read, Enum)
 
 instance A.ToJSON Mode where
-  toJSON Always = "always"
-  toJSON Exported = "exported"
+  toJSON Always      = "always"
+  toJSON Exported    = "exported"
   toJSON Diagnostics = "diagnostics"
 
 instance A.FromJSON Mode where

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -63,18 +63,46 @@ data PluginDescriptor ideState =
                    , pluginRules        :: !(Rules ())
                    , pluginCommands     :: ![PluginCommand ideState]
                    , pluginHandlers     :: PluginHandlers ideState
-                   , pluginCustomConfig :: CustomConfig
+                   , pluginConfigDescriptor :: ConfigDescriptor
                    , pluginNotificationHandlers :: PluginNotificationHandlers ideState
                    }
 
--- | An existential wrapper of 'Properties', used only for documenting and generating config templates
+-- | An existential wrapper of 'Properties'
 data CustomConfig = forall r. CustomConfig (Properties r)
 
-emptyCustomConfig :: CustomConfig
-emptyCustomConfig = CustomConfig emptyProperties
+-- | Describes the configuration a plugin.
+-- A plugin may be configurable in such form:
+-- @
+-- {
+--  "plugin-id": {
+--    "globalOn": true,
+--    "codeActionsOn": true,
+--    "codeLensOn": true,
+--    "config": {
+--      "property1": "foo"
+--     }
+--   }
+-- }
+-- @
+-- @globalOn@, @codeActionsOn@, and @codeLensOn@ etc. are called generic configs,
+-- which can be inferred from handlers registered by the plugin.
+-- @config@ is called custom config, which is defined using 'Properties'.
+data ConfigDescriptor = ConfigDescriptor {
+  -- | Whether or not to generate generic configs.
+  configEnableGenericConfig :: Bool,
+  -- | Whether or not to generate @diagnosticsOn@ config.
+  -- Diagnostics emit in arbitrary shake rules,
+  -- so we can't know statically if the plugin produces diagnostics
+  configHasDiagnostics      :: Bool,
+  -- | Custom config.
+  configCustomConfig        :: CustomConfig
+}
 
 mkCustomConfig :: Properties r -> CustomConfig
 mkCustomConfig = CustomConfig
+
+defaultConfigDescriptor :: ConfigDescriptor
+defaultConfigDescriptor = ConfigDescriptor True False (mkCustomConfig emptyProperties)
 
 -- | Methods that can be handled by plugins.
 -- 'ExtraParams' captures any extra data the IDE passes to the handlers for this method
@@ -267,7 +295,7 @@ defaultPluginDescriptor plId =
     mempty
     mempty
     mempty
-    emptyCustomConfig
+    defaultConfigDescriptor
     mempty
 
 newtype CommandId = CommandId T.Text

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -96,6 +96,7 @@ descriptor plId = (defaultPluginDescriptor plId)
       , PluginCommand "applyAll" "Apply all hints to the file" applyAllCmd
       ]
     , pluginHandlers = mkPluginHandler STextDocumentCodeAction codeActionProvider
+    , pluginConfigDescriptor = defaultConfigDescriptor {configHasDiagnostics = True}
   }
 
 -- This rule only exists for generating file diagnostics

--- a/plugins/hls-tactics-plugin/src/Wingman/Plugin.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Plugin.hs
@@ -59,8 +59,8 @@ descriptor plId = (defaultPluginDescriptor plId)
       , mkPluginHandler STextDocumentCodeLens codeLensProvider
       ]
   , pluginRules = wingmanRules plId
-  , pluginCustomConfig =
-      mkCustomConfig properties
+  , pluginConfigDescriptor =
+      defaultConfigDescriptor {configCustomConfig = mkCustomConfig properties}
   }
 
 


### PR DESCRIPTION
As discussed in https://github.com/haskell/vscode-haskell/issues/378#issuecomment-820711751, in order to make the generated vscode extension schema more handy, this PR introduces a new data type taking place of the old `pluginCustomConfig` in `PluginDescriptor`:

```haskell
data ConfigDescriptor = ConfigDescriptor {
  configEnableGenericConfig :: Bool,
  configHasDiagnostics      :: Bool,
  configCustomConfig        :: CustomConfig
}
```

* We shouold set `configHasDiagnostics` to `True` explicitly in plugin like hlint, so that we could generate `diagnosticsOn` option for it.
* Plugin will have single `globalOn` option only if it has one capability; otherwise we use specific capabilities such as `codeActionOn`, `codeLensOn`, etc. as options.
* Normally, we won't hope disable capabilities of ghcide-hover-and-symbols plugin. So we set `configEnableGenericConfig` to `False` to avoid generating options of this plugin.