### PR TITLE
Prepare ghcide release v1.3.0.0

### DIFF
--- a/ghcide/CHANGELOG.md
+++ b/ghcide/CHANGELOG.md
@@ -1,3 +1,15 @@
+### 1.3.0.0 (2021-05-09)
+* Replace unsafe getmodtime with unix package (#1778) - Pepe Iborra
+* Progress reporting improvements (#1784) - Pepe Iborra
+* Unify session loading using implicit-hie (#1783) - fendor
+* Fix remove constraint (#1578) - Kostas Dermentzis
+* Fix wrong extend import while type constuctor and data constructor have the same name (#1775) - Lei Zhu
+* Imporve vscode extension schema generation (#1742) - Potato Hatsue
+* Add hls-graph abstracting over shake (#1748) - Neil Mitchell
+* Tease apart the custom SYB from ExactPrint (#1746) - Sandy Maguire
+* fix class method completion (#1741) - Lei Zhu
+* Fix: #1690 - Infix typed holes are now filled using infix notation (#1708) - Oliver Madine
+
 ### 1.2.0.2 (2021-04-13)
 * Bracketing for snippet completions (#1709) - Oliver Madine
 * Don't suggest destruct actions for already-destructed terms (#1715) - Sandy Maguire

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -80,6 +80,7 @@ versions:
 # - 1.0.0
 # - ghcide-v1.1.0
 # - ghcide-v1.2.0
+# - ghcide-v1.3.0
 - upstream: origin/master
 - HEAD
 

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.2.0.2
+version:            1.3.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -67,14 +67,13 @@ library
         optparse-applicative,
         parallel,
         prettyprinter-ansi-terminal,
-        prettyprinter-ansi-terminal,
         prettyprinter,
         regex-tdfa >= 1.3.1.0,
         retrie,
         rope-utf16-splay,
         safe,
         safe-exceptions,
-        hls-graph,
+        hls-graph ^>= 1.3,
         sorted-list,
         sqlite-simple,
         stm,

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -40,6 +40,7 @@ import           HscTypes                                     (HomeModInfo,
 import qualified Data.Binary                                  as B
 import           Data.ByteString                              (ByteString)
 import qualified Data.ByteString.Lazy                         as LBS
+import           Data.HashMap.Strict                          (HashMap)
 import           Data.Text                                    (Text)
 import           Data.Time
 import           Development.IDE.Import.FindImports           (ArtifactsLocation)
@@ -353,6 +354,8 @@ type instance RuleResult GetModSummary = ModSummaryResult
 -- | Generate a ModSummary with the timestamps and preprocessed content elided, for more successful early cutoff
 type instance RuleResult GetModSummaryWithoutTimestamps = ModSummaryResult
 
+type instance RuleResult GetFilesOfInterest = HashMap NormalizedFilePath FileOfInterestStatus
+
 data GetParsedModule = GetParsedModule
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetParsedModule
@@ -509,6 +512,12 @@ data GhcSessionIO = GhcSessionIO deriving (Eq, Show, Typeable, Generic)
 instance Hashable GhcSessionIO
 instance NFData   GhcSessionIO
 instance Binary   GhcSessionIO
+
+data GetFilesOfInterest = GetFilesOfInterest
+    deriving (Eq, Show, Typeable, Generic)
+instance Hashable GetFilesOfInterest
+instance NFData   GetFilesOfInterest
+instance Binary   GetFilesOfInterest
 
 makeLensesWith
     (lensRules & lensField .~ mappingNamer (pure . (++ "L")))

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -152,16 +152,6 @@ import           Control.Applicative
 toIdeResult :: Either [FileDiagnostic] v -> IdeResult v
 toIdeResult = either (, Nothing) (([],) . Just)
 
-defineNoFile :: IdeRule k v => (k -> Action v) -> Rules ()
-defineNoFile f = defineNoDiagnostics $ \k file -> do
-    if file == emptyFilePath then do res <- f k; return (Just res) else
-        fail $ "Rule " ++ show k ++ " should always be called with the empty string for a file"
-
-defineEarlyCutOffNoFile :: IdeRule k v => (k -> Action (BS.ByteString, v)) -> Rules ()
-defineEarlyCutOffNoFile f = defineEarlyCutoff $ RuleNoDiagnostics $ \k file -> do
-    if file == emptyFilePath then do (hash, res) <- f k; return (Just hash, Just res) else
-        fail $ "Rule " ++ show k ++ " should always be called with the empty string for a file"
-
 ------------------------------------------------------------
 -- Exposed API
 ------------------------------------------------------------

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -44,6 +44,7 @@ module Development.IDE.Core.Shake(
     define, defineNoDiagnostics,
     defineEarlyCutoff,
     defineOnDisk, needOnDisk, needOnDisks,
+    defineNoFile, defineEarlyCutOffNoFile,
     getDiagnostics,
     mRunLspT, mRunLspTCallback,
     getHiddenDiagnostics,
@@ -832,6 +833,16 @@ defineEarlyCutoff (Rule op) = addRule $ \(Q (key, file)) (old :: Maybe BS.ByteSt
     defineEarlyCutoff' True key file old mode $ op key file
 defineEarlyCutoff (RuleNoDiagnostics op) = addRule $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file isSuccess $ do
     defineEarlyCutoff' False key file old mode $ second (mempty,) <$> op key file
+
+defineNoFile :: IdeRule k v => (k -> Action v) -> Rules ()
+defineNoFile f = defineNoDiagnostics $ \k file -> do
+    if file == emptyFilePath then do res <- f k; return (Just res) else
+        fail $ "Rule " ++ show k ++ " should always be called with the empty string for a file"
+
+defineEarlyCutOffNoFile :: IdeRule k v => (k -> Action (BS.ByteString, v)) -> Rules ()
+defineEarlyCutOffNoFile f = defineEarlyCutoff $ RuleNoDiagnostics $ \k file -> do
+    if file == emptyFilePath then do (hash, res) <- f k; return (Just hash, Just res) else
+        fail $ "Rule " ++ show k ++ " should always be called with the empty string for a file"
 
 defineEarlyCutoff'
     :: IdeRule k v

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 category:           Development
 name:               haskell-language-server
-version:            1.1.0.0
+version:            1.1.0.1
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -62,7 +62,7 @@ library
     , cryptohash-sha1
     , data-default
     , ghc
-    , ghcide                ^>=1.2
+    , ghcide                ^>=1.3
     , gitrev
     , lsp
     , hie-bios

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-graph
-version:       1.1.0.0
+version:       1.3.0.0
 synopsis:      Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/hls-graph/src/Development/IDE/Graph.hs
+++ b/hls-graph/src/Development/IDE/Graph.hs
@@ -7,7 +7,7 @@ module Development.IDE.Graph(
     actionFinally, actionBracket, actionCatch,
     Shake.ShakeException(..),
     -- * Configuration
-    ShakeOptions(shakeThreads, shakeFiles, shakeExtra),
+    ShakeOptions(shakeAllowRedefineRules, shakeThreads, shakeFiles, shakeExtra),
     getShakeExtra, getShakeExtraRules, newShakeExtra,
     -- * Explicit parallelism
     parallel,

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       1.1.0.0
+version:       1.1.0.1
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -50,7 +50,7 @@ library
     , opentelemetry
     , process
     , regex-tdfa            >=1.3.1.0
-    , hls-graph
+    , hls-graph             ^>=1.3
     , text
     , unordered-containers
 

--- a/hls-plugin-api/src/Ide/Plugin/ConfigUtils.hs
+++ b/hls-plugin-api/src/Ide/Plugin/ConfigUtils.hs
@@ -5,16 +5,15 @@
 
 module Ide.Plugin.ConfigUtils where
 
-import qualified Data.Aeson                as A
-import qualified Data.Aeson.Types          as A
-import           Data.Containers.ListUtils (nubOrd)
-import           Data.Default              (def)
-import qualified Data.Dependent.Map        as DMap
-import qualified Data.Dependent.Sum        as DSum
-import qualified Data.HashMap.Lazy         as HMap
+import qualified Data.Aeson            as A
+import qualified Data.Aeson.Types      as A
+import           Data.Default          (def)
+import qualified Data.Dependent.Map    as DMap
+import qualified Data.Dependent.Sum    as DSum
+import qualified Data.HashMap.Lazy     as HMap
+import           Data.List             (nub)
 import           Ide.Plugin.Config
-import           Ide.Plugin.Properties     (toDefaultJSON,
-                                            toVSCodeExtensionSchema)
+import           Ide.Plugin.Properties (toDefaultJSON, toVSCodeExtensionSchema)
 import           Ide.Types
 import           Language.LSP.Types
 
@@ -65,7 +64,7 @@ pluginsToDefaultConfig IdePlugins {..} =
         -- }
         --
         genericDefaultConfig =
-          let x = ["diagnosticsOn" A..= True | configHasDiagnostics] <> nubOrd (mconcat (handlersToGenericDefaultConfig <$> handlers))
+          let x = ["diagnosticsOn" A..= True | configHasDiagnostics] <> nub (mconcat (handlersToGenericDefaultConfig <$> handlers))
            in case x of
                 -- if the plugin has only one capability, we produce globalOn instead of the specific one;
                 -- otherwise we don't produce globalOn at all
@@ -108,7 +107,7 @@ pluginsToVSCodeExtensionSchema IdePlugins {..} = A.object $ mconcat $ singlePlug
         genericSchema =
           let x =
                 [withIdPrefix "diagnosticsOn" A..= schemaEntry "diagnostics" | configHasDiagnostics]
-                  <> nubOrd (mconcat (handlersToGenericSchema <$> handlers))
+                  <> nub (mconcat (handlersToGenericSchema <$> handlers))
            in case x of
                 -- If the plugin has only one capability, we produce globalOn instead of the specific one;
                 -- otherwise we don't produce globalOn at all

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       1.0.0.0
+version:       1.0.0.1
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -41,7 +41,7 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  ^>=1.2
+    , ghcide                   >=1.3 && <1.4
     , hls-graph
     , hls-plugin-api          ^>=1.1
     , hspec

--- a/plugins/hls-brittany-plugin/hls-brittany-plugin.cabal
+++ b/plugins/hls-brittany-plugin/hls-brittany-plugin.cabal
@@ -25,7 +25,7 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          ^>=1.2
+    , ghcide           >=1.2 && <1.4
     , hls-plugin-api  ^>=1.1
     , lens
     , lsp-types

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -29,7 +29,7 @@ library
     , containers
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.2
+    , ghcide                 >=1.2 && <1.4
     , hls-plugin-api        ^>=1.1
     , lens
     , lsp

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -61,7 +61,7 @@ library
     , ghc
     , ghc-boot-th
     , ghc-paths
-    , ghcide                ^>=1.2
+    , ghcide                 >=1.2 && <1.4
     , hashable
     , hls-plugin-api        ^>=1.1
     , lens

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-explicit-imports-plugin
-version:            1.0.0.1
+version:            1.0.0.2
 synopsis:           Explicit imports plugin for Haskell Language Server
 license:            Apache-2.0
 license-file:       LICENSE
@@ -20,7 +20,7 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                ^>=1.2
+    , ghcide                ^>=1.3
     , hls-plugin-api        ^>=1.1
     , lsp
     , lsp-types

--- a/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
+++ b/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
@@ -29,7 +29,7 @@ library
     , containers
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.2
+    , ghcide                 >=1.2 && <1.4
     , hls-plugin-api        ^>=1.1
     , lsp-types
     , text

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -41,7 +41,7 @@ library
     , extra
     , filepath
     , ghc-exactprint        >=0.6.3.4
-    , ghcide                ^>=1.2
+    , ghcide                 >=1.2 && <1.4
     , hashable
     , hlint                 ^>=3.2
     , hls-plugin-api        ^>=1.1

--- a/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
+++ b/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
@@ -14,13 +14,13 @@ extra-source-files:
 library
   exposed-modules:  Ide.Plugin.RefineImports
   hs-source-dirs:   src
-  build-depends:    
+  build-depends:
     , aeson
     , base        >=4.12 && <5
     , containers
     , deepseq
     , ghc
-    , ghcide                ^>=1.2
+    , ghcide                ^>=1.3
     , hls-plugin-api        ^>=1.1
     , lsp
     , lsp-types

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -22,7 +22,7 @@ library
     , directory
     , extra
     , ghc
-    , ghcide                ^>=1.2
+    , ghcide                 >=1.2 && <1.4
     , hashable
     , hls-plugin-api        ^>=1.1
     , lsp

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -40,7 +40,7 @@ library
     , foldl
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.2
+    , ghcide                 >=1.2 && <1.4
     , hls-plugin-api        ^>=1.1
     , lens
     , lsp

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -22,7 +22,7 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide           ^>=1.2
+    , ghcide            >=1.2 && <1.4
     , hls-plugin-api   ^>=1.1
     , lsp-types
     , mtl

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 category:           Development
 name:               hls-tactics-plugin
-version:            1.1.0.0
+version:            1.1.0.1
 synopsis:           Wingman plugin for Haskell Language Server
 description:        Please see README.md
 author:             Sandy Maguire, Reed Mullanix
@@ -73,7 +73,7 @@ library
     , ghc-boot-th
     , ghc-exactprint
     , ghc-source-gen
-    , ghcide                ^>=1.2
+    , ghcide                ^>=1.3
     , hls-plugin-api        ^>=1.1
     , lens
     , lsp


### PR DESCRIPTION
- [x] Wait for #1778 before landing.

I have tried to relax constraints where possible and bump version numbers where needed, but this is impossibly hard to get right without some automation.

Once the release is landed, I plan to upload the following to Hackage:

 - ghcide
 - his-plugin-api
 - hls-graph
 - explicit imports plugin
 
EDIT: took the chance to include some pure refactorings that change module signatures.