### PR TITLE
Replace the unsafe getmodtime with safe posix calls

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -108,8 +108,6 @@ library
     else
       build-depends:
         unix
-      c-sources:
-        cbits/getmodtime.c
 
     default-extensions:
         ApplicativeDo

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -55,15 +55,7 @@ import           System.IO.Error
 #ifdef mingw32_HOST_OS
 import qualified System.Directory                             as Dir
 #else
-import           Data.Time.Clock.System                       (SystemTime (MkSystemTime),
-                                                               systemToUTCTime)
-import           Foreign.C.String
-import           Foreign.C.Types
-import           Foreign.Marshal                              (alloca)
-import           Foreign.Ptr
-import           Foreign.Storable
-import qualified System.Posix.Error                           as Posix
-import           System.Posix.Files                           (getFileStatus, modificationTimeHiRes)
+import           System.Posix.Files                           ( getFileStatus, modificationTimeHiRes)
 #endif
 
 import qualified Development.IDE.Types.Logger                 as L

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -19,7 +19,8 @@ module Development.IDE.Core.FileStore(
     resetInterfaceStore,
     getModificationTimeImpl,
     addIdeGlobal,
-    getFileContentsImpl
+    getFileContentsImpl,
+    getModTime
     ) where
 
 import           Control.Concurrent.STM                       (atomically)
@@ -31,7 +32,6 @@ import           Control.Monad.IO.Class
 import qualified Data.ByteString                              as BS
 import           Data.Either.Extra
 import qualified Data.HashMap.Strict                          as HM
-import           Data.Int                                     (Int64)
 import qualified Data.Map.Strict                              as Map
 import           Data.Maybe
 import qualified Data.Rope.UTF16                              as Rope

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -197,7 +197,7 @@ resetFileStore ideState changes = mask $ \_ ->
 getModTime :: FilePath -> IO POSIXTime
 getModTime f =
 #ifdef mingw32_HOST_OS
-    Dir.getModificationTime f
+    utcTimeToPOSIXSeconds <$> Dir.getModificationTime f
 #else
     modificationTimeHiRes <$> getFileStatus f
 #endif

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -21,14 +21,15 @@ import           Data.Aeson.Types                             (Value)
 import           Data.Binary
 import           Data.Hashable
 import qualified Data.Map                                     as M
+import           Data.Time.Clock.POSIX
 import           Data.Typeable
 import           Development.IDE.GHC.Compat                   hiding
                                                               (HieFileResult)
 import           Development.IDE.GHC.Util
+import           Development.IDE.Graph
 import           Development.IDE.Import.DependencyInformation
 import           Development.IDE.Types.HscEnvEq               (HscEnvEq)
 import           Development.IDE.Types.KnownTargets
-import           Development.IDE.Graph
 import           GHC.Generics                                 (Generic)
 
 import           HscTypes                                     (HomeModInfo,
@@ -39,7 +40,6 @@ import           HscTypes                                     (HomeModInfo,
 import qualified Data.Binary                                  as B
 import           Data.ByteString                              (ByteString)
 import qualified Data.ByteString.Lazy                         as LBS
-import           Data.Int                                     (Int64)
 import           Data.Text                                    (Text)
 import           Data.Time
 import           Development.IDE.Import.FindImports           (ArtifactsLocation)
@@ -295,9 +295,7 @@ type instance RuleResult GetModificationTime = FileVersion
 
 data FileVersion
     = VFSVersion !Int
-    | ModificationTime
-      !Int64   -- ^ Large unit (platform dependent, do not make assumptions)
-      !Int64   -- ^ Small unit (platform dependent, do not make assumptions)
+    | ModificationTime !POSIXTime
     deriving (Show, Generic)
 
 instance NFData FileVersion


### PR DESCRIPTION
We don't need the 2X faster but unsafe getmodtime anymore since GetModificationTime is no longer called O(N) times but only O(FOI) times, where N is the number of known targets and FOI is the number of files of interest.

The main problem with the internal implementation of `getModTime` is that it's not cross platform. The `unix` package implements support for more platforms: https://github.com/haskell/unix/blob/master/System/Posix/Files/Common.hsc#L344-L365

This change switches to the safer `unix` implementation, which provides nanosecond resolution in systems that support it.