### PR TITLE
Add upper bound to hlint

### DIFF
--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -43,7 +43,7 @@ library
     , ghc-exactprint        >=0.6.3.4
     , ghcide                ^>=1.2
     , hashable
-    , hlint                 >=3.2
+    , hlint                 ^>=3.2
     , hls-plugin-api        ^>=1.1
     , hslogger
     , lens


### PR DESCRIPTION
* Without the upper bound, cabal picks hlint-3.* which brings ghc-lib-9.* causing compile errors (what this has not been catched by ci before?)
* This has to be backported to hackage-1.1.0 to make progress towards #1774