### PR TITLE
Let Wingman peek through type families

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
@@ -13,6 +13,7 @@ module Wingman.CodeGen
 import           ConLike
 import           Control.Lens ((%~), (<>~), (&))
 import           Control.Monad.Except
+import           Control.Monad.Reader (ask)
 import           Control.Monad.State
 import           Data.Bool (bool)
 import           Data.Functor ((<&>))
@@ -24,6 +25,7 @@ import           Data.Traversable
 import           DataCon
 import           Development.IDE.GHC.Compat
 import           GHC.Exts
+import           GHC.SourceGen (occNameToStr)
 import           GHC.SourceGen.Binds
 import           GHC.SourceGen.Expr
 import           GHC.SourceGen.Overloaded
@@ -39,8 +41,6 @@ import           Wingman.Judgements.Theta
 import           Wingman.Machinery
 import           Wingman.Naming
 import           Wingman.Types
-import GHC.SourceGen (occNameToStr)
-import Control.Monad.Reader (ask)
 
 
 destructMatches

--- a/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
@@ -23,6 +23,7 @@ import           Development.IDE.Core.Compile (lookupName)
 import           Development.IDE.GHC.Compat hiding (exprType)
 import           DsExpr (dsExpr)
 import           DsMonad (initDs)
+import           FamInst (tcLookupDataFamInst_maybe)
 import           FamInstEnv (normaliseType)
 import           GHC.SourceGen (lambda)
 import           Generics.SYB (Data, everything, everywhere, listify, mkQ, mkT)
@@ -377,7 +378,21 @@ mkFunTys' =
 
 
 ------------------------------------------------------------------------------
--- | Expand type families
+-- | Expand type and data families
 normalizeType :: Context -> Type -> Type
-normalizeType ctx = snd . normaliseType  (ctxFamInstEnvs ctx) Nominal
+normalizeType ctx ty =
+  let ty' = expandTyFam ctx ty
+   in case tcSplitTyConApp_maybe ty' of
+        Just (tc, tys) ->
+          -- try to expand any data families
+          case tcLookupDataFamInst_maybe (ctxFamInstEnvs ctx) tc tys of
+            Just (dtc, dtys, _) -> mkAppTys (mkTyConTy dtc) dtys
+            Nothing -> ty'
+        Nothing -> ty'
+
+------------------------------------------------------------------------------
+-- | Expand type families
+expandTyFam :: Context -> Type -> Type
+expandTyFam ctx = snd . normaliseType  (ctxFamInstEnvs ctx) Nominal
+
 

--- a/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
@@ -23,9 +23,10 @@ import           Development.IDE.Core.Compile (lookupName)
 import           Development.IDE.GHC.Compat hiding (exprType)
 import           DsExpr (dsExpr)
 import           DsMonad (initDs)
+import           FamInstEnv (normaliseType)
 import           GHC.SourceGen (lambda)
 import           Generics.SYB (Data, everything, everywhere, listify, mkQ, mkT)
-import           GhcPlugins (extractModule, GlobalRdrElt (gre_name))
+import           GhcPlugins (extractModule, GlobalRdrElt (gre_name), Role (Nominal))
 import           OccName
 import           TcRnMonad
 import           TcType
@@ -373,4 +374,10 @@ mkFunTys' =
 #else
   mkVisFunTys
 #endif
+
+
+------------------------------------------------------------------------------
+-- | Expand type families
+normalizeType :: Context -> Type -> Type
+normalizeType ctx = snd . normaliseType  (ctxFamInstEnvs ctx) Nominal
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
@@ -17,7 +17,7 @@ import           Development.IDE.Spans.LocalBindings
 import           OccName
 import           SrcLoc
 import           Type
-import           Wingman.GHC (algebraicTyCon)
+import           Wingman.GHC (algebraicTyCon, normalizeType)
 import           Wingman.Types
 
 
@@ -69,11 +69,19 @@ withNewGoal :: a -> Judgement' a -> Judgement' a
 withNewGoal t = field @"_jGoal" .~ t
 
 
-introduce :: Hypothesis a -> Judgement' a -> Judgement' a
+normalizeHypothesis :: Functor f => Context -> f CType -> f CType
+normalizeHypothesis = fmap . coerce . normalizeType
+
+normalizeJudgement :: Functor f => Context -> f CType -> f CType
+normalizeJudgement = normalizeHypothesis
+
+
+introduce :: Context -> Hypothesis CType -> Judgement' CType -> Judgement' CType
 -- NOTE(sandy): It's important that we put the new hypothesis terms first,
 -- since 'jAcceptableDestructTargets' will never destruct a pattern that occurs
 -- after a previously-destructed term.
