### PR TITLE
Fix flake compat

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,4 +8,4 @@
     sha256 = lock.nodes.flake-compat.locked.narHash; }
 ) {
   src =  ./.;
-}).defaultNix
+}).shellNix


### PR DESCRIPTION
Closes #1846

We should enter `devShell` rather than the shell of `defaultPackage`.