### PR TITLE
[pluging][refine-import] Do not refine to Internal module

### DIFF
--- a/plugins/hls-refine-imports-plugin/test/Main.hs
+++ b/plugins/hls-refine-imports-plugin/test/Main.hs
@@ -21,6 +21,7 @@ main = defaultTestRunner $
     "Refine Imports"
     [ codeActionGoldenTest "WithOverride" 3 1
     , codeLensGoldenTest "UsualCase" 1
+    , codeLensGoldenTest "DontUseInternal" 1
     ]
 
 plugin :: PluginDescriptor IdeState

--- a/plugins/hls-refine-imports-plugin/test/testdata/DontUseInternal.expected.hs
+++ b/plugins/hls-refine-imports-plugin/test/testdata/DontUseInternal.expected.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import H
+import E ( e2 )
+import Data.List (intercalate)
+
+main :: IO ()
+main = putStrLn 
+     $ "hello " 
+    <> intercalate ", " [h, e2]

--- a/plugins/hls-refine-imports-plugin/test/testdata/DontUseInternal.hs
+++ b/plugins/hls-refine-imports-plugin/test/testdata/DontUseInternal.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import H
+import D
+import Data.List (intercalate)
+
+main :: IO ()
+main = putStrLn 
+     $ "hello " 
+    <> intercalate ", " [h, e2]

--- a/plugins/hls-refine-imports-plugin/test/testdata/H.hs
+++ b/plugins/hls-refine-imports-plugin/test/testdata/H.hs
@@ -1,0 +1,3 @@
+module H (module H.Internal) where
+
+import H.Internal

--- a/plugins/hls-refine-imports-plugin/test/testdata/H/Internal.hs
+++ b/plugins/hls-refine-imports-plugin/test/testdata/H/Internal.hs
@@ -1,0 +1,4 @@
+module H.Internal where
+
+h :: String 
+h = "h"

--- a/plugins/hls-refine-imports-plugin/test/testdata/hie.yaml
+++ b/plugins/hls-refine-imports-plugin/test/testdata/hie.yaml
@@ -3,6 +3,7 @@ cradle:
     arguments:
     - UsualCase.hs
     - WithOverride.hs
+    - DontUseInternal.hs
     - A.hs
     - B.hs
     - C.hs
@@ -10,3 +11,5 @@ cradle:
     - E.hs
     - F.hs
     - G.hs
+    - H.hs
+    - H/Internal.hs


### PR DESCRIPTION
So we shouldn't refine imports to use internal modules, for example the following should not happen:

```
import H
```

refined to

```
import H.Internal (h)
```


corresponding test attached :)
