### PR TITLE
Synchronous progress reporting in tests

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -150,6 +150,7 @@ library
         Development.IDE.Core.OfInterest
         Development.IDE.Core.PositionMapping
         Development.IDE.Core.Preprocessor
+        Development.IDE.Core.ProgressReporting
         Development.IDE.Core.Rules
         Development.IDE.Core.RuleTypes
         Development.IDE.Core.Service

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -32,6 +32,7 @@ import           Control.Monad.Trans.Maybe
 import qualified Data.ByteString.Lazy                         as LBS
 import           Data.List.Extra                              (nubOrd)
 import           Data.Maybe                                   (catMaybes)
+import           Development.IDE.Core.ProgressReporting
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
 import           Development.IDE.Import.DependencyInformation
@@ -95,8 +96,8 @@ modifyFilesOfInterest state f = do
 kick :: Action ()
 kick = do
     files <- HashMap.keys <$> getFilesOfInterest
-    ShakeExtras{progressUpdate} <- getShakeExtras
-    liftIO $ progressUpdate KickStarted
+    ShakeExtras{progress} <- getShakeExtras
+    liftIO $ progressUpdate progress KickStarted
 
     -- Update the exports map for FOIs
     results <- uses GenerateCore files <* uses GetHieAst files
@@ -116,4 +117,4 @@ kick = do
         !exportsMap'' = maybe mempty createExportsMap ifaces
     void $ liftIO $ modifyVar' exportsMap $ (exportsMap'' <>) . (exportsMap' <>)
 
