### PR TITLE
Add hls-graph abstracting over shake

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,7 @@ packages:
          ./
          ./hie-compat
          ./shake-bench
+         ./hls-graph
          ./ghcide
          ./hls-plugin-api
          ./hls-test-utils

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -26,7 +26,7 @@ import qualified Development.IDE.Main              as Main
 import qualified Development.IDE.Plugin.HLS.GhcIde as GhcIde
 import qualified Development.IDE.Plugin.Test       as Test
 import           Development.IDE.Types.Options
-import           Development.Shake                 (ShakeOptions (shakeThreads))
+import           Development.IDE.Graph                 (ShakeOptions (shakeThreads))
 import           Ide.Plugin.Config                 (Config (checkParents, checkProject))
 import           Ide.Plugin.ConfigUtils            (pluginsToDefaultConfig,
                                                     pluginsToVSCodeExtensionSchema)
@@ -109,4 +109,3 @@ main = do
                 , optCheckProject = pure $ checkProject config
                 }
         }
-

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -74,7 +74,7 @@ library
         rope-utf16-splay,
         safe,
         safe-exceptions,
-        shake >= 0.18.4,
+        hls-graph,
         sorted-list,
         sqlite-simple,
         stm,
@@ -288,7 +288,7 @@ executable ghcide
         ghcide,
         lens,
         optparse-applicative,
-        shake,
+        hls-graph,
         text,
         unordered-containers,
         aeson-pretty
@@ -358,6 +358,7 @@ test-suite ghcide-tests
         safe,
         safe-exceptions,
         shake,
+        hls-graph,
         tasty,
         tasty-expected-failure,
         tasty-hunit,
@@ -410,6 +411,7 @@ executable ghcide-bench
         optparse-applicative,
         process,
         safe-exceptions,
