### PR TITLE
[explicit-imports] Take in a predicate to filter modules

### DIFF
--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -10,6 +10,7 @@
 
 module Ide.Plugin.ExplicitImports
   ( descriptor
+  , descriptorForModules
   , extractMinimalImports
   , within
   ) where
@@ -45,7 +46,14 @@ importCommandId = "ImportLensCommand"
 
 -- | The "main" function of a plugin
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId =
+descriptor = descriptorForModules (/= moduleName pRELUDE)
+
+descriptorForModules
+    :: (ModuleName -> Bool)
+      -- ^ Predicate to select modules that will be annotated
+    -> PluginId
+    -> PluginDescriptor IdeState
+descriptorForModules pred plId =
   (defaultPluginDescriptor plId)
     {
       -- This plugin provides a command handler
@@ -54,9 +62,9 @@ descriptor plId =
       pluginRules = minimalImportsRule,
       pluginHandlers = mconcat
         [ -- This plugin provides code lenses
-          mkPluginHandler STextDocumentCodeLens lensProvider
+          mkPluginHandler STextDocumentCodeLens $ lensProvider pred
           -- This plugin provides code actions
-        , mkPluginHandler STextDocumentCodeAction codeActionProvider
+        , mkPluginHandler STextDocumentCodeAction $ codeActionProvider pred
         ]
     }
 
@@ -87,8 +95,9 @@ runImportCommand _state (ImportCommandParams edit) = do
 -- the provider should produce one code lens associated to the import statement:
 --
 -- > import Data.List (intercalate, sortBy)
-lensProvider :: PluginMethodHandler IdeState TextDocumentCodeLens
+lensProvider :: (ModuleName -> Bool) -> PluginMethodHandler IdeState TextDocumentCodeLens
 lensProvider
+  pred
   state -- ghcide state, used to retrieve typechecking artifacts
   pId -- plugin Id
   CodeLensParams {_textDocument = TextDocumentIdentifier {_uri}}
@@ -105,7 +114,7 @@ lensProvider
               sequence
                 [ generateLens pId _uri edit
                   | (imp, Just minImport) <- minImports,
-                    Just edit <- [mkExplicitEdit posMapping imp minImport]
+                    Just edit <- [mkExplicitEdit pred posMapping imp minImport]
                 ]
             return $ Right (List $ catMaybes commands)
           _ ->
@@ -115,8 +124,8 @@ lensProvider
 
 -- | If there are any implicit imports, provide one code action to turn them all
 --   into explicit imports.
-codeActionProvider :: PluginMethodHandler IdeState TextDocumentCodeAction
-codeActionProvider ideState _pId (CodeActionParams _ _ docId range _context)
+codeActionProvider :: (ModuleName -> Bool) -> PluginMethodHandler IdeState TextDocumentCodeAction
+codeActionProvider pred ideState _pId (CodeActionParams _ _ docId range _context)
   | TextDocumentIdentifier {_uri} <- docId,
     Just nfp <- uriToNormalizedFilePath $ toNormalizedUri _uri = liftIO $
     do
@@ -135,7 +144,7 @@ codeActionProvider ideState _pId (CodeActionParams _ _ docId range _context)
                 [ e
                   | (imp, Just explicit) <-
                       maybe [] getMinimalImportsResult minImports,
-                    Just e <- [mkExplicitEdit zeroMapping imp explicit]
+                    Just e <- [mkExplicitEdit pred zeroMapping imp explicit]
                 ]
               caExplicitImports = InR CodeAction {..}
               _title = "Make all imports explicit"
@@ -219,8 +228,8 @@ extractMinimalImports (Just hsc) (Just TcModuleResult {..}) = do
   return (imports, minimalImports)
 extractMinimalImports _ _ = return ([], Nothing)
 
-mkExplicitEdit :: PositionMapping -> LImportDecl pass -> T.Text -> Maybe TextEdit
-mkExplicitEdit posMapping (L src imp) explicit
+mkExplicitEdit :: (ModuleName -> Bool) -> PositionMapping -> LImportDecl pass -> T.Text -> Maybe TextEdit
+mkExplicitEdit pred posMapping (L src imp) explicit
   -- Explicit import list case
   | ImportDecl {ideclHiding = Just (False, _)} <- imp =
     Nothing
@@ -228,7 +237,7 @@ mkExplicitEdit posMapping (L src imp) explicit
     RealSrcSpan l <- src,
     L _ mn <- ideclName imp,
     -- (almost) no one wants to see an explicit import list for Prelude
-    mn /= moduleName pRELUDE,
+    pred mn,
     Just rng <- toCurrentRange posMapping $ realSrcSpanToRange l =
     Just $ TextEdit rng explicit
   | otherwise =


### PR DESCRIPTION
This is intended for custom LSP servers and generalises the current filtering of Prelude