### PR TITLE
Perform name lookup directly in TacticsM

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/Context.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Context.hs
@@ -25,10 +25,9 @@ mkContext
     -> TcGblEnv
     -> HscEnv
     -> ExternalPackageState
-    -> KnownThings
     -> [Evidence]
     -> Context
-mkContext cfg locals tcg hscenv eps kt ev = fix $ \ctx ->
+mkContext cfg locals tcg hscenv eps ev = fix $ \ctx ->
   Context
     { ctxDefiningFuncs
         = fmap (second $ coerce $ normalizeType ctx) locals
@@ -47,7 +46,6 @@ mkContext cfg locals tcg hscenv eps kt ev = fix $ \ctx ->
           (eps_inst_env eps)
           (tcg_inst_env tcg)
           (tcVisibleOrphanMods tcg)
-    , ctxKnownThings = kt
     , ctxTheta = evidenceToThetaType ev
     , ctx_hscEnv = hscenv
     , ctx_occEnv = tcg_rdr_env tcg
@@ -78,19 +76,6 @@ getFunBindId _ = []
 getCurrentDefinitions :: MonadReader Context m => m [(OccName, CType)]
 getCurrentDefinitions = asks ctxDefiningFuncs
 
-
-------------------------------------------------------------------------------
--- | Extract something from 'KnownThings'.
-getKnownThing :: MonadReader Context m => (KnownThings -> a) -> m a
-getKnownThing f = asks $ f . ctxKnownThings
-
-
-------------------------------------------------------------------------------
--- | Like 'getInstance', but uses a class from the 'KnownThings'.
-getKnownInstance :: MonadReader Context m => (KnownThings -> Class) -> [Type] -> m (Maybe (Class, PredType))
-getKnownInstance f tys = do
-  cls <- getKnownThing f
-  getInstance cls tys
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Context.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Context.hs
@@ -8,7 +8,7 @@ import           Data.Foldable.Extra (allM)
 import           Data.Maybe (fromMaybe, isJust, mapMaybe)
 import qualified Data.Set as S
 import           Development.IDE.GHC.Compat
-import           GhcPlugins (ExternalPackageState (eps_inst_env), piResultTys, eps_fam_inst_env)
+import           GhcPlugins (ExternalPackageState (eps_inst_env), piResultTys, eps_fam_inst_env, extractModule)
 import           InstEnv (lookupInstEnv, InstEnvs(..), is_dfun)
 import           OccName
 import           TcRnTypes
@@ -23,11 +23,12 @@ mkContext
     :: Config
     -> [(OccName, CType)]
     -> TcGblEnv
+    -> HscEnv
     -> ExternalPackageState
     -> KnownThings
     -> [Evidence]
     -> Context
-mkContext cfg locals tcg eps kt ev = fix $ \ctx ->
+mkContext cfg locals tcg hscenv eps kt ev = fix $ \ctx ->
   Context
     { ctxDefiningFuncs
         = fmap (second $ coerce $ normalizeType ctx) locals
@@ -48,6 +49,9 @@ mkContext cfg locals tcg eps kt ev = fix $ \ctx ->
           (tcVisibleOrphanMods tcg)
     , ctxKnownThings = kt
     , ctxTheta = evidenceToThetaType ev
+    , ctx_hscEnv = hscenv
+    , ctx_occEnv = tcg_rdr_env tcg
+    , ctx_module = extractModule tcg
     }
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/EmptyCase.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/EmptyCase.hs
@@ -59,7 +59,6 @@ codeLensProvider state plId (CodeLensParams _ _ (TextDocumentIdentifier uri))
   | Just nfp <- uriToNormalizedFilePath $ toNormalizedUri uri = do
       let stale a = runStaleIde "codeLensProvider" state nfp a
 
-      cfg <- getTacticConfig plId
       ccs <- getClientCapabilities
       liftIO $ fromMaybeT (Right $ List []) $ do
         dflags <- getIdeDynflags state nfp

--- a/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
@@ -4,6 +4,7 @@
 module Wingman.GHC where
 
 import           Bag (bagToList)
+import           Class (classTyVars)
 import           ConLike
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe (MaybeT(..))
@@ -36,7 +37,6 @@ import           Unify
 import           Unique
 import           Var
 import           Wingman.Types
-import Class (classTyVars)
 
 
 tcTyVar_maybe :: Type -> Maybe Var

--- a/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
@@ -5,10 +5,10 @@ module Wingman.GHC where
 
 import           Bag (bagToList)
 import           ConLike
-import           Control.Applicative (empty)
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe (MaybeT(..))
 import           CoreUtils (exprType)
+import           Data.Bool (bool)
 import           Data.Function (on)
 import           Data.Functor ((<&>))
 import           Data.List (isPrefixOf)
@@ -18,8 +18,6 @@ import           Data.Set (Set)
 import qualified Data.Set as S
 import           Data.Traversable
 import           DataCon
-import           Development.IDE (HscEnvEq (hscEnv))
-import           Development.IDE.Core.Compile (lookupName)
 import           Development.IDE.GHC.Compat hiding (exprType)
 import           DsExpr (dsExpr)
 import           DsMonad (initDs)
@@ -27,16 +25,18 @@ import           FamInst (tcLookupDataFamInst_maybe)
 import           FamInstEnv (normaliseType)
 import           GHC.SourceGen (lambda)
 import           Generics.SYB (Data, everything, everywhere, listify, mkQ, mkT)
-import           GhcPlugins (extractModule, GlobalRdrElt (gre_name), Role (Nominal))
+import           GhcPlugins (Role (Nominal))
 import           OccName
 import           TcRnMonad
 import           TcType
 import           TyCoRep
 import           Type
 import           TysWiredIn (charTyCon, doubleTyCon, floatTyCon, intTyCon)
+import           Unify
 import           Unique
 import           Var
 import           Wingman.Types
+import Class (classTyVars)
 
 
 tcTyVar_maybe :: Type -> Maybe Var
@@ -323,40 +323,6 @@ unXPat (XPat (L _ pat)) = unXPat pat
 unXPat pat              = pat
 
 
-------------------------------------------------------------------------------
--- | Build a 'KnownThings'.
-knownThings :: TcGblEnv -> HscEnvEq -> MaybeT IO KnownThings
-knownThings tcg hscenv= do
-  let cls = knownClass tcg hscenv
-  KnownThings
-    <$> cls (mkClsOcc "Semigroup")
-    <*> cls (mkClsOcc "Monoid")
-
-
-------------------------------------------------------------------------------
--- | Like 'knownThing' but specialized to classes.
-knownClass :: TcGblEnv -> HscEnvEq -> OccName -> MaybeT IO Class
-knownClass = knownThing $ \case
-  ATyCon tc -> tyConClass_maybe tc
-  _         -> Nothing
-
-
-------------------------------------------------------------------------------
--- | Helper function for defining 'knownThings'.
-knownThing :: (TyThing -> Maybe a) -> TcGblEnv -> HscEnvEq -> OccName -> MaybeT IO a
-knownThing f tcg hscenv occ = do
-  let modul = extractModule tcg
-      rdrenv = tcg_rdr_env tcg
-
-  case lookupOccEnv rdrenv occ of
-    Nothing -> empty
-    Just elts -> do
-      mvar <- lift $ lookupName (hscEnv hscenv) modul $ gre_name $ head elts
-      case mvar of
-        Just tt -> liftMaybe $ f tt
-        _ -> empty
-
-
 liftMaybe :: Monad m => Maybe a -> MaybeT m a
 liftMaybe a = MaybeT $ pure a
 
@@ -395,4 +361,35 @@ normalizeType ctx ty =
 expandTyFam :: Context -> Type -> Type
 expandTyFam ctx = snd . normaliseType  (ctxFamInstEnvs ctx) Nominal
 
+
+------------------------------------------------------------------------------
+-- | Like 'tcUnifyTy', but takes a list of skolems to prevent unification of.
+tryUnifyUnivarsButNotSkolems :: Set TyVar -> CType -> CType -> Maybe TCvSubst
+tryUnifyUnivarsButNotSkolems skolems goal inst =
+  case tcUnifyTysFG
+         (bool BindMe Skolem . flip S.member skolems)
+         [unCType inst]
+         [unCType goal] of
+    Unifiable subst -> pure subst
+    _               -> Nothing
+
+
+updateSubst :: TCvSubst -> TacticState -> TacticState
+updateSubst subst s = s { ts_unifier = unionTCvSubst subst (ts_unifier s) }
+
+
+------------------------------------------------------------------------------
+-- | Get the class methods of a 'PredType', correctly dealing with
+-- instantiation of quantified class types.
+methodHypothesis :: PredType -> Maybe [HyInfo CType]
+methodHypothesis ty = do
+  (tc, apps) <- splitTyConApp_maybe ty
+  cls <- tyConClass_maybe tc
+  let methods = classMethods cls
+      tvs     = classTyVars cls
+      subst   = zipTvSubst tvs apps
+  pure $ methods <&> \method ->
+    let (_, _, ty) = tcSplitSigmaTy $ idType method
+    in ( HyInfo (occName method) (ClassMethodPrv $ Uniquely cls) $ CType $ substTy subst ty
+       )
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements/Theta.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements/Theta.hs
@@ -32,7 +32,7 @@ import           TcEvidence
 import           TcType (substTy)
 import           TcType (tcTyConAppTyCon_maybe)
 import           TysPrim (eqPrimTyCon)
-import           Wingman.Machinery
+import           Wingman.GHC
 import           Wingman.Types
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/KnownStrategies.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/KnownStrategies.hs
@@ -1,15 +1,13 @@
 module Wingman.KnownStrategies where
 
-import Control.Applicative (empty)
 import Control.Monad.Error.Class
-import Control.Monad.Reader.Class (asks)
 import Data.Foldable (for_)
-import OccName (mkVarOcc)
+import OccName (mkVarOcc, mkClsOcc)
 import Refinery.Tactic
-import Wingman.Context (getCurrentDefinitions, getKnownInstance)
+import Wingman.Context (getCurrentDefinitions)
 import Wingman.Judgements (jGoal)
 import Wingman.KnownStrategies.QuickCheck (deriveArbitrary)
-import Wingman.Machinery (tracing)
+import Wingman.Machinery (tracing, getKnownInstance)
 import Wingman.Tactics
 import Wingman.Types
 
@@ -57,7 +55,7 @@ deriveMappend = do
   destructAll
   split
   g <- goal
-  minst <- getKnownInstance kt_semigroup
+  minst <- getKnownInstance (mkClsOcc "Semigroup")
          . pure
          . unCType
          $ jGoal g
@@ -79,7 +77,7 @@ deriveMempty :: TacticsM ()
 deriveMempty = do
   split
   g <- goal
-  minst <- getKnownInstance kt_monoid [unCType $ jGoal g]
+  minst <- getKnownInstance (mkClsOcc "Monoid") [unCType $ jGoal g]
   for_ minst $ \(cls, df) -> do
     applyMethod cls df $ mkVarOcc "mempty"
   try assumption

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
@@ -213,9 +213,8 @@ judgementForHole state nfp range cfg = do
       -- involved, so it's not crucial to track ages.
       let henv = untrackedStaleValue $ hscenv
       eps <- liftIO $ readIORef $ hsc_EPS $ hscEnv henv
-      kt <- knownThings (untrackedStaleValue tcg) henv
 
-      (jdg, ctx) <- liftMaybe $ mkJudgementAndContext cfg g binds new_rss tcg (hscEnv henv) eps kt
+      (jdg, ctx) <- liftMaybe $ mkJudgementAndContext cfg g binds new_rss tcg (hscEnv henv) eps
       let mp = getMetaprogramAtSpan (fmap RealSrcSpan tcg_rss) tcg_t
 
       dflags <- getIdeDynflags state nfp
@@ -240,9 +239,8 @@ mkJudgementAndContext
     -> TrackedStale TcGblEnv
     -> HscEnv
     -> ExternalPackageState
-    -> KnownThings
     -> Maybe (Judgement, Context)
-mkJudgementAndContext cfg g (TrackedStale binds bmap) rss (TrackedStale tcg tcgmap) hscenv eps kt = do
+mkJudgementAndContext cfg g (TrackedStale binds bmap) rss (TrackedStale tcg tcgmap) hscenv eps = do
   binds_rss <- mapAgeFrom bmap rss
   tcg_rss <- mapAgeFrom tcgmap rss
 
@@ -254,7 +252,6 @@ mkJudgementAndContext cfg g (TrackedStale binds bmap) rss (TrackedStale tcg tcgm
               (unTrack tcg)
               hscenv
               eps
-              kt
               evidence
       top_provs = getRhsPosVals tcg_rss tcs
       already_destructed = getAlreadyDestructed (fmap RealSrcSpan tcg_rss) tcs

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer/Metaprogram.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer/Metaprogram.hs
@@ -10,7 +10,6 @@ module Wingman.LanguageServer.Metaprogram
 
 import           Control.Applicative (empty)
 import           Control.Monad
-import           Control.Monad.Reader (runReaderT)
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Maybe
 import           Data.List (find)
@@ -52,8 +51,7 @@ hoverProvider state plId (HoverParams (TextDocumentIdentifier uri) (unsafeMkCurr
             Just (trss, program) -> do
               let tr_range = fmap realSrcSpanToRange trss
               HoleJudgment{hj_jdg=jdg, hj_ctx=ctx} <- judgementForHole state nfp tr_range cfg
-              ps <- getParserState state nfp ctx
-              z <- liftIO $ flip runReaderT ps $ attempt_it ctx jdg $ T.unpack program
+              z <- liftIO $ attempt_it ctx jdg $ T.unpack program
               pure $ Hover
                 { _contents = HoverContents
                             $ MarkupContent MkMarkdown

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer/TacticProviders.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer/TacticProviders.hs
@@ -12,7 +12,6 @@ module Wingman.LanguageServer.TacticProviders
   ) where
 
 import           Control.Monad
-import           Control.Monad.Reader (runReaderT)
 import           Data.Aeson
 import           Data.Bool (bool)
 import           Data.Coerce
@@ -34,7 +33,6 @@ import           Wingman.Auto
 import           Wingman.GHC
 import           Wingman.Judgements
 import           Wingman.Machinery (useNameFromHypothesis)
-import           Wingman.Metaprogramming.Lexer (ParserContext)
 import           Wingman.Metaprogramming.Parser (parseMetaprogram)
 import           Wingman.Tactics
 import           Wingman.Types
@@ -42,19 +40,19 @@ import           Wingman.Types
 
 ------------------------------------------------------------------------------
 -- | A mapping from tactic commands to actual tactics for refinery.
-commandTactic :: ParserContext -> TacticCommand -> T.Text -> IO (TacticsM ())
-commandTactic _ Auto                   = pure . const auto
-commandTactic _ Intros                 = pure . const intros
-commandTactic _ Destruct               = pure . useNameFromHypothesis destruct . mkVarOcc . T.unpack
-commandTactic _ DestructPun            = pure . useNameFromHypothesis destructPun . mkVarOcc . T.unpack
-commandTactic _ Homomorphism           = pure . useNameFromHypothesis homo . mkVarOcc . T.unpack
-commandTactic _ DestructLambdaCase     = pure . const destructLambdaCase
-commandTactic _ HomomorphismLambdaCase = pure . const homoLambdaCase
-commandTactic _ DestructAll            = pure . const destructAll
-commandTactic _ UseDataCon             = pure . userSplit . mkVarOcc . T.unpack
-commandTactic _ Refine                 = pure . const refine
-commandTactic _ BeginMetaprogram       = pure . const metaprogram
-commandTactic c RunMetaprogram         = flip runReaderT c . parseMetaprogram
+commandTactic :: TacticCommand -> T.Text -> TacticsM ()
+commandTactic Auto                   = const auto
+commandTactic Intros                 = const intros
+commandTactic Destruct               = useNameFromHypothesis destruct . mkVarOcc . T.unpack
+commandTactic DestructPun            = useNameFromHypothesis destructPun . mkVarOcc . T.unpack
+commandTactic Homomorphism           = useNameFromHypothesis homo . mkVarOcc . T.unpack
+commandTactic DestructLambdaCase     = const destructLambdaCase
+commandTactic HomomorphismLambdaCase = const homoLambdaCase
+commandTactic DestructAll            = const destructAll
+commandTactic UseDataCon             = userSplit . mkVarOcc . T.unpack
+commandTactic Refine                 = const refine
+commandTactic BeginMetaprogram       = const metaprogram
+commandTactic RunMetaprogram         = parseMetaprogram
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Lexer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Lexer.hs
@@ -7,30 +7,16 @@ module Wingman.Metaprogramming.Lexer where
 
 import           Control.Applicative
 import           Control.Monad
-import           Control.Monad.Reader (ReaderT)
 import           Data.Foldable (asum)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Void
-import           Development.IDE.GHC.Compat (HscEnv, Module)
-import           GhcPlugins (GlobalRdrElt)
 import           Name
 import qualified Text.Megaparsec as P
 import qualified Text.Megaparsec.Char as P
 import qualified Text.Megaparsec.Char.Lexer as L
-import           Wingman.Types (Context)
 
-
-------------------------------------------------------------------------------
--- | Everything we need in order to call 'Wingman.Machinery.getOccNameType'.
-data ParserContext = ParserContext
-  { ps_hscEnv :: HscEnv
-  , ps_occEnv :: OccEnv [GlobalRdrElt]
-  , ps_module :: Module
-  , ps_context :: Context
-  }
-
-type Parser = P.ParsecT Void Text (ReaderT ParserContext IO)
+type Parser = P.Parsec Void Text
 
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Plugin.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Plugin.hs
@@ -8,7 +8,6 @@ module Wingman.Plugin
   , TacticCommand (..)
   ) where
 
-import           Control.Exception (evaluate)
 import           Control.Monad
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Maybe
@@ -40,7 +39,6 @@ import           Wingman.Range
 import           Wingman.StaticPlugin
 import           Wingman.Tactics
 import           Wingman.Types
-import Wingman.Metaprogramming.Lexer (ParserContext)
 
 
 descriptor :: PluginId -> PluginDescriptor IdeState
@@ -51,7 +49,7 @@ descriptor plId = (defaultPluginDescriptor plId)
               PluginCommand
                 (tcCommandId tc)
                 (tacticDesc $ tcCommandName tc)
-                (tacticCmd (flip commandTactic tc) plId))
+                (tacticCmd (commandTactic tc) plId))
                 [minBound .. maxBound]
           , pure $
               PluginCommand
@@ -102,7 +100,7 @@ showUserFacingMessage ufm = do
 
 
 tacticCmd
-    :: (ParserContext -> T.Text -> IO (TacticsM ()))
+    :: (T.Text -> TacticsM ())
     -> PluginId
     -> CommandFunction IdeState TacticParams
 tacticCmd tac pId state (TacticParams uri range var_name)
@@ -116,11 +114,11 @@ tacticCmd tac pId state (TacticParams uri range var_name)
         let span = fmap (rangeToRealSrcSpan (fromNormalizedFilePath nfp)) hj_range
         TrackedStale pm pmmap <- stale GetAnnotatedParsedSource
         pm_span <- liftMaybe $ mapAgeFrom pmmap span
-        pc <- getParserState state nfp hj_ctx
-        t <- liftIO $ tac pc var_name
+        let t = tac var_name
 
-        timingOut (cfg_timeout_seconds cfg * seconds) $ join $
-          case runTactic hj_ctx hj_jdg t of
+        timingOut (cfg_timeout_seconds cfg * seconds) $ do
+          res <- liftIO $ runTactic hj_ctx hj_jdg t
+          pure $ join $ case res of
             Left errs ->  do
               traceMX "errs" errs
               Left TacticErrors
@@ -153,9 +151,9 @@ seconds = 1e6
 
 timingOut
     :: Int  -- ^ Time in microseconds
-    -> a    -- ^ Computation to run
+    -> IO a    -- ^ Computation to run
     -> MaybeT IO a
-timingOut t m = MaybeT $ timeout t $ evaluate m
+timingOut t m = MaybeT $ timeout t m
 
 
 mkErr :: ErrorCode -> T.Text -> ResponseError

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -33,6 +33,7 @@ import           Development.IDE.GHC.Orphans ()
 import           FamInstEnv (FamInstEnvs)
 import           GHC.Generics
 import           GHC.SourceGen (var)
+import           GhcPlugins (GlobalRdrElt)
 import           InstEnv (InstEnvs(..))
 import           OccName
 import           Refinery.Tactic
@@ -302,7 +303,7 @@ data Judgement' a = Judgement
 type Judgement = Judgement' CType
 
 
-newtype ExtractM a = ExtractM { unExtractM :: Reader Context a }
+newtype ExtractM a = ExtractM { unExtractM :: ReaderT Context IO a }
     deriving newtype (Functor, Applicative, Monad, MonadReader Context)
 
 ------------------------------------------------------------------------------
@@ -422,6 +423,9 @@ data Context = Context
   , ctxInstEnvs      :: InstEnvs
   , ctxFamInstEnvs   :: FamInstEnvs
   , ctxTheta         :: Set CType
+  , ctx_hscEnv       :: HscEnv
+  , ctx_occEnv       :: OccEnv [GlobalRdrElt]
+  , ctx_module       :: Module
   }
 
 instance Show Context where
