### PR TITLE
relax megaparsec constraint in hls-tactics-plugin

### DIFF
--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -83,7 +83,7 @@ library
     , hyphenation
     , lens
     , lsp
-    , megaparsec            ^>=9
+    , megaparsec            >=8 && < 10
     , mtl
     , parser-combinators
     , prettyprinter


### PR DESCRIPTION
The plugin builds fine with megaparsec-8.0