### PR TITLE
Wingman: Ensure homomorphic destruct covers all constructors in the domain

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer/TacticProviders.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer/TacticProviders.hs
@@ -126,9 +126,8 @@ commandProvider DestructLambdaCase =
       provide DestructLambdaCase ""
 commandProvider HomomorphismLambdaCase =
   requireHoleSort (== Hole) $
-  -- TODO(sandy): Needs the new test
   requireExtension LambdaCase $
-    filterGoalType ((== Just True) . lambdaCaseable) $
+    filterGoalType (liftLambdaCase False homoFilter) $
       provide HomomorphismLambdaCase ""
 commandProvider DestructAll =
   requireHoleSort (== Hole) $
@@ -319,6 +318,16 @@ homoFilter codomain domain =
   case uncoveredDataCons domain codomain of
     Just s -> S.null s
     _ -> False
+
+
+------------------------------------------------------------------------------
+-- | Lift a function of (codomain, domain) over a lambda case.
+liftLambdaCase :: r -> (Type -> Type -> r) -> Type -> r
+liftLambdaCase nil f t =
+  case tacticsSplitFunTy t of
+    (_, _, arg : _, res) -> f res arg
+    _ -> nil
+
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
@@ -198,8 +198,23 @@ destructPun hi = requireConcreteHole $ tracing "destructPun(user)" $
 ------------------------------------------------------------------------------
 -- | Case split, using the same data constructor in the matches.
 homo :: HyInfo CType -> TacticsM ()
-homo = requireConcreteHole . tracing "homo" . rule . destruct' False (\dc jdg ->
-  buildDataCon False jdg dc $ snd $ splitAppTys $ unCType $ jGoal jdg)
+homo hi = requireConcreteHole . tracing "homo" $ do
+  jdg <- goal
+  let g = jGoal jdg
+
+  -- Ensure that every data constructor in the domain type is covered in the
+  -- codomain; otherwise 'homo' will produce an ill-typed program.
+  case (uncoveredDataCons (coerce $ hi_type hi) (coerce g)) of
+    Just uncovered_dcs ->
+      unless (S.null uncovered_dcs) $
+        throwError  $ TacticPanic "Can't cover every datacon in domain"
+    _ -> throwError $ TacticPanic "Unable to fetch datacons"
+
+  rule
+    $ destruct'
+        False
+        (\dc jdg -> buildDataCon False jdg dc $ snd $ splitAppTys $ unCType $ jGoal jdg)
+    $ hi
 
 
 ------------------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
@@ -35,3 +35,69 @@ spec = do
     destructTest "a"  7 17 "LayoutSplitPattern"
     destructTest "a"  8 26 "LayoutSplitPatSyn"
 
+  describe "providers" $ do
+    mkTest
+      "Produces destruct and homomorphism code actions"
+      "T2" 2 21
+      [ (id, Destruct, "eab")
+      , (id, Homomorphism, "eab")
+      , (not, DestructPun, "eab")
+      ]
+
+    mkTest
+      "Won't suggest homomorphism on the wrong type"
+      "T2" 8 8
+      [ (not, Homomorphism, "global")
+      ]
+
+    mkTest
+      "Produces (homomorphic) lambdacase code actions"
+      "T3" 4 24
+      [ (id, HomomorphismLambdaCase, "")
+      , (id, DestructLambdaCase, "")
+      ]
+
+    mkTest
+      "Produces lambdacase code actions"
+      "T3" 7 13
+      [ (id, DestructLambdaCase, "")
+      ]
+
+    mkTest
+      "Doesn't suggest lambdacase without -XLambdaCase"
+      "T2" 11 25
+      [ (not, DestructLambdaCase, "")
+      ]
+
+    mkTest
+      "Doesn't suggest destruct if already destructed"
+      "ProvideAlreadyDestructed" 6 18
+      [ (not, Destruct, "x")
+      ]
+
+    mkTest
+      "...but does suggest destruct if destructed in a different branch"
+      "ProvideAlreadyDestructed" 9 7
+      [ (id, Destruct, "x")
+      ]
+
+    mkTest
+      "Doesn't suggest destruct on class methods"
+      "ProvideLocalHyOnly" 2 12
+      [ (not, Destruct, "mempty")
+      ]
+
+    mkTest
+      "Suggests homomorphism if the domain is bigger than the codomain"
+      "ProviderHomomorphism" 11 13
+      [ (id, Homomorphism, "g")
+      ]
+
+    mkTest
+      "Doesn't suggest homomorphism if the domain is smaller than the codomain"
+      "ProviderHomomorphism" 14 14
+      [ (not, Homomorphism, "g")
+      , (id, Destruct, "g")
+      ]
+
+

