### PR TITLE
Wingman: Tactical support for deep recursion

### DIFF
--- a/plugins/hls-tactics-plugin/COMMANDS.md
+++ b/plugins/hls-tactics-plugin/COMMANDS.md
@@ -23,6 +23,7 @@ running  `application` will produce:
 ```haskell
 f (_ :: a)
 ```
+
 ## apply
 
 arguments: single reference.  
@@ -46,6 +47,7 @@ running  `apply f` will produce:
 ```haskell
 f (_ :: a)
 ```
+
 ## assume
 
 arguments: single reference.  
@@ -69,6 +71,7 @@ running  `assume some_a_val` will produce:
 ```haskell
 some_a_val
 ```
+
 ## assumption
 
 arguments: none.  
@@ -92,6 +95,7 @@ running  `assumption` will produce:
 ```haskell
 some_a_val
 ```
+
 ## auto
 
 arguments: none.  
@@ -116,6 +120,7 @@ running  `auto` will produce:
 ```haskell
 g . f
 ```
+
 ## binary
 
 arguments: none.  
@@ -139,6 +144,7 @@ running  `binary` will produce:
 ```haskell
 (_3 :: a -> a -> Int) (_1 :: a) (_2 :: a)
 ```
+
 ## cata
 
 arguments: single reference.  
@@ -168,6 +174,7 @@ case x of
         a2_c = f a2
      in _
 ```
+
 ## collapse
 
 arguments: none.  
@@ -193,6 +200,7 @@ running  `collapse` will produce:
 ```haskell
 (_ :: a -> a -> a -> a) a1 a2 a3
 ```
+
 ## ctor
 
 arguments: single reference.  
@@ -214,6 +222,29 @@ running  `ctor Just` will produce:
 ```haskell
 Just (_ :: a)
 ```
+
+## deep_of
+
+arguments: single reference.  
+non-deterministic.
+
+> Nest the given function (in module scope) with itself arbitrarily many times. NOTE: The resulting function is necessarily unsaturated, so you will likely need `with_arg` to use this tactic in a saturated context.
+
+
+### Example
+
+Given:
+
+```haskell
+_ :: [(Int, Either Bool a)] -> [(Int, Either Bool b)]
+```
+
+running  `deep_of fmap` will produce:
+
+```haskell
+fmap (fmap (fmap _))
+```
+
 ## destruct
 
 arguments: single reference.  
@@ -239,6 +270,7 @@ case a of
   False -> _
   True -> _
 ```
+
 ## destruct_all
 
 arguments: none.  
@@ -271,6 +303,7 @@ case a of
     Nothing -> _
     Just i -> _
 ```
+
 ## homo
 
 arguments: single reference.  
@@ -298,6 +331,7 @@ case e of
   Left a -> Left (_ :: x)
   Right b -> Right (_ :: y)
 ```
+
 ## intro
 
 arguments: single binding.  
@@ -319,6 +353,7 @@ running  `intro aye` will produce:
 ```haskell
 \aye -> (_ :: b -> c -> d)
 ```
+
 ## intros
 
 arguments: varadic binding.  
@@ -368,6 +403,7 @@ running  `intros x y z w` will produce:
 ```haskell
 \x y z -> (_ :: d)
 ```
+
 ## obvious
 
 arguments: none.  
@@ -389,6 +425,7 @@ running  `obvious` will produce:
 ```haskell
 []
 ```
+
 ## pointwise
 
 arguments: tactic.  
@@ -412,6 +449,7 @@ running  `pointwise (use mappend)` will produce:
 ```haskell
 mappend _ _
 ```
+
 ## recursion
 
 arguments: none.  
@@ -435,6 +473,7 @@ running  `recursion` will produce:
 ```haskell
 foo (_ :: Int) (_ :: b)
 ```
+
 ## sorry
 
 arguments: none.  
@@ -456,6 +495,7 @@ running  `sorry` will produce:
 ```haskell
 _ :: b
 ```
+
 ## split
 
 arguments: none.  
@@ -477,6 +517,38 @@ running  `split` will produce:
 ```haskell
 Right (_ :: b)
 ```
+
+## try
+
+arguments: tactic.  
+non-deterministic.
+
+> Simultaneously run and do not run a tactic. Subsequent tactics will bind on both states.
+
+
+### Example
+
+Given:
+
+```haskell
+f :: a -> b
+
+_ :: b
+```
+
+running  `try apply f` will produce:
+
+```haskell
+-- BOTH of:
+
+f (_ :: a)
+
+-- and
+
+_ :: b
+
+```
+
 ## unary
 
 arguments: none.  
