### PR TITLE
Workaround for GHC 8.10.5 on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,6 @@ jobs:
 
     - name: Tentative Workaround for GHC 8.10.5 on macOS
       if: matrix.os == 'macOS-latest' && matrix.ghc == '8.10.5'
-      env:
-        GHC_VER: ${{ matrix.ghc }}
       run: |
         echo "# uninstalling CommandLineTools (see https://github.com/haskell/haskell-language-server/issues/1913#issuecomment-861667786)"
         sudo rm -rf /Library/Developer/CommandLineTools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,6 @@ jobs:
             ghc: '8.8.3' # fails due to segfault
           - os: windows-latest
             ghc: '8.8.2' # fails due to error with Cabal
-          - os: macOS-latest
-            ghc: '8.10.5' # https://gitlab.haskell.org/ghc/ghc/-/issues/19968
         include:
           - os: windows-latest
             ghc: '8.10.2.2' # only available for windows and choco
@@ -73,6 +71,14 @@ jobs:
         GHC_VER: ${{ matrix.ghc }}
       run: |
         echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
+
+    - name: Tentative Workaround for GHC 8.10.5 on macOS
+      if: matrix.os == 'macOS-latest' && matrix.ghc == '8.10.5'
+      env:
+        GHC_VER: ${{ matrix.ghc }}
+      run: |
+        echo "# uninstalling CommandLineTools (see https://github.com/haskell/haskell-language-server/issues/1913#issuecomment-861667786)"
+        sudo rm -rf /Library/Developer/CommandLineTools
 
     - name: Build Server
       # Try building it twice in case of flakey builds on Windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,6 @@ jobs:
           # This build get stuck frequently
           # - os: windows-latest
           #   ghc: '8.6.4'
-        exclude:
-          # Not able to build 'network' package
-          # See https://gitlab.haskell.org/ghc/ghc/-/issues/19968
-          - os: macOS-latest
-            ghc: '8.10.5'
 
     steps:
       - if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
@@ -97,6 +92,12 @@ jobs:
         run: |
           echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
+
+      - name: Tentative Workaround for GHC 8.10.5 on macOS
+        if: matrix.os == 'macOS-latest' && matrix.ghc == '8.10.5'
+        run: |
+          echo "# uninstalling CommandLineTools (see https://github.com/haskell/haskell-language-server/issues/1913#issuecomment-861667786)"
+          sudo rm -rf /Library/Developer/CommandLineTools
 
       # Needs to be before Cache Cabal so the cache can detect changes to the modified cabal.project file
       - if: ${{ needs.pre_job.outputs.should_skip != 'true' && matrix.ghc == '9.0.1' }}


### PR DESCRIPTION
As pointed out by @mouse07410 in #1913, we can build HLS with GHC 8.10.5 on macOS just by removing CommandLineTools from the environment.
This PR tries to adopt this workaround in a rather ad-hoc manner.