-    liftIO $ progressUpdate KickCompleted
+    liftIO $ progressUpdate progress KickCompleted

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE RankNTypes #-}
+module Development.IDE.Core.ProgressReporting
+  ( ProgressEvent(..)
+  , ProgressReporting(..)
+  , noProgressReporting
+  , delayedProgressReporting
+  -- utilities, reexported for use in Core.Shake
+  , mRunLspT
+  , mRunLspTCallback
+  )
+   where
+
+import           Control.Concurrent.Async
+import           Control.Concurrent.STM
+import           Control.Concurrent.Strict
+import           Control.Monad.Extra
+import           Control.Monad.IO.Class
+import qualified Control.Monad.STM              as STM
+import           Control.Monad.Trans.Class      (lift)
+import qualified Data.HashMap.Strict            as HMap
+import qualified Data.Text                      as T
+import           Data.Unique
+import           Development.IDE.GHC.Orphans    ()
+import           Development.IDE.Graph          hiding (ShakeValue)
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Options
+import qualified Language.LSP.Server            as LSP
+import           Language.LSP.Types
+import qualified Language.LSP.Types             as LSP
+import           System.Time.Extra
+import           UnliftIO.Exception             (bracket_)
+
+data ProgressEvent
+    = KickStarted
+    | KickCompleted
+
+data ProgressReporting  = ProgressReporting
+  { progressUpdate :: ProgressEvent -> IO ()
+  , inProgress     :: forall a. NormalizedFilePath -> Action a -> Action a
+  , progressStop   :: IO ()
+  }
+
+noProgressReporting :: IO ProgressReporting
+noProgressReporting = return $ ProgressReporting
+  { progressUpdate = const $ pure ()
+  , inProgress = const id
+  , progressStop   = pure ()
+  }
+
+delayedProgressReporting
+  :: Maybe (LSP.LanguageContextEnv c)
+  -> ProgressReportingStyle
+  -> IO ProgressReporting
+delayedProgressReporting lspEnv optProgressStyle = do
+    inProgressVar <- newVar (HMap.empty @NormalizedFilePath @Int)
+    mostRecentProgressEvent <- newTVarIO KickCompleted
+    progressAsync <- async $
+            progressThread optProgressStyle mostRecentProgressEvent inProgressVar
+    let progressUpdate = atomically . writeTVar mostRecentProgressEvent
+        progressStop   = cancel progressAsync
+        inProgress :: NormalizedFilePath -> Action a -> Action a
+        inProgress = withProgressVar inProgressVar
+    return ProgressReporting{..}
+    where
+        -- The progress thread is a state machine with two states:
+        --   1. Idle
+        --   2. Reporting a kick event
+        -- And two transitions, modelled by 'ProgressEvent':
+        --   1. KickCompleted - transitions from Reporting into Idle
+        --   2. KickStarted - transitions from Idle into Reporting
+        progressThread style mostRecentProgressEvent inProgress = progressLoopIdle
+          where
+            progressLoopIdle = do
+                atomically $ do
+                    v <- readTVar mostRecentProgressEvent
+                    case v of
+                        KickCompleted -> STM.retry
+                        KickStarted   -> return ()
+                asyncReporter <- async $ mRunLspT lspEnv lspShakeProgress
+                progressLoopReporting asyncReporter
+            progressLoopReporting asyncReporter = do
+                atomically $ do
+                    v <- readTVar mostRecentProgressEvent
+                    case v of
+                        KickStarted   -> STM.retry
+                        KickCompleted -> return ()
+                cancel asyncReporter
+                progressLoopIdle
+
+            lspShakeProgress :: LSP.LspM config ()
+            lspShakeProgress = do
+                -- first sleep a bit, so we only show progress messages if it's going to take
+                -- a "noticable amount of time" (we often expect a thread kill to arrive before the sleep finishes)
+                liftIO $ sleep 0.1
+                u <- ProgressTextToken . T.pack . show . hashUnique <$> liftIO newUnique
+
+                void $ LSP.sendRequest LSP.SWindowWorkDoneProgressCreate
+                    LSP.WorkDoneProgressCreateParams { _token = u } $ const (pure ())
+
+                bracket_
+                  (start u)
+                  (stop u)
+                  (loop u 0)
+                where
+                    start id = LSP.sendNotification LSP.SProgress $
+                        LSP.ProgressParams
+                            { _token = id
+                            , _value = LSP.Begin $ WorkDoneProgressBeginParams
+                              { _title = "Processing"
+                              , _cancellable = Nothing
+                              , _message = Nothing
+                              , _percentage = Nothing
+                              }
+                            }
+                    stop id = LSP.sendNotification LSP.SProgress
+                        LSP.ProgressParams
+                            { _token = id
+                            , _value = LSP.End WorkDoneProgressEndParams
+                              { _message = Nothing
+                              }
+                            }
+                    sample = 0.1
+                    loop id prev = do
+                        liftIO $ sleep sample
+                        current <- liftIO $ readVar inProgress
+                        let done = length $ filter (== 0) $ HMap.elems current
+                        let todo = HMap.size current
+                        let next = 100 * fromIntegral done / fromIntegral todo
+                        when (next /= prev) $
+                          LSP.sendNotification LSP.SProgress $
+                          LSP.ProgressParams
+                              { _token = id
+                              , _value = LSP.Report $ case style of
+                                  Explicit -> LSP.WorkDoneProgressReportParams
+                                    { _cancellable = Nothing
+                                    , _message = Just $ T.pack $ show done <> "/" <> show todo
+                                    , _percentage = Nothing
+                                    }
+                                  Percentage -> LSP.WorkDoneProgressReportParams
+                                    { _cancellable = Nothing
+                                    , _message = Nothing
+                                    , _percentage = Just next
+                                    }
+                                  NoProgress -> LSP.WorkDoneProgressReportParams
+                                    { _cancellable = Nothing
+                                    , _message = Nothing
+                                    , _percentage = Nothing
+                                    }
+                              }
+                        loop id next
+
+        withProgressVar var file = actionBracket (f succ) (const $ f pred) . const
+            -- This functions are deliberately eta-expanded to avoid space leaks.
+            -- Do not remove the eta-expansion without profiling a session with at
+            -- least 1000 modifications.
+            where f shift = void $ modifyVar' var $ HMap.insertWith (\_ x -> shift x) file (shift 0)
+
+mRunLspT :: Applicative m => Maybe (LSP.LanguageContextEnv c ) -> LSP.LspT c m () -> m ()
+mRunLspT (Just lspEnv) f = LSP.runLspT lspEnv f
+mRunLspT Nothing _       = pure ()
+
+mRunLspTCallback :: Monad m
+                 => Maybe (LSP.LanguageContextEnv c)
+                 -> (LSP.LspT c m a -> LSP.LspT c m a)
+                 -> m a
+                 -> m a
+mRunLspTCallback (Just lspEnv) f g = LSP.runLspT lspEnv $ f (lift g)
+mRunLspTCallback Nothing _ g       = g

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -135,6 +135,7 @@ stop id = LSP.sendNotification LSP.SProgress
 
 progress :: (LSP.MonadLsp config f) =>
   ProgressReportingStyle -> Seconds -> HashMap NormalizedFilePath Int -> ProgressToken -> f Seconds
