### PR TITLE
Apply formats again

### DIFF
--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -22,11 +22,11 @@ import           Development.IDE                   (Logger (Logger),
                                                     Priority (Info), action)
 import           Development.IDE.Core.OfInterest   (kick)
 import           Development.IDE.Core.Rules        (mainRule)
+import           Development.IDE.Graph             (ShakeOptions (shakeThreads))
 import qualified Development.IDE.Main              as Main
 import qualified Development.IDE.Plugin.HLS.GhcIde as GhcIde
 import qualified Development.IDE.Plugin.Test       as Test
 import           Development.IDE.Types.Options
-import           Development.IDE.Graph                 (ShakeOptions (shakeThreads))
 import           Ide.Plugin.Config                 (Config (checkParents, checkProject))
 import           Ide.Plugin.ConfigUtils            (pluginsToDefaultConfig,
                                                     pluginsToVSCodeExtensionSchema)

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -143,7 +143,7 @@ loadWithImplicitCradle :: Maybe FilePath
 loadWithImplicitCradle mHieYaml rootDir = do
   crdl       <- case mHieYaml of
     Just yaml -> HieBios.loadCradle yaml
-    Nothing -> loadImplicitHieCradle $ addTrailingPathSeparator rootDir
+    Nothing   -> loadImplicitHieCradle $ addTrailingPathSeparator rootDir
   return crdl
 
 getInitialGhcLibDirDefault :: IO (Maybe LibDir)

--- a/ghcide/src/Control/Concurrent/Strict.hs
+++ b/ghcide/src/Control/Concurrent/Strict.hs
@@ -4,11 +4,11 @@ module Control.Concurrent.Strict
     ,module Control.Concurrent.Extra
     ) where
 
-import Control.Concurrent.Extra hiding (modifyVar, modifyVar_)
+import           Control.Concurrent.Extra hiding (modifyVar, modifyVar_)
 import qualified Control.Concurrent.Extra as Extra
-import Control.Exception (evaluate)
-import Data.Tuple.Extra (dupe)
-import Control.Monad (void)
+import           Control.Exception        (evaluate)
+import           Control.Monad            (void)
+import           Data.Tuple.Extra         (dupe)
 
 -- | Strict modification that returns the new value
 modifyVar' :: Var a -> (a -> a) -> IO a

--- a/ghcide/src/Development/IDE.hs
+++ b/ghcide/src/Development/IDE.hs
@@ -44,6 +44,8 @@ import           Development.IDE.Core.Shake            as X (FastResult (..),
                                                              use_, uses, uses_)
 import           Development.IDE.GHC.Error             as X
 import           Development.IDE.GHC.Util              as X
+import           Development.IDE.Graph                 as X (Action, RuleResult,
+                                                             Rules, action)
 import           Development.IDE.Plugin                as X
 import           Development.IDE.Types.Diagnostics     as X
 import           Development.IDE.Types.HscEnvEq        as X (HscEnvEq (..),
@@ -51,5 +53,3 @@ import           Development.IDE.Types.HscEnvEq        as X (HscEnvEq (..),
                                                              hscEnvWithImportPaths)
 import           Development.IDE.Types.Location        as X
 import           Development.IDE.Types.Logger          as X
-import           Development.IDE.Graph                     as X (Action, RuleResult,
-                                                             Rules, action)

--- a/ghcide/src/Development/IDE/Core/Actions.hs
+++ b/ghcide/src/Development/IDE/Core/Actions.hs
@@ -28,9 +28,9 @@ import           Development.IDE.GHC.Compat           hiding (TargetFile,
                                                        parseModule,
                                                        typecheckModule,
                                                        writeHieFile)
+import           Development.IDE.Graph
 import qualified Development.IDE.Spans.AtPoint        as AtPoint
 import           Development.IDE.Types.Location
-import           Development.IDE.Graph
 import qualified HieDb
 import           Language.LSP.Types                   (DocumentHighlight (..),
                                                        SymbolInformation (..))

--- a/ghcide/src/Development/IDE/Core/Debouncer.hs
+++ b/ghcide/src/Development/IDE/Core/Debouncer.hs
@@ -11,10 +11,10 @@ module Development.IDE.Core.Debouncer
 import           Control.Concurrent.Async
 import           Control.Concurrent.Strict
 import           Control.Exception
-import           Control.Monad            (join)
-import           Data.Foldable            (traverse_)
-import           Data.HashMap.Strict      (HashMap)
-import qualified Data.HashMap.Strict      as Map
+import           Control.Monad             (join)
+import           Data.Foldable             (traverse_)
+import           Data.HashMap.Strict       (HashMap)
+import qualified Data.HashMap.Strict       as Map
 import           Data.Hashable
 import           System.Time.Extra
 

--- a/ghcide/src/Development/IDE/Core/FileExists.hs
+++ b/ghcide/src/Development/IDE/Core/FileExists.hs
@@ -22,9 +22,9 @@ import           Development.IDE.Core.FileStore
 import           Development.IDE.Core.IdeConfiguration
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
+import           Development.IDE.Graph
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
-import           Development.IDE.Graph
 import           Language.LSP.Server                   hiding (getVirtualFile)
 import           Language.LSP.Types
 import           Language.LSP.Types.Capabilities

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -55,7 +55,8 @@ import           System.IO.Error
 #ifdef mingw32_HOST_OS
 import qualified System.Directory                             as Dir
 #else
-import           System.Posix.Files                           ( getFileStatus, modificationTimeHiRes)
+import           System.Posix.Files                           (getFileStatus,
+                                                               modificationTimeHiRes)
 #endif
 
 import qualified Development.IDE.Types.Logger                 as L

--- a/ghcide/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/ghcide/src/Development/IDE/Core/IdeConfiguration.hs
@@ -20,8 +20,8 @@ import           Data.HashSet                   (HashSet, singleton)
 import           Data.Hashable                  (Hashed, hashed, unhashed)
 import           Data.Text                      (Text, isPrefixOf)
 import           Development.IDE.Core.Shake
-import           Development.IDE.Types.Location
 import           Development.IDE.Graph
+import           Development.IDE.Types.Location
 import           Language.LSP.Types
 import           System.FilePath                (isRelative)
 

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -111,7 +111,10 @@ import           Development.IDE.GHC.Compat                   hiding
                                                                writeHieFile)
 import           Development.IDE.GHC.Error
 import           Development.IDE.GHC.ExactPrint
