### PR TITLE
avoid holding onto the hie bytestring when indexing

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.4.0.1
+version:            1.4.0.2
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors


### PR DESCRIPTION
This can save significant amounts of memory on large repos, as shown by the heap profiles generated using the edit experiment on a module with >10K transitive deps.

BEFORE
<img width="1434" alt="Screenshot 2021-06-20 at 11 41 05" src="https://user-images.githubusercontent.com/26626/122670976-78762e80-d1bc-11eb-9268-341dda8d7073.png">


AFTER 
<img width="1408" alt="Screenshot 2021-06-20 at 11 41 57" src="https://user-images.githubusercontent.com/26626/122671004-9348a300-d1bc-11eb-8e75-ad3e5bb23e68.png">
