### PR TITLE
Remove hls-ghc-x.y from install script and wrapper

### DIFF
--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -133,7 +133,7 @@ findProjectCradle :: IO (Cradle Void)
 findProjectCradle = do
   d <- getCurrentDirectory
 
-  let initialFp = (d </> "a")
+  let initialFp = d </> "a"
   hieYaml <- Session.findCradle def initialFp
 
   -- Some log messages

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -55,7 +55,7 @@ launchHaskellLanguageServer parsedArgs = do
     _                          -> pure ()
 
   d <- getCurrentDirectory
-  
+
   -- search for the project cradle type
   cradle <- findProjectCradle
 
@@ -88,11 +88,7 @@ launchHaskellLanguageServer parsedArgs = do
 
   let
     hlsBin = "haskell-language-server-" ++ ghcVersion
-    backupHlsBin =
-      case dropWhileEnd (/='.') ghcVersion of
-        [] -> "haskell-language-server"
-        xs -> "haskell-language-server-" ++ init xs
-    candidates' = [hlsBin, backupHlsBin, "haskell-language-server"]
+    candidates' = [hlsBin, "haskell-language-server"]
     candidates = map (++ exeExtension) candidates'
 
   hPutStrLn stderr $ "haskell-language-server exe candidates: " ++ show candidates

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -72,20 +72,17 @@ cabalInstallHls versionNumber args = do
     ++ installMethod
     ++ args
 
-  let minorVerExe = "haskell-language-server-" ++ versionNumber <.> exe
-      majorVerExe = "haskell-language-server-" ++ dropExtension versionNumber <.> exe
+  let verExe = "haskell-language-server-" ++ versionNumber <.> exe
 
   let copyCmd old new = if os == "mingw32"
                         then liftIO $ copyFile old new
                         else command [] "ln" ["-f", old, new]
-  copyCmd (localBin </> "haskell-language-server" <.> exe) (localBin </> minorVerExe)
-  copyCmd (localBin </> "haskell-language-server" <.> exe) (localBin </> majorVerExe)
+  copyCmd (localBin </> "haskell-language-server" <.> exe) (localBin </> verExe)
 
   printLine $   "Copied executables "
              ++ ("haskell-language-server-wrapper" <.> exe) ++ ", "
              ++ ("haskell-language-server" <.> exe) ++ ", "
-             ++ majorVerExe ++ " and "
-             ++ minorVerExe
+             ++ verExe
              ++ " to " ++ localBin
 
 getProjectFile :: VersionNumber -> Action FilePath

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -105,7 +105,7 @@ checkCabal args = do
   return cabalVersion
 
 getCabalVersion :: [String] -> Action String
-getCabalVersion args = trimmedStdout <$> (execCabal $ ["--numeric-version"] ++ args)
+getCabalVersion args = trimmedStdout <$> execCabal ("--numeric-version" : args)
 
 -- | Error message when the `cabal` binary is an older version
 cabalInstallIsOldFailMsg :: String -> String

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -39,8 +39,6 @@ stackInstallHls mbVersionNumber args = do
                         else command [] "ln" ["-f", old, new]
   copyCmd (localBinDir </> hls)
            (localBinDir </> "haskell-language-server-" ++ versionNumber <.> exe)
-  copyCmd (localBinDir </> hls)
-           (localBinDir </> "haskell-language-server-" ++ dropExtension versionNumber <.> exe)
 
 getGhcVersionOfCfgFile :: String -> [String] -> Action VersionNumber
 getGhcVersionOfCfgFile stackFile args = do

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -49,7 +49,7 @@ getGhcVersionOfCfgFile stackFile args = do
 -- | check `stack` has the required version
 checkStack :: [String] -> Action ()
 checkStack args = do
-  stackVersion <- trimmedStdout <$> (execStackShake $ ["--numeric-version"] ++ args)
+  stackVersion <- trimmedStdout <$> execStackShake ("--numeric-version" : args)
   unless (checkVersion requiredStackVersion stackVersion) $ do
     printInStars $ stackExeIsOldFailMsg stackVersion
     error $ stackExeIsOldFailMsg stackVersion

--- a/src/Ide/Version.hs
+++ b/src/Ide/Version.hs
@@ -43,9 +43,9 @@ data ProgramsOfInterest = ProgramsOfInterest
 showProgramVersionOfInterest :: ProgramsOfInterest -> String
 showProgramVersionOfInterest ProgramsOfInterest {..} =
   unlines
-    [ concat ["cabal:\t\t", showVersionWithDefault cabalVersion]
-    , concat ["stack:\t\t", showVersionWithDefault stackVersion]
-    , concat ["ghc:\t\t", showVersionWithDefault ghcVersion]
+    [ "cabal:\t\t" ++ showVersionWithDefault cabalVersion
+    , "stack:\t\t" ++ showVersionWithDefault stackVersion
+    , "ghc:\t\t" ++ showVersionWithDefault ghcVersion
     ]
   where
     showVersionWithDefault :: Maybe Version -> String


### PR DESCRIPTION
Closes #1728

As discussed in the issue, executables like `haskell-language-server-8.10` are really confusing - they could be the symlink of `haskell-language-server-8.10.2`, `haskell-language-server-8.10.3`, or even `haskell-language-server-8.10.4`, but those are definitely not interchangeable. So it's time to remove them. Now running `./cabal-hls-install hls-8.10.4` will create `haskell-language-server-wrapper`, `haskell-language-server`, and `haskell-language-server-8.10.4`.