-introduce hy = field @"_jHypothesis" %~ mappend hy
+introduce ctx hy =
+  field @"_jHypothesis" %~ mappend (normalizeHypothesis ctx hy)
 
 
 ------------------------------------------------------------------------------
@@ -393,17 +401,19 @@ substJdg subst = fmap $ coerce . substTy subst . coerce
 
 
 mkFirstJudgement
-    :: Hypothesis CType
+    :: Context
+    -> Hypothesis CType
     -> Bool  -- ^ are we in the top level rhs hole?
     -> Type
     -> Judgement' CType
-mkFirstJudgement hy top goal = Judgement
-  { _jHypothesis        = hy
-  , _jBlacklistDestruct = False
-  , _jWhitelistSplit    = True
-  , _jIsTopHole         = top
-  , _jGoal              = CType goal
-  }
+mkFirstJudgement ctx hy top goal =
+  Judgement
+    { _jHypothesis        = fmap (coerce $ normalizeType ctx) hy
+    , _jBlacklistDestruct = False
+    , _jWhitelistSplit    = True
+    , _jIsTopHole         = top
+    , _jGoal              = CType $ normalizeType ctx goal
+    }
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
@@ -407,13 +407,14 @@ mkFirstJudgement
     -> Type
     -> Judgement' CType
 mkFirstJudgement ctx hy top goal =
-  Judgement
-    { _jHypothesis        = fmap (coerce $ normalizeType ctx) hy
-    , _jBlacklistDestruct = False
-    , _jWhitelistSplit    = True
-    , _jIsTopHole         = top
-    , _jGoal              = CType $ normalizeType ctx goal
-    }
+  normalizeJudgement ctx $
+    Judgement
+      { _jHypothesis        = hy
+      , _jBlacklistDestruct = False
+      , _jWhitelistSplit    = True
+      , _jIsTopHole         = top
+      , _jGoal              = CType goal
+      }
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
@@ -275,7 +275,9 @@ mkJudgementAndContext cfg g (TrackedStale binds bmap) rss (TrackedStale tcg tcgm
       subst = ts_unifier $ appEndo (foldMap (Endo . evidenceToSubst) evidence) defaultTacticState
   pure $
     ( disallowing AlreadyDestructed already_destructed
-    $ fmap (CType . substTyAddInScope subst . unCType) $ mkFirstJudgement
+    $ fmap (CType . substTyAddInScope subst . unCType) $
+        mkFirstJudgement
+          ctx
           (local_hy <> cls_hy)
           (isRhsHole tcg_rss tcs)
           g

--- a/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
@@ -49,10 +49,13 @@ newSubgoal
     :: Judgement
     -> Rule
 newSubgoal j = do
-    unifier <- gets ts_unifier
-    subgoal
-      $ substJdg unifier
-      $ unsetIsTopHole j
+  ctx <- ask
+  unifier <- gets ts_unifier
+  subgoal
+    $ normalizeJudgement ctx
+    $ substJdg unifier
+    $ unsetIsTopHole
+    $ normalizeJudgement ctx j
 
 
 tacticToRule :: Judgement -> TacticsM () -> Rule

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -26,8 +26,11 @@ import           Data.Set (Set)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Tree
+import           Development.IDE (Range)
+import           Development.IDE.Core.UseStale
 import           Development.IDE.GHC.Compat hiding (Node)
 import           Development.IDE.GHC.Orphans ()
+import           FamInstEnv (FamInstEnvs)
 import           GHC.Generics
 import           GHC.SourceGen (var)
 import           InstEnv (InstEnvs(..))
@@ -39,8 +42,6 @@ import           UniqSupply (takeUniqFromSupply, mkSplitUniqSupply, UniqSupply)
 import           Unique (nonDetCmpUnique, Uniquable, getUnique, Unique)
 import           Wingman.Debug
 import           Wingman.FeatureSet
-import Development.IDE.Core.UseStale
-import Development.IDE (Range)
 
 
 ------------------------------------------------------------------------------
@@ -422,6 +423,7 @@ data Context = Context
   , ctxConfig        :: Config
   , ctxKnownThings   :: KnownThings
   , ctxInstEnvs      :: InstEnvs
+  , ctxFamInstEnvs   :: FamInstEnvs
   , ctxTheta         :: Set CType
   }
 
@@ -452,6 +454,7 @@ emptyContext
       , ctxModuleFuncs = mempty
       , ctxConfig = emptyConfig
       , ctxKnownThings = error "empty known things from emptyContext"
+      , ctxFamInstEnvs = mempty
       , ctxInstEnvs = InstEnvs mempty mempty mempty
       , ctxTheta = mempty
       }