+progress NoProgress _ _ _ = return 0
 progress style prev current id = do
     let done = length $ filter (== 0) $ HMap.elems current
     let todo = HMap.size current

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -21,14 +21,13 @@ import           Data.Foldable                  (for_)
 import           Data.HashMap.Strict            (HashMap)
 import qualified Data.HashMap.Strict            as HMap
 import           Data.IORef
+import           Data.IORef.Extra               (atomicModifyIORef'_)
 import qualified Data.Text                      as T
 import           Data.Unique
 import           Development.IDE.GHC.Orphans    ()
 import           Development.IDE.Graph          hiding (ShakeValue)
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
-import           GHC.IORef                      (atomicModifyIORef'_,
-                                                 atomicSwapIORef)
 import qualified Language.LSP.Server            as LSP
 import           Language.LSP.Types
 import qualified Language.LSP.Types             as LSP
@@ -68,7 +67,7 @@ directProgressReporting sample env style = do
           writeIORef st (Just u)
           mRunLspT env $ start u
         progressUpdate KickCompleted = do
-            mbToken <- atomicSwapIORef st Nothing
+            mbToken <- atomicModifyIORef st (Nothing,)
             for_ mbToken $ \u ->
                 mRunLspT env $ stop u
 

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -17,7 +17,7 @@ import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import qualified Control.Monad.STM              as STM
 import           Control.Monad.Trans.Class      (lift)
-import           Data.Foldable                  (for_)
+import           Data.Foldable                  (for_, traverse_)
 import           Data.HashMap.Strict            (HashMap)
 import qualified Data.HashMap.Strict            as HMap
 import           Data.IORef
@@ -65,6 +65,7 @@ directProgressReporting sample env style = do
     inProgressVar <- newIORef (HMap.empty @NormalizedFilePath @Int)
 
     let progressUpdate KickStarted = do
+          readIORef st >>= traverse_ (mRunLspT env . stop)
           u <- newProgressToken
           mRunLspT env $ do
               ready <- create u

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -4,11 +4,11 @@ module Development.IDE.Core.ProgressReporting
   , ProgressReporting(..)
   , noProgressReporting
   , delayedProgressReporting
+  , directProgressReporting
   -- utilities, reexported for use in Core.Shake
   , mRunLspT
   , mRunLspTCallback
-  )
-   where
+  ) where
 
 import           Control.Concurrent.Async
 import           Control.Concurrent.STM
@@ -17,13 +17,18 @@ import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import qualified Control.Monad.STM              as STM
 import           Control.Monad.Trans.Class      (lift)
+import           Data.Foldable                  (for_)
+import           Data.HashMap.Strict            (HashMap)
 import qualified Data.HashMap.Strict            as HMap
+import           Data.IORef
 import qualified Data.Text                      as T
 import           Data.Unique
 import           Development.IDE.GHC.Orphans    ()
 import           Development.IDE.Graph          hiding (ShakeValue)
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
+import           GHC.IORef                      (atomicModifyIORef'_,
+                                                 atomicSwapIORef)
 import qualified Language.LSP.Server            as LSP
 import           Language.LSP.Types
 import qualified Language.LSP.Types             as LSP
@@ -47,113 +52,169 @@ noProgressReporting = return $ ProgressReporting
   , progressStop   = pure ()
   }
 
