### PR TITLE
Fix wrong extend import while type constuctor and data constructor have the same name

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -783,7 +783,8 @@ suggestExtendImport exportsMap (L _ HsModule {hsmodImports}) Diagnostic{_range=_
           | otherwise = []
         lookupExportMap binding mod
           | Just match <- Map.lookup binding (getExportsMap exportsMap)
-          -- Only for the situation that data constructor name is same as type constructor name
+          -- Only for the situation that data constructor name is same as type constructor name,
+          -- let ident with parent be in front of the one without.
           , sortedMatch <- sortBy (\ident1 ident2 -> parent ident2 `compare` parent ident1) (Set.toList match)
           , idents <- filter (\ident -> moduleNameText ident == mod) sortedMatch
           , (not . null) idents -- Ensure fallback while `idents` is empty

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1408,6 +1408,25 @@ extendImportTests = testGroup "extend import actions"
                     , "import A (pattern Some)"
                     , "k (Some x) = x"
                     ])
+        , testSession "type constructor name same as data constructor name" $ template
+            [("ModuleA.hs", T.unlines
+                    [ "module ModuleA where"
+                    , "newtype Foo = Foo Int"
+                    ])]
+            ("ModuleB.hs", T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA(Foo)"
+                    , "f :: Foo"
+                    , "f = Foo 1"
+                    ])
+            (Range (Position 3 4) (Position 3 6))
+            ["Add Foo(Foo) to the import list of ModuleA"]
+            (T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA(Foo (Foo))"
+                    , "f :: Foo"
+                    , "f = Foo 1"
+                    ])
         ]
       where
         codeActionTitle CodeAction{_title=x} = x


### PR DESCRIPTION
Fix #1768.

Normally, there only one ident info has the same name as the target module, but if the type constructor and the data constructor have the same name, it will deduce two, which causes the original matching pattern to fail and [fallback](https://github.com/haskell/haskell-language-server/blob/master/ghcide/src/Development/IDE/Plugin/CodeAction.hs#L790).

Without affecting the previous work, I re-ordered the match result by making the one with a parent in front of the one without if it has two items.