### PR TITLE
Update nix to GHC 8.10.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1621151593,
-        "narHash": "sha256-wC8kXOdXwI3YyAeqv6LKZCmjqnjXovHI1UzOrma4kWA=",
+        "lastModified": 1624977608,
+        "narHash": "sha256-i/QZI5qM4eYw2wWGd/OjruBx53FqUPq+sdAWmyIQ0ws=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2c015d33d1b36070c64b726662db42c6c87b7be",
+        "rev": "db6e089456cdddcd7e2c1d8dac37a505c797e8fa",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1620897287,
-        "narHash": "sha256-UU0SysjA5h1NMCQhA0lKaeqy9gCBqpq/5dW1BWLbIXo=",
+        "lastModified": 1624971177,
+        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "40a51af82c1181b9dea3526c4124eee077e30213",
+        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -73,21 +73,6 @@
           tweaks = hself: hsuper:
             with haskell.lib; {
 
-              # https://github.com/haskell/haskell-language-server/pull/1858
-              # Remove this override when nixpkgs has this package
-              apply-refact_0_9_3_0 = hself.callCabal2nix "apply-refact"
-                (builtins.fetchTarball {
-                  url =
-                    "https://hackage.haskell.org/package/apply-refact-0.9.3.0/apply-refact-0.9.3.0.tar.gz";
-                  sha256 =
-                    "1jfq1aw91finlpq5nn7a96za4c8j13jk6jmx2867fildxwrik2qj";
-                }) { };
-
-              hls-hlint-plugin = hsuper.hls-hlint-plugin.override {
-                hlint = hself.hlint_3_2_7;
-                apply-refact = hself.apply-refact_0_9_3_0;
-              };
-
               hls-tactics-plugin = hsuper.hls-tactics-plugin.override {
                 refinery = hself.refinery_0_3_0_0;
               };
@@ -112,8 +97,8 @@
           hlsHpkgs = compiler: extended haskell.packages.${compiler};
 
           # Support of GenChangelogs.hs
-          gen-hls-changelogs =
-            let myGHC = haskellPackages.ghcWithPackages (p: with p; [ github ]);
+          gen-hls-changelogs = hpkgs:
+            let myGHC = hpkgs.ghcWithPackages (p: with p; [ github ]);
             in runCommand "gen-hls-changelogs" {
               passAsFile = [ "text" ];
               preferLocalBuild = true;
@@ -137,10 +122,12 @@
         };
 
         # Pre-commit hooks to run stylish-haskell
-        pre-commit-check = pre-commit-hooks.lib.${system}.run {
+        pre-commit-check = hpkgs: pre-commit-hooks.lib.${system}.run {
           src = ./.;
           hooks = {
             stylish-haskell.enable = true;
+            # use stylish-haskell with our target ghc
+            stylish-haskell.entry = "${hpkgs.stylish-haskell}/bin/stylish-haskell --inplace";
             stylish-haskell.excludes = [
               # Ignored files
               "^Setup.hs$"
@@ -178,9 +165,9 @@
             doBenchmark = true;
             packages = p:
               with builtins;
-              map (name: p.${name}) (attrNames pkgs.hlsSources);
-            buildInputs = [ gmp zlib ncurses capstone tracy gen-hls-changelogs ]
-              ++ (with haskellPackages; [
+              map (name: p.${name}) (attrNames hlsSources);
+            buildInputs = [ gmp zlib ncurses capstone tracy (gen-hls-changelogs hpkgs) ]
+              ++ (with hpkgs; [
                 cabal-install
                 hlint
                 ormolu
@@ -193,7 +180,7 @@
               export LD_LIBRARY_PATH=${gmp}/lib:${zlib}/lib:${ncurses}/lib:${capstone}/lib
               export DYLD_LIBRARY_PATH=${gmp}/lib:${zlib}/lib:${ncurses}/lib:${capstone}/lib
               export PATH=$PATH:$HOME/.local/bin
-              ${pre-commit-check.shellHook}
+              ${(pre-commit-check hpkgs).shellHook}
             '';
           };
         # Create a hls executable
@@ -218,14 +205,14 @@
           haskell-language-server-884-dev = mkDevShell ghc884;
           haskell-language-server-8104-dev = mkDevShell ghc8104;
           haskell-language-server-8105-dev = mkDevShell ghc8105;
-          haskell-language-server-901-dev = mkDevShell ghc901;
+          haskell-language-server-901-dev = builtins.throw "Nix expression for developing HLS in GHC 9.0.1 is not yet available"; # mkDevShell ghc901;
 
           # hls package
           haskell-language-server = mkExe ghcDefault;
           haskell-language-server-884 = mkExe ghc884;
           haskell-language-server-8104 = mkExe ghc8104;
           haskell-language-server-8105 = mkExe ghc8105;
-          haskell-language-server-901 = mkExe ghc901;
+          haskell-language-server-901 = builtins.throw "Nix expression for building HLS in GHC 9.0.1 is not yet available"; # mkExe ghc901;
         };
 
         defaultPackage = packages.haskell-language-server;


### PR DESCRIPTION
* leverage https://github.com/NixOS/nixpkgs/pull/127438, the default GHC version now is 8.10.5
* try to unify GHC used in the development shell - `gen-hls-changelogs` and  `pre-commit-hooks` shouldn't use the default GHC version
* mark `haskell-language-server-901` and `haskell-language-server-901-dev` as broken - there are too many dependencies not buildable in nixpkgs GHC 9.0.1 packages set