+-- | A 'ProgressReporting' that sends the WorkDone Begin and End notifications
+--   synchronously. Progress notifications are sent from a sampling thread.
+directProgressReporting
+    :: Double -- ^ sampling rate
+    -> Maybe (LSP.LanguageContextEnv config)
+    -> ProgressReportingStyle
+    -> IO ProgressReporting
+directProgressReporting sample env style = do
+    st <- newIORef Nothing
+    inProgressVar <- newIORef (HMap.empty @NormalizedFilePath @Int)
+
+    let progressUpdate KickStarted = do
+          u <- newProgressToken
+          writeIORef st (Just u)
+          mRunLspT env $ start u
+        progressUpdate KickCompleted = do
+            mbToken <- atomicSwapIORef st Nothing
+            for_ mbToken $ \u ->
+                mRunLspT env $ stop u
+
+        inProgress file = actionBracket (f file succ) (const $ f file pred) . const
+        -- This function is deliberately eta-expanded to avoid space leaks.
+        -- Do not remove the eta-expansion without profiling a session with at
+        -- least 1000 modifications.
+        f file shift = atomicModifyIORef'_ inProgressVar $
+                HMap.insertWith (\_ x -> shift x) file (shift 0)
+
+        progressLoop :: Double -> LSP.LspM a ()
+        progressLoop prev = do
+            mbToken <- liftIO $ readIORef st
+            case mbToken of
+                Nothing ->
+                    liftIO (sleep sample) >> progressLoop 0
+                Just t -> do
+                    current <- liftIO $ readIORef inProgressVar
+                    prev <- progress style prev current t
+                    liftIO $ sleep sample
+                    progressLoop prev
+
+    progressThread <- async $ mRunLspT env $ progressLoop 0
+    let progressStop = cancel progressThread
+
+    pure ProgressReporting {..}
+
+-- | A 'ProgressReporting' that enqueues Begin and End notifications in a new
+--   thread, with a grace period (nothing will be sent if 'KickCompleted' arrives
+--   before the end of the grace period).
+--   Avoid using in tests where progress notifications are used to assert invariants.
 delayedProgressReporting
-  :: Maybe (LSP.LanguageContextEnv c)
+  :: Double  -- ^ sampling rate, also used as grace period before Begin
+  -> Maybe (LSP.LanguageContextEnv c)
   -> ProgressReportingStyle
   -> IO ProgressReporting
-delayedProgressReporting lspEnv optProgressStyle = do
+delayedProgressReporting sample lspEnv style = do
     inProgressVar <- newVar (HMap.empty @NormalizedFilePath @Int)
     mostRecentProgressEvent <- newTVarIO KickCompleted
     progressAsync <- async $
-            progressThread optProgressStyle mostRecentProgressEvent inProgressVar
+        progressThread mostRecentProgressEvent inProgressVar
     let progressUpdate = atomically . writeTVar mostRecentProgressEvent
         progressStop   = cancel progressAsync
         inProgress :: NormalizedFilePath -> Action a -> Action a
         inProgress = withProgressVar inProgressVar
     return ProgressReporting{..}
