### PR TITLE
Use cabal-install if nix is failing in CI

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,49 +1,9 @@
 pull_request_rules:
-- actions:
-    merge:
-      strict: smart+fasttrack
-      method: squash
-  name: Automatically merge pull requests
-  conditions:
-  - status-success=bench-example (8.10.4, ubuntu-latest, Cabal-3.0.0.0)
-  - status-success=bench-example (8.10.4, ubuntu-latest, lsp-types-1.0.0.1)
-  # disabled (too slow, ~4h) until hie-bios >0.7.2 is released
-  # - status-success=bench-example (8.10.4, ubuntu-latest, bench_example_HLS)
-
-  - status-success=nix (default, ubuntu-latest)
-  - status-success=nix (default, macOS-latest)
-
-  - status-success=test (8.10.4, ubuntu-latest)
-  - status-success=test (8.10.4, macOS-latest)
-  - status-success=test (8.10.3, ubuntu-latest)
-  - status-success=test (8.10.3, macOS-latest)
-  - status-success=test (8.10.2, ubuntu-latest)
-  - status-success=test (8.10.2, macOS-latest)
-  - status-success=test (8.8.4, ubuntu-latest)
-  - status-success=test (8.8.4, macOS-latest)
-  - status-success=test (8.8.3, ubuntu-latest)
-  - status-success=test (8.8.3, macOS-latest)
-  - status-success=test (8.8.2, ubuntu-latest)
-  - status-success=test (8.8.2, macOS-latest)
-  - status-success=test (8.6.5, ubuntu-latest)
-  - status-success=test (8.6.5, macOS-latest)
-  - status-success=test (8.6.4, ubuntu-latest)
-  - status-success=test (8.6.4, macOS-latest)
-  - status-success=test (windows-latest, 8.10.4, true)
-  - status-success=test (windows-latest, 8.10.3)
-  - status-success=test (windows-latest, 8.6.5, true)
-  - status-success=test (windows-latest, 8.10.2.2)
-  # - status-success=test (windows-latest, 8.6.4)
-
-  - 'status-success=ci/circleci: ghc-8.10.4'
-  - 'status-success=ci/circleci: ghc-8.10.3'
-  - 'status-success=ci/circleci: ghc-8.10.2'
-  - 'status-success=ci/circleci: ghc-8.8.4'
-  - 'status-success=ci/circleci: ghc-8.8.3'
-  - 'status-success=ci/circleci: ghc-8.8.2'
-  - 'status-success=ci/circleci: ghc-8.6.5'
-  - 'status-success=ci/circleci: ghc-8.6.4'
-  - 'status-success=ci/circleci: ghc-default'
-
-  - label=merge me
-  - '#approved-reviews-by>=1'
+  - actions:
+      merge:
+        strict: smart+fasttrack
+        method: squash
+    name: Automatically merge pull requests
+    conditions:
+      - label=merge me
+      - '#approved-reviews-by>=1'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -47,7 +47,7 @@ jobs:
         name: haskell-language-server
         authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
     - if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      run: nix build
+      run: nix build || (nix develop --command cabal update && nix develop --command cabal build)
     - if: ${{ needs.pre_job.outputs.should_skip != 'true' && env.HAS_TOKEN == 'true' }}
       run: nix develop --profile dev && cachix push haskell-language-server dev
     - if: ${{ needs.pre_job.outputs.should_skip != 'true' && env.HAS_TOKEN == 'true' }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    branches:
+      - master
 
 jobs:
   pre_job:
@@ -17,11 +20,10 @@ jobs:
           cancel_others: true
           paths_ignore: '["**/docs/**", "**.md", "**/LICENSE", ".circleci/**", "install/**"]'
 
-  nix:
+  # Enter the development shell and run `cabal build`
+  develop:
     needs: pre_job
     runs-on: ${{ matrix.os }}
-    env:
-      HAS_TOKEN: ${{ secrets.HLS_CACHIX_AUTH_TOKEN != '' }}
 
     strategy:
       fail-fast: false
@@ -41,14 +43,43 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
         nix_path: nixpkgs=channel:nixos-unstable
-    - if: ${{ needs.pre_job.outputs.should_skip != 'true' && env.HAS_TOKEN == 'true' }}
-      uses: cachix/cachix-action@v8
+    - if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      uses: cachix/cachix-action@v10
+      with:
+        name: haskell-language-server
+        # Disable pushing, we will do that in job `build`
+        skipPush: true
+    - if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      run: |
+        nix develop --command cabal update
+        nix develop --command cabal build
+
+  # Build and then push HLS binaries with developmet shell to cachix
+  # This job runs when PRs are merged to master, and should be excluded from branch protections
+  build:
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.repository_owner == 'haskell' && github.ref == 'ref/heads/master' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+      uses: cachix/install-nix-action@v13
+      with:
+        install_url: https://nixos-nix-install-tests.cachix.org/serve/lb41az54kzk6j12p81br4bczary7m145/install
+        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+        nix_path: nixpkgs=channel:nixos-unstable
+      uses: cachix/cachix-action@v10
       with:
         name: haskell-language-server
         authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
-    - if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      run: nix build || (nix develop --command cabal update && nix develop --command cabal build)
-    - if: ${{ needs.pre_job.outputs.should_skip != 'true' && env.HAS_TOKEN == 'true' }}
-      run: nix develop --profile dev && cachix push haskell-language-server dev
-    - if: ${{ needs.pre_job.outputs.should_skip != 'true' && env.HAS_TOKEN == 'true' }}
-      run: nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server
+      run: |
+        nix build
+        nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server
+        nix develop --profile dev && cachix push haskell-language-server dev

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -65,21 +65,21 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
 
     steps:
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
       with:
         submodules: true
-      uses: cachix/install-nix-action@v13
+    - uses: cachix/install-nix-action@v13
       with:
         install_url: https://nixos-nix-install-tests.cachix.org/serve/lb41az54kzk6j12p81br4bczary7m145/install
         install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
         extra_nix_config: |
           experimental-features = nix-command flakes
         nix_path: nixpkgs=channel:nixos-unstable
-      uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v10
       with:
         name: haskell-language-server
         authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
-      run: |
+    - run: |
         nix build
         nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server
         nix develop --profile dev && cachix push haskell-language-server dev

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -80,6 +80,6 @@ jobs:
         name: haskell-language-server
         authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
     - run: |
+        nix develop --profile dev && cachix push haskell-language-server dev
         nix build
         nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server
-        nix develop --profile dev && cachix push haskell-language-server dev

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+# This file is the compt layer of flakes: https://github.com/edolstra/flake-compat
+# See flake.nix for details
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).defaultNix


### PR DESCRIPTION
We have decided to maintain the nix packaging (building HLS binaries in nix) in #1827. Ideally, we are always have HLS binaries prepared without `cabal-install`. However, PRs that update project dependencies like #1858 may be blocked by nix ci, since nixpkgs does not have the new dependency yet, and even if it has, a bump of nixpkgs is required. It's unreasonable to require every contributor to handle nix things, so this PR add a fallback in CI, which uses `cabal-install` to build HLS in case some required packages are missing in nixpkgs.

Also adds `default.nix`, so that the legacy `nix-build` can work.