@@ -500,6 +572,7 @@ running  `unary` will produce:
 ```haskell
 (_2 :: a -> Int) (_1 :: a)
 ```
+
 ## use
 
 arguments: single reference.  
@@ -523,3 +596,28 @@ running  `use isSpace` will produce:
 ```haskell
 isSpace (_ :: Char)
 ```
+
+## with_arg
+
+arguments: none.  
+deterministic.
+
+> Fill the current goal with a function application. This can be useful when you'd like to fill in the argument before the function, or when you'd like to use a non-saturated function in a saturated context.
+
+
+### Example
+
+> Where `a` is a new unifiable type variable.
+
+Given:
+
+```haskell
+_ :: r
+```
+
+running  `with_arg` will produce:
+
+```haskell
+(_2 :: a -> r) (_1 :: a)
+```
+

--- a/plugins/hls-tactics-plugin/COMMANDS.md
+++ b/plugins/hls-tactics-plugin/COMMANDS.md
@@ -223,28 +223,6 @@ running  `ctor Just` will produce:
 Just (_ :: a)
 ```
 
-## deep_of
-
-arguments: single reference.  
-non-deterministic.
-
-> Nest the given function (in module scope) with itself arbitrarily many times. NOTE: The resulting function is necessarily unsaturated, so you will likely need `with_arg` to use this tactic in a saturated context.
-
-
-### Example
-
-Given:
-
-```haskell
-_ :: [(Int, Either Bool a)] -> [(Int, Either Bool b)]
-```
-
-running  `deep_of fmap` will produce:
-
-```haskell
-fmap (fmap (fmap _))
-```
-
 ## destruct
 
 arguments: single reference.  
@@ -402,6 +380,28 @@ running  `intros x y z w` will produce:
 
 ```haskell
 \x y z -> (_ :: d)
+```
+
+## nested
+
+arguments: single reference.  
+non-deterministic.
+
+> Nest the given function (in module scope) with itself arbitrarily many times. NOTE: The resulting function is necessarily unsaturated, so you will likely need `with_arg` to use this tactic in a saturated context.
+
+
+### Example
+
+Given:
+
+```haskell
+_ :: [(Int, Either Bool a)] -> [(Int, Either Bool b)]
+```
+
+running  `nested fmap` will produce:
+
+```haskell
+fmap (fmap (fmap _))
 ```
 
 ## obvious

--- a/plugins/hls-tactics-plugin/COMMANDS.md
+++ b/plugins/hls-tactics-plugin/COMMANDS.md
@@ -536,7 +536,7 @@ f :: a -> b
 _ :: b
 ```
 