-    where
-        -- The progress thread is a state machine with two states:
-        --   1. Idle
-        --   2. Reporting a kick event
-        -- And two transitions, modelled by 'ProgressEvent':
-        --   1. KickCompleted - transitions from Reporting into Idle
-        --   2. KickStarted - transitions from Idle into Reporting
-        progressThread style mostRecentProgressEvent inProgress = progressLoopIdle
-          where
-            progressLoopIdle = do
-                atomically $ do
-                    v <- readTVar mostRecentProgressEvent
-                    case v of
-                        KickCompleted -> STM.retry
-                        KickStarted   -> return ()
-                asyncReporter <- async $ mRunLspT lspEnv lspShakeProgress
-                progressLoopReporting asyncReporter
-            progressLoopReporting asyncReporter = do
-                atomically $ do
-                    v <- readTVar mostRecentProgressEvent
-                    case v of
-                        KickStarted   -> STM.retry
-                        KickCompleted -> return ()
-                cancel asyncReporter
-                progressLoopIdle
-
-            lspShakeProgress :: LSP.LspM config ()
-            lspShakeProgress = do
+  where
+    -- The progress thread is a state machine with two states:
+    --   1. Idle
+    --   2. Reporting a kick event
+    -- And two transitions, modelled by 'ProgressEvent':
+    --   1. KickCompleted - transitions from Reporting into Idle
+    --   2. KickStarted - transitions from Idle into Reporting
+    progressThread mostRecentProgressEvent inProgress = progressLoopIdle
+      where
+        progressLoopIdle = do
+            atomically $ do
+                v <- readTVar mostRecentProgressEvent
+                case v of
+                    KickCompleted -> STM.retry
+                    KickStarted   -> return ()
+            asyncReporter <- async $ mRunLspT lspEnv $ do
                 -- first sleep a bit, so we only show progress messages if it's going to take
                 -- a "noticable amount of time" (we often expect a thread kill to arrive before the sleep finishes)
-                liftIO $ sleep 0.1
-                u <- ProgressTextToken . T.pack . show . hashUnique <$> liftIO newUnique
+                liftIO $ sleep sample
+                lspShakeProgress style inProgress
+            progressLoopReporting asyncReporter
+        progressLoopReporting asyncReporter = do
+            atomically $ do
+                v <- readTVar mostRecentProgressEvent
+                case v of
+                    KickStarted   -> STM.retry
+                    KickCompleted -> return ()
+            cancel asyncReporter
+            progressLoopIdle
 
-                void $ LSP.sendRequest LSP.SWindowWorkDoneProgressCreate
-                    LSP.WorkDoneProgressCreateParams { _token = u } $ const (pure ())
+    lspShakeProgress style inProgress = do
+        u <- liftIO newProgressToken
 
-                bracket_
-                  (start u)
-                  (stop u)
-                  (loop u 0)
-                where
-                    start id = LSP.sendNotification LSP.SProgress $
-                        LSP.ProgressParams
-                            { _token = id
-                            , _value = LSP.Begin $ WorkDoneProgressBeginParams
-                              { _title = "Processing"
-                              , _cancellable = Nothing
-                              , _message = Nothing
-                              , _percentage = Nothing
-                              }
-                            }
-                    stop id = LSP.sendNotification LSP.SProgress
-                        LSP.ProgressParams
-                            { _token = id
-                            , _value = LSP.End WorkDoneProgressEndParams
-                              { _message = Nothing
-                              }
-                            }
-                    sample = 0.1
-                    loop id prev = do
-                        liftIO $ sleep sample
-                        current <- liftIO $ readVar inProgress
-                        let done = length $ filter (== 0) $ HMap.elems current
-                        let todo = HMap.size current
-                        let next = 100 * fromIntegral done / fromIntegral todo
-                        when (next /= prev) $
-                          LSP.sendNotification LSP.SProgress $
-                          LSP.ProgressParams
-                              { _token = id
-                              , _value = LSP.Report $ case style of
-                                  Explicit -> LSP.WorkDoneProgressReportParams
-                                    { _cancellable = Nothing
-                                    , _message = Just $ T.pack $ show done <> "/" <> show todo
-                                    , _percentage = Nothing
-                                    }
-                                  Percentage -> LSP.WorkDoneProgressReportParams
-                                    { _cancellable = Nothing
-                                    , _message = Nothing
-                                    , _percentage = Just next
-                                    }
-                                  NoProgress -> LSP.WorkDoneProgressReportParams
-                                    { _cancellable = Nothing
-                                    , _message = Nothing
-                                    , _percentage = Nothing
-                                    }
-                              }
-                        loop id next
+        void $ LSP.sendRequest LSP.SWindowWorkDoneProgressCreate
+            LSP.WorkDoneProgressCreateParams { _token = u } $ const (pure ())
 
