### PR TITLE
Add ghc-9.0.1 to the build release script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.5', '8.10.4', '8.10.3', '8.10.2', '8.8.4', '8.8.3', '8.6.5', '8.6.4']
+        ghc: ['9.0.1', '8.10.5', '8.10.4', '8.10.3', '8.10.2', '8.8.4', '8.8.3', '8.6.5', '8.6.4']
         os: [ubuntu-18.04, macOS-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -38,11 +38,15 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.2'
 
+    - if: ${{ matrix.ghc == '9.0.1' }}
+      name: Use modified cabal.project for ghc9
+      run: cp cabal-ghc901.project cabal.project
+
     - name: Shorten binary names
       run: |
         sed -i.bak -e 's/haskell-language-server/hls/g' \
                    -e 's/haskell_language_server/hls/g' \
-                   haskell-language-server.cabal
+                   haskell-language-server.cabal cabal.project
         sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
                    src/**/*.hs exe/*.hs
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.2'
+        cabal-version: '3.4'
 
     - if: ${{ matrix.ghc == '9.0.1' }}
       name: Use modified cabal.project for ghc9

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -84,7 +84,7 @@ source-repository-package
 
 write-ghc-environment-files: never
 
-index-state: 2021-06-17T10:08:24Z
+index-state: 2021-06-21T19:57:32Z
 
 constraints:
     -- These plugins doesn't work on GHC9 yet

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -82,21 +82,13 @@ source-repository-package
   subdir: lsp-test
 -- https://github.com/haskell/lsp/pull/312
 
-source-repository-package
-  type: git
-  location: https://github.com/diagrams/active
-  tag: ca23431a8dfa013992f9164ccc882a3277361f17
--- https://github.com/diagrams/active/pull/36
-
 write-ghc-environment-files: never
 
-index-state: 2021-05-21T05:01:41Z
+index-state: 2021-06-17T10:08:24Z
 
 constraints:
-    -- Diagrams doesn't support optparse-applicative >= 0.16 yet
-    optparse-applicative < 0.16
     -- These plugins doesn't work on GHC9 yet
-    , haskell-language-server -brittany -class -eval -fourmolu -ormolu -splice -stylishhaskell -tactic -refineImports
+    haskell-language-server -brittany -class -eval -fourmolu -ormolu -splice -stylishhaskell -tactic -refineImports
 
 
 allow-newer:
@@ -112,7 +104,6 @@ allow-newer:
     -- multistate:base,
     -- ghc-source-gen:ghc,
 
-    active:base,
     assoc:base,
     cryptohash-md5:base,
     cryptohash-sha1:base,
@@ -121,17 +112,13 @@ allow-newer:
     deepseq:base,
     dependent-sum:some,
     dependent-sum:constraints,
-    diagrams-contrib:base,
-    diagrams-contrib:lens,
-    diagrams-contrib:random,
-    diagrams-core:base,
-    diagrams-core:lens,
-    diagrams-lib:base,
-    diagrams-lib:lens,
     diagrams-postscript:base,
     diagrams-postscript:lens,
-    diagrams-svg:base,
-    diagrams-svg:lens,
+    diagrams-postscript:diagrams-core,
+    diagrams-postscript:monoid-extras,
+    diagrams:diagrams-core,
+    Chart-diagrams:diagrams-core,
+    SVGFonts:diagrams-core,
     dual-tree:base,
     -- Does this make any sense?
     entropy:Cabal,

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -96,7 +96,7 @@ constraints:
     -- Diagrams doesn't support optparse-applicative >= 0.16 yet
     optparse-applicative < 0.16
     -- These plugins doesn't work on GHC9 yet
-    , haskell-language-server -brittany -class -eval -fourmolu -modulename -ormolu -splice -stylishhaskell -tactic -refineImports
+    , haskell-language-server -brittany -class -eval -fourmolu -ormolu -splice -stylishhaskell -tactic -refineImports
 
 
 allow-newer:

--- a/cabal.project
+++ b/cabal.project
@@ -36,7 +36,7 @@ source-repository-package
 
 write-ghc-environment-files: never
 
-index-state: 2021-05-21T05:01:41Z
+index-state: 2021-06-21T19:57:32Z
 
 constraints:
     -- Diagrams doesn't support optparse-applicative >= 0.16 yet


### PR DESCRIPTION
See also discussion here: https://github.com/haskell/haskell-language-server/pull/1912#issuecomment-862982762

Is this sensible, @jneira?