--- a/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/DestructSpec.hs
@@ -89,15 +89,27 @@ spec = do
 
     mkTest
       "Suggests homomorphism if the domain is bigger than the codomain"
-      "ProviderHomomorphism" 11 13
+      "ProviderHomomorphism" 12 13
       [ (id, Homomorphism, "g")
       ]
 
     mkTest
       "Doesn't suggest homomorphism if the domain is smaller than the codomain"
-      "ProviderHomomorphism" 14 14
+      "ProviderHomomorphism" 15 14
       [ (not, Homomorphism, "g")
       , (id, Destruct, "g")
       ]
 
+    mkTest
+      "Suggests lambda homomorphism if the domain is bigger than the codomain"
+      "ProviderHomomorphism" 18 14
+      [ (id, HomomorphismLambdaCase, "")
+      ]
+
+    mkTest
+      "Doesn't suggest lambda homomorphism if the domain is smaller than the codomain"
+      "ProviderHomomorphism" 21 15
+      [ (not, HomomorphismLambdaCase, "")
+      , (id, DestructLambdaCase, "")
+      ]
 

--- a/plugins/hls-tactics-plugin/test/ProviderSpec.hs
+++ b/plugins/hls-tactics-plugin/test/ProviderSpec.hs
@@ -14,55 +14,9 @@ spec = do
     "T1" 2 14
     [ (id, Intros, "")
     ]
-  mkTest
-    "Produces destruct and homomorphism code actions"
-    "T2" 2 21
-    [ (id, Destruct, "eab")
-    , (id, Homomorphism, "eab")
-    , (not, DestructPun, "eab")
-    ]
-  mkTest
-    "Won't suggest homomorphism on the wrong type"
-    "T2" 8 8
-    [ (not, Homomorphism, "global")
-    ]
+
   mkTest
     "Won't suggest intros on the wrong type"
     "T2" 8 8
     [ (not, Intros, "")
     ]
-  mkTest
-    "Produces (homomorphic) lambdacase code actions"
-    "T3" 4 24
-    [ (id, HomomorphismLambdaCase, "")
-    , (id, DestructLambdaCase, "")
-    ]
-  mkTest
-    "Produces lambdacase code actions"
-    "T3" 7 13
-    [ (id, DestructLambdaCase, "")
-    ]
-  mkTest
-    "Doesn't suggest lambdacase without -XLambdaCase"
-    "T2" 11 25
-    [ (not, DestructLambdaCase, "")
-    ]
-
-  mkTest
-    "Doesn't suggest destruct if already destructed"
-    "ProvideAlreadyDestructed" 6 18
-    [ (not, Destruct, "x")
-    ]
-
-  mkTest
-    "...but does suggest destruct if destructed in a different branch"
-    "ProvideAlreadyDestructed" 9 7
-    [ (id, Destruct, "x")
-    ]
-
-  mkTest
-    "Doesn't suggest destruct on class methods"
-    "ProvideLocalHyOnly" 2 12
-    [ (not, Destruct, "mempty")
-    ]
-

--- a/plugins/hls-tactics-plugin/test/golden/ProviderHomomorphism.hs
+++ b/plugins/hls-tactics-plugin/test/golden/ProviderHomomorphism.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE GADTs #-}
+
+data GADT a where
+  B1 :: GADT Bool
+  B2 :: GADT Bool
+  Int :: GADT Int
+  Var :: GADT a
+
+
+hasHomo :: GADT Bool -> GADT a
+hasHomo g = _
+
+cantHomo :: GADT a -> GADT Int
+cantHomo g = _
+

--- a/plugins/hls-tactics-plugin/test/golden/ProviderHomomorphism.hs
+++ b/plugins/hls-tactics-plugin/test/golden/ProviderHomomorphism.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GADTs      #-}
+{-# LANGUAGE LambdaCase #-}
 
 data GADT a where
   B1 :: GADT Bool
@@ -12,4 +13,10 @@ hasHomo g = _
 
 cantHomo :: GADT a -> GADT Int
 cantHomo g = _
+
+hasHomoLam :: GADT Bool -> GADT a
+hasHomoLam = _
+
+cantHomoLam :: GADT a -> GADT Int
+cantHomoLam = _
 


### PR DESCRIPTION
This PR changes the behavior of the `homo` tactic, ensuring that it is total and well-typed to apply. Before, it would just automatically fill in the data constructors, regardless of whether they were the right type. The new logic is to check which data constructors are possible in the domain, and which in the codomain, and to subtract the latter from the former. If this set is non-empty, it means either the thing won't type check, or that due to some GADT equalities, it's impossible to map some constructors. Either way, the tactic should fail, and does now.

Fixes #565 