### PR TITLE
Technology preview: Keep track of changes to minimize rebuilds

### DIFF
--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -236,8 +236,6 @@ loadSessionWithOptions SessionLoadingOptions{..} dir = do
   -- Version of the mappings above
   version <- newVar 0
   let returnWithVersion fun = IdeGhcSession fun <$> liftIO (readVar version)
-  let invalidateShakeCache = do
-        void $ modifyVar' version succ
   -- This caches the mapping from Mod.hs -> hie.yaml
   cradleLoc <- liftIO $ memoIO $ \v -> do
       res <- findCradle v
@@ -253,6 +251,9 @@ loadSessionWithOptions SessionLoadingOptions{..} dir = do
   return $ do
     extras@ShakeExtras{logger, restartShakeSession, ideNc, knownTargetsVar, lspEnv
                       } <- getShakeExtras
+    let invalidateShakeCache = do
+            void $ modifyVar' version succ
+            recordDirtyKeys extras GhcSessionIO [emptyFilePath]
 
     IdeOptions{ optTesting = IdeTesting optTesting
               , optCheckProject = getCheckProject

--- a/ghcide/src/Development/IDE.hs
+++ b/ghcide/src/Development/IDE.hs
@@ -15,7 +15,7 @@ import           Development.IDE.Core.FileExists       as X (getFileExists)
 import           Development.IDE.Core.FileStore        as X (getFileContents)
 import           Development.IDE.Core.IdeConfiguration as X (IdeConfiguration (..),
                                                              isWorkspaceFile)
-import           Development.IDE.Core.OfInterest       as X (getFilesOfInterest)
+import           Development.IDE.Core.OfInterest       as X (getFilesOfInterestUntracked)
 import           Development.IDE.Core.RuleTypes        as X
 import           Development.IDE.Core.Rules            as X (IsHiFileStable (..),
                                                              getClientConfigAction,

--- a/ghcide/src/Development/IDE/Core/Actions.hs
+++ b/ghcide/src/Development/IDE/Core/Actions.hs
@@ -116,7 +116,7 @@ highlightAtPoint file pos = runMaybeT $ do
 refsAtPoint :: NormalizedFilePath -> Position -> Action [Location]
 refsAtPoint file pos = do
     ShakeExtras{hiedb} <- getShakeExtras
-    fs <- HM.keys <$> getFilesOfInterest
+    fs <- HM.keys <$> getFilesOfInterestUntracked
     asts <- HM.fromList . mapMaybe sequence . zip fs <$> usesWithStale GetHieAst fs
     AtPoint.referencesAtPoint hiedb file pos (AtPoint.FOIReferences asts)
 

--- a/ghcide/src/Development/IDE/Core/FileExists.hs
+++ b/ghcide/src/Development/IDE/Core/FileExists.hs
@@ -102,9 +102,11 @@ modifyFileExists state changes = do
     void $ modifyVar' var $ HashMap.union (HashMap.mapMaybe fromChange changesMap)
     -- See Note [Invalidating file existence results]
     -- flush previous values
-    let (_fileModifChanges, fileExistChanges) =
+    let (fileModifChanges, fileExistChanges) =
             partition ((== FcChanged) . snd) (HashMap.toList changesMap)
     mapM_ (deleteValue (shakeExtras state) GetFileExists . fst) fileExistChanges
+    recordDirtyKeys (shakeExtras state) GetFileExists $ map fst fileExistChanges
+    recordDirtyKeys (shakeExtras state) GetModificationTime $ map fst fileModifChanges
 
 fromChange :: FileChangeType -> Maybe Bool
 fromChange FcCreated = Just True

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -14,7 +14,6 @@ module Development.IDE.Core.FileStore(
     VFSHandle,
     makeVFSHandle,
     makeLSPVFSHandle,
-    isFileOfInterestRule,
     resetFileStore,
     resetInterfaceStore,
     getModificationTimeImpl,
@@ -40,8 +39,7 @@ import qualified Data.Rope.UTF16                              as Rope
 import qualified Data.Text                                    as T
 import           Data.Time
 import           Data.Time.Clock.POSIX
-import           Development.IDE.Core.OfInterest              (OfInterestVar (..),
-                                                               getFilesOfInterest)
+import           Development.IDE.Core.OfInterest              (OfInterestVar (..))
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Orphans                  ()
@@ -50,6 +48,7 @@ import           Development.IDE.Import.DependencyInformation
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
+import           Development.IDE.Types.Shake                  (SomeShakeValue)
 import           HieDb.Create                                 (deleteMissingRealFiles)
 import           Ide.Plugin.Config                            (CheckParents (..),
                                                                Config)
@@ -66,6 +65,9 @@ import qualified Development.IDE.Types.Logger                 as L
 
 import qualified Data.Binary                                  as B
 import qualified Data.ByteString.Lazy                         as LBS
+import qualified Data.HashSet                                 as HSet
+import           Data.IORef.Extra                             (atomicModifyIORef_)
+import           Data.List                                    (foldl')
 import qualified Data.Text                                    as Text
 import           Development.IDE.Core.IdeConfiguration        (isWorkspaceFile)
 import           Language.LSP.Server                          hiding
@@ -116,19 +118,6 @@ addWatchedFileRule isWatched = defineNoDiagnostics $ \AddWatchedFile f -> do
             Just env -> fmap Just $ liftIO $ LSP.runLspT env $
                 registerFileWatches [fromNormalizedFilePath f]
             Nothing -> pure $ Just False
-
-isFileOfInterestRule :: Rules ()
-isFileOfInterestRule = defineEarlyCutoff $ RuleNoDiagnostics $ \IsFileOfInterest f -> do
-    filesOfInterest <- getFilesOfInterest
-    let foi = maybe NotFOI IsFOI $ f `HM.lookup` filesOfInterest
-        fp  = summarize foi
-        res = (Just fp, Just foi)
-    return res
-    where
-    summarize NotFOI                   = BS.singleton 0
-    summarize (IsFOI OnDisk)           = BS.singleton 1
-    summarize (IsFOI (Modified False)) = BS.singleton 2
-    summarize (IsFOI (Modified True))  = BS.singleton 3
 
 
 getModificationTimeRule :: VFSHandle -> Rules ()
@@ -183,19 +172,20 @@ resetInterfaceStore state f = do
 
 -- | Reset the GetModificationTime state of watched files
 resetFileStore :: IdeState -> [FileEvent] -> IO ()
-resetFileStore ideState changes = mask $ \_ ->
-    forM_ changes $ \(FileEvent uri c) ->
+resetFileStore ideState changes = mask $ \_ -> do
+    -- we record FOIs document versions in all the stored values
+    -- so NEVER reset FOIs to avoid losing their versions
+    OfInterestVar foisVar <- getIdeGlobalExtras (shakeExtras ideState)
+    fois <- readVar foisVar
+    forM_ changes $ \(FileEvent uri c) -> do
         case c of
             FcChanged
               | Just f <- uriToFilePath uri
-              -> do
-                  -- we record FOIs document versions in all the stored values
-                  -- so NEVER reset FOIs to avoid losing their versions
-                  OfInterestVar foisVar <- getIdeGlobalExtras (shakeExtras ideState)
-                  fois <- readVar foisVar
-                  unless (HM.member (toNormalizedFilePath f) fois) $ do
-                    deleteValue (shakeExtras ideState) GetModificationTime (toNormalizedFilePath' f)
+              , nfp <- toNormalizedFilePath f
+              , not $ HM.member nfp fois
+              -> deleteValue (shakeExtras ideState) GetModificationTime nfp
             _ -> pure ()
+
 
 -- Dir.getModificationTime is surprisingly slow since it performs
 -- a ton of conversions. Since we do not actually care about
@@ -262,7 +252,6 @@ fileStoreRules vfs isWatched = do
     addIdeGlobal vfs
     getModificationTimeRule vfs
     getFileContentsRule vfs
-    isFileOfInterestRule
     addWatchedFileRule isWatched
 
 -- | Note that some buffer for a specific file has been modified but not
@@ -281,7 +270,8 @@ setFileModified state saved nfp = do
     VFSHandle{..} <- getIdeGlobalState state
     when (isJust setVirtualFileContents) $
         fail "setFileModified can't be called on this type of VFSHandle"
-    shakeRestart state []
+    recordDirtyKeys (shakeExtras state) GetModificationTime [nfp]
+    restartShakeSession (shakeExtras state) []
     when checkParents $
       typecheckParents state nfp
 
@@ -301,17 +291,19 @@ typecheckParentsAction nfp = do
           `catch` \(e :: SomeException) -> log (show e)
         () <$ uses GetModIface rs
 
--- | Note that some buffer somewhere has been modified, but don't say what.
+-- | Note that some keys have been modified and restart the session
 --   Only valid if the virtual file system was initialised by LSP, as that
 --   independently tracks which files are modified.
-setSomethingModified :: IdeState -> IO ()
-setSomethingModified state = do
+setSomethingModified :: IdeState -> [SomeShakeValue] -> IO ()
+setSomethingModified state keys = do
     VFSHandle{..} <- getIdeGlobalState state
     when (isJust setVirtualFileContents) $
         fail "setSomethingModified can't be called on this type of VFSHandle"
     -- Update database to remove any files that might have been renamed/deleted
     atomically $ writeTQueue (indexQueue $ hiedbWriter $ shakeExtras state) deleteMissingRealFiles
-    void $ shakeRestart state []
+    atomicModifyIORef_ (dirtyKeys $ shakeExtras state) $ \x ->
+        foldl' (flip HSet.insert) x keys
+    void $ restartShakeSession (shakeExtras state) []
 
 registerFileWatches :: [String] -> LSP.LspT Config IO Bool
 registerFileWatches globs = do
@@ -338,7 +330,7 @@ registerFileWatches globs = do
           -- support that: https://github.com/bubba/lsp-test/issues/77
           watchers = [ watcher (Text.pack glob) | glob <- globs ]
 
-        void $ LSP.sendRequest LSP.SClientRegisterCapability regParams (const $ pure ())
+        void $ LSP.sendRequest LSP.SClientRegisterCapability regParams (const $ pure ()) -- TODO handle response
         return True
       else return False
 

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -5,10 +5,13 @@
 {-# LANGUAGE TypeFamilies      #-}
 
 -- | Utilities and state for the files of interest - those which are currently
---   open in the editor. The useful function is 'getFilesOfInterest'.
+--   open in the editor. The rule is 'IsFileOfInterest'
 module Development.IDE.Core.OfInterest(
     ofInterestRules,
-    getFilesOfInterest, setFilesOfInterest, modifyFilesOfInterest,
+    getFilesOfInterestUntracked,
+    addFileOfInterest,
+    deleteFileOfInterest,
+    setFilesOfInterest,
     kick, FileOfInterestStatus(..),
     OfInterestVar(..)
     ) where
@@ -16,7 +19,6 @@ module Development.IDE.Core.OfInterest(
 import           Control.Concurrent.Strict
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Data.Binary
 import           Data.HashMap.Strict                          (HashMap)
 import qualified Data.HashMap.Strict                          as HashMap
 import qualified Data.Text                                    as T
@@ -24,7 +26,7 @@ import           Development.IDE.Graph
 
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
-import qualified Data.ByteString.Lazy                         as LBS
+import qualified Data.ByteString                              as BS
 import           Data.List.Extra                              (nubOrd)
 import           Data.Maybe                                   (catMaybes)
 import           Development.IDE.Core.ProgressReporting
@@ -43,15 +45,19 @@ instance IsIdeGlobal OfInterestVar
 ofInterestRules :: Rules ()
 ofInterestRules = do
     addIdeGlobal . OfInterestVar =<< liftIO (newVar HashMap.empty)
-    defineEarlyCutOffNoFile $ \GetFilesOfInterest -> do
+    defineEarlyCutoff $ RuleNoDiagnostics $ \IsFileOfInterest f -> do
         alwaysRerun
         filesOfInterest <- getFilesOfInterestUntracked
-        let !cutoff = LBS.toStrict $ encode $ HashMap.toList filesOfInterest
-        pure (cutoff, filesOfInterest)
+        let foi = maybe NotFOI IsFOI $ f `HashMap.lookup` filesOfInterest
+            fp  = summarize foi
+            res = (Just fp, Just foi)
+        return res
+    where
+    summarize NotFOI                   = BS.singleton 0
+    summarize (IsFOI OnDisk)           = BS.singleton 1
+    summarize (IsFOI (Modified False)) = BS.singleton 2
+    summarize (IsFOI (Modified True))  = BS.singleton 3
 
--- | Get the files that are open in the IDE.
-getFilesOfInterest :: Action (HashMap NormalizedFilePath FileOfInterestStatus)
-getFilesOfInterest = useNoFile_ GetFilesOfInterest
 
 ------------------------------------------------------------
 -- Exposed API
@@ -59,29 +65,39 @@ getFilesOfInterest = useNoFile_ GetFilesOfInterest
 -- | Set the files-of-interest - not usually necessary or advisable.
 --   The LSP client will keep this information up to date.
 setFilesOfInterest :: IdeState -> HashMap NormalizedFilePath FileOfInterestStatus -> IO ()
-setFilesOfInterest state files = modifyFilesOfInterest state (const files)
+setFilesOfInterest state files = do
+    OfInterestVar var <- getIdeGlobalState state
+    writeVar var files
 
 getFilesOfInterestUntracked :: Action (HashMap NormalizedFilePath FileOfInterestStatus)
 getFilesOfInterestUntracked = do
     OfInterestVar var <- getIdeGlobalAction
     liftIO $ readVar var
 
--- | Modify the files-of-interest - not usually necessary or advisable.
---   The LSP client will keep this information up to date.
-modifyFilesOfInterest
-  :: IdeState
-  -> (HashMap NormalizedFilePath FileOfInterestStatus -> HashMap NormalizedFilePath FileOfInterestStatus)
-  -> IO ()
-modifyFilesOfInterest state f = do
+addFileOfInterest :: IdeState -> NormalizedFilePath -> FileOfInterestStatus -> IO ()
+addFileOfInterest state f v = do
     OfInterestVar var <- getIdeGlobalState state
-    files <- modifyVar' var f
-    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ HashMap.toList files)
+    (prev, files) <- modifyVar var $ \dict -> do
+        let (prev, new) = HashMap.alterF (, Just v) f dict
+        pure (new, (prev, dict))
+    when (prev /= Just v) $
+        recordDirtyKeys (shakeExtras state) IsFileOfInterest [f]
+    logDebug (ideLogger state) $
+        "Set files of interest to: " <> T.pack (show files)
+
+deleteFileOfInterest :: IdeState -> NormalizedFilePath -> IO ()
+deleteFileOfInterest state f = do
+    OfInterestVar var <- getIdeGlobalState state
+    files <- modifyVar' var $ HashMap.delete f
+    recordDirtyKeys (shakeExtras state) IsFileOfInterest [f]
+    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show files)
+
 
 -- | Typecheck all the files of interest.
 --   Could be improved
 kick :: Action ()
 kick = do
-    files <- HashMap.keys <$> getFilesOfInterest
+    files <- HashMap.keys <$> getFilesOfInterestUntracked
     ShakeExtras{progress} <- getShakeExtras
     liftIO $ progressUpdate progress KickStarted
 

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -40,7 +40,6 @@ import           HscTypes                                     (HomeModInfo,
 import qualified Data.Binary                                  as B
 import           Data.ByteString                              (ByteString)
 import qualified Data.ByteString.Lazy                         as LBS
-import           Data.HashMap.Strict                          (HashMap)
 import           Data.Text                                    (Text)
 import           Data.Time
 import           Development.IDE.Import.FindImports           (ArtifactsLocation)
@@ -356,8 +355,6 @@ type instance RuleResult GetModSummary = ModSummaryResult
 -- | Generate a ModSummary with the timestamps and preprocessed content elided, for more successful early cutoff
 type instance RuleResult GetModSummaryWithoutTimestamps = ModSummaryResult
 
-type instance RuleResult GetFilesOfInterest = HashMap NormalizedFilePath FileOfInterestStatus
-
 data GetParsedModule = GetParsedModule
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetParsedModule
@@ -520,12 +517,6 @@ data GhcSessionIO = GhcSessionIO deriving (Eq, Show, Typeable, Generic)
 instance Hashable GhcSessionIO
 instance NFData   GhcSessionIO
 instance Binary   GhcSessionIO
-
-data GetFilesOfInterest = GetFilesOfInterest
-    deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetFilesOfInterest
-instance NFData   GetFilesOfInterest
-instance Binary   GetFilesOfInterest
 
 makeLensesWith
     (lensRules & lensField .~ mappingNamer (pure . (++ "L")))

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -22,7 +22,6 @@ import           Development.IDE.Types.Logger
 import           Development.IDE.Types.Options
 
 import           Control.Monad.Extra
-import qualified Data.HashMap.Strict                   as M
 import qualified Data.HashSet                          as S
 import qualified Data.Text                             as Text
 
@@ -35,6 +34,8 @@ import           Development.IDE.Core.FileStore        (registerFileWatches,
                                                         setSomethingModified,
                                                         typecheckParents)
 import           Development.IDE.Core.OfInterest
+import           Development.IDE.Core.RuleTypes        (GetClientSettings (..))
+import           Development.IDE.Types.Shake           (toKey)
 import           Ide.Plugin.Config                     (CheckParents (CheckOnClose))
 import           Ide.Types
 
@@ -49,7 +50,7 @@ descriptor plId = (defaultPluginDescriptor plId) { pluginNotificationHandlers = 
       whenUriFile _uri $ \file -> do
           -- We don't know if the file actually exists, or if the contents match those on disk
           -- For example, vscode restores previously unsaved contents on open
-          modifyFilesOfInterest ide (M.insert file Modified{firstOpen=True})
+          addFileOfInterest ide file Modified{firstOpen=True}
           setFileModified ide False file
           logDebug (ideLogger ide) $ "Opened text document: " <> getUri _uri
 
@@ -57,21 +58,21 @@ descriptor plId = (defaultPluginDescriptor plId) { pluginNotificationHandlers = 
       \ide _ (DidChangeTextDocumentParams identifier@VersionedTextDocumentIdentifier{_uri} changes) -> liftIO $ do
         updatePositionMapping ide identifier changes
         whenUriFile _uri $ \file -> do
-          modifyFilesOfInterest ide (M.insert file Modified{firstOpen=False})
+          addFileOfInterest ide file Modified{firstOpen=False}
           setFileModified ide False file
         logDebug (ideLogger ide) $ "Modified text document: " <> getUri _uri
 
   , mkPluginNotificationHandler LSP.STextDocumentDidSave $
       \ide _ (DidSaveTextDocumentParams TextDocumentIdentifier{_uri} _) -> liftIO $ do
         whenUriFile _uri $ \file -> do
-            modifyFilesOfInterest ide (M.insert file OnDisk)
+            addFileOfInterest ide file OnDisk
             setFileModified ide True file
         logDebug (ideLogger ide) $ "Saved text document: " <> getUri _uri
 
   , mkPluginNotificationHandler LSP.STextDocumentDidClose $
         \ide _ (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> liftIO $ do
           whenUriFile _uri $ \file -> do
-              modifyFilesOfInterest ide (M.delete file)
+              deleteFileOfInterest ide file
               -- Refresh all the files that depended on this
               checkParents <- optCheckParents =<< getIdeOptionsIO (shakeExtras ide)
               when (checkParents >= CheckOnClose) $ typecheckParents ide file
@@ -85,7 +86,7 @@ descriptor plId = (defaultPluginDescriptor plId) { pluginNotificationHandlers = 
         logDebug (ideLogger ide) $ "Watched file events: " <> msg
         modifyFileExists ide fileEvents
         resetFileStore ide fileEvents
-        setSomethingModified ide
+        setSomethingModified ide []
 
   , mkPluginNotificationHandler LSP.SWorkspaceDidChangeWorkspaceFolders $
       \ide _ (DidChangeWorkspaceFoldersParams events) -> liftIO $ do
@@ -100,7 +101,7 @@ descriptor plId = (defaultPluginDescriptor plId) { pluginNotificationHandlers = 
         let msg = Text.pack $ show cfg
         logDebug (ideLogger ide) $ "Configuration changed: " <> msg
         modifyClientSettings ide (const $ Just cfg)
-        setSomethingModified ide
+        setSomethingModified ide [toKey GetClientSettings emptyFilePath ]
 
   , mkPluginNotificationHandler LSP.SInitialized $ \ide _ _ -> do
       --------- Initialize Shake session --------------------------------------------------------------------

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -81,6 +81,8 @@ data IdeOptions = IdeOptions
   , optSkipProgress       :: forall a. Typeable a => a -> Bool
       -- ^ Predicate to select which rule keys to exclude from progress reporting.
   , optProgressStyle      :: ProgressReportingStyle
+  , optRunSubset          :: Bool
+      -- ^ Experimental feature to re-run only the subset of the Shake graph that has changed
   }
 
 optShakeFiles :: IdeOptions -> Maybe FilePath
@@ -142,6 +144,7 @@ defaultIdeOptions session = IdeOptions
     ,optModifyDynFlags = mempty
     ,optSkipProgress = defaultSkipProgress
     ,optProgressStyle = Explicit
+    ,optRunSubset = False
     }
 
 defaultSkipProgress :: Typeable a => a -> Bool

--- a/ghcide/src/Development/IDE/Types/Shake.hs
+++ b/ghcide/src/Development/IDE/Types/Shake.hs
@@ -8,11 +8,12 @@ module Development.IDE.Types.Shake
     ValueWithDiagnostics (..),
     Values,
     Key (..),
+    SomeShakeValue,
     BadDependency (..),
     ShakeValue(..),
     currentValue,
     isBadDependency,
-  toShakeValue,encodeShakeValue,decodeShakeValue)
+  toShakeValue,encodeShakeValue,decodeShakeValue,toKey,toNoFileKey)
 where
 
 import           Control.DeepSeq
@@ -26,7 +27,9 @@ import           Data.Vector                          (Vector)
 import           Development.IDE.Core.PositionMapping
 import           Development.IDE.Graph                (RuleResult,
                                                        ShakeException (shakeExceptionInner))
+import qualified Development.IDE.Graph                as Shake
 import           Development.IDE.Graph.Classes
+import           Development.IDE.Graph.Database       (SomeShakeValue (..))
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location
 import           GHC.Generics
@@ -54,7 +57,7 @@ data ValueWithDiagnostics
 type Values = HashMap (NormalizedFilePath, Key) ValueWithDiagnostics
 
 -- | Key type
-data Key = forall k . (Typeable k, Hashable k, Eq k, Show k) => Key k
+data Key = forall k . (Typeable k, Hashable k, Eq k, NFData k, Show k) => Key k
 
 instance Show Key where
   show (Key k) = show k
@@ -64,7 +67,14 @@ instance Eq Key where
                      | otherwise = False
 
 instance Hashable Key where
-    hashWithSalt salt (Key key) = hashWithSalt salt (typeOf key, key)
+    hashWithSalt salt (Key key) = hashWithSalt salt key
+
+instance Binary Key where
+    get = error "not really"
+    put _ = error "not really"
+
+instance NFData Key where
+    rnf (Key k) = rnf k
 
 -- | When we depend on something that reported an error, and we fail as a direct result, throw BadDependency
 --   which short-circuits the rest of the action
@@ -76,6 +86,13 @@ isBadDependency x
     | Just (x :: ShakeException) <- fromException x = isBadDependency $ shakeExceptionInner x
     | Just (_ :: BadDependency) <- fromException x = True
     | otherwise = False
+
+
+toKey :: Shake.ShakeValue k => k -> NormalizedFilePath -> SomeShakeValue
+toKey = (SomeShakeValue .) . curry Q
+
+toNoFileKey :: (Show k, Typeable k, Eq k, Hashable k, Binary k, NFData k) => k -> SomeShakeValue
+toNoFileKey k = toKey k emptyFilePath
 
 newtype Q k = Q (k, NormalizedFilePath)
     deriving newtype (Eq, Hashable, NFData)

--- a/hls-graph/src/Development/IDE/Graph/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Database.hs
@@ -1,8 +1,9 @@
 
 module Development.IDE.Graph.Database(
     Shake.ShakeDatabase,
+    Shake.SomeShakeValue(..),
     shakeOpenDatabase,
-    shakeRunDatabase,
+    shakeRunDatabaseForKeys,
     Shake.shakeProfileDatabase,
     ) where
 
@@ -14,5 +15,9 @@ import qualified Development.Shake.Database             as Shake
 shakeOpenDatabase :: ShakeOptions -> Rules () -> IO (IO Shake.ShakeDatabase, IO ())
 shakeOpenDatabase a b = Shake.shakeOpenDatabase (fromShakeOptions a) (fromRules b)
 
-shakeRunDatabase :: Shake.ShakeDatabase -> [Action a] -> IO ([a], [IO ()])
-shakeRunDatabase a b = Shake.shakeRunDatabase a (map fromAction b)
+shakeRunDatabaseForKeys
+    :: Maybe [Shake.SomeShakeValue]       -- ^ Set of keys changed since last run
+    -> Shake.ShakeDatabase
+    -> [Action a]
+    -> IO ([a], [IO ()])
+shakeRunDatabaseForKeys keys a b = Shake.shakeRunDatabaseForKeys keys a (map fromAction b)

--- a/hls-graph/src/Development/IDE/Graph/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Database.hs
@@ -1,23 +1,36 @@
 
+{-# LANGUAGE ExistentialQuantification #-}
 module Development.IDE.Graph.Database(
     Shake.ShakeDatabase,
-    Shake.SomeShakeValue(..),
+    SomeShakeValue(..),
     shakeOpenDatabase,
     shakeRunDatabaseForKeys,
     Shake.shakeProfileDatabase,
     ) where
 
+import           Data.Typeable
 import           Development.IDE.Graph.Internal.Action
 import           Development.IDE.Graph.Internal.Options
 import           Development.IDE.Graph.Internal.Rules
+import           Development.Shake                      (ShakeValue)
+import           Development.Shake.Classes
 import qualified Development.Shake.Database             as Shake
 
 shakeOpenDatabase :: ShakeOptions -> Rules () -> IO (IO Shake.ShakeDatabase, IO ())
 shakeOpenDatabase a b = Shake.shakeOpenDatabase (fromShakeOptions a) (fromRules b)
 
+data SomeShakeValue = forall k . ShakeValue k => SomeShakeValue k
+instance Eq SomeShakeValue where SomeShakeValue a == SomeShakeValue b = cast a == Just b
+instance Hashable SomeShakeValue where hashWithSalt s (SomeShakeValue x) = hashWithSalt s x
+instance Show SomeShakeValue where show (SomeShakeValue x) = show x
+
 shakeRunDatabaseForKeys
-    :: Maybe [Shake.SomeShakeValue]       -- ^ Set of keys changed since last run
+    :: Maybe [SomeShakeValue]
+      -- ^ Set of keys changed since last run. 'Nothing' means everything has changed
     -> Shake.ShakeDatabase
     -> [Action a]
     -> IO ([a], [IO ()])
-shakeRunDatabaseForKeys keys a b = Shake.shakeRunDatabaseForKeys keys a (map fromAction b)
+shakeRunDatabaseForKeys _keys a b =
+    -- Shake upstream does not accept the set of keys changed yet
+    -- https://github.com/ndmitchell/shake/pull/802
+    Shake.shakeRunDatabase a (map fromAction b)

--- a/plugins/default/src/Ide/Plugin/Example.hs
+++ b/plugins/default/src/Ide/Plugin/Example.hs
@@ -77,7 +77,7 @@ exampleRules = do
     return ([diag], Just ())
 
   action $ do
-    files <- getFilesOfInterest
+    files <- getFilesOfInterestUntracked
     void $ uses Example $ Map.keys files
 
 mkDiag :: NormalizedFilePath

--- a/plugins/default/src/Ide/Plugin/Example2.hs
+++ b/plugins/default/src/Ide/Plugin/Example2.hs
@@ -75,7 +75,7 @@ exampleRules = do
     return ([diag], Just ())
 
   action $ do
-    files <- getFilesOfInterest
+    files <- getFilesOfInterestUntracked
     void $ uses Example2 $ Map.keys files
 
 mkDiag :: NormalizedFilePath

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -120,8 +120,7 @@ type instance RuleResult GetHlintDiagnostics = ()
 
 -- | Hlint rules to generate file diagnostics based on hlint hints
 -- | This rule is recomputed when:
--- | - The files of interest have changed via `getFilesOfInterest`
--- | - One of those files has been edited via
+-- | - A file has been edited via
 -- |    - `getIdeas` -> `getParsedModule` in any case
 -- |    - `getIdeas` -> `getFileContents` if the hls ghc does not match the hlint default ghc
 -- | - The client settings have changed, to honour the `hlintOn` setting, via `getClientConfigAction`
@@ -140,7 +139,7 @@ rules plugin = do
     liftIO $ argsSettings flags
 
   action $ do
-    files <- getFilesOfInterest
+    files <- getFilesOfInterestUntracked
     void $ uses GetHlintDiagnostics $ Map.keys files
 
   where

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
@@ -27,7 +27,7 @@ import           Data.Set (Set)
 import qualified Data.Set as S
 import qualified Data.Text as T
 import           Data.Traversable
-import           Development.IDE (getFilesOfInterest, ShowDiagnostic (ShowDiag), srcSpanToRange)
+import           Development.IDE (getFilesOfInterestUntracked, ShowDiagnostic (ShowDiag), srcSpanToRange)
 import           Development.IDE (hscEnv)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Rules (usePropertyAction)
@@ -549,7 +549,7 @@ wingmanRules plId = do
               )
 
   action $ do
-    files <- getFilesOfInterest
+    files <- getFilesOfInterestUntracked
     void $ uses WriteDiagnostics $ Map.keys files
 
 


### PR DESCRIPTION
_NOTE: This is a technology preview of something I have been working on for several months. It requires extending `his-graph` to accept the set of keys that have changed since the last build as an input, of which there isn't a final implementation yet. There is a Shake implementation (https://github.com/ndmitchell/shake/pull/802), but it might end up being reimplemented  in #1759 instead. Details still being worked out._

This PR extends ghcide to keep track of the set of rules that have changed since the last successful build. This information is then shard with his-graph, which can then use it to minimize the amount of build rules visited.

## Motivation

When his-graph runs a rule, it first tells it whether its dependencies have changed. Ghcide uses this information to skip evaluation and perform a lookup on the Values state when the dependencies have not changed. Even though this lookup is fast, the constant overheads are significant and the cost can add up. Currently, in order to evaluate a `TypeCheck Some.Module` rule, Ghcide needs to perform a number of lookups proportional to the transitive imports  of `Some.Module`. This PR makes it technically possible to make the number of lookups independent of the number of transitive imports.

## Example

Consider the "edit" experiment on the Cabal 3.0.0.0 example of the benchmark suite, which performs a whitespace edit on the `Distribution.Simple` module and measures the typecheck time. Ghcide installs an LSP handler for the `TextDocumentDidChange` event that triggers a rebuild of the `TypeCheck Distribution.Simple` rule. However, this doesn't tell his-graph that the only thing that has changed since the last build is the `GetModificationTime Distribution.Simple` rule. Without this information, hls-graph needs to evaluate all the dependencies (collected in the previous run) of the `TypeCheck Distribution.Simple` rule to find out if they have changed since last run, and only then it can run the `TypeCheck` rule.

The `TypeCheck Distribution.Simple` rule depends on two other rules:
- `GhcSessionDeps Distribution.Simple`
- `GetParsedModule Distribution.Simple`

Again, before evaluating either of these two other rules, his-graph needs to run their dependencies to find out whether they have changed. In the case of `GhcSessionDeps`, this includes:
1. `GetTransitiveDependencies D.S`
2. `GetModIface X` for all X in the transitive dependencies of D.S
3. `GhcSession D.S`

Because of 2, his-graph needs to run a number of build rules proportional to the transitive deps of the module being type checked. We know that these runs will be just lookups, since nothing has changed in their dependencies all the way to the leaf rules, but still it's a significant overhead that could be avoided if we were to tell his-graph that the only rule that has changed is the file contents of `Distribution.Simple`. That's what this PR does.

Visually, the open telemetry traces below show the before and after (using https://github.com/ndmitchell/shake/pull/802) of the example. The traces show all the rules evaluated by Shake during the evaluation of `TypeCheck Distribution.Simple`. 

### Before
Takes around 700ms to do a TypeCheck of the module and the statistics table shows all the other rules visited during the evaluation.
![Before detail](https://user-images.githubusercontent.com/26626/119256922-ed087e00-bbba-11eb-9abd-9a4163c07165.png)

### After
Typecheck completes in only 70ms and the number of rules visited, while still proportional to the count of transitive imports, is much lower. Why is it still proportional? I haven't investigated but I suspect it's related to the `NeedsCompilation` rules depending on the whole project via the `ModuleGraph` rule. 
![After detail](https://user-images.githubusercontent.com/26626/119257009-4d97bb00-bbbb-11eb-9f89-441d3c54b518.png)

## Implementation Details

There is a new `dirtyKeys` mutable set to keep track of world changes, which are collected from LSP notifications. We already register file watchers for haskell source files, but this needs to be extended to any other files that we care about, e.g. cradle dependencies. Need to check whether this is already done.

- [x] File watches for cradle dependencies and TH dependencies

The set of dirty keys is handed over to his-graph in the call to `shakeRunDatabase`. his-graph is responsible for keeping track of the transitive dirty set across builds. For example, if `GetModificationTime D.S` has become dirty, all its reverse dependencies must be tagged as dirty too. his-graph can remove a rule from the dirty set once it's been evaluated, which may not happen in this build.

Other bits: 
- Rules that are not in the dirty set will not be evaluated, even if they are `alwaysRerun`. Missing rules will lead to stale results and hard to diagnose bugs. There is a flag `optRunSubset` that controls whether we call his-graph in the old way (everything has potentially changed) or in the new way (only these rules have changed) intended to debug these issues. 
- Rules cannot be removed from the dirty set until positive that they have been evaluated by hls-graph, specially since builds can be interrupted at any time. 
- The tracking of files of interest now becomes much more precise: currently everything depends on `GetFilesOfInterest`, this rule is now gone. 

## Merging

This work has been sitting in my fork for too long. Before I forget the details, I want to get it reviewed and possibly merged too even if there isn't a working hls-graph implementation available yet. The changes should be a no-op in terms of functionality and the costs of tracking dirty rules are negligible, so I think it should be safe to merge.

A version of these changes running against https://github.com/ndmitchell/shake/pull/802 and exercising the test and bench suites is available at https://github.com/pepeiborra/ide/pull/9
