### PR TITLE
Properly scope GADT equality evidence in the judgment

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
@@ -68,8 +68,6 @@ destructMatches use_field_puns f scrut t jdg = do
             -- #syn_scoped
             method_hy = foldMap evidenceToHypothesis ev
             args = conLikeInstOrigArgTys' con apps
-        modify $ evidenceToSubst ev
-        subst <- gets ts_unifier
         ctx <- ask
 
         let names_in_scope = hyNamesInScope hy
@@ -80,7 +78,7 @@ destructMatches use_field_puns f scrut t jdg = do
         let hy' = patternHypothesis scrut con jdg
                 $ zip names'
                 $ coerce args
-            j = fmap (CType . substTyAddInScope subst . unCType)
+            j = withNewCoercions (evidenceToCoercions ev)
               $ introduce ctx hy'
               $ introduce ctx method_hy
               $ withNewGoal g jdg

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
@@ -69,6 +69,10 @@ withNewGoal :: a -> Judgement' a -> Judgement' a
 withNewGoal t = field @"_jGoal" .~ t
 
 
+withNewCoercions :: [(a, a)] -> Judgement' a -> Judgement' a
+withNewCoercions ev = field @"j_coercion" <>~ ev
+
+
 normalizeHypothesis :: Functor f => Context -> f CType -> f CType
 normalizeHypothesis = fmap . coerce . normalizeType
 
@@ -414,6 +418,7 @@ mkFirstJudgement ctx hy top goal =
       , _jWhitelistSplit    = True
       , _jIsTopHole         = top
       , _jGoal              = CType goal
+      , j_coercion          = mempty
       }
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
@@ -69,6 +69,8 @@ withNewGoal :: a -> Judgement' a -> Judgement' a
 withNewGoal t = field @"_jGoal" .~ t
 
 
+------------------------------------------------------------------------------
+-- | Add some new type equalities to the local judgement.
 withNewCoercions :: [(a, a)] -> Judgement' a -> Judgement' a
 withNewCoercions ev = field @"j_coercion" <>~ ev
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements/Theta.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements/Theta.hs
@@ -5,14 +5,17 @@ module Wingman.Judgements.Theta
   ( Evidence
   , getEvidenceAtHole
   , mkEvidence
+  , evidenceToCoercions
   , evidenceToSubst
   , evidenceToHypothesis
   , evidenceToThetaType
+  , allEvidenceToSubst
   ) where
 
 import           Class (classTyVars)
 import           Control.Applicative (empty)
 import           Control.Lens (preview)
+import           Data.Coerce (coerce)
 import           Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import           Data.Generics.Sum (_Ctor)
 import           Data.Set (Set)
@@ -108,6 +111,11 @@ allEvidenceToSubst skolems ((a, b) : evs) =
    in unionTCvSubst subst
     $ allEvidenceToSubst skolems
     $ fmap (substPair subst) evs
+
+------------------------------------------------------------------------------
+-- | Update our knowledge of which types are equal.
+evidenceToCoercions :: [Evidence] -> [(CType, CType)]
+evidenceToCoercions = coerce . mapMaybe (preview $ _Ctor @"EqualityOfTypes")
 
 ------------------------------------------------------------------------------
 -- | Update our knowledge of which types are equal.

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements/Theta.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements/Theta.hs
@@ -113,7 +113,7 @@ allEvidenceToSubst skolems ((a, b) : evs) =
     $ fmap (substPair subst) evs
 
 ------------------------------------------------------------------------------
--- | Update our knowledge of which types are equal.
+-- | Given some 'Evidence', get a list of which types are now equal.
 evidenceToCoercions :: [Evidence] -> [(CType, CType)]
 evidenceToCoercions = coerce . mapMaybe (preview $ _Ctor @"EqualityOfTypes")
 
@@ -122,9 +122,7 @@ evidenceToCoercions = coerce . mapMaybe (preview $ _Ctor @"EqualityOfTypes")
 evidenceToSubst :: [Evidence] -> TacticState -> TacticState
 evidenceToSubst evs ts =
   updateSubst
-    (allEvidenceToSubst (ts_skolems ts)
-      $ mapMaybe (preview $ _Ctor @"EqualityOfTypes")
-      $ evs)
+    (allEvidenceToSubst (ts_skolems ts) . coerce $ evidenceToCoercions evs)
     ts
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
@@ -32,6 +32,7 @@ import           Type (tyCoVarsOfTypeWellScoped)
 import           Wingman.Context (getInstance)
 import           Wingman.GHC (tryUnifyUnivarsButNotSkolems, updateSubst)
 import           Wingman.Judgements
+import           Wingman.Judgements.Theta (allEvidenceToSubst)
 import           Wingman.Simplify (simplify)
 import           Wingman.Types
 
@@ -48,10 +49,12 @@ newSubgoal
     -> Rule
 newSubgoal j = do
   ctx <- ask