-        withProgressVar var file = actionBracket (f succ) (const $ f pred) . const
-            -- This functions are deliberately eta-expanded to avoid space leaks.
-            -- Do not remove the eta-expansion without profiling a session with at
-            -- least 1000 modifications.
-            where f shift = void $ modifyVar' var $ HMap.insertWith (\_ x -> shift x) file (shift 0)
+        bracket_ (start u) (stop u) (loop u 0)
+        where
+            loop id prev = do
+                liftIO $ sleep sample
+                current <- liftIO $ readVar inProgress
+                next <- progress style prev current id
+                loop id next
+
+    withProgressVar var file = actionBracket (f succ) (const $ f pred) . const
+        -- This functions are deliberately eta-expanded to avoid space leaks.
+        -- Do not remove the eta-expansion without profiling a session with at
+        -- least 1000 modifications.
+        where f shift = void $ modifyVar' var $ HMap.insertWith (\_ x -> shift x) file (shift 0)
+
+newProgressToken :: IO ProgressToken
+newProgressToken = ProgressTextToken . T.pack . show . hashUnique <$> liftIO newUnique
+
+
+start :: LSP.MonadLsp config f => ProgressToken -> f ()
+start id = LSP.sendNotification LSP.SProgress $
+    LSP.ProgressParams
+        { _token = id
+        , _value = LSP.Begin $ WorkDoneProgressBeginParams
+            { _title = "Processing"
+            , _cancellable = Nothing
+            , _message = Nothing
+            , _percentage = Nothing
+            }
+        }
+stop :: LSP.MonadLsp config f => ProgressToken -> f ()
+stop id = LSP.sendNotification LSP.SProgress
+    LSP.ProgressParams
+        { _token = id
+        , _value = LSP.End WorkDoneProgressEndParams
+            { _message = Nothing
+            }
+        }
+
+progress :: (LSP.MonadLsp config f) =>
+  ProgressReportingStyle -> Double -> HashMap NormalizedFilePath Int -> ProgressToken -> f Double
+progress style prev current id = do
+    let done = length $ filter (== 0) $ HMap.elems current
+    let todo = HMap.size current
+    let next = 100 * fromIntegral done / fromIntegral todo
+    when (next /= prev) $ LSP.sendNotification LSP.SProgress $ LSP.ProgressParams
+        { _token = id
+        , _value = LSP.Report $ case style of
+            Explicit -> LSP.WorkDoneProgressReportParams
+                { _cancellable = Nothing
+                , _message = Just $ T.pack $ show done <> "/" <> show todo
+                , _percentage = Nothing
+                }
+            Percentage -> LSP.WorkDoneProgressReportParams
+                { _cancellable = Nothing
+                , _message = Nothing
+                , _percentage = Just next
+                }
+            NoProgress -> LSP.WorkDoneProgressReportParams
+                { _cancellable = Nothing
+                , _message = Nothing
+                , _percentage = Nothing
+                }
+        }
+    return next
 
 mRunLspT :: Applicative m => Maybe (LSP.LanguageContextEnv c ) -> LSP.LspT c m () -> m ()
 mRunLspT (Just lspEnv) f = LSP.runLspT lspEnv f

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -486,12 +486,11 @@ shakeOpen lspEnv defaultConfig logger debouncer
         let hiedbWriter = HieDbWriter{..}
         exportsMap <- newVar mempty
 
-        progress <-
+        progress <- do
+            let delay = if testing then 0 else 0.1
+                sampling = 0.1
             if reportProgress
-                then (if testing
-                        then directProgressReporting
-                        else delayedProgressReporting
-                     ) 0.1 lspEnv optProgressStyle
+                then makeProgressReporting delay sampling lspEnv optProgressStyle
                 else noProgressReporting
         actionQueue <- newQueue
 

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -183,9 +183,7 @@ data ShakeExtras = ShakeExtras
     -- positions in a version of that document to positions in the latest version
     -- First mapping is delta from previous version and second one is an
     -- accumlation of all previous mappings.
