### PR TITLE
Cleanup stack build output in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,12 @@ defaults: &defaults
     - run:
         name: Build (we need the exe for tests)
         # need j1, else ghc-lib-parser triggers OOM
-        command: stack -j 1 --stack-yaml=${STACK_FILE} install
+        command: stack -j 1 --stack-yaml=${STACK_FILE} install --no-terminal
         no_output_timeout: 30m
 
     - run:
         name: Build Testsuite without running it
-        command: stack -j 1 --stack-yaml=${STACK_FILE} build --test --no-run-tests
+        command: stack -j 1 --stack-yaml=${STACK_FILE} build --test --no-run-tests --no-terminal
         no_output_timeout: 30m
 
     - store_artifacts:
@@ -54,7 +54,7 @@ defaults: &defaults
 
     - run:
         name: Build including tests
-        command: stack --stack-yaml=${STACK_FILE} test --no-run-tests
+        command: stack --stack-yaml=${STACK_FILE} test --no-run-tests --no-terminal
         no_output_timeout: 120m
 
     - save_cache:


### PR DESCRIPTION
Figuring out stuff from circleci logs is currently pretty annoying due to stack's ansi terminal progress output:

![Screenshot from 2021-06-09 19-05-53](https://user-images.githubusercontent.com/2716069/121398627-d6ea1400-c955-11eb-8fd3-ece8e42d5618.png)

This are great when running stack interactively, but they clutter output in CI.
This behavior can be disabled by using `--no-terminal`. From `stack build --help`:

```
  --[no-]terminal          Enable/disable overriding terminal detection in the
                           case of running in a false terminal
```