-import           Development.IDE.GHC.Util hiding (modifyDynFlags)
+import           Development.IDE.GHC.Util                     hiding
+                                                              (modifyDynFlags)
+import           Development.IDE.Graph
+import           Development.IDE.Graph.Classes                hiding (get, put)
 import           Development.IDE.Import.DependencyInformation
 import           Development.IDE.Import.FindImports
 import qualified Development.IDE.Spans.AtPoint                as AtPoint
@@ -122,8 +125,6 @@ import           Development.IDE.Types.HscEnvEq
 import           Development.IDE.Types.Location
 import qualified Development.IDE.Types.Logger                 as L
 import           Development.IDE.Types.Options
-import           Development.IDE.Graph
-import           Development.IDE.Graph.Classes                    hiding (get, put)
 import           Fingerprint
 import           GHC.Generics                                 (Generic)
 import           GHC.IO.Encoding
@@ -140,11 +141,16 @@ import           Module
 import           System.Directory                             (canonicalizePath)
 import           TcRnMonad                                    (tcg_dependent_files)
 
-import           Ide.Plugin.Properties (HasProperty, KeyNameProxy, Properties, ToHsType, useProperty)
-import           Ide.Types (PluginId, DynFlagsModifications(dynFlagsModifyGlobal, dynFlagsModifyParser))
-import           Data.Default (def)
-import           Ide.PluginUtils (configForPlugin)
 import           Control.Applicative
+import           Data.Default                                 (def)
+import           Ide.Plugin.Properties                        (HasProperty,
+                                                               KeyNameProxy,
+                                                               Properties,
+                                                               ToHsType,
+                                                               useProperty)
+import           Ide.PluginUtils                              (configForPlugin)
+import           Ide.Types                                    (DynFlagsModifications (dynFlagsModifyGlobal, dynFlagsModifyParser),
+                                                               PluginId)
 
 -- | This is useful for rules to convert rules that can only produce errors or
 -- a result into the more general IdeResult type that supports producing

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -148,8 +148,8 @@ import           Control.Exception.Extra                hiding (bracket_)
 import           Data.Default
 import           HieDb.Types
 import           Ide.Plugin.Config
