### PR TITLE
Trace more Shake evaluation details

### DIFF
--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -829,9 +829,9 @@ defineEarlyCutoff
     :: IdeRule k v
     => RuleBody k v
     -> Rules ()
-defineEarlyCutoff (Rule op) = addRule $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file isSuccess $ do
+defineEarlyCutoff (Rule op) = addRule $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file mode isSuccess $ do
     defineEarlyCutoff' True key file old mode $ op key file
-defineEarlyCutoff (RuleNoDiagnostics op) = addRule $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file isSuccess $ do
+defineEarlyCutoff (RuleNoDiagnostics op) = addRule $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file mode isSuccess $ do
     defineEarlyCutoff' False key file old mode $ second (mempty,) <$> op key file
 
 defineNoFile :: IdeRule k v => (k -> Action v) -> Rules ()
@@ -904,9 +904,9 @@ defineEarlyCutoff' doDiagnostics key file old mode action = do
                     (encodeShakeValue bs) $
                     A res
 
-isSuccess :: RunResult (A v) -> Bool
-isSuccess (RunResult _ _ (A Failed{})) = False
-isSuccess _                            = True
+isSuccess :: A v -> Bool
+isSuccess (A Failed{}) = False
+isSuccess _            = True
 
 -- | Rule type, input file
 data QDisk k = QDisk k NormalizedFilePath

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -96,9 +96,7 @@ otTracedAction key file mode success act
             res <- act
             unless (success $ runValue res) $ setTag sp "error" "1"
             setTag sp "changed" $ case res of
-              RunResult ChangedRecomputeSame _ _ -> "0"
-              RunResult ChangedNothing _ _       -> "0"
-              RunResult ChangedRecomputeDiff _ _ -> "0"
+              RunResult x _ _ -> fromString $ show x
             return res)
   | otherwise = act
 


### PR DESCRIPTION
Opentelemetry traces have proven very useful for understanding the evaluation and performance of the Shake rules. This change adds more information to those traces:

- What mode a rule is running in - is this a full rerun (dependencies changed) or just a lookup in the values state?
- Whether the rule value changed after running

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/26626/119250275-da7c4d80-bb96-11eb-863d-4710dddfadbb.png">
