### PR TITLE
Avoid package-qualified import in Fourmolu plugin

### DIFF
--- a/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE LambdaCase               #-}
 {-# LANGUAGE OverloadedStrings        #-}
-{-# LANGUAGE PackageImports           #-}
 {-# LANGUAGE TypeApplications         #-}
 
 module Ide.Plugin.Fourmolu (
@@ -25,7 +24,7 @@ import           Ide.Types
 import           Language.LSP.Server         hiding (defaultConfig)
 import           Language.LSP.Types
 import           Language.LSP.Types.Lens
-import           "fourmolu" Ormolu
+import           Ormolu
 import           System.FilePath
 
 -- ---------------------------------------------------------------------

--- a/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
+++ b/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PackageImports    #-}
 {-# LANGUAGE TypeApplications  #-}
 
 module Ide.Plugin.Ormolu
@@ -21,7 +20,7 @@ import           Ide.PluginUtils
 import           Ide.Types
 import           Language.LSP.Server         hiding (defaultConfig)
 import           Language.LSP.Types
-import           "ormolu" Ormolu
+import           Ormolu
 import           System.FilePath             (takeFileName)
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
Nobody likes `PackageImports`. And it's unnecessary since #1823.