-import qualified Ide.PluginUtils                      as HLS
-import           Ide.Types                            (PluginId)
+import qualified Ide.PluginUtils                        as HLS
+import           Ide.Types                              (PluginId)
 
 -- | We need to serialize writes to the database, so we send any function that
 -- needs to write to the database over the channel, where it will be picked up by

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE NoApplicativeDo #-}
-{-# LANGUAGE CPP #-}
 module Development.IDE.Core.Tracing
     ( otTracedHandler
     , otTracedAction
@@ -32,12 +32,12 @@ import           Debug.Trace.Flags              (userTracingEnabled)
 import           Development.IDE.Core.RuleTypes (GhcSession (GhcSession),
                                                  GhcSessionDeps (GhcSessionDeps),
                                                  GhcSessionIO (GhcSessionIO))
+import           Development.IDE.Graph          (Action, actionBracket)
 import           Development.IDE.Types.Location (Uri (..))
 import           Development.IDE.Types.Logger   (Logger, logDebug, logInfo)
 import           Development.IDE.Types.Shake    (Key (..), Value,
                                                  ValueWithDiagnostics (..),
                                                  Values)
-import           Development.IDE.Graph              (Action, actionBracket)
 import           Foreign.Storable               (Storable (sizeOf))
 import           HeapSize                       (recursiveSize, runHeapsize)
 import           Ide.PluginUtils                (installSigUsr1Handler)

--- a/ghcide/src/Development/IDE/Core/UseStale.hs
+++ b/ghcide/src/Development/IDE/Core/UseStale.hs
@@ -20,19 +20,23 @@ module Development.IDE.Core.UseStale
   ) where
 
 import           Control.Arrow
-import           Control.Category (Category)
-import qualified Control.Category as C
-import           Control.DeepSeq (NFData)
+import           Control.Category                     (Category)
+import qualified Control.Category                     as C
+import           Control.DeepSeq                      (NFData)
 import           Data.Aeson
-import           Data.Coerce (coerce)
-import           Data.Functor ((<&>))
-import           Data.Functor.Identity (Identity(Identity))
-import           Data.Kind (Type)
-import           Data.String (fromString)
-import           Development.IDE (NormalizedFilePath, IdeRule, Action, Range, rangeToRealSrcSpan, realSrcSpanToRange)
+import           Data.Coerce                          (coerce)
+import           Data.Functor                         ((<&>))
+import           Data.Functor.Identity                (Identity (Identity))
+import           Data.Kind                            (Type)
+import           Data.String                          (fromString)
+import           Development.IDE                      (Action, IdeRule,
+                                                       NormalizedFilePath,
+                                                       Range,
+                                                       rangeToRealSrcSpan,
+                                                       realSrcSpanToRange)
 import qualified Development.IDE.Core.PositionMapping as P
-import qualified Development.IDE.Core.Shake as IDE
-import qualified FastString as FS
+import qualified Development.IDE.Core.Shake           as IDE
+import qualified FastString                           as FS
 import           SrcLoc
 
 

--- a/ghcide/src/Development/IDE/GHC/Compat.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat.hs
@@ -1,10 +1,10 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PatternSynonyms   #-}
 {-# OPTIONS -Wno-dodgy-imports -Wno-incomplete-uni-patterns #-}
 
 -- | Attempt at hiding the GHC version differences we can.
@@ -62,60 +62,56 @@ module Development.IDE.GHC.Compat(
     ,isQualifiedImport) where
 
 #if MIN_VERSION_ghc(8,10,0)
-import LinkerTypes
+import           LinkerTypes
 #endif
 
-import StringBuffer
+import           Compat.HieAst      (enrichHie, mkHieFile)
+import           Compat.HieBin
+import           Compat.HieTypes
+import           Compat.HieUtils
+import qualified Data.ByteString    as BS
+import           Data.IORef
+import           DynFlags           hiding (ExposePackage)
 import qualified DynFlags
-import DynFlags hiding (ExposePackage)
-import Fingerprint (Fingerprint)
+import           Fingerprint        (Fingerprint)
+import           HscTypes
+import           MkIface
 import qualified Module
-import Packages
-import Data.IORef
-import HscTypes
-import NameCache
-import qualified Data.ByteString as BS
-import MkIface
-import TcRnTypes
-import Compat.HieAst (mkHieFile,enrichHie)
-import Compat.HieBin
-import Compat.HieTypes
-import Compat.HieUtils
+import           NameCache
+import           Packages
+import           StringBuffer
+import           TcRnTypes
 
 #if MIN_VERSION_ghc(8,10,0)
-import GHC.Hs.Extension
+import           GHC.Hs.Extension
 #else
-import HsExtension
+import           HsExtension
 #endif
 
+import           Avail
+import           GHC                hiding (HasSrcSpan, ModLocation, getLoc,
+                                     lookupName)
 import qualified GHC
 import qualified TyCoRep
-import GHC hiding (
-      ModLocation,
-      HasSrcSpan,
-      lookupName,
-      getLoc
-    )
-import Avail
 #if MIN_VERSION_ghc(8,8,0)
-import Data.List (foldl')
+import           Data.List          (foldl')
 #else
-import Data.List (foldl', isSuffixOf)
+import           Data.List          (foldl', isSuffixOf)
 #endif
 
-import DynamicLoading
-import Plugins (Plugin(parsedResultAction), withPlugins)
-import Data.Map.Strict (Map)
+import           Data.Map.Strict    (Map)
+import           DynamicLoading
+import           Plugins            (Plugin (parsedResultAction), withPlugins)
 
 #if !MIN_VERSION_ghc(8,8,0)
-import System.FilePath ((-<.>))
+import           System.FilePath    ((-<.>))
 #endif
 
 #if !MIN_VERSION_ghc(8,8,0)
 import qualified EnumSet
 
-import System.IO
-import Foreign.ForeignPtr
+import           Foreign.ForeignPtr
+import           System.IO
 
 
 hPutStringBuffer :: Handle -> StringBuffer -> IO ()
@@ -303,8 +299,8 @@ pattern FunTy arg res <- TyCoRep.FunTy arg res
 isQualifiedImport :: ImportDecl a -> Bool
 #if MIN_VERSION_ghc(8,10,0)
 isQualifiedImport ImportDecl{ideclQualified = NotQualified} = False
-isQualifiedImport ImportDecl{} = True
+isQualifiedImport ImportDecl{}                              = True
 #else
-isQualifiedImport ImportDecl{ideclQualified} = ideclQualified
+isQualifiedImport ImportDecl{ideclQualified}                = ideclQualified
 #endif
-isQualifiedImport _ = False
+isQualifiedImport _                                         = False

--- a/ghcide/src/Development/IDE/GHC/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/GHC/ExactPrint.hs
@@ -32,42 +32,46 @@ module Development.IDE.GHC.ExactPrint
     )
 where
 
-import BasicTypes (appPrec)
-import Control.Applicative (Alternative)
-import Control.Monad
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans.Class
-import Control.Monad.Trans.Except
-import Control.Monad.Zip
-import qualified Data.DList as DL
-import Data.Either.Extra (mapLeft)
-import Data.Functor.Classes
-import Data.Functor.Contravariant
-import qualified Data.Text as T
-import Development.IDE.Core.RuleTypes
-import Development.IDE.Core.Service (runAction)
-import Development.IDE.Core.Shake
-import Development.IDE.GHC.Compat hiding (parseExpr)
-import Development.IDE.Types.Location
-import Development.IDE.Graph (RuleResult, Rules)
-import Development.IDE.Graph.Classes
-import qualified GHC.Generics as GHC
-import Generics.SYB
-import Generics.SYB.GHC
-import Ide.PluginUtils
-import Language.Haskell.GHC.ExactPrint
-import Language.Haskell.GHC.ExactPrint.Parsers
-import Language.LSP.Types
-import Language.LSP.Types.Capabilities (ClientCapabilities)
-import Outputable (Outputable, ppr, showSDoc)
-import Retrie.ExactPrint hiding (parseDecl, parseExpr, parsePattern, parseType)
-import Parser (parseIdentifier)
-import Data.Traversable (for)
-import Data.Foldable (Foldable(fold))
-import Data.Bool (bool)
-import Data.Monoid (All(All), getAll)
-import Control.Arrow
+import           BasicTypes                              (appPrec)
+import           Control.Applicative                     (Alternative)
+import           Control.Arrow
+import           Control.Monad
+import qualified Control.Monad.Fail                      as Fail
+import           Control.Monad.IO.Class                  (MonadIO)
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Except
+import           Control.Monad.Zip
+import           Data.Bool                               (bool)
+import qualified Data.DList                              as DL
+import           Data.Either.Extra                       (mapLeft)
+import           Data.Foldable                           (Foldable (fold))
+import           Data.Functor.Classes
+import           Data.Functor.Contravariant
+import           Data.Monoid                             (All (All), getAll)
+import qualified Data.Text                               as T
+import           Data.Traversable                        (for)
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Service            (runAction)
+import           Development.IDE.Core.Shake
+import           Development.IDE.GHC.Compat              hiding (parseExpr)
+import           Development.IDE.Graph                   (RuleResult, Rules)
+import           Development.IDE.Graph.Classes
+import           Development.IDE.Types.Location
+import qualified GHC.Generics                            as GHC
+import           Generics.SYB
+import           Generics.SYB.GHC
+import           Ide.PluginUtils
+import           Language.Haskell.GHC.ExactPrint
+import           Language.Haskell.GHC.ExactPrint.Parsers
+import           Language.LSP.Types
+import           Language.LSP.Types.Capabilities         (ClientCapabilities)
+import           Outputable                              (Outputable, ppr,
+                                                          showSDoc)
+import           Parser                                  (parseIdentifier)
+import           Retrie.ExactPrint                       hiding (parseDecl,
+                                                          parseExpr,
+                                                          parsePattern,
+                                                          parseType)
 
 
 ------------------------------------------------------------------------------
@@ -230,7 +234,7 @@ graft' needs_space dst val = Graft $ \dflags a -> do
             ( mkT $
                 \case
                     (L src _ :: Located ast) | src == dst -> val'
-                    l -> l
+                    l                                     -> l
             )
             a
 

--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -18,7 +18,8 @@ import qualified Data.Text                      as T
 import           Development.IDE.Core.Rules
 import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Compat
-import           Development.IDE.GHC.Error      (realSrcSpanToRange, rangeToRealSrcSpan)
+import           Development.IDE.GHC.Error      (rangeToRealSrcSpan,
+                                                 realSrcSpanToRange)
 import           Development.IDE.Types.Location
 import           Language.LSP.Server            (LspM)
 import           Language.LSP.Types

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -46,7 +46,7 @@ import           Development.IDE.Core.Shake            (IdeState (shakeExtras),
 import           Development.IDE.Core.Tracing          (measureMemory)
 import           Development.IDE.Graph                 (action)
 import           Development.IDE.LSP.LanguageServer    (runLanguageServer)
-import           Development.IDE.Plugin                (Plugin (pluginHandlers, pluginRules, pluginModifyDynflags))
+import           Development.IDE.Plugin                (Plugin (pluginHandlers, pluginModifyDynflags, pluginRules))
 import           Development.IDE.Plugin.HLS            (asGhcIdePlugin)
 import qualified Development.IDE.Plugin.HLS.GhcIde     as Ghcide
 import           Development.IDE.Session               (SessionLoadingOptions,
@@ -60,7 +60,8 @@ import           Development.IDE.Types.Logger          (Logger (Logger))
 import           Development.IDE.Types.Options         (IdeGhcSession,
                                                         IdeOptions (optCheckParents, optCheckProject, optReportProgress),
                                                         clientSupportsProgress,
-                                                        defaultIdeOptions, optModifyDynFlags)
+                                                        defaultIdeOptions,
+                                                        optModifyDynFlags)
 import           Development.IDE.Types.Shake           (Key (Key))
 import           GHC.IO.Encoding                       (setLocaleEncoding)
 import           GHC.IO.Handle                         (hDuplicate)

--- a/ghcide/src/Development/IDE/Plugin.hs
+++ b/ghcide/src/Development/IDE/Plugin.hs
@@ -4,12 +4,12 @@ import           Data.Default
 import           Development.IDE.Graph
 
 import           Development.IDE.LSP.Server
-import           Ide.Types (DynFlagsModifications)
+import           Ide.Types                  (DynFlagsModifications)
 import qualified Language.LSP.Server        as LSP
 
 data Plugin c = Plugin
-    {pluginRules    :: Rules ()
-    ,pluginHandlers :: LSP.Handlers (ServerM c)
+    {pluginRules          :: Rules ()
+    ,pluginHandlers       :: LSP.Handlers (ServerM c)
     ,pluginModifyDynflags :: DynFlagsModifications
     }
 

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -165,15 +165,15 @@ findSigOfDeclRanged :: Range -> [LHsDecl p] -> Maybe (Sig p)
 findSigOfDeclRanged range decls = do
   dec <- findDeclContainingLoc (_start range) decls
   case dec of
-     L _ (SigD _ sig@TypeSig {}) -> Just sig
+     L _ (SigD _ sig@TypeSig {})     -> Just sig
      L _ (ValD _ (bind :: HsBind p)) -> findSigOfBind range bind
-     _ -> Nothing
+     _                               -> Nothing
 
 findSigOfBind :: Range -> HsBind p -> Maybe (Sig p)
 findSigOfBind range bind =
     case bind of
       FunBind {} -> findSigOfLMatch (unLoc $ mg_alts (fun_matches bind))
-      _ -> Nothing
+      _          -> Nothing
   where
     findSigOfLMatch :: [LMatch p (LHsExpr p)] -> Maybe (Sig p)
     findSigOfLMatch ls = do
@@ -188,7 +188,7 @@ findSigOfBind range bind =
           grhs <- findDeclContainingLoc (_start range) (grhssGRHSs grhs)
           case unLoc grhs of
             GRHS _ _ bd -> findSigOfExpr (unLoc bd)
-            _ -> Nothing
+            _           -> Nothing
 
     findSigOfExpr :: HsExpr p -> Maybe (Sig p)
     findSigOfExpr = go

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/RuleTypes.hs
@@ -8,9 +8,9 @@ import           Control.DeepSeq                (NFData)
 import           Data.Binary                    (Binary)
 import           Data.Hashable                  (Hashable)
 import           Data.Typeable                  (Typeable)
+import           Development.IDE.Graph          (RuleResult)
 import           Development.IDE.Types.Exports
 import           Development.IDE.Types.HscEnvEq (HscEnvEq)
-import           Development.IDE.Graph              (RuleResult)
 import           GHC.Generics                   (Generic)
 
 -- Rule type for caching Package Exports

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -25,13 +25,13 @@ import           Development.IDE.GHC.Error                    (rangeToSrcSpan)
 import           Development.IDE.GHC.ExactPrint               (Annotated (annsA),
                                                                GetAnnotatedParsedSource (GetAnnotatedParsedSource))
 import           Development.IDE.GHC.Util                     (prettyPrint)
+import           Development.IDE.Graph
+import           Development.IDE.Graph.Classes
 import           Development.IDE.Plugin.CodeAction.ExactPrint
 import           Development.IDE.Plugin.Completions.Logic
 import           Development.IDE.Plugin.Completions.Types
 import           Development.IDE.Types.HscEnvEq               (hscEnv)
 import           Development.IDE.Types.Location
-import           Development.IDE.Graph
-import           Development.IDE.Graph.Classes
 import           GHC.Exts                                     (toList)
 import           GHC.Generics
 import           Ide.Plugin.Config                            (Config)

--- a/ghcide/src/Development/IDE/Plugin/HLS.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS.hs
@@ -24,11 +24,11 @@ import           Data.String
 import qualified Data.Text                    as T
 import           Development.IDE.Core.Shake
 import           Development.IDE.Core.Tracing
+import           Development.IDE.Graph        (Rules)
 import           Development.IDE.LSP.Server
 import           Development.IDE.Plugin
 import qualified Development.IDE.Plugin       as P
 import           Development.IDE.Types.Logger
-import           Development.IDE.Graph            (Rules)
 import           Ide.Plugin.Config
 import           Ide.PluginUtils              (getClientConfig)
 import           Ide.Types                    as HLS

--- a/ghcide/src/Development/IDE/Plugin/Test.hs
+++ b/ghcide/src/Development/IDE/Plugin/Test.hs
@@ -18,6 +18,7 @@ import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Bifunctor
 import           Data.CaseInsensitive           (CI, original)
+import           Data.Default                   (def)
 import           Data.Maybe                     (isJust)
 import           Data.String
 import           Data.Text                      (Text, pack)
@@ -25,20 +26,19 @@ import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Service
 import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Compat
+import           Development.IDE.Graph          (Action)
 import           Development.IDE.LSP.Server
 import           Development.IDE.Plugin
+import qualified Development.IDE.Plugin         as P
 import           Development.IDE.Types.Action
 import           Development.IDE.Types.HscEnvEq (HscEnvEq (hscEnv))
 import           Development.IDE.Types.Location (fromUri)
-import           Development.IDE.Graph              (Action)
 import           GHC.Generics                   (Generic)
 import           GhcPlugins                     (HscEnv (hsc_dflags))
 import           Ide.Types
 import qualified Language.LSP.Server            as LSP
 import           Language.LSP.Types
 import           System.Time.Extra
-import qualified Development.IDE.Plugin as P
-import Data.Default (def)
 
 data TestRequest
     = BlockSeconds Seconds           -- ^ :: Null

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -35,13 +35,13 @@ import           Development.IDE.Core.Service        (getDiagnostics)
 import           Development.IDE.Core.Shake          (getHiddenDiagnostics, use)
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Util            (printName)
+import           Development.IDE.Graph.Classes
 import           Development.IDE.Spans.Common        (safeTyThingType)
 import           Development.IDE.Spans.LocalBindings (Bindings, getFuzzyScope)
 import           Development.IDE.Types.Location      (Position (Position, _character, _line),
                                                       Range (Range, _end, _start),
                                                       toNormalizedFilePath',
                                                       uriToFilePath')
-import           Development.IDE.Graph.Classes
 import           GHC.Generics                        (Generic)
 import           GhcPlugins                          (GlobalRdrEnv,
                                                       HscEnv (hsc_dflags), SDoc,

--- a/ghcide/src/Development/IDE/Spans/LocalBindings.hs
+++ b/ghcide/src/Development/IDE/Spans/LocalBindings.hs
@@ -12,12 +12,15 @@ module Development.IDE.Spans.LocalBindings
 import           Control.DeepSeq
 import           Control.Monad
 import           Data.Bifunctor
-import           Data.IntervalMap.FingerTree (IntervalMap, Interval (..))
-import qualified Data.IntervalMap.FingerTree as IM
-import qualified Data.List as L
-import qualified Data.Map as M
-import qualified Data.Set as S
-import           Development.IDE.GHC.Compat (RefMap, identType, identInfo, getScopeFromContext, getBindSiteFromContext, Scope(..), Name, Type)
+import           Data.IntervalMap.FingerTree    (Interval (..), IntervalMap)
+import qualified Data.IntervalMap.FingerTree    as IM
+import qualified Data.List                      as L
+import qualified Data.Map                       as M
+import qualified Data.Set                       as S
+import           Development.IDE.GHC.Compat     (Name, RefMap, Scope (..), Type,
+                                                 getBindSiteFromContext,
+                                                 getScopeFromContext, identInfo,
+                                                 identType)
 import           Development.IDE.GHC.Error
 import           Development.IDE.Types.Location
 import           NameEnv
@@ -53,7 +56,7 @@ localBindings refmap = bimap mk mk $ unzip $ do
         Just scopes <- pure $ getScopeFromContext info
         scope <- scopes >>= \case
           LocalScope scope -> pure $ realSrcSpanToInterval scope
-          _ -> []
+          _                -> []
         pure ( scope
             , unitNameEnv name (name,ty)
             )

--- a/ghcide/src/Development/IDE/Types/Action.hs
+++ b/ghcide/src/Development/IDE/Types/Action.hs
@@ -15,8 +15,8 @@ import           Data.HashSet                 (HashSet)
 import qualified Data.HashSet                 as Set
 import           Data.Hashable                (Hashable (..))
 import           Data.Unique                  (Unique)
+import           Development.IDE.Graph        (Action)
 import           Development.IDE.Types.Logger
-import           Development.IDE.Graph            (Action)
 import           Numeric.Natural
 
 data DelayedAction a = DelayedAction

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -24,8 +24,8 @@ import           Data.Unique
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error     (catchSrcErrors)
 import           Development.IDE.GHC.Util      (lookupPackageConfig)
-import           Development.IDE.Types.Exports (ExportsMap, createExportsMap)
 import           Development.IDE.Graph.Classes
+import           Development.IDE.Types.Exports (ExportsMap, createExportsMap)
 import           GhcPlugins                    (HscEnv (hsc_dflags),
                                                 InstalledPackageInfo (exposedModules),
                                                 Module (..),

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -22,8 +22,8 @@ module Development.IDE.Types.Options
 import qualified Data.Text                         as T
 import           Data.Typeable
 import           Development.IDE.Core.RuleTypes
-import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Graph
+import           Development.IDE.Types.Diagnostics
 import           GHC                               hiding (parseModule,
                                                     typecheckModule)
 import           GhcPlugins                        as GHC hiding (fst3, (<>))

--- a/ghcide/src/Development/IDE/Types/Shake.hs
+++ b/ghcide/src/Development/IDE/Types/Shake.hs
@@ -24,11 +24,11 @@ import           Data.Hashable
 import           Data.Typeable
 import           Data.Vector                          (Vector)
 import           Development.IDE.Core.PositionMapping
-import           Development.IDE.Types.Diagnostics
-import           Development.IDE.Types.Location
-import           Development.IDE.Graph                    (RuleResult,
+import           Development.IDE.Graph                (RuleResult,
                                                        ShakeException (shakeExceptionInner))
 import           Development.IDE.Graph.Classes
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
 import           GHC.Generics
 import           Language.LSP.Types
 

--- a/ghcide/src/Generics/SYB/GHC.hs
+++ b/ghcide/src/Generics/SYB/GHC.hs
@@ -10,12 +10,12 @@ module Generics.SYB.GHC
       largestM
     ) where
 
-import Control.Monad
-import Data.Functor.Compose (Compose(Compose))
-import Data.Monoid (Any(Any))
-import Development.IDE.GHC.Compat
-import Development.IDE.Graph.Classes
-import Generics.SYB
+import           Control.Monad
+import           Data.Functor.Compose          (Compose (Compose))
+import           Data.Monoid                   (Any (Any))
+import           Development.IDE.GHC.Compat
+import           Development.IDE.Graph.Classes
+import           Generics.SYB
 
 
 -- | A generic query intended to be used for calling 'smallestM' and
@@ -80,7 +80,7 @@ smallestM q f = fmap snd . go
         Just True -> do
           it@(r, x') <- gmapMQ go x
           case r of
-            Any True -> pure it
+            Any True  -> pure it
             Any False -> fmap (Any True,) $ f x'
         Just False -> pure (mempty, x)
 
@@ -100,9 +100,9 @@ largestM q f = go
     go :: GenericM m
     go x = do
       case q x of
-        Just True -> f x
+        Just True  -> f x
         Just False -> pure x
-        Nothing -> gmapM go x
+        Nothing    -> gmapM go x
 
 newtype MonadicQuery r m a = MonadicQuery
   { runMonadicQuery :: m (r, a)

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -35,8 +35,8 @@ import           Development.IDE.Core.PositionMapping     (PositionResult (..),
                                                            positionResultToMaybe,
                                                            toCurrent)
 import           Development.IDE.Core.Shake               (Q (..))
-import qualified Development.IDE.Main                     as IDE
 import           Development.IDE.GHC.Util
+import qualified Development.IDE.Main                     as IDE
 import           Development.IDE.Plugin.Completions.Types (extendImportCommandId)
 import           Development.IDE.Plugin.TypeLenses        (typeLensCommandId)
 import           Development.IDE.Spans.Common
@@ -74,37 +74,37 @@ import           System.IO.Extra                          hiding (withTempDir)
 import qualified System.IO.Extra
 import           System.Info.Extra                        (isWindows)
 import           System.Process.Extra                     (CreateProcess (cwd),
-                                                           proc,
-                                                           readCreateProcessWithExitCode, createPipe)
+                                                           createPipe, proc,
+                                                           readCreateProcessWithExitCode)
 import           Test.QuickCheck
 -- import Test.QuickCheck.Instances ()
+import           Control.Concurrent                       (threadDelay)
+import           Control.Concurrent.Async
 import           Control.Lens                             ((^.))
 import           Control.Monad.Extra                      (whenJust)
+import           Data.IORef
+import           Data.IORef.Extra                         (atomicModifyIORef_)
+import           Data.String                              (IsString (fromString))
 import           Data.Tuple.Extra
+import           Development.IDE.Core.FileStore           (getModTime)
 import           Development.IDE.Plugin.CodeAction        (matchRegExMultipleImports)
+import qualified Development.IDE.Plugin.HLS.GhcIde        as Ghcide
 import           Development.IDE.Plugin.Test              (TestRequest (BlockSeconds, GetInterfaceFilesDir),
                                                            WaitForIdeRuleResult (..),
                                                            blockCommandId)
+import           Ide.PluginUtils                          (pluginDescToIdePlugins)
+import           Ide.Types
+import qualified Language.LSP.Types                       as LSP
 import qualified Language.LSP.Types.Lens                  as L
+import qualified Progress
 import           System.Time.Extra
 import           Test.Tasty
 import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.HUnit
 import           Test.Tasty.Ingredients.Rerun
 import           Test.Tasty.QuickCheck
-import           Data.IORef
-import           Ide.PluginUtils (pluginDescToIdePlugins)
-import           Control.Concurrent.Async
-import           Ide.Types
-import           Data.String                              (IsString(fromString))
-import qualified Language.LSP.Types                       as LSP
-import           Data.IORef.Extra                         (atomicModifyIORef_)
-import qualified Development.IDE.Plugin.HLS.GhcIde        as Ghcide
+import           Text.Printf                              (printf)
 import           Text.Regex.TDFA                          ((=~))
-import qualified Progress
-import Development.IDE.Core.FileStore (getModTime)
-import Control.Concurrent (threadDelay)
-import Text.Printf (printf)
 
 waitForProgressBegin :: Session ()
 waitForProgressBegin = skipManyTill anyMessage $ satisfyMaybe $ \case

--- a/ghcide/test/exe/Progress.hs
+++ b/ghcide/test/exe/Progress.hs
@@ -1,9 +1,9 @@
 module Progress (tests) where
 
-import Development.IDE.Core.ProgressReporting
+import qualified Data.HashMap.Strict                    as Map
+import           Development.IDE.Core.ProgressReporting
 import           Test.Tasty
 import           Test.Tasty.HUnit
-import qualified Data.HashMap.Strict as Map
 
 tests :: TestTree
 tests = testGroup "Progress"

--- a/hls-graph/src/Development/IDE/Graph.hs
+++ b/hls-graph/src/Development/IDE/Graph.hs
@@ -19,7 +19,7 @@ module Development.IDE.Graph(
     reschedule,
     ) where
 
-import qualified Development.Shake as Shake
-import Development.IDE.Graph.Internal.Action
-import Development.IDE.Graph.Internal.Options
-import Development.IDE.Graph.Internal.Rules
+import           Development.IDE.Graph.Internal.Action
+import           Development.IDE.Graph.Internal.Options
+import           Development.IDE.Graph.Internal.Rules
+import qualified Development.Shake                      as Shake

--- a/hls-graph/src/Development/IDE/Graph/Classes.hs
+++ b/hls-graph/src/Development/IDE/Graph/Classes.hs
@@ -3,4 +3,4 @@ module Development.IDE.Graph.Classes(
     Show(..), Typeable, Eq(..), Hashable(..), Binary(..), NFData(..)
     ) where
 
-import Development.Shake.Classes
+import           Development.Shake.Classes

--- a/hls-graph/src/Development/IDE/Graph/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Database.hs
@@ -6,10 +6,10 @@ module Development.IDE.Graph.Database(
     Shake.shakeProfileDatabase,
     ) where
 
-import qualified Development.Shake.Database as Shake
-import Development.IDE.Graph.Internal.Action
-import Development.IDE.Graph.Internal.Options
-import Development.IDE.Graph.Internal.Rules
+import           Development.IDE.Graph.Internal.Action
+import           Development.IDE.Graph.Internal.Options
+import           Development.IDE.Graph.Internal.Rules
+import qualified Development.Shake.Database             as Shake
 
 shakeOpenDatabase :: ShakeOptions -> Rules () -> IO (IO Shake.ShakeDatabase, IO ())
 shakeOpenDatabase a b = Shake.shakeOpenDatabase (fromShakeOptions a) (fromRules b)

--- a/hls-graph/src/Development/IDE/Graph/Internal/Action.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Action.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 module Development.IDE.Graph.Internal.Action where
 
-import qualified Development.Shake as Shake
-import qualified Development.Shake.Rule as Shake
-import Development.Shake.Classes
-import Control.Exception
-import Control.Monad.IO.Class
-import Control.Monad.Fail
+import           Control.Exception
+import           Control.Monad.Fail
+import           Control.Monad.IO.Class
+import qualified Development.Shake         as Shake
+import           Development.Shake.Classes
+import qualified Development.Shake.Rule    as Shake
 
 newtype Action a = Action {fromAction :: Shake.Action a}
     deriving (Monad, Applicative, Functor, MonadIO, MonadFail)

--- a/hls-graph/src/Development/IDE/Graph/Internal/Options.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Options.hs
@@ -2,18 +2,18 @@
 
 module Development.IDE.Graph.Internal.Options where
 
-import qualified Development.Shake as Shake
-import qualified Data.HashMap.Strict as Map
-import Development.IDE.Graph.Internal.Action
-import Development.IDE.Graph.Internal.Rules
-import Data.Dynamic
+import           Data.Dynamic
+import qualified Data.HashMap.Strict                   as Map
+import           Development.IDE.Graph.Internal.Action
+import           Development.IDE.Graph.Internal.Rules
+import qualified Development.Shake                     as Shake
 
 data ShakeOptions = ShakeOptions {
-    shakeThreads :: Int,
-    shakeFiles :: FilePath,
-    shakeExtra :: Maybe Dynamic,
+    shakeThreads            :: Int,
+    shakeFiles              :: FilePath,
+    shakeExtra              :: Maybe Dynamic,
     shakeAllowRedefineRules :: Bool,
-    shakeTimings :: Bool
+    shakeTimings            :: Bool
     }
 
 shakeOptions :: ShakeOptions

--- a/hls-graph/src/Development/IDE/Graph/Internal/Rules.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Rules.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 module Development.IDE.Graph.Internal.Rules where
 
-import qualified Development.Shake as Shake
-import qualified Development.Shake.Rule as Shake
-import Development.Shake.Classes
-import Development.IDE.Graph.Internal.Action
-import Control.Monad.IO.Class
-import Control.Monad.Fail
-import qualified Data.ByteString as BS
+import           Control.Monad.Fail
+import           Control.Monad.IO.Class
+import qualified Data.ByteString                       as BS
+import           Development.IDE.Graph.Internal.Action
+import qualified Development.Shake                     as Shake
+import           Development.Shake.Classes
+import qualified Development.Shake.Rule                as Shake
 
 newtype Rules a = Rules {fromRules :: Shake.Rules a}
     deriving (Monoid, Semigroup, Monad, Applicative, Functor, MonadIO, MonadFail)

--- a/hls-graph/src/Development/IDE/Graph/Rule.hs
+++ b/hls-graph/src/Development/IDE/Graph/Rule.hs
@@ -10,6 +10,6 @@ module Development.IDE.Graph.Rule(
     apply, apply1,
     ) where
 
-import qualified Development.Shake.Rule as Shake
-import Development.IDE.Graph.Internal.Action
-import Development.IDE.Graph.Internal.Rules
+import           Development.IDE.Graph.Internal.Action
+import           Development.IDE.Graph.Internal.Rules
+import qualified Development.Shake.Rule                as Shake

--- a/hls-plugin-api/src/Ide/Plugin/Properties.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Properties.hs
@@ -48,7 +48,7 @@ import           Data.Either          (fromRight)
 import           Data.Function        ((&))
 import           Data.Kind            (Constraint, Type)
 import qualified Data.Map.Strict      as Map
-import           Data.Proxy (Proxy (..))
+import           Data.Proxy           (Proxy (..))
 import qualified Data.Text            as T
 import           GHC.OverloadedLabels (IsLabel (..))
 import           GHC.TypeLits

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -86,7 +86,14 @@ in (import sources.nixpkgs
       # default_stages = ["manual" "push"];
       hooks = {
         stylish-haskell.enable = true;
-        stylish-haskell.excludes = [ "^Setup.hs$" "test/testdata/.*$" "test/data/.*$" "^hie-compat/.*$" "^plugins/hls-tactics-plugin/.*$" ];
+        stylish-haskell.excludes = [
+          # Ignored files
+          "^Setup.hs$" "test/testdata/.*$" "test/data/.*$" "test/manual/lhs/.*$" "^hie-compat/.*$" "^plugins/hls-tactics-plugin/.*$"
+
+          # Temporarily ignored files
+          # Stylish-haskell (and other formatters) does not work well with some CPP usages in these files
+          "^ghcide/src/Development/IDE/GHC/Compat.hs$" "^plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs$" "^ghcide/test/exe/Main.hs$" "ghcide/src/Development/IDE/Core/Rules.hs" "^hls-test-utils/src/Test/Hls/Util.hs$"
+        ];
       };
     };
   }

--- a/plugins/default/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/default/src/Ide/Plugin/Fourmolu.hs
@@ -25,7 +25,7 @@ import           Ide.PluginUtils             (makeDiffTextEdit)
 
 import           Control.Monad.IO.Class
 import           Ide.Types
-import           Language.LSP.Server hiding (defaultConfig)
+import           Language.LSP.Server         hiding (defaultConfig)
 import           Language.LSP.Types
 import           Language.LSP.Types.Lens
 import           "fourmolu" Ormolu

--- a/plugins/default/src/Ide/Plugin/Ormolu.hs
+++ b/plugins/default/src/Ide/Plugin/Ormolu.hs
@@ -21,7 +21,7 @@ import           GHC.LanguageExtensions.Type
 import           GhcPlugins                  (HscEnv (hsc_dflags))
 import           Ide.PluginUtils
 import           Ide.Types
-import           Language.LSP.Server hiding (defaultConfig)
+import           Language.LSP.Server         hiding (defaultConfig)
 import           Language.LSP.Types
 import           "ormolu" Ormolu
 import           System.FilePath             (takeFileName)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# OPTIONS_GHC -Wwarn #-}
 
 {- |
@@ -9,15 +9,12 @@ module Ide.Plugin.Eval (
     descriptor,
 ) where
 
-import Development.IDE (IdeState)
+import           Development.IDE          (IdeState)
 import qualified Ide.Plugin.Eval.CodeLens as CL
-import Ide.Types (
-    PluginDescriptor (..),
-    PluginId,
-    defaultPluginDescriptor,
-    mkPluginHandler
- )
-import Language.LSP.Types
+import           Ide.Types                (PluginDescriptor (..), PluginId,
+                                           defaultPluginDescriptor,
+                                           mkPluginHandler)
+import           Language.LSP.Types
 
 -- |Plugin descriptor
 descriptor :: PluginId -> PluginDescriptor IdeState

--- a/plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs
+++ b/plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MagicHash             #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE RecordWildCards       #-}
@@ -14,7 +15,6 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ViewPatterns          #-}
-{-# LANGUAGE NamedFieldPuns        #-}
 
 module Ide.Plugin.Splice
     ( descriptor,
@@ -24,7 +24,8 @@ where
 import           Control.Applicative             (Alternative ((<|>)))
 import           Control.Arrow
 import qualified Control.Foldl                   as L
-import           Control.Lens                    (ix, view, (%~), (<&>), (^.), Identity(..))
+import           Control.Lens                    (Identity (..), ix, view, (%~),
+                                                  (<&>), (^.))
 import           Control.Monad
 import           Control.Monad.Extra             (eitherM)
 import qualified Control.Monad.Fail              as Fail

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -15,12 +15,12 @@ import qualified Data.ByteString.Lazy.Char8    as LBS
 import           Data.Default
 import qualified Data.Text                     as T
 import           Development.IDE.Core.Rules
+import           Development.IDE.Graph         (ShakeOptions (shakeThreads))
 import           Development.IDE.Main          (isLSP)
 import qualified Development.IDE.Main          as Main
 import qualified Development.IDE.Session       as Session
 import           Development.IDE.Types.Logger  as G
 import qualified Development.IDE.Types.Options as Ghcide
-import           Development.IDE.Graph             (ShakeOptions (shakeThreads))
 import           Ide.Arguments
 import           Ide.Logger
 import           Ide.Plugin.ConfigUtils        (pluginsToDefaultConfig,

--- a/test/wrapper/Main.hs
+++ b/test/wrapper/Main.hs
@@ -1,4 +1,4 @@
-import           Data.List.Extra    (trimEnd, isInfixOf)
+import           Data.List.Extra    (isInfixOf, trimEnd)
 import           Data.Maybe
 import           System.Environment
 import           System.Process


### PR DESCRIPTION
I'm now considering adding CI check for styling, but one big issue is that Haskell formatters (including Stylish-haskell, Ormolu, and Brittany) are not able to parse some specific usage of CPP pragmas.
For example, formatters cannot parse this code:
```Haskell
  test
#if defined(SOME_MACRO)
    = definition1
#else
    = definition2
#endif
```
and give an error. (However, if we move `test` to both branches they do not give an error)

We have quite a lot modules using pragmas in this way, so adding CI check will cause an unnecessary problems to modifying these modules.

Any idea will be appreciated.