+        hls-graph,
         shake,
         text
     hs-source-dirs: bench/lib bench/exe

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -56,7 +56,7 @@ import           Development.IDE.Types.HscEnvEq       (HscEnvEq, newHscEnvEq,
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger
 import           Development.IDE.Types.Options
-import           Development.Shake                    (Action)
+import           Development.IDE.Graph                    (Action)
 import           GHC.Check
 import qualified HIE.Bios                             as HieBios
 import           HIE.Bios.Environment                 hiding (getCacheDir)

--- a/ghcide/src/Development/IDE.hs
+++ b/ghcide/src/Development/IDE.hs
@@ -51,5 +51,5 @@ import           Development.IDE.Types.HscEnvEq        as X (HscEnvEq (..),
                                                              hscEnvWithImportPaths)
 import           Development.IDE.Types.Location        as X
 import           Development.IDE.Types.Logger          as X
-import           Development.Shake                     as X (Action, RuleResult,
+import           Development.IDE.Graph                     as X (Action, RuleResult,
                                                              Rules, action)

--- a/ghcide/src/Development/IDE/Core/Actions.hs
+++ b/ghcide/src/Development/IDE/Core/Actions.hs
@@ -30,7 +30,7 @@ import           Development.IDE.GHC.Compat           hiding (TargetFile,
                                                        writeHieFile)
 import qualified Development.IDE.Spans.AtPoint        as AtPoint
 import           Development.IDE.Types.Location
-import           Development.Shake                    hiding (Diagnostic)
+import           Development.IDE.Graph                    hiding (Diagnostic)
 import qualified HieDb
 import           Language.LSP.Types                   (DocumentHighlight (..),
                                                        SymbolInformation (..))

--- a/ghcide/src/Development/IDE/Core/Actions.hs
+++ b/ghcide/src/Development/IDE/Core/Actions.hs
@@ -30,7 +30,7 @@ import           Development.IDE.GHC.Compat           hiding (TargetFile,
                                                        writeHieFile)
 import qualified Development.IDE.Spans.AtPoint        as AtPoint
 import           Development.IDE.Types.Location
-import           Development.IDE.Graph                    hiding (Diagnostic)
+import           Development.IDE.Graph
 import qualified HieDb
 import           Language.LSP.Types                   (DocumentHighlight (..),
                                                        SymbolInformation (..))

--- a/ghcide/src/Development/IDE/Core/FileExists.hs
+++ b/ghcide/src/Development/IDE/Core/FileExists.hs
@@ -24,7 +24,7 @@ import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
-import           Development.Shake
+import           Development.IDE.Graph
 import           Language.LSP.Server                   hiding (getVirtualFile)
 import           Language.LSP.Types
 import           Language.LSP.Types.Capabilities

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -46,7 +46,7 @@ import           Development.IDE.Import.DependencyInformation
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
-import           Development.Shake
+import           Development.IDE.Graph
 import           HieDb.Create                                 (deleteMissingRealFiles)
 import           Ide.Plugin.Config                            (CheckParents (..))
 import           System.IO.Error

--- a/ghcide/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/ghcide/src/Development/IDE/Core/IdeConfiguration.hs
@@ -21,7 +21,7 @@ import           Data.Hashable                  (Hashed, hashed, unhashed)
 import           Data.Text                      (Text, isPrefixOf)
 import           Development.IDE.Core.Shake
 import           Development.IDE.Types.Location
-import           Development.Shake
+import           Development.IDE.Graph
 import           Language.LSP.Types
 import           System.FilePath                (isRelative)
 

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -24,7 +24,7 @@ import qualified Data.HashMap.Strict                          as HashMap
 import           Data.Hashable
 import qualified Data.Text                                    as T
 import           Data.Typeable
-import           Development.Shake
+import           Development.IDE.Graph
 import           GHC.Generics
 
 import           Control.Monad.Trans.Class
@@ -117,4 +117,3 @@ kick = do
     void $ liftIO $ modifyVar' exportsMap $ (exportsMap'' <>) . (exportsMap' <>)
 
     liftIO $ progressUpdate KickCompleted
-

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -28,7 +28,7 @@ import           Development.IDE.GHC.Util
 import           Development.IDE.Import.DependencyInformation
 import           Development.IDE.Types.HscEnvEq               (HscEnvEq)
 import           Development.IDE.Types.KnownTargets
-import           Development.Shake
+import           Development.IDE.Graph
 import           GHC.Generics                                 (Generic)
 
 import           HscTypes                                     (HomeModInfo,

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -123,9 +123,9 @@ import           Development.IDE.Types.HscEnvEq
 import           Development.IDE.Types.Location
 import qualified Development.IDE.Types.Logger                 as L
 import           Development.IDE.Types.Options
-import           Development.Shake                            hiding
+import           Development.IDE.Graph                            hiding
                                                               (Diagnostic)
-import           Development.Shake.Classes                    hiding (get, put)
+import           Development.IDE.Graph.Classes                    hiding (get, put)
 import           Fingerprint
 import           GHC.Generics                                 (Generic)
 import           GHC.IO.Encoding

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -123,8 +123,7 @@ import           Development.IDE.Types.HscEnvEq
 import           Development.IDE.Types.Location
 import qualified Development.IDE.Types.Logger                 as L
 import           Development.IDE.Types.Options
-import           Development.IDE.Graph                            hiding
-                                                              (Diagnostic)
+import           Development.IDE.Graph
 import           Development.IDE.Graph.Classes                    hiding (get, put)
 import           Fingerprint
 import           GHC.Generics                                 (Generic)

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -23,7 +23,7 @@ import           Development.IDE.Core.FileExists (fileExistsRules)
 import           Development.IDE.Core.OfInterest
 import           Development.IDE.Types.Logger    as Logger
 import           Development.IDE.Types.Options   (IdeOptions (..))
-import           Development.Shake
+import           Development.IDE.Graph
 import           Ide.Plugin.Config
 import qualified Language.LSP.Server             as LSP
 import qualified Language.LSP.Types              as LSP

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -119,12 +119,12 @@ import           Development.IDE.Types.Logger         hiding (Priority)
 import qualified Development.IDE.Types.Logger         as Logger
 import           Development.IDE.Types.Options
 import           Development.IDE.Types.Shake
-import           Development.Shake                    hiding (Info, ShakeValue,
+import           Development.IDE.Graph                    hiding (Info, ShakeValue,
                                                        doesFileExist)
-import qualified Development.Shake                    as Shake
-import           Development.Shake.Classes
-import           Development.Shake.Database
-import           Development.Shake.Rule
+import qualified Development.IDE.Graph                    as Shake
+import           Development.IDE.Graph.Classes
+import           Development.IDE.Graph.Database
+import           Development.IDE.Graph.Rule
 import           GHC.Generics
 import           Language.LSP.Diagnostics
 import qualified Language.LSP.Server                  as LSP

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -119,8 +119,7 @@ import           Development.IDE.Types.Logger         hiding (Priority)
 import qualified Development.IDE.Types.Logger         as Logger
 import           Development.IDE.Types.Options
 import           Development.IDE.Types.Shake
-import           Development.IDE.Graph                    hiding (Info, ShakeValue,
-                                                       doesFileExist)
+import           Development.IDE.Graph                    hiding (ShakeValue)
 import qualified Development.IDE.Graph                    as Shake
 import           Development.IDE.Graph.Classes
 import           Development.IDE.Graph.Database

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -38,7 +38,7 @@ import           Development.IDE.Types.Logger   (Logger, logDebug, logInfo)
 import           Development.IDE.Types.Shake    (Key (..), Value,
                                                  ValueWithDiagnostics (..),
                                                  Values)
-import           Development.Shake              (Action, actionBracket)
+import           Development.IDE.Graph              (Action, actionBracket)
 import           Foreign.Storable               (Storable (sizeOf))
 import           HeapSize                       (recursiveSize, runHeapsize)
 import           Ide.PluginUtils                (installSigUsr1Handler)
@@ -230,4 +230,3 @@ repeatUntilJust nattempts action = do
     case res of
         Nothing -> repeatUntilJust (nattempts-1) action
         Just{}  -> return res
-

--- a/ghcide/src/Development/IDE/GHC/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/GHC/ExactPrint.hs
@@ -50,8 +50,8 @@ import Development.IDE.Core.Service (runAction)
 import Development.IDE.Core.Shake
 import Development.IDE.GHC.Compat hiding (parseExpr)
 import Development.IDE.Types.Location
-import Development.Shake (RuleResult, Rules)
-import Development.Shake.Classes
+import Development.IDE.Graph (RuleResult, Rules)
+import Development.IDE.Graph.Classes
 import qualified GHC.Generics as GHC
 import Generics.SYB
 import Generics.SYB.GHC

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -61,7 +61,7 @@ import           Development.IDE.Types.Options         (IdeGhcSession,
                                                         clientSupportsProgress,
                                                         defaultIdeOptions)
 import           Development.IDE.Types.Shake           (Key (Key))
-import           Development.Shake                     (action)
+import           Development.IDE.Graph                     (action)
 import           GHC.IO.Encoding                       (setLocaleEncoding)
 import           GHC.IO.Handle                         (hDuplicate)
 import           HIE.Bios.Cradle                       (findCradle)

--- a/ghcide/src/Development/IDE/Plugin.hs
+++ b/ghcide/src/Development/IDE/Plugin.hs
@@ -1,7 +1,7 @@
 module Development.IDE.Plugin ( Plugin(..) ) where
 
 import           Data.Default
-import           Development.Shake
+import           Development.IDE.Graph
 
 import           Development.IDE.LSP.Server
 import qualified Language.LSP.Server        as LSP

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/RuleTypes.hs
@@ -10,7 +10,7 @@ import           Data.Hashable                  (Hashable)
 import           Data.Typeable                  (Typeable)
 import           Development.IDE.Types.Exports
 import           Development.IDE.Types.HscEnvEq (HscEnvEq)
-import           Development.Shake              (RuleResult)
+import           Development.IDE.Graph              (RuleResult)
 import           GHC.Generics                   (Generic)
 
 -- Rule type for caching Package Exports

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -31,8 +31,8 @@ import           Development.IDE.Plugin.Completions.Logic
 import           Development.IDE.Plugin.Completions.Types
 import           Development.IDE.Types.HscEnvEq               (hscEnv)
 import           Development.IDE.Types.Location
-import           Development.Shake
-import           Development.Shake.Classes
+import           Development.IDE.Graph
+import           Development.IDE.Graph.Classes
 import           GHC.Exts                                     (toList)
 import           GHC.Generics
 import           Ide.Plugin.Config                            (Config)

--- a/ghcide/src/Development/IDE/Plugin/HLS.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS.hs
@@ -27,7 +27,7 @@ import           Development.IDE.Core.Tracing
 import           Development.IDE.LSP.Server
 import           Development.IDE.Plugin
 import           Development.IDE.Types.Logger
-import           Development.Shake            (Rules)
+import           Development.IDE.Graph            (Rules)
 import           Ide.Plugin.Config
 import           Ide.PluginUtils              (getClientConfig)
 import           Ide.Types                    as HLS

--- a/ghcide/src/Development/IDE/Plugin/Test.hs
+++ b/ghcide/src/Development/IDE/Plugin/Test.hs
@@ -30,7 +30,7 @@ import           Development.IDE.Plugin
 import           Development.IDE.Types.Action
 import           Development.IDE.Types.HscEnvEq (HscEnvEq (hscEnv))
 import           Development.IDE.Types.Location (fromUri)
-import           Development.Shake              (Action)
+import           Development.IDE.Graph              (Action)
 import           GHC.Generics                   (Generic)
 import           GhcPlugins                     (HscEnv (hsc_dflags))
 import           Ide.Types

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -41,7 +41,7 @@ import           Development.IDE.Types.Location      (Position (Position, _chara
                                                       Range (Range, _end, _start),
                                                       toNormalizedFilePath',
                                                       uriToFilePath')
-import           Development.Shake.Classes
+import           Development.IDE.Graph.Classes
 import           GHC.Generics                        (Generic)
 import           GhcPlugins                          (GlobalRdrEnv,
                                                       HscEnv (hsc_dflags), SDoc,

--- a/ghcide/src/Development/IDE/Types/Action.hs
+++ b/ghcide/src/Development/IDE/Types/Action.hs
@@ -16,7 +16,7 @@ import qualified Data.HashSet                 as Set
 import           Data.Hashable                (Hashable (..))
 import           Data.Unique                  (Unique)
 import           Development.IDE.Types.Logger
-import           Development.Shake            (Action)
+import           Development.IDE.Graph            (Action)
 import           Numeric.Natural
 
 data DelayedAction a = DelayedAction

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -25,7 +25,7 @@ import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error     (catchSrcErrors)
 import           Development.IDE.GHC.Util      (lookupPackageConfig)
 import           Development.IDE.Types.Exports (ExportsMap, createExportsMap)
-import           Development.Shake.Classes
+import           Development.IDE.Graph.Classes
 import           GhcPlugins                    (HscEnv (hsc_dflags),
                                                 InstalledPackageInfo (exposedModules),
                                                 Module (..),
@@ -164,4 +164,3 @@ onceAsync act = do
             pure (OnceRunning x, unmask $ run x)
 
 data Once a = OncePending | OnceRunning (Async a)
-

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -23,7 +23,7 @@ import qualified Data.Text                         as T
 import           Data.Typeable
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Types.Diagnostics
-import           Development.Shake
+import           Development.IDE.Graph
 import           GHC                               hiding (parseModule,
                                                     typecheckModule)
 import           GhcPlugins                        as GHC hiding (fst3, (<>))

--- a/ghcide/src/Development/IDE/Types/Shake.hs
+++ b/ghcide/src/Development/IDE/Types/Shake.hs
@@ -26,9 +26,9 @@ import           Data.Vector                          (Vector)
 import           Development.IDE.Core.PositionMapping
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location
-import           Development.Shake                    (RuleResult,
+import           Development.IDE.Graph                    (RuleResult,
                                                        ShakeException (shakeExceptionInner))
-import           Development.Shake.Classes
+import           Development.IDE.Graph.Classes
 import           GHC.Generics
 import           Language.LSP.Types
 

--- a/ghcide/src/Generics/SYB/GHC.hs
+++ b/ghcide/src/Generics/SYB/GHC.hs
@@ -14,7 +14,7 @@ import Control.Monad
 import Data.Functor.Compose (Compose(Compose))
 import Data.Monoid (Any(Any))
 import Development.IDE.GHC.Compat
-import Development.Shake.Classes
+import Development.IDE.Graph.Classes
 import Generics.SYB
 
 
@@ -122,4 +122,3 @@ gmapMQ f = runMonadicQuery . gfoldl k pure
   where
     k :: Data d => MonadicQuery r f (d -> b) -> d -> MonadicQuery r f b
     k c x = c <*> MonadicQuery (f x)
-

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -73,7 +73,7 @@ library
     , optparse-applicative
     , optparse-simple
     , process
-    , shake
+    , hls-graph
     , safe-exceptions
     , sqlite-simple
     , unordered-containers
@@ -332,7 +332,7 @@ executable haskell-language-server
     , mtl
     , regex-tdfa
     , safe-exceptions
-    , shake
+    , hls-graph
     , sqlite-simple
     , temporary
     , transformers

--- a/hls-graph/LICENSE
+++ b/hls-graph/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
-name:          hls-plugin-api
+name:          hls-graph
 version:       1.1.0.0
-synopsis:      Haskell Language Server API for plugin communication
+synopsis:      Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
 
@@ -26,39 +26,15 @@ source-repository head
 
 library
   exposed-modules:
-    Ide.Logger
-    Ide.Plugin.Config
-    Ide.Plugin.ConfigUtils
-    Ide.Plugin.Properties
-    Ide.PluginUtils
-    Ide.Types
+    Development.IDE.Graph
+    Development.IDE.Graph.Classes
+    Development.IDE.Graph.Database
+    Development.IDE.Graph.Rule
 
   hs-source-dirs:     src
   build-depends:
-    , aeson
-    , base                  >=4.12    && <5
-    , containers
-    , data-default
-    , dependent-map
-    , dependent-sum
-    , Diff                  ^>=0.4.0
-    , dlist
-    , hashable
-    , hslogger
-    , lens
-    , lsp                   ^>=1.2
-    , opentelemetry
-    , process
-    , regex-tdfa            >=1.3.1.0
-    , hls-graph
-    , text
-    , unordered-containers
-
-  if os(windows)
-    build-depends: Win32
-
-  else
-    build-depends: unix
+    , base >=4.12 && <5
+    , shake >= 0.18.4
 
   ghc-options:
     -Wall -Wredundant-constraints -Wno-name-shadowing

--- a/hls-graph/src/Development/IDE/Graph.hs
+++ b/hls-graph/src/Development/IDE/Graph.hs
@@ -1,70 +1,22 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 module Development.IDE.Graph(
-    shake,
     shakeOptions,
-    Rules, action, withoutActions, alternatives, priority, versioned,
-    Action, traced,
-    liftIO, actionOnException, actionFinally, actionBracket, actionCatch, actionRetry, runAfter,
+    Rules,
+    Action, action,
+    actionFinally, actionBracket, actionCatch,
     ShakeException(..),
     -- * Configuration
-    ShakeOptions(..), Rebuild(..), Lint(..), Change(..),
-    getShakeOptions, getShakeOptionsRules, getHashedShakeVersion,
+    ShakeOptions(shakeThreads, shakeFiles, shakeExtra),
     getShakeExtra, getShakeExtraRules, addShakeExtra,
-    -- ** Command line
-    shakeArgs, shakeArgsWith, shakeArgsOptionsWith, shakeOptDescrs, addHelpSuffix,
-    -- ** Targets
-    getTargets, addTarget, withTargetDocs, withoutTargets,
-    -- ** Progress reporting
-    Progress(..), progressSimple, progressDisplay, progressTitlebar, progressProgram, getProgress,
-    -- ** Verbosity
-    Verbosity(..), getVerbosity, putVerbose, putInfo, putWarn, putError, withVerbosity, quietly,
-    -- * Running commands
-    command, command_, cmd, cmd_, unit,
-    Stdout(..), StdoutTrim(..), Stderr(..), Stdouterr(..), Exit(..), Process(..), CmdTime(..), CmdLine(..), FSATrace(..),
-    CmdResult, CmdString, CmdOption(..),
-    addPath, addEnv,
     -- * Explicit parallelism
-    parallel, forP, par,
-    -- * Utility functions
-    copyFile', copyFileChanged,
-    readFile', readFileLines,
-    writeFile', writeFileLines, writeFileChanged,
-    removeFiles, removeFilesAfter,
-    withTempFile, withTempDir,
-    withTempFileWithin, withTempDirWithin,
-    -- * File rules
-    need, want, (%>), (|%>), (?>), phony, (~>), phonys,
-    (&%>), (&?>),
-    orderOnly, orderOnlyAction,
-    FilePattern, (?==), (<//>), filePattern,
-    needed, trackRead, trackWrite, trackAllow,
-    -- * Directory rules
-    doesFileExist, doesDirectoryExist, getDirectoryContents, getDirectoryFiles, getDirectoryDirs,
-    getDirectoryFilesIO,
-    -- * Environment rules
-    getEnv, getEnvWithDefault, getEnvError,
+    parallel,
     -- * Oracle rules
-    ShakeValue, RuleResult, addOracle, addOracleCache, addOracleHash, askOracle, askOracles,
+    ShakeValue, RuleResult,
     -- * Special rules
     alwaysRerun,
-    -- * Resources
-    Resource, newResource, newResourceIO, withResource, withResources,
-    newThrottle, newThrottleIO,
-    unsafeExtraThread,
-    -- * Cache
-    newCache, newCacheIO,
-    historyDisable, produces,
     -- * Batching
-    needHasChanged,
-    resultHasChanged,
-    batch,
     reschedule,
-    -- * Deprecated
-    askOracleWith,
-    deprioritize,
-    pattern Quiet, pattern Normal, pattern Loud, pattern Chatty,
-    putLoud, putNormal, putQuiet
     ) where
 
 import Development.Shake

--- a/hls-graph/src/Development/IDE/Graph.hs
+++ b/hls-graph/src/Development/IDE/Graph.hs
@@ -1,4 +1,70 @@
+{-# LANGUAGE PatternSynonyms #-}
 
-module Development.IDE.Graph(module X) where
+module Development.IDE.Graph(
+    shake,
+    shakeOptions,
+    Rules, action, withoutActions, alternatives, priority, versioned,
+    Action, traced,
+    liftIO, actionOnException, actionFinally, actionBracket, actionCatch, actionRetry, runAfter,
+    ShakeException(..),
+    -- * Configuration
+    ShakeOptions(..), Rebuild(..), Lint(..), Change(..),
+    getShakeOptions, getShakeOptionsRules, getHashedShakeVersion,
+    getShakeExtra, getShakeExtraRules, addShakeExtra,
+    -- ** Command line
+    shakeArgs, shakeArgsWith, shakeArgsOptionsWith, shakeOptDescrs, addHelpSuffix,
+    -- ** Targets
+    getTargets, addTarget, withTargetDocs, withoutTargets,
+    -- ** Progress reporting
+    Progress(..), progressSimple, progressDisplay, progressTitlebar, progressProgram, getProgress,
+    -- ** Verbosity
+    Verbosity(..), getVerbosity, putVerbose, putInfo, putWarn, putError, withVerbosity, quietly,
+    -- * Running commands
+    command, command_, cmd, cmd_, unit,
+    Stdout(..), StdoutTrim(..), Stderr(..), Stdouterr(..), Exit(..), Process(..), CmdTime(..), CmdLine(..), FSATrace(..),
+    CmdResult, CmdString, CmdOption(..),
+    addPath, addEnv,
+    -- * Explicit parallelism
+    parallel, forP, par,
+    -- * Utility functions
+    copyFile', copyFileChanged,
+    readFile', readFileLines,
+    writeFile', writeFileLines, writeFileChanged,
+    removeFiles, removeFilesAfter,
+    withTempFile, withTempDir,
+    withTempFileWithin, withTempDirWithin,
+    -- * File rules
+    need, want, (%>), (|%>), (?>), phony, (~>), phonys,
+    (&%>), (&?>),
+    orderOnly, orderOnlyAction,
+    FilePattern, (?==), (<//>), filePattern,
+    needed, trackRead, trackWrite, trackAllow,
+    -- * Directory rules
+    doesFileExist, doesDirectoryExist, getDirectoryContents, getDirectoryFiles, getDirectoryDirs,
+    getDirectoryFilesIO,
+    -- * Environment rules
+    getEnv, getEnvWithDefault, getEnvError,
+    -- * Oracle rules
+    ShakeValue, RuleResult, addOracle, addOracleCache, addOracleHash, askOracle, askOracles,
+    -- * Special rules
+    alwaysRerun,
+    -- * Resources
+    Resource, newResource, newResourceIO, withResource, withResources,
+    newThrottle, newThrottleIO,
+    unsafeExtraThread,
+    -- * Cache
+    newCache, newCacheIO,
+    historyDisable, produces,
+    -- * Batching
+    needHasChanged,
+    resultHasChanged,
+    batch,
+    reschedule,
+    -- * Deprecated
+    askOracleWith,
+    deprioritize,
+    pattern Quiet, pattern Normal, pattern Loud, pattern Chatty,
+    putLoud, putNormal, putQuiet
+    ) where
 
-import Development.Shake as X
+import Development.Shake

--- a/hls-graph/src/Development/IDE/Graph.hs
+++ b/hls-graph/src/Development/IDE/Graph.hs
@@ -1,0 +1,4 @@
+
+module Development.IDE.Graph(module X) where
+
+import Development.Shake as X

--- a/hls-graph/src/Development/IDE/Graph/Classes.hs
+++ b/hls-graph/src/Development/IDE/Graph/Classes.hs
@@ -1,4 +1,6 @@
 
-module Development.IDE.Graph.Classes(module X) where
+module Development.IDE.Graph.Classes(
+    Show(..), Typeable, Eq(..), Hashable(..), Binary(..), NFData(..)
+    ) where
 
-import Development.Shake.Classes as X
+import Development.Shake.Classes

--- a/hls-graph/src/Development/IDE/Graph/Classes.hs
+++ b/hls-graph/src/Development/IDE/Graph/Classes.hs
@@ -1,0 +1,4 @@
+
+module Development.IDE.Graph.Classes(module X) where
+
+import Development.Shake.Classes as X

--- a/hls-graph/src/Development/IDE/Graph/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Database.hs
@@ -2,13 +2,8 @@
 module Development.IDE.Graph.Database(
     ShakeDatabase,
     shakeOpenDatabase,
-    shakeWithDatabase,
-    shakeOneShotDatabase,
     shakeRunDatabase,
-    shakeLiveFilesDatabase,
     shakeProfileDatabase,
-    shakeErrorsDatabase,
-    shakeRunAfter
     ) where
 
 import Development.Shake.Database

--- a/hls-graph/src/Development/IDE/Graph/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Database.hs
@@ -1,0 +1,4 @@
+
+module Development.IDE.Graph.Database(module X) where
+
+import Development.Shake.Database as X

--- a/hls-graph/src/Development/IDE/Graph/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Database.hs
@@ -1,4 +1,14 @@
 
-module Development.IDE.Graph.Database(module X) where
+module Development.IDE.Graph.Database(
+    ShakeDatabase,
+    shakeOpenDatabase,
+    shakeWithDatabase,
+    shakeOneShotDatabase,
+    shakeRunDatabase,
+    shakeLiveFilesDatabase,
+    shakeProfileDatabase,
+    shakeErrorsDatabase,
+    shakeRunAfter
+    ) where
 
-import Development.Shake.Database as X
+import Development.Shake.Database

--- a/hls-graph/src/Development/IDE/Graph/Rule.hs
+++ b/hls-graph/src/Development/IDE/Graph/Rule.hs
@@ -7,18 +7,6 @@ module Development.IDE.Graph.Rule(
     -- * Calling builtin rules
     -- | Wrappers around calling Shake rules. In general these should be specialised to a builtin rule.
     apply, apply1,
-    -- * User rules
-    -- | Define user rules that can be used by builtin rules.
-    --   Absent any builtin rule making use of a user rule at a given type, a user rule will have on effect -
-    --   they have no inherent effect or interpretation on their own.
-    addUserRule, getUserRuleList, getUserRuleMaybe, getUserRuleOne,
-    -- * Lint integration
-    -- | Provide lint warnings when running code.
-    lintTrackRead, lintTrackWrite, lintTrackAllow,
-    -- * History caching
-    -- | Interact with the non-local cache. When using the cache it is important that all
-    --   rules have accurate 'BuiltinIdentity' functions.
-    historyIsEnabled, historySave, historyLoad
     ) where
 
 import Development.Shake.Rule

--- a/hls-graph/src/Development/IDE/Graph/Rule.hs
+++ b/hls-graph/src/Development/IDE/Graph/Rule.hs
@@ -1,0 +1,4 @@
+
+module Development.IDE.Graph.Rule(module X) where
+
+import Development.Shake.Rule as X

--- a/hls-graph/src/Development/IDE/Graph/Rule.hs
+++ b/hls-graph/src/Development/IDE/Graph/Rule.hs
@@ -1,4 +1,24 @@
 
-module Development.IDE.Graph.Rule(module X) where
+module Development.IDE.Graph.Rule(
+    -- * Defining builtin rules
+    -- | Functions and types for defining new types of Shake rules.
+    addBuiltinRule,
+    BuiltinLint, noLint, BuiltinIdentity, noIdentity, BuiltinRun, RunMode(..), RunChanged(..), RunResult(..),
+    -- * Calling builtin rules
+    -- | Wrappers around calling Shake rules. In general these should be specialised to a builtin rule.
+    apply, apply1,
+    -- * User rules
+    -- | Define user rules that can be used by builtin rules.
+    --   Absent any builtin rule making use of a user rule at a given type, a user rule will have on effect -
+    --   they have no inherent effect or interpretation on their own.
+    addUserRule, getUserRuleList, getUserRuleMaybe, getUserRuleOne,
+    -- * Lint integration
+    -- | Provide lint warnings when running code.
+    lintTrackRead, lintTrackWrite, lintTrackAllow,
+    -- * History caching
+    -- | Interact with the non-local cache. When using the cache it is important that all
+    --   rules have accurate 'BuiltinIdentity' functions.
+    historyIsEnabled, historySave, historyLoad
+    ) where
 
-import Development.Shake.Rule as X
+import Development.Shake.Rule

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -38,7 +38,7 @@ import           Data.Semigroup
 import           Data.String
 import qualified Data.Text                       as T
 import           Data.Text.Encoding              (encodeUtf8)
-import           Development.Shake               hiding (command)
+import           Development.IDE.Graph           hiding (command)
 import           GHC.Generics
 import           Ide.Plugin.Config
 import           Ide.Plugin.Properties

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -38,7 +38,7 @@ import           Data.Semigroup
 import           Data.String
 import qualified Data.Text                       as T
 import           Data.Text.Encoding              (encodeUtf8)
-import           Development.IDE.Graph           hiding (command)
+import           Development.IDE.Graph
 import           GHC.Generics
 import           Ide.Plugin.Config
 import           Ide.Plugin.Properties

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -51,7 +51,7 @@ library
     , lsp                     ^>=1.2
     , lsp-test                ==0.14.0.0
     , lsp-types               ^>=1.2
-    , shake
+    , hls-graph
     , tasty
     , tasty-expected-failure
     , tasty-golden

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -33,7 +33,7 @@ import           Development.IDE.Main
 import qualified Development.IDE.Main              as Ghcide
 import qualified Development.IDE.Plugin.HLS.GhcIde as Ghcide
 import           Development.IDE.Types.Options
-import           Development.Shake                 (ShakeOptions (shakeThreads))
+import           Development.IDE.Graph                 (ShakeOptions (shakeThreads))
 import           GHC.IO.Handle
 import           Ide.Plugin.Config                 (Config, formattingProvider)
 import           Ide.PluginUtils                   (pluginDescToIdePlugins)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,6 +25,7 @@ let
         ourSources = {
             haskell-language-server = gitignoreSource ../.;
             ghcide = gitignoreSource ../ghcide;
+            hls-graph = gitignoreSource ../hls-graph;
             shake-bench = gitignoreSource ../shake-bench;
             hie-compat = gitignoreSource ../hie-compat;
             hls-plugin-api = gitignoreSource ../hls-plugin-api;

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -25,7 +25,7 @@ library
     , hls-plugin-api        ^>=1.1.0.0
     , lsp
     , lsp-types
-    , shake
+    , hls-graph
     , text
     , unordered-containers
 

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -26,7 +26,7 @@ import qualified Data.Text                            as T
 import           Development.IDE
 import           Development.IDE.Core.PositionMapping
 import           Development.IDE.GHC.Compat
-import           Development.Shake.Classes
+import           Development.IDE.Graph.Classes
 import           GHC.Generics                         (Generic)
 import           Ide.PluginUtils                      (mkLspCommand)
 import           Ide.Types

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -80,7 +80,7 @@ library
     , mtl
     , refinery              ^>=0.3
     , retrie                >=0.1.1.0
-    , shake
+    , hls-graph
     , syb
     , text
     , transformers

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
@@ -38,8 +38,8 @@ import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error (realSrcSpanToRange)
 import           Development.IDE.GHC.ExactPrint
 import           Development.IDE.Spans.LocalBindings (Bindings, getDefiningBindings)
-import           Development.Shake (Action, RuleResult, Rules, action)
-import           Development.Shake.Classes (Typeable, Binary, Hashable, NFData)
+import           Development.IDE.Graph (Action, RuleResult, Rules, action)
+import           Development.IDE.Graph.Classes (Typeable, Binary, Hashable, NFData)
 import qualified FastString
 import           GHC.Generics (Generic)
 import           GhcPlugins (tupleDataCon, consDataCon, substTyAddInScope, ExternalPackageState, HscEnv (hsc_EPS), liftIO)
@@ -541,4 +541,3 @@ mkWorkspaceEdits
 mkWorkspaceEdits dflags ccs uri pm g = do
   let response = transform dflags ccs uri g pm
    in first (InfrastructureError . T.pack) response
-

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -19,7 +19,7 @@ import           Development.IDE.Main          (isLSP)
 import qualified Development.IDE.Main          as Main
 import           Development.IDE.Types.Logger  as G
 import qualified Development.IDE.Types.Options as Ghcide
-import           Development.Shake             (ShakeOptions (shakeThreads))
+import           Development.IDE.Graph             (ShakeOptions (shakeThreads))
 import           Ide.Arguments
 import           Ide.Logger
 import           Ide.Plugin.ConfigUtils        (pluginsToDefaultConfig,

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -3,6 +3,7 @@ resolver: nightly-2020-12-09
 packages:
   - .
   - ./hie-compat
+  - ./hls-graph
   - ./ghcide/
   - ./hls-plugin-api
   - ./hls-test-utils

--- a/stack-8.10.3.yaml
+++ b/stack-8.10.3.yaml
@@ -3,6 +3,7 @@ resolver: lts-17.2 # Last ghc-8.10.3 lts
 packages:
   - .
   - ./hie-compat
+  - ./hls-graph
   - ./ghcide/
   - ./hls-plugin-api
   - ./hls-test-utils

--- a/stack-8.10.4.yaml
+++ b/stack-8.10.4.yaml
@@ -3,6 +3,7 @@ resolver: lts-17.4
 packages:
   - .
   - ./hie-compat
+  - ./hls-graph
   - ./ghcide/
   - ./hls-plugin-api
   - ./hls-test-utils

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -4,6 +4,7 @@ compiler: ghc-8.6.4
 packages:
   - .
   - ./hie-compat
+  - ./hls-graph
   - ./ghcide/
 # - ./shake-bench
   - ./hls-plugin-api

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -3,6 +3,7 @@ resolver: lts-14.27 # Last 8.6.5
 packages:
   - .
   - ./hie-compat
+  - ./hls-graph
   - ./ghcide/
   - ./hls-plugin-api
   - ./hls-test-utils

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -3,6 +3,7 @@ resolver: lts-15.3 # Last 8.8.2
 packages:
   - .
   - ./hie-compat
+  - ./hls-graph
   - ./ghcide/
   - ./hls-plugin-api
   - ./hls-test-utils

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -3,6 +3,7 @@ resolver: lts-16.11 # Last 8.8.3
 packages:
   - .
   - ./hie-compat
+  - ./hls-graph
   - ./ghcide/
   - ./shake-bench
   - ./hls-plugin-api

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -3,6 +3,7 @@ resolver: lts-16.31 # last 8.8.4 lts
 packages:
   - .
   - ./hie-compat
+  - ./hls-graph
   - ./ghcide/
   - ./shake-bench
   - ./hls-plugin-api

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,8 @@ resolver: lts-14.27 # Last 8.6.5
 packages:
   - .
   - ./hie-compat
-  - ./ghcide/
+  - ./hls-graph
+  - ./ghcide
   - ./hls-plugin-api
   - ./hls-test-utils
   # - ./shake-bench


### PR DESCRIPTION
This patch creates a project hls-graph which reexposes the stuff from `shake` which we use. That gives us more flexibility to be explicit about what we are using from Shake, and consider moving to alternatives. Note that we use Shake in two different contexts in HLS, both as a graph underpinning HLS, and as a file-based build system. These two pieces use quite distinct subsets of Shake, so I've converted those that us Shake as an in-memory graph, but not using it as a file-based build system.

The context behind this patch is that I'm not convinced Shake is a suitable substrate as we continue to scale. Having reviewed @pepeiborra's patches adding reverse dependencies, it feels increasingly like Shake is trying to serve two masters. Concerns about garbage collection and space leaks with rdeps are problems for both Shake the build system and hls-graph the graph underpinning HLS - but in almost completely opposite ways. (That doesn't mean I don't think we should merge the rdeps into Shake, more that I'm exploring the landscape first.)

This patch doesn't require us to decide whether we use Shake or not. But makes it easier if we decide not to. Locally I have further patches that reimplement this API without Shake, but using the same approach as Shake. I'm just debugging them, and then I'll performance test, and then I imagine we'll want to have a big discussion about them. I don't think splitting the API prejudges that we'll abandon Shake though.