### PR TITLE
Include testdata in hls-refine-imports-plugin.cabal

### DIFF
--- a/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
+++ b/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
@@ -8,7 +8,10 @@ author:             rayshih
 maintainer:         mnf.shih@gmail.com
 category:           Development
 build-type:         Simple
-extra-source-files: LICENSE
+extra-source-files:
+  LICENSE
+  test/testdata/*.hs
+  test/testdata/*.yaml
 
 library
   exposed-modules:    Ide.Plugin.RefineImports


### PR DESCRIPTION
It's currently missing in the hackage tarball:

```
Refine Imports
  WithOverride (golden): Error while initializing: ResponseError {_code = InternalError, _message = "Error on initialize: /build/haskell-hls-refine-imports-plugin/src/hls-refine-imports-plugin-1.0.0.0/test/testdata: changeWorkingDirectory: does not exist (No such file or directory)", _xdata = Nothing}
Error while initializing: ResponseError {_code = InternalError, _message = "Error on initialize: /build/haskell-hls-refine-imports-plugin/src/hls-refine-imports-plugin-1.0.0.0/test/testdata: changeWorkingDirectory: does not exist (No such file or directory)", _xdata = Nothing}
FAIL (1.42s)
```