### PR TITLE
Fall back to hiedb for invalid srcspan paths

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -135,6 +135,7 @@ jobs:
     - if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       name: untar
       run: |
+        mkdir -p ~/.cabal
         tar xzf workspace.tar.gz
         tar xzf cabal.tar.gz --directory ~/.cabal
 

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.4.0.0
+version:            1.4.0.1
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors


### PR DESCRIPTION
When reusing .hie files from a cloud cache, the paths may not match the local file system. 

Let's fall back to the hiedb in case it contains local paths