### PR TITLE
Add bounds for base in hls-stylish-haskell-plugin

### DIFF
--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -17,7 +17,7 @@ library
   exposed-modules:  Ide.Plugin.StylishHaskell
   hs-source-dirs:   src
   build-depends:
-    , base
+    , base             >=4.12 && <5
     , directory
     , filepath
     , ghc
@@ -41,5 +41,5 @@ test-suite tests
     , base
     , bytestring
     , hls-stylish-haskell-plugin
-    , hls-test-utils  ^>= 1.0
+    , hls-test-utils              ^>=1.0
     , text


### PR DESCRIPTION
That was my fault ─ I'll pay attention to the bounds of `base` package next time.