### PR TITLE
Allow symbol identifiers in tactics

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Lexer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Lexer.hs
@@ -8,6 +8,7 @@ module Wingman.Metaprogramming.Lexer where
 import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.Reader (ReaderT)
+import           Data.Foldable (asum)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Void
@@ -17,8 +18,7 @@ import           Name
 import qualified Text.Megaparsec as P
 import qualified Text.Megaparsec.Char as P
 import qualified Text.Megaparsec.Char.Lexer as L
-import Wingman.Types (Context)
-import Data.Foldable (asum)
+import           Wingman.Types (Context)
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Lexer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Lexer.hs
@@ -67,6 +67,8 @@ symchar = asum
   , P.char '/'
   , P.char '?'
   , P.char '~'
+  , P.char '|'
+  , P.char '\\'
   ]
 
 lexeme :: Parser a -> Parser a

--- a/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
@@ -33,4 +33,5 @@ spec = do
     metaTest 11 11 "MetaUseMethod"
     metaTest  9 38 "MetaCataCollapse"
     metaTest  7 16 "MetaCataCollapseUnary"
+    metaTest  4 28 "MetaUseSymbol"
 

--- a/plugins/hls-tactics-plugin/test/golden/MetaUseSymbol.expected.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaUseSymbol.expected.hs
@@ -1,0 +1,4 @@
+import Data.Monoid
+
+resolve :: Sum Int
+resolve = _ <> _

--- a/plugins/hls-tactics-plugin/test/golden/MetaUseSymbol.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaUseSymbol.hs
@@ -1,0 +1,4 @@
+import Data.Monoid
+
+resolve :: Sum Int
+resolve = [wingman| use (<>) |]


### PR DESCRIPTION
The metaprogram parser used to choke on symbol identifiers, which meant it was impossible to ever reference things like `(<>)`. This works correctly now.