-    ,inProgress :: forall a . NormalizedFilePath -> Action a -> Action a
-    -- ^ Report progress for a rule
-    ,progressUpdate :: ProgressEvent -> IO ()
+    ,progress :: ProgressReporting
     ,ideTesting :: IdeTesting
     -- ^ Whether to enable additional lsp messages used by the test suite for checking invariants
     ,restartShakeSession :: [DelayedAction ()] -> IO ()
@@ -378,12 +376,11 @@ newtype ShakeSession = ShakeSession
 -- | A Shake database plus persistent store. Can be thought of as storing
 --   mappings from @(FilePath, k)@ to @RuleResult k@.
 data IdeState = IdeState
-    {shakeDb               :: ShakeDatabase
-    ,shakeSession          :: MVar ShakeSession
-    ,shakeClose            :: IO ()
-    ,shakeExtras           :: ShakeExtras
-    ,shakeDatabaseProfile  :: ShakeDatabase -> IO (Maybe FilePath)
-    ,stopProgressReporting :: IO ()
+    {shakeDb              :: ShakeDatabase
+    ,shakeSession         :: MVar ShakeSession
+    ,shakeClose           :: IO ()
+    ,shakeExtras          :: ShakeExtras
+    ,shakeDatabaseProfile :: ShakeDatabase -> IO (Maybe FilePath)
     }
 
 
@@ -473,7 +470,7 @@ shakeOpen lspEnv defaultConfig logger debouncer
 
     us <- mkSplitUniqSupply 'r'
     ideNc <- newIORef (initNameCache us knownKeyNames)
-    (shakeExtras, stopProgressReporting) <- do
+    shakeExtras <- do
         globals <- newVar HMap.empty
         state <- newVar HMap.empty
         diagnostics <- newVar mempty
@@ -489,7 +486,7 @@ shakeOpen lspEnv defaultConfig logger debouncer
         let hiedbWriter = HieDbWriter{..}
         exportsMap <- newVar mempty
 
-        ProgressReporting{..} <-
+        progress <-
             if reportProgress
                 then (if testing
                         then directProgressReporting
@@ -499,9 +496,8 @@ shakeOpen lspEnv defaultConfig logger debouncer
         actionQueue <- newQueue
 
         let clientCapabilities = maybe def LSP.resClientCapabilities lspEnv
-            extras = ShakeExtras{..}
 
-        pure (extras, progressStop)
+        pure ShakeExtras{..}
     (shakeDbM, shakeClose) <-
         shakeOpenDatabase
             opts { shakeExtra = newShakeExtra shakeExtras }
@@ -534,7 +530,7 @@ shakeShut IdeState{..} = withMVar shakeSession $ \runner -> do
     -- request so we first abort that.
     void $ cancelShakeSession runner
     shakeClose
-    stopProgressReporting
+    progressStop $ progress shakeExtras
 
 
 -- | This is a variant of withMVar where the first argument is run unmasked and if it throws
@@ -849,9 +845,9 @@ defineEarlyCutoff'
     -> Action (Maybe BS.ByteString, IdeResult v)
     -> Action (RunResult (A (RuleResult k)))
 defineEarlyCutoff' doDiagnostics key file old mode action = do
-    extras@ShakeExtras{state, inProgress, logger} <- getShakeExtras
+    extras@ShakeExtras{state, progress, logger} <- getShakeExtras
     options <- getIdeOptions
-    (if optSkipProgress options key then id else inProgress file) $ do
+    (if optSkipProgress options key then id else inProgress progress file) $ do
         val <- case old of
             Just old | mode == RunDependenciesSame -> do
                 v <- liftIO $ getValues state key file

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -469,7 +469,7 @@ shakeOpen :: Maybe (LSP.LanguageContextEnv Config)
           -> Rules ()
           -> IO IdeState
 shakeOpen lspEnv defaultConfig logger debouncer
-  shakeProfileDir (IdeReportProgress inProgress) ideTesting@(IdeTesting testing) hiedb indexQueue vfs opts rules = mdo
+  shakeProfileDir (IdeReportProgress reportProgress) ideTesting@(IdeTesting testing) hiedb indexQueue vfs opts rules = mdo
 
     us <- mkSplitUniqSupply 'r'
     ideNc <- newIORef (initNameCache us knownKeyNames)
@@ -490,8 +490,11 @@ shakeOpen lspEnv defaultConfig logger debouncer
         exportsMap <- newVar mempty
 
         ProgressReporting{..} <-
-            if inProgress
-                then delayedProgressReporting lspEnv optProgressStyle
+            if reportProgress
+                then (if testing
+                        then directProgressReporting
+                        else delayedProgressReporting
+                     ) 0.1 lspEnv optProgressStyle
                 else noProgressReporting
         actionQueue <- newQueue
 

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -487,10 +487,10 @@ shakeOpen lspEnv defaultConfig logger debouncer
         exportsMap <- newVar mempty
 
         progress <- do
-            let delay = if testing then 0 else 0.1
-                sampling = 0.1
+            let before = if testing then 0 else 0.1
+                after = if testing then 0.1 else 0
             if reportProgress
-                then makeProgressReporting delay sampling lspEnv optProgressStyle
+                then makeProgressReporting before after lspEnv optProgressStyle
                 else noProgressReporting
         actionQueue <- newQueue
 

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -898,7 +898,6 @@ defineEarlyCutoff' doDiagnostics key file old mode action = do
                     (if eq then ChangedRecomputeSame else ChangedRecomputeDiff)
                     (encodeShakeValue bs) $
                     A res
-    where
 
 isSuccess :: RunResult (A v) -> Bool
 isSuccess (RunResult _ _ (A Failed{})) = False

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4997,18 +4997,16 @@ clientSettingsTest :: TestTree
 clientSettingsTest = testGroup "client settings handling"
     [ testSession "ghcide restarts shake session on config changes" $ do
             void $ skipManyTill anyMessage $ message SClientRegisterCapability
+            waitForProgressDone
             sendNotification SWorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON ("" :: String)))
-            nots <- skipManyTill anyMessage $ count 3 loggingNotification
-            isMessagePresent "Restarting build session" (map getLogMessage nots)
+            skipManyTill anyMessage restartingBuildSession
 
     ]
