### PR TITLE
Clear the ms_hspp_buf for non FOIs

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.4.0.2
+version:            1.4.0.3
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -58,6 +58,7 @@ module Development.IDE.Core.Rules(
     typeCheckRuleDefinition,
     ) where
 
+import           Control.Applicative
 import           Control.Concurrent.Async                     (concurrently)
 import           Control.Concurrent.Strict
 import           Control.Exception.Safe

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -802,7 +802,7 @@ getModSummaryRule = do
                 foi <- use_ IsFileOfInterest f
                 bufFingerPrint <- liftIO $
                     fingerprintFromStringBuffer $ fromJust $ ms_hspp_buf $ msrModSummary res
-                let fingerPrint = fingerprintFingerprints
+                let !fingerPrint = fingerprintToBS $ fingerprintFingerprints
                         [ msrFingerprint res, bufFingerPrint ]
                     !res' = case foi of
                         NotFOI -> res
@@ -810,7 +810,7 @@ getModSummaryRule = do
                                 {ms_hspp_buf = Just $ error "ms_hspp_buf is cleared for non FOIs"}
                             }
                         _ -> res
-                return ( Just (fingerprintToBS fingerPrint) , ([], Just res'))
+                return ( Just fingerPrint, ([], Just res'))
             Left diags -> return (Nothing, (diags, Nothing))
 
     defineEarlyCutoff $ RuleNoDiagnostics $ \GetModSummaryWithoutTimestamps f -> do

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -810,7 +810,7 @@ getModSummaryRule = do
                                 {ms_hspp_buf = Just $ error "ms_hspp_buf is cleared for non FOIs"}
                             }
                         _ -> res
-                return ( Just fingerPrint, ([], Just res'))
+                return (Just fingerPrint, ([], Just res'))
             Left diags -> return (Nothing, (diags, Nothing))
 
     defineEarlyCutoff $ RuleNoDiagnostics $ \GetModSummaryWithoutTimestamps f -> do


### PR DESCRIPTION
We parse the mod summary for all the project targets at startup in order to build the module graph, which means that we store the preprocessed source of the entire project in memory for the duration of the session. 

This is wasteful, we should release those preprocessed sources and compute them again if needed later. But what's the best way to do this? 

One option would be to add a new `GetModSummaryWithoutPreprocessedSource` rule, but we already have `GetModSummary` and `GetModSummaryWithoutTimestamps`, so where does this end?

A simpler option is adopted in this PR. Since we only ever use the preprocessed buffer stored in the `ModSummary` when parsing, and (I believe) we only ever parse FOIs, it should be safe to clear them out for non FOIs.