### PR TITLE
Progress reporting improvements

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -150,6 +150,7 @@ library
         Development.IDE.Core.OfInterest
         Development.IDE.Core.PositionMapping
         Development.IDE.Core.Preprocessor
+        Development.IDE.Core.ProgressReporting
         Development.IDE.Core.Rules
         Development.IDE.Core.RuleTypes
         Development.IDE.Core.Service

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -32,6 +32,7 @@ import           Control.Monad.Trans.Maybe
 import qualified Data.ByteString.Lazy                         as LBS
 import           Data.List.Extra                              (nubOrd)
 import           Data.Maybe                                   (catMaybes)
+import           Development.IDE.Core.ProgressReporting
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
 import           Development.IDE.Import.DependencyInformation
@@ -95,8 +96,8 @@ modifyFilesOfInterest state f = do
 kick :: Action ()
 kick = do
     files <- HashMap.keys <$> getFilesOfInterest
-    ShakeExtras{progressUpdate} <- getShakeExtras
-    liftIO $ progressUpdate KickStarted
+    ShakeExtras{progress} <- getShakeExtras
+    liftIO $ progressUpdate progress KickStarted
 
     -- Update the exports map for FOIs
     results <- uses GenerateCore files <* uses GetHieAst files
@@ -116,4 +117,4 @@ kick = do
         !exportsMap'' = maybe mempty createExportsMap ifaces
     void $ liftIO $ modifyVar' exportsMap $ (exportsMap'' <>) . (exportsMap' <>)
 