-  where getLogMessage :: FromServerMessage -> T.Text
-        getLogMessage (FromServerMess SWindowLogMessage (NotificationMessage _ _ (LogMessageParams _ msg))) = msg
-        getLogMessage _ = ""
-
-        isMessagePresent expectedMsg actualMsgs = liftIO $
-            assertBool ("\"" ++ expectedMsg ++ "\" is not present in: " ++ show actualMsgs)
-                       (any ((expectedMsg `isSubsequenceOf`) . show) actualMsgs)
+  where
+    restartingBuildSession :: Session ()
+    restartingBuildSession = do
+        FromServerMess SWindowLogMessage NotificationMessage{_params = LogMessageParams{..}} <- loggingNotification
+        guard $ "Restarting build session" `T.isInfixOf` _message
 
 referenceTests :: TestTree
 referenceTests = testGroup "references"

--- a/plugins/hls-splice-plugin/test/Main.hs
+++ b/plugins/hls-splice-plugin/test/Main.hs
@@ -99,7 +99,8 @@ goldenTestWithEdit input tc line col =
                         { _start = Position 0 0
                         , _end = Position (length lns + 1) 1
                         }
-            liftIO $ sleep 3
+            waitForProgressDone -- cradle
+            waitForProgressDone
             alt <- liftIO $ T.readFile (input <.> "error")
             void $ applyEdit doc $ TextEdit theRange alt
             changeDoc doc [TextDocumentContentChangeEvent (Just theRange) Nothing alt]
@@ -131,5 +132,5 @@ pointRange
 
 -- | Get the title of a code action.
 codeActionTitle :: (Command |? CodeAction) -> Maybe Text
-codeActionTitle InL{}                               = Nothing
+codeActionTitle InL{}                                 = Nothing
 codeActionTitle (InR(CodeAction title _ _ _ _ _ _ _)) = Just title


### PR DESCRIPTION
The WorkDoneBegin and WorkDoneEnd notifications are now sent synchronously for tests, to avoid timing issues reported in #1749 

 