### PR TITLE
Fix unwanted import refinement

### DIFF
--- a/plugins/hls-refine-imports-plugin/test/testdata/F.hs
+++ b/plugins/hls-refine-imports-plugin/test/testdata/F.hs
@@ -1,0 +1,7 @@
+module F (module F, module G) where
+
+import G
+
+f1 :: String 
+f1 = "f1"
+

--- a/plugins/hls-refine-imports-plugin/test/testdata/G.hs
+++ b/plugins/hls-refine-imports-plugin/test/testdata/G.hs
@@ -1,0 +1,4 @@
+module G where
+
+g1 :: String 
+g1 = "g1"

--- a/plugins/hls-refine-imports-plugin/test/testdata/WithOverride.expected.hs
+++ b/plugins/hls-refine-imports-plugin/test/testdata/WithOverride.expected.hs
@@ -3,9 +3,10 @@ module Main where
 import B ( b1 )
 import C ( c1 )
 import D
+import F
 import Data.List (intercalate)
 
 main :: IO ()
 main = putStrLn 
      $ "hello " 
-    <> intercalate ", " [b1, c1, e1]
+    <> intercalate ", " [b1, c1, e1, f1, g1]

--- a/plugins/hls-refine-imports-plugin/test/testdata/WithOverride.hs
+++ b/plugins/hls-refine-imports-plugin/test/testdata/WithOverride.hs
@@ -2,9 +2,10 @@ module Main where
 
 import A
 import D
+import F
 import Data.List (intercalate)
 
 main :: IO ()
 main = putStrLn 
      $ "hello " 
-    <> intercalate ", " [b1, c1, e1]
+    <> intercalate ", " [b1, c1, e1, f1, g1]

--- a/plugins/hls-refine-imports-plugin/test/testdata/hie.yaml
+++ b/plugins/hls-refine-imports-plugin/test/testdata/hie.yaml
@@ -8,3 +8,5 @@ cradle:
     - C.hs
     - D.hs
     - E.hs
+    - F.hs
+    - G.hs


### PR DESCRIPTION
The problem

If module F imports and exports G, but it also has it's own bindings defined like this:

```
module F (module F, module G) where

import G

f1 :: String
f1 = "f1"
```

And the usage of F is

```
import F (f1, g1)
```

before this pr it will suggest refinement like

```
import G (g1)
```

This is definitely wrong.

The correct one should be not suggesting refinement in this case, since `f1` is definitely needed, so does module F

See the attached test change for full example