-    liftIO $ progressUpdate KickCompleted
+    liftIO $ progressUpdate progress KickCompleted

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE RankNTypes #-}
+module Development.IDE.Core.ProgressReporting
+  ( ProgressEvent(..)
+  , ProgressReporting(..)
+  , noProgressReporting
+  , delayedProgressReporting
+  -- utilities, reexported for use in Core.Shake
+  , mRunLspT
+  , mRunLspTCallback
+  )
+   where
+
+import           Control.Concurrent.Async
+import           Control.Concurrent.STM
+import           Control.Concurrent.Strict
+import           Control.Monad.Extra
+import           Control.Monad.IO.Class
+import qualified Control.Monad.STM              as STM
+import           Control.Monad.Trans.Class      (lift)
+import qualified Data.HashMap.Strict            as HMap
+import qualified Data.Text                      as T
+import           Data.Unique
+import           Development.IDE.GHC.Orphans    ()
+import           Development.IDE.Graph          hiding (ShakeValue)
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Options
+import qualified Language.LSP.Server            as LSP
+import           Language.LSP.Types
+import qualified Language.LSP.Types             as LSP
+import           System.Time.Extra
+import           UnliftIO.Exception             (bracket_)
+
+data ProgressEvent
+    = KickStarted
+    | KickCompleted
+
+data ProgressReporting  = ProgressReporting
+  { progressUpdate :: ProgressEvent -> IO ()
+  , inProgress     :: forall a. NormalizedFilePath -> Action a -> Action a
+  , progressStop   :: IO ()
+  }
+
+noProgressReporting :: IO ProgressReporting
+noProgressReporting = return $ ProgressReporting
+  { progressUpdate = const $ pure ()
+  , inProgress = const id
+  , progressStop   = pure ()
+  }
+
+delayedProgressReporting
+  :: Maybe (LSP.LanguageContextEnv c)
+  -> ProgressReportingStyle
+  -> IO ProgressReporting
+delayedProgressReporting lspEnv optProgressStyle = do
+    inProgressVar <- newVar (HMap.empty @NormalizedFilePath @Int)
+    mostRecentProgressEvent <- newTVarIO KickCompleted
+    progressAsync <- async $
+            progressThread optProgressStyle mostRecentProgressEvent inProgressVar
+    let progressUpdate = atomically . writeTVar mostRecentProgressEvent
+        progressStop   = cancel progressAsync
+        inProgress :: NormalizedFilePath -> Action a -> Action a
+        inProgress = withProgressVar inProgressVar
+    return ProgressReporting{..}
+    where
+        -- The progress thread is a state machine with two states:
+        --   1. Idle
+        --   2. Reporting a kick event
+        -- And two transitions, modelled by 'ProgressEvent':
+        --   1. KickCompleted - transitions from Reporting into Idle
+        --   2. KickStarted - transitions from Idle into Reporting
+        progressThread style mostRecentProgressEvent inProgress = progressLoopIdle
+          where
+            progressLoopIdle = do
+                atomically $ do
+                    v <- readTVar mostRecentProgressEvent
+                    case v of
+                        KickCompleted -> STM.retry
+                        KickStarted   -> return ()
+                asyncReporter <- async $ mRunLspT lspEnv lspShakeProgress
+                progressLoopReporting asyncReporter
+            progressLoopReporting asyncReporter = do
+                atomically $ do
+                    v <- readTVar mostRecentProgressEvent
+                    case v of
+                        KickStarted   -> STM.retry
+                        KickCompleted -> return ()
+                cancel asyncReporter
+                progressLoopIdle
+
+            lspShakeProgress :: LSP.LspM config ()
+            lspShakeProgress = do
+                -- first sleep a bit, so we only show progress messages if it's going to take
+                -- a "noticable amount of time" (we often expect a thread kill to arrive before the sleep finishes)
+                liftIO $ sleep 0.1
+                u <- ProgressTextToken . T.pack . show . hashUnique <$> liftIO newUnique
+
+                void $ LSP.sendRequest LSP.SWindowWorkDoneProgressCreate
+                    LSP.WorkDoneProgressCreateParams { _token = u } $ const (pure ())
+
+                bracket_
+                  (start u)
+                  (stop u)
+                  (loop u 0)
+                where
+                    start id = LSP.sendNotification LSP.SProgress $
+                        LSP.ProgressParams
+                            { _token = id
+                            , _value = LSP.Begin $ WorkDoneProgressBeginParams
+                              { _title = "Processing"
+                              , _cancellable = Nothing
+                              , _message = Nothing
+                              , _percentage = Nothing
+                              }
+                            }
+                    stop id = LSP.sendNotification LSP.SProgress
+                        LSP.ProgressParams
+                            { _token = id
+                            , _value = LSP.End WorkDoneProgressEndParams
+                              { _message = Nothing
+                              }
+                            }
+                    sample = 0.1
+                    loop id prev = do
+                        liftIO $ sleep sample
+                        current <- liftIO $ readVar inProgress
+                        let done = length $ filter (== 0) $ HMap.elems current
+                        let todo = HMap.size current
+                        let next = 100 * fromIntegral done / fromIntegral todo
+                        when (next /= prev) $
+                          LSP.sendNotification LSP.SProgress $
+                          LSP.ProgressParams
+                              { _token = id
+                              , _value = LSP.Report $ case style of
+                                  Explicit -> LSP.WorkDoneProgressReportParams
+                                    { _cancellable = Nothing
+                                    , _message = Just $ T.pack $ show done <> "/" <> show todo
+                                    , _percentage = Nothing
+                                    }
+                                  Percentage -> LSP.WorkDoneProgressReportParams
+                                    { _cancellable = Nothing
+                                    , _message = Nothing
+                                    , _percentage = Just next
+                                    }
+                                  NoProgress -> LSP.WorkDoneProgressReportParams
+                                    { _cancellable = Nothing
+                                    , _message = Nothing
+                                    , _percentage = Nothing
+                                    }
+                              }
+                        loop id next
+
+        withProgressVar var file = actionBracket (f succ) (const $ f pred) . const
+            -- This functions are deliberately eta-expanded to avoid space leaks.
+            -- Do not remove the eta-expansion without profiling a session with at
+            -- least 1000 modifications.
+            where f shift = void $ modifyVar' var $ HMap.insertWith (\_ x -> shift x) file (shift 0)
+
+mRunLspT :: Applicative m => Maybe (LSP.LanguageContextEnv c ) -> LSP.LspT c m () -> m ()
+mRunLspT (Just lspEnv) f = LSP.runLspT lspEnv f
+mRunLspT Nothing _       = pure ()
+
+mRunLspTCallback :: Monad m
+                 => Maybe (LSP.LanguageContextEnv c)
+                 -> (LSP.LspT c m a -> LSP.LspT c m a)
+                 -> m a
+                 -> m a
+mRunLspTCallback (Just lspEnv) f g = LSP.runLspT lspEnv $ f (lift g)
+mRunLspTCallback Nothing _ g       = g

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -131,7 +131,7 @@ delayedProgressReporting before after lspEnv optProgressStyle = do
                         let done = length $ filter (== 0) $ HMap.elems current
                         let todo = HMap.size current
                         let next = 100 * fromIntegral done / fromIntegral todo