-running  `try apply f` will produce:
+running  `try (apply f)` will produce:
 
 ```haskell
 -- BOTH of:

--- a/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
@@ -113,7 +113,7 @@ freshTyvars t = do
         case M.lookup tv reps of
           Just tv' -> tv'
           Nothing  -> tv
-      ) t
+      ) $ snd $ tcSplitForAllTys t
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/KnownStrategies.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/KnownStrategies.hs
@@ -35,7 +35,7 @@ deriveFmap = do
   try intros
   overAlgebraicTerms homo
   choice
-    [ overFunctions apply >> auto' 2
+    [ overFunctions (apply Saturated) >> auto' 2
     , assumption
     , recursion
     ]

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
@@ -354,6 +354,23 @@ commands =
           "(_ :: a -> a -> a -> a) a1 a2 a3"
       ]
 
+  , command "try" Nondeterministic Tactic
+      "Simultaneously run and do not run a tactic. Subsequent tactics will bind on both states."
+      (pure . R.try)
+      [ Example
+          Nothing
+          ["apply f"]
+          [ EHI "f" "a -> b"
+          ]
+          (Just "b")
+          $ T.pack $ unlines
+            [ "BOTH of:\n"
+            , "f (_ :: a)"
+            , "\nand\n"
+            , "_ :: b"
+            ]
+      ]
+
   ]
 
 
@@ -374,9 +391,7 @@ bindOne t t1 = t R.<@> [t1]
 
 operators :: [[P.Operator Parser (TacticsM ())]]
 operators =
-    [ [ P.Prefix (symbol "*"   $> R.many_) ]
-    , [ P.Prefix (symbol "try" $> R.try) ]
-    , [ P.InfixR (symbol "|"   $> (R.<%>) )]
+    [ [ P.InfixR (symbol "|"   $> (R.<%>) )]
     , [ P.InfixL (symbol ";"   $> (>>))
       , P.InfixL (symbol ","   $> bindOne)
       ]

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
@@ -353,7 +353,7 @@ commands =
       (pure . R.try)
       [ Example
           Nothing
-          ["apply f"]
+          ["(apply f)"]
           [ EHI "f" "a -> b"
           ]
           (Just "b")

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
@@ -358,18 +358,34 @@ commands =
           ]
           (Just "b")
           $ T.pack $ unlines
-            [ "BOTH of:\n"
+            [ "-- BOTH of:\n"
             , "f (_ :: a)"
-            , "\nand\n"
+            , "\n-- and\n"
             , "_ :: b"
             ]
       ]
 
-  , command "deepening" Nondeterministic Nullary
-      ""
-      (pure $ deep2 2)
-      [ ]
+  , command "deep_of" Nondeterministic (Ref One)
+      "Nest the given function (in module scope) with itself arbitrarily many times. NOTE: The resulting function is necessarily unsaturated, so you will likely need `with_arg` to use this tactic in a saturated context."
+      (pure . deep_of)
+      [ Example
+          Nothing
+          ["fmap"]
+          []
+          (Just "[(Int, Either Bool a)] -> [(Int, Either Bool b)]")
+          "fmap (fmap (fmap _))"
+      ]
 
+  , command "with_arg" Deterministic Nullary
+      "Fill the current goal with a function application. This can be useful when you'd like to fill in the argument before the function, or when you'd like to use a non-saturated function in a saturated context."
+      (pure with_arg)
+      [ Example
+          (Just "Where `a` is a new unifiable type variable.")
+          []
+          []
+          (Just "r")
+          "(_2 :: a -> r) (_1 :: a)"
+      ]
   ]
 
 
@@ -437,7 +453,7 @@ parseMetaprogram
 -- | Automatically generate the metaprogram command reference.
 writeDocumentation :: IO ()
 writeDocumentation =
-  writeFile "plugins/hls-tactics-plugin/COMMANDS.md" $
+  writeFile "COMMANDS.md" $
     unlines
       [ "# Wingman Metaprogram Command Reference"
       , ""

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
@@ -365,9 +365,9 @@ commands =
             ]
       ]
 
-  , command "deep_of" Nondeterministic (Ref One)
+  , command "nested" Nondeterministic (Ref One)
       "Nest the given function (in module scope) with itself arbitrarily many times. NOTE: The resulting function is necessarily unsaturated, so you will likely need `with_arg` to use this tactic in a saturated context."
-      (pure . deep_of)
+      (pure . nested)
       [ Example
           Nothing
           ["fmap"]

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser/Documentation.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser/Documentation.hs
@@ -150,6 +150,7 @@ prettyCommand (MC name syn det desc _ exs) = vsep
   , ">" <+> align (pretty desc)
   , mempty
   , vsep $ fmap (prettyExample name) exs
+  , mempty
   ]
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
@@ -538,8 +538,8 @@ cata hi = do
 
 ------------------------------------------------------------------------------
 -- | Deeply nest an unsaturated function onto itself
-deep_of :: OccName -> TacticsM ()
-deep_of = deepening . use (Unsaturated 1)
+nested :: OccName -> TacticsM ()
+nested = deepening . use (Unsaturated 1)
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
@@ -70,6 +70,9 @@ assume name = rule $ \jdg -> do
     Nothing -> throwError $ UndefinedHypothesis name
 
 
+------------------------------------------------------------------------------
+-- | Like 'apply', but uses an 'OccName' available in the context
+-- or the module
 use :: Saturation -> OccName -> TacticsM ()
 use sat occ = do
   ctx <- ask
@@ -533,13 +536,21 @@ cata hi = do
       $ Hypothesis unifiable_diff
 
 
+------------------------------------------------------------------------------
+-- | Deeply nest an unsaturated function onto itself
 deep_of :: OccName -> TacticsM ()
 deep_of = deepening . use (Unsaturated 1)
 
+
+------------------------------------------------------------------------------
+-- | Repeatedly bind a tactic on its first hole
 deep :: Int -> TacticsM () -> TacticsM ()
 deep 0 _ = pure ()
 deep n t = foldr1 bindOne $ replicate n t
 
+
+------------------------------------------------------------------------------
+-- | Try 'deep' for arbitrary depths.
 deepening :: TacticsM () -> TacticsM ()
 deepening t =
   asum $ fmap (flip deep t) [0 .. 100]

--- a/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
@@ -37,4 +37,5 @@ spec = do
     metaTest  6 46 "MetaPointwise"
     metaTest  4 28 "MetaUseSymbol"
     metaTest  7 53 "MetaDeepOf"
+    metaTest  2 34 "MetaWithArg"
 

--- a/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
@@ -36,3 +36,5 @@ spec = do
     metaTest 21 32 "MetaCataAST"
     metaTest  6 46 "MetaPointwise"
     metaTest  4 28 "MetaUseSymbol"
+    metaTest  7 53 "MetaDeepOf"
+

--- a/plugins/hls-tactics-plugin/test/golden/MetaDeepOf.expected.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaDeepOf.expected.hs
@@ -1,0 +1,8 @@
+whats_it_deep_of
+    :: (a -> a)
+    -> [(Int, Either Bool (Maybe [a]))]
+    -> [(Int, Either Bool (Maybe [a]))]
+-- The assumption here is necessary to tie-break in favor of the longest
+-- nesting of fmaps.
+whats_it_deep_of f = fmap (fmap (fmap (fmap (fmap f))))
+

--- a/plugins/hls-tactics-plugin/test/golden/MetaDeepOf.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaDeepOf.hs
@@ -1,0 +1,8 @@
+whats_it_deep_of
+    :: (a -> a)
+    -> [(Int, Either Bool (Maybe [a]))]
+    -> [(Int, Either Bool (Maybe [a]))]
+-- The assumption here is necessary to tie-break in favor of the longest
+-- nesting of fmaps.
+whats_it_deep_of f = [wingman| deep_of fmap, assumption |]
+

--- a/plugins/hls-tactics-plugin/test/golden/MetaDeepOf.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaDeepOf.hs
@@ -4,5 +4,5 @@ whats_it_deep_of
     -> [(Int, Either Bool (Maybe [a]))]
 -- The assumption here is necessary to tie-break in favor of the longest
 -- nesting of fmaps.
-whats_it_deep_of f = [wingman| deep_of fmap, assumption |]
+whats_it_deep_of f = [wingman| nested fmap, assumption |]
 

--- a/plugins/hls-tactics-plugin/test/golden/MetaTry.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaTry.hs
@@ -1,2 +1,2 @@
 foo :: a -> (b, a)
-foo a = [wingman| split; try assumption |]
+foo a = [wingman| split; try (assumption) |]

--- a/plugins/hls-tactics-plugin/test/golden/MetaWithArg.expected.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaWithArg.expected.hs
@@ -1,0 +1,2 @@
+wat :: a -> b
+wat a = _ a

--- a/plugins/hls-tactics-plugin/test/golden/MetaWithArg.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaWithArg.hs
@@ -1,0 +1,2 @@
+wat :: a -> b
+wat a = [wingman| with_arg, assumption |]


### PR DESCRIPTION
This PR is a bit of a hodge-podge, sorry! It primarily removes the `try` and `*` tactic operators, replacing them with better functionality. 

`try` has become a regular tactic, while `*` deserves to rot away. Instead, there is now `nested` which nests a function call into itself as many times as necessary to typecheck. This is the original motivation for `*`, but it never actually succeeded at that.

In order to get `nested` working, I needed to be able to work with _unsaturated_ function applications (Wingman tries really hard to saturate everything, and then eta reduce everything before presenting it.) The application tactics now take a new `Saturation` parameter, letting you tweak how many unsaturated arguments they take, and there's a corresponding `with_arg` tactic to shift into an unsaturated context.

Finally, while playing with this stuff, I learned that `freshTyvars` didn't do what it said on the tin; it claims to instantiate `forall` tys, but instead it would just alpha rename them. So that's fixed now too!

---

The result of all this is that the metaprogramming language is now powerful enough to express "generically write `fmap`":

```
  intros f x
, homo x
; assumption      -- every term is either an assumption, or
| ( with_arg
  , assumption    -- some assumption that has been applied to
  , nested fmap   -- 0 or more nested fmaps
  , assume f      -- before calling f
  )
```