--- a/plugins/hls-tactics-plugin/test/AutoTupleSpec.hs
+++ b/plugins/hls-tactics-plugin/test/AutoTupleSpec.hs
@@ -36,6 +36,7 @@ spec = describe "auto for tuple" $ do
           runTactic
             emptyContext
             (mkFirstJudgement
+              emptyContext
               (Hypothesis $ pure $ HyInfo (mkVarOcc "x") UserPrv $ CType in_type)
               True
               out_type)

--- a/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
@@ -18,6 +18,8 @@ spec = do
     destructTest "a"     6 18 "DestructPun"
     destructTest "fp"   31 14 "DestructCthulhu"
     destructTest "b"     7 10 "DestructTyFam"
+    destructTest "b"     7 10 "DestructDataFam"
+    destructTest "b"    17 10 "DestructTyToDataFam"
 
   describe "layout" $ do
     destructTest "b"  4  3 "LayoutBind"

--- a/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
@@ -17,6 +17,7 @@ spec = do
     destructTest "a"     7 25 "SplitPattern"
     destructTest "a"     6 18 "DestructPun"
     destructTest "fp"   31 14 "DestructCthulhu"
+    destructTest "b"     7 10 "DestructTyFam"
 
   describe "layout" $ do
     destructTest "b"  4  3 "LayoutBind"

--- a/plugins/hls-tactics-plugin/test/golden/DestructDataFam.expected.hs
+++ b/plugins/hls-tactics-plugin/test/golden/DestructDataFam.expected.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeFamilies #-}
+
+data family Yo
+data instance Yo = Heya Int
+
+test :: Yo -> Int
+test (Heya n) = _
+

--- a/plugins/hls-tactics-plugin/test/golden/DestructDataFam.hs
+++ b/plugins/hls-tactics-plugin/test/golden/DestructDataFam.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeFamilies #-}
+
+data family Yo
+data instance Yo = Heya Int
+
+test :: Yo -> Int
+test b = _
+

--- a/plugins/hls-tactics-plugin/test/golden/DestructTyFam.expected.hs
+++ b/plugins/hls-tactics-plugin/test/golden/DestructTyFam.expected.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE TypeFamilies #-}
+
+type family Yo where
+  Yo = Bool
+
+test :: Yo -> Int
+test False = _
+test True = _
+

--- a/plugins/hls-tactics-plugin/test/golden/DestructTyFam.hs
+++ b/plugins/hls-tactics-plugin/test/golden/DestructTyFam.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeFamilies #-}
+
+type family Yo where
+  Yo = Bool
+
+test :: Yo -> Int
+test b = _
+

--- a/plugins/hls-tactics-plugin/test/golden/DestructTyToDataFam.expected.hs
+++ b/plugins/hls-tactics-plugin/test/golden/DestructTyToDataFam.expected.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+type family T1 a where
+  T1 a = T2 Int
+
+type family T2 a
+type instance T2 Int = T3
+
+type family T3 where
+  T3 = Yo
+
+data family Yo
+data instance Yo = Heya Int
+
+test :: T1 Bool -> Int
+test (Heya n) = _
+

--- a/plugins/hls-tactics-plugin/test/golden/DestructTyToDataFam.hs
+++ b/plugins/hls-tactics-plugin/test/golden/DestructTyToDataFam.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+type family T1 a where
+  T1 a = T2 Int
+
+type family T2 a
+type instance T2 Int = T3
+
+type family T3 where
+  T3 = Yo
+
+data family Yo
+data instance Yo = Heya Int
+
+test :: T1 Bool -> Int
+test b = _
+


### PR DESCRIPTION
This PR fixes a bug where type families would be opaque to Wingman, even if they weren't stuck. Now, we normalize any types coming into the judgment.

Fixes #1874