-                        when (next /= prev) $
+                        when (style /= NoProgress && next /= prev) $
                           LSP.sendNotification LSP.SProgress $
                           LSP.ProgressParams
                               { _token = id
@@ -146,11 +146,7 @@ delayedProgressReporting before after lspEnv optProgressStyle = do
                                     , _message = Nothing
                                     , _percentage = Just next
                                     }
-                                  NoProgress -> LSP.WorkDoneProgressReportParams
-                                    { _cancellable = Nothing
-                                    , _message = Nothing
-                                    , _percentage = Nothing
-                                    }
+                                  NoProgress -> error "unreachable"
                               }
                         loop id next
 

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -895,7 +895,6 @@ defineEarlyCutoff' doDiagnostics key file old mode action = do
                     (if eq then ChangedRecomputeSame else ChangedRecomputeDiff)
                     (encodeShakeValue bs) $
                     A res
-    where
 
 isSuccess :: RunResult (A v) -> Bool
 isSuccess (RunResult _ _ (A Failed{})) = False

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -110,6 +110,7 @@ data ProgressReportingStyle
     = Percentage -- ^ Report using the LSP @_percentage@ field
     | Explicit   -- ^ Report using explicit 123/456 text
     | NoProgress -- ^ Do not report any percentage
+    deriving Eq
 
 
 clientSupportsProgress :: LSP.ClientCapabilities -> IdeReportProgress

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -5087,6 +5087,7 @@ clientSettingsTest :: TestTree
 clientSettingsTest = testGroup "client settings handling"
     [ testSession "ghcide restarts shake session on config changes" $ do
             void $ skipManyTill anyMessage $ message SClientRegisterCapability
+            void $ createDoc "A.hs" "haskell" "module A where"
             waitForProgressDone
             sendNotification SWorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON ("" :: String)))
             skipManyTill anyMessage restartingBuildSession

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -144,7 +144,7 @@ waitForProgressDone :: Session ()
 waitForProgressDone = loop
   where
     loop = do
-      ~() <- skipManyTill anyMessage $ satisfyMaybe $ \case
+      () <- skipManyTill anyMessage $ satisfyMaybe $ \case
         FromServerMess SProgress (NotificationMessage _ _ (ProgressParams _ (End _))) -> Just ()
         _ -> Nothing
       done <- null <$> getIncompleteProgressSessions

--- a/plugins/hls-splice-plugin/test/Main.hs
+++ b/plugins/hls-splice-plugin/test/Main.hs
@@ -99,7 +99,8 @@ goldenTestWithEdit input tc line col =
                         { _start = Position 0 0
                         , _end = Position (length lns + 1) 1
                         }
-            liftIO $ sleep 3
+            waitForProgressDone -- cradle
+            waitForProgressDone
             alt <- liftIO $ T.readFile (input <.> "error")
             void $ applyEdit doc $ TextEdit theRange alt
             changeDoc doc [TextDocumentContentChangeEvent (Just theRange) Nothing alt]
@@ -131,5 +132,5 @@ pointRange
 
 -- | Get the title of a code action.
 codeActionTitle :: (Command |? CodeAction) -> Maybe Text
-codeActionTitle InL{}                               = Nothing
+codeActionTitle InL{}                                 = Nothing
 codeActionTitle (InR(CodeAction title _ _ _ _ _ _ _)) = Just title

--- a/test/utils/Test/Hls/Command.hs
+++ b/test/utils/Test/Hls/Command.hs
@@ -23,7 +23,7 @@ hlsCommand :: String
 {-# NOINLINE hlsCommand #-}
 hlsCommand = unsafePerformIO $ do
   testExe <- fromMaybe "haskell-language-server" <$> lookupEnv "HLS_TEST_EXE"
-  pure $ testExe ++ " --lsp -d -j2 -l test-logs/" ++ logFilePath
+  pure $ testExe ++ " --lsp -d -j4 -l test-logs/" ++ logFilePath
 
 hlsCommandVomit :: String
 hlsCommandVomit = hlsCommand ++ " --vomit"


### PR DESCRIPTION
Rework of #1770. Summary of changes:

1. progress reporting logic extracted into its own module
2. Removed one layer of async handling, reducing the chances of race conditions
3. Correctly implement the LSP spec for `window/workDoneProgress/create` by waiting until the client has responded
4. Fix bugs: division by zero (when `todo` is 0) and handling when `NoProgress` 
5. Performance: the reporting loop is now O(1) instead of O(N) in the number of files

I think this is the best we can do to close #1749 while sharing the same logic for both tests and app code