### PR TITLE
Pin nix-pre-commit-hooks

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,6 @@
 { sources ? import ./sources.nix }:
 let
-  nix-pre-commit-hooks = (import (builtins.fetchTarball "https://github.com/cachix/pre-commit-hooks.nix/tarball/master/" + "/nix/") { sources = sources; }).packages;
+  nix-pre-commit-hooks = (import (builtins.fetchTarball "https://github.com/cachix/pre-commit-hooks.nix/tarball/87fb108527c7865ebee2ffe9af6154cb761ec9e0/" + "/nix/") { sources = sources; }).packages;
   overlay = _self: pkgs:
     let
         sharedOverrides = {


### PR DESCRIPTION
This PR supersede #1779.

Fixes this GitHub nix action issue:
```
error: attribute 'run' missing, at /Users/runner/work/haskell-language-server/haskell-language-server/nix/default.nix:83:24
(use '--show-trace' to show detailed location information)
Error: Process completed with exit code 1.
```