@@ -454,6 +458,9 @@ emptyContext
       , ctxFamInstEnvs = mempty
       , ctxInstEnvs = InstEnvs mempty mempty mempty
       , ctxTheta = mempty
+      , ctx_hscEnv = error "empty hsc env from emptyContext"
+      , ctx_occEnv = emptyOccEnv
+      , ctx_module = error "empty module from emptyContext"
       }
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -419,7 +419,6 @@ data Context = Context
   , ctxModuleFuncs   :: [(OccName, CType)]
     -- ^ Everything defined in the current module
   , ctxConfig        :: Config
-  , ctxKnownThings   :: KnownThings
   , ctxInstEnvs      :: InstEnvs
   , ctxFamInstEnvs   :: FamInstEnvs
   , ctxTheta         :: Set CType
@@ -439,14 +438,6 @@ instance Show Context where
 
 
 ------------------------------------------------------------------------------
--- | Things we'd like to look up, that don't exist in TysWiredIn.
-data KnownThings = KnownThings
-  { kt_semigroup :: Class
-  , kt_monoid    :: Class
-  }
-
-
-------------------------------------------------------------------------------
 -- | An empty context
 emptyContext :: Context
 emptyContext
@@ -454,7 +445,6 @@ emptyContext
       { ctxDefiningFuncs = mempty
       , ctxModuleFuncs = mempty
       , ctxConfig = emptyConfig
-      , ctxKnownThings = error "empty known things from emptyContext"
       , ctxFamInstEnvs = mempty
       , ctxInstEnvs = InstEnvs mempty mempty mempty
       , ctxTheta = mempty

--- a/plugins/hls-tactics-plugin/test/AutoTupleSpec.hs
+++ b/plugins/hls-tactics-plugin/test/AutoTupleSpec.hs
@@ -2,17 +2,18 @@
 
 module AutoTupleSpec where
 
-import           Data.Either                  (isRight)
-import           Wingman.Judgements (mkFirstJudgement)
-import           Wingman.Machinery
-import           Wingman.Tactics    (auto')
-import           Wingman.Types
-import           OccName                      (mkVarOcc)
-import           Test.Hspec
-import           Test.QuickCheck
-import           Type                         (mkTyVarTy)
-import           TysPrim                      (alphaTyVars)
-import           TysWiredIn                   (mkBoxedTupleTy)
+import Data.Either (isRight)
+import OccName (mkVarOcc)
+import System.IO.Unsafe
+import Test.Hspec
+import Test.QuickCheck
+import Type (mkTyVarTy)
+import TysPrim (alphaTyVars)
+import TysWiredIn (mkBoxedTupleTy)
+import Wingman.Judgements (mkFirstJudgement)
+import Wingman.Machinery
+import Wingman.Tactics (auto')
+import Wingman.Types
 
 
 spec :: Spec
@@ -33,14 +34,15 @@ spec = describe "auto for tuple" $ do
               <$> randomGroups vars
       pure $
           -- We should always be able to find a solution
-          runTactic
-            emptyContext
-            (mkFirstJudgement
+          unsafePerformIO
+            (runTactic
               emptyContext
-              (Hypothesis $ pure $ HyInfo (mkVarOcc "x") UserPrv $ CType in_type)
-              True
-              out_type)
-            (auto' $ n * 2) `shouldSatisfy` isRight
+              (mkFirstJudgement
+                emptyContext
+                (Hypothesis $ pure $ HyInfo (mkVarOcc "x") UserPrv $ CType in_type)
+                True
+                out_type)
+              (auto' $ n * 2)) `shouldSatisfy` isRight
 
 
 randomGroups :: [a] -> Gen [[a]]

--- a/plugins/hls-tactics-plugin/test/UnificationSpec.hs
+++ b/plugins/hls-tactics-plugin/test/UnificationSpec.hs
@@ -16,7 +16,7 @@ import           Test.QuickCheck
 import           Type (mkTyVarTy)
 import           TysPrim (alphaTyVars)
 import           TysWiredIn (mkBoxedTupleTy)
-import           Wingman.Machinery
+import           Wingman.GHC
 import           Wingman.Types
 
 


### PR DESCRIPTION
I'd managed to keep `IO` out of `TacticsM` thus far, but over time, it was beginning to creek. Rather than just looking up things like `Monoid` if they were needed, I'd build a big static map of everything that might need to be looked up (`KnownThings`). And then, since user code in the metaprograms would need to look things up in the module, I stuck the _parser_ in `IO`, plus a bunch of tomfoolery to make everything work. 

This PR just bites the bullet and puts some `IO` into `TacticsM`, allowing for runtime lookups. In doing so, it removes `KnownThings` and a bunch of cruft around the `Parser`. Everything is cleaner and there's a lot of red.