+  skolems <- gets ts_skolems
+  let coercions = allEvidenceToSubst skolems $ coerce $ j_coercion j
   unifier <- gets ts_unifier
   subgoal
     $ normalizeJudgement ctx
-    $ substJdg unifier
+    $ substJdg (unionTCvSubst unifier coercions)
     $ unsetIsTopHole
     $ normalizeJudgement ctx j
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
@@ -13,7 +13,7 @@ import           Control.Monad (unless)
 import           Control.Monad.Except (throwError)
 import           Control.Monad.Extra (anyM)
 import           Control.Monad.Reader.Class (MonadReader (ask))
-import           Control.Monad.State.Strict (StateT(..), runStateT, gets)
+import           Control.Monad.State.Strict (StateT(..), runStateT)
 import           Data.Bool (bool)
 import           Data.Foldable
 import           Data.Functor ((<&>))
@@ -72,6 +72,10 @@ assume name = rule $ \jdg -> do
 recursion :: TacticsM ()
 -- TODO(sandy): This tactic doesn't fire for the @AutoThetaFix@ golden test,
 -- presumably due to running afoul of 'requireConcreteHole'. Look into this!
+
+-- TODO(sandy): There's a bug here! This should use the polymorphic defining
+-- types, not the ones available via 'getCurrentDefinitions'. As it is, this
+-- tactic doesn't support polymorphic recursion.
 recursion = requireConcreteHole $ tracing "recursion" $ do
   defs <- getCurrentDefinitions
   attemptOn (const defs) $ \(name, ty) -> markRecursion $ do
@@ -349,7 +353,7 @@ destructAll = do
            $ unHypothesis
            $ jHypothesis jdg
   for_ args $ \arg -> do
-    subst <- gets ts_unifier
+    subst <- getSubstForJudgement =<< goal
     destruct $ fmap (coerce substTy subst) arg
 
 --------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -297,9 +297,9 @@ data Judgement' a = Judgement
   , _jWhitelistSplit    :: !Bool
   , _jIsTopHole         :: !Bool
   , _jGoal              :: !a
-  , j_coercion          :: [(a, a)]
+  , j_coercion          :: TCvSubst
   }
-  deriving stock (Eq, Generic, Functor, Show)
+  deriving stock (Generic, Functor, Show)
 
 type Judgement = Judgement' CType
 
@@ -329,7 +329,6 @@ data TacticError
   | TooPolymorphic
   | NotInScope OccName
   | TacticPanic String
-  deriving stock (Eq)
 
 instance Show TacticError where
     show (UndefinedHypothesis name) =

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -297,6 +297,7 @@ data Judgement' a = Judgement
   , _jWhitelistSplit    :: !Bool
   , _jIsTopHole         :: !Bool
   , _jGoal              :: !a
+  , j_coercion          :: [(a, a)]
   }
   deriving stock (Eq, Generic, Functor, Show)
 

--- a/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
@@ -33,6 +33,6 @@ spec = do
     metaTest 11 11 "MetaUseMethod"
     metaTest  9 38 "MetaCataCollapse"
     metaTest  7 16 "MetaCataCollapseUnary"
-    metaTest 21 32 "MetaCataAST"
+    metaTest 10 32 "MetaCataAST"
     metaTest  6 46 "MetaPointwise"
     metaTest  4 28 "MetaUseSymbol"

--- a/plugins/hls-tactics-plugin/test/golden/MetaCataAST.expected.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaCataAST.expected.hs
@@ -7,19 +7,8 @@ data AST a where
     Equal :: AST a -> AST a -> AST Bool
 
 eval :: AST a -> a
--- NOTE(sandy): There is an unrelated bug that is shown off in this test
--- namely, that
---
--- @eval (IntLit n) = _@
---
--- but should be
---
--- @eval (IntLit n) = n@
---
--- https://github.com/haskell/haskell-language-server/issues/1937
-
 eval (BoolLit b) = b
-eval (IntLit n) = _
+eval (IntLit n) = n
 eval (If ast ast' ast_a)
   = let
       ast_c = eval ast

--- a/plugins/hls-tactics-plugin/test/golden/MetaCataAST.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaCataAST.hs
@@ -7,16 +7,5 @@ data AST a where
     Equal :: AST a -> AST a -> AST Bool
 
 eval :: AST a -> a
--- NOTE(sandy): There is an unrelated bug that is shown off in this test
--- namely, that
---
--- @eval (IntLit n) = _@
---
--- but should be
---
--- @eval (IntLit n) = n@
---
--- https://github.com/haskell/haskell-language-server/issues/1937
-
 eval = [wingman| intros x, cata x; collapse |]
 


### PR DESCRIPTION
Wingman was incorrectly adding GADT equalities to the global substitution, meaning it would think type equalities persisted between GADT branches. This lead to #1937, and is easily fixed by tracking this evidence in the local `Judgment`, rather than the global `TacticState`.

Fixes #1937