### PR TITLE
nix: add support for ghc 9.0.1

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -91,16 +91,16 @@ jobs:
         name: haskell-language-server
         authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
     - name: Build development shell
-      run: |
-        nix develop --profile dev
-        nix develop .#haskell-language-server-901-dev --profile dev
+      run: nix develop --profile dev
+    - name: Build development shell (GHC 9.0.1)
+      run: nix develop .#haskell-language-server-901-dev --profile dev
     - name: Push development shell
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: cachix push haskell-language-server dev
     - name: Build binaries
-      run: |
-        nix build
-        nix build .#haskell-language-server-901
+      run: nix build
+    - name: Build binaries (GHC 9.0.1)
+      run: nix build .#haskell-language-server-901
     - name: Push binaries
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -91,12 +91,16 @@ jobs:
         name: haskell-language-server
         authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
     - name: Build development shell
-      run: nix develop --profile dev
+      run: |
+        nix develop --profile dev
+        nix develop .#haskell-language-server-901-dev --profile dev
     - name: Push development shell
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: cachix push haskell-language-server dev
     - name: Build binaries
-      run: nix build
+      run: |
+        nix build
+        nix build .#haskell-language-server-901
     - name: Push binaries
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -75,6 +75,13 @@ source-repository-package
   subdir: lsp-test
 -- https://github.com/haskell/lsp/pull/312
 
+-- benchmark dependency
+source-repository-package
+  type: git
+  location: https://github.com/berberman/operational
+  tag: 0e062895678f49fd673ae493371262cfb8c5ab56
+-- https://github.com/HeinrichApfelmus/operational/pull/26
+
 write-ghc-environment-files: never
 
 index-state: 2021-06-30T16:00:00Z

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -74,6 +74,9 @@ let
         hself.callCabal2nix "dependent-sum" "${dependent-sum-src}/dependent-sum"
         { };
 
+      dependent-sum-template = hself.callCabal2nix "dependent-sum-template"
+        "${dependent-sum-src}/dependent-sum-template" { };
+
       hlint = hself.hlint_3_3_1;
 
       ghc-lib-parser = hself.ghc-lib-parser_9_0_1_20210324;

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -2,16 +2,16 @@
 { pkgs }:
 
 let
-  removePluginPackages = hpkgs:
-    removeAttrs hpkgs [
-      "hls-tactics-plugin"
-      "hls-brittany-plugin"
-      "hls-stylish-haskell-plugin"
-      "hls-fourmolu-plugin"
-      "hls-splice-plugin"
-      "hls-ormolu-plugin"
-      "hls-eval-plugin"
-    ];
+  disabledPlugins = [
+    "hls-tactics-plugin"
+    "hls-brittany-plugin"
+    "hls-stylish-haskell-plugin"
+    "hls-fourmolu-plugin"
+    "hls-splice-plugin"
+    "hls-ormolu-plugin"
+    "hls-eval-plugin"
+  ];
+
   hpkgsOverride = hself: hsuper:
     with pkgs.haskell.lib;
     let
@@ -98,4 +98,7 @@ let
           "-f-tactic"
         ]) { };
     };
-in { tweakHpkgs = hpkgs: removePluginPackages (hpkgs.extend hpkgsOverride); }
+in {
+  inherit disabledPlugins;
+  tweakHpkgs = hpkgs: hpkgs.extend hpkgsOverride;
+}

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -10,6 +10,7 @@ let
       "hls-fourmolu-plugin"
       "hls-splice-plugin"
       "hls-ormolu-plugin"
+      "hls-eval-plugin"
     ];
   hpkgsOverride = hself: hsuper:
     with pkgs.haskell.lib;
@@ -84,17 +85,17 @@ let
 
       ghc-lib-parser-ex = hself.ghc-lib-parser-ex_9_0_0_4;
 
-      # Disable plugins
+      # Re-generate HLS drv excluding some plugins
       haskell-language-server =
-        appendConfigureFlags hsuper.haskell-language-server [
-          "-brittany"
-          "-eval"
-          "-fourmolu"
-          "-ormolu"
-          "-splice"
-          "-stylishhaskell"
-          "-tactic"
-          "-refineImports"
-        ];
+        hself.callCabal2nixWithOptions "haskell-language-server" ./.
+        (pkgs.lib.concatStringsSep " " [
+          "-f-brittany"
+          "-f-eval"
+          "-f-fourmolu"
+          "-f-ormolu"
+          "-f-splice"
+          "-f-stylishhaskell"
+          "-f-tactic"
+        ]) { };
     };
-in { tweakHpkgs = hpkgs: (removePluginPackages hpkgs).extend hpkgsOverride; }
+in { tweakHpkgs = hpkgs: removePluginPackages (hpkgs.extend hpkgsOverride); }

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -79,11 +79,19 @@ let
         hself.callCabal2nix "dependent-sum" "${dependent-sum-src}/dependent-sum"
         { };
 
-      hlint = hself.callCabal2nix "hlint" hlint_3_3_1-src { };
+      hlint = hself.hlint_3_3_1;
 
       ghc-lib-parser = hself.ghc-lib-parser_9_0_1_20210324;
 
       ghc-lib-parser-ex = hself.ghc-lib-parser-ex_9_0_0_4;
+
+      operational = hself.callCabal2nix "operational"
+        (pkgs.fetchFromGitHub {
+          owner = "berberman";
+          repo = "operational";
+          rev = "0e062895678f49fd673ae493371262cfb8c5ab56";
+          sha256 = "P+aocEcqCN8klnW3IMrmIqq6ztBZJxk4sBp1ewN6YaA=";
+        }) { };
 
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -90,6 +90,12 @@ let
         sha256 = "P+aocEcqCN8klnW3IMrmIqq6ztBZJxk4sBp1ewN6YaA=";
       }) { };
 
+      diagrams-core = hself.diagrams-core_1_5_0;
+
+      diagrams-lib = hself.diagrams-lib_1_4_4;
+
+      dual-tree = hself.dual-tree_0_2_3_0;
+
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =
         hself.callCabal2nixWithOptions "haskell-language-server" ./.

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -90,9 +90,6 @@ let
         sha256 = "P+aocEcqCN8klnW3IMrmIqq6ztBZJxk4sBp1ewN6YaA=";
       }) { };
 
-      # needs https://github.com/JonasDuregard/sized-functors/pull/9
-      dual-tree = dontCheck hsuper.dual-tree;
-
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =
         hself.callCabal2nixWithOptions "haskell-language-server" ./.

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -96,6 +96,8 @@ let
 
       dual-tree = hself.dual-tree_0_2_3_0;
 
+      monoid-extras = hself.monoid-extras_0_6;
+
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =
         hself.callCabal2nixWithOptions "haskell-language-server" ./.

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -107,7 +107,11 @@ let
         ]) { };
 
       # YOLO
-      mkDerivation = args: hsuper.mkDerivation (args // { jailbreak = true; });
+      mkDerivation = args:
+        hsuper.mkDerivation (args // {
+          jailbreak = true;
+          doCheck = false;
+        });
     };
 in {
   inherit disabledPlugins;

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -28,11 +28,6 @@ let
         rev = "8cf4c7fbc3bfa2be475a17bb7c94a1e1e9a830b5";
         sha256 = "WtxTB6ufTZC6SxOtGSfhlO4mY0y9eWejMSa0yUJ7dHQ=";
       };
-      hlint_3_3_1-src = builtins.fetchTarball {
-        url =
-          "https://hackage.haskell.org/package/hlint-3.3.1/hlint-3.3.1.tar.gz";
-        sha256 = "03vb4s4w8k5vp5cjzg7m2bsinbjz1j2aqx4q06syq4r5vb3ai5yq";
-      };
     in {
       blaze-textual = hself.callCabal2nix "blaze-textual"
         (pkgs.fetchFromGitHub {
@@ -85,13 +80,15 @@ let
 
       ghc-lib-parser-ex = hself.ghc-lib-parser-ex_9_0_0_4;
 
-      operational = hself.callCabal2nix "operational"
-        (pkgs.fetchFromGitHub {
-          owner = "berberman";
-          repo = "operational";
-          rev = "0e062895678f49fd673ae493371262cfb8c5ab56";
-          sha256 = "P+aocEcqCN8klnW3IMrmIqq6ztBZJxk4sBp1ewN6YaA=";
-        }) { };
+      operational = hself.callCabal2nix "operational" (pkgs.fetchFromGitHub {
+        owner = "berberman";
+        repo = "operational";
+        rev = "0e062895678f49fd673ae493371262cfb8c5ab56";
+        sha256 = "P+aocEcqCN8klnW3IMrmIqq6ztBZJxk4sBp1ewN6YaA=";
+      }) { };
+
+      # needs https://github.com/JonasDuregard/sized-functors/pull/9
+      dual-tree = dontCheck hsuper.dual-tree;
 
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -97,6 +97,9 @@ let
           "-f-stylishhaskell"
           "-f-tactic"
         ]) { };
+
+      # YOLO
+      mkDerivation = args: hsuper.mkDerivation (args // { jailbreak = true; });
     };
 in {
   inherit disabledPlugins;

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -78,14 +78,11 @@ let
         hself.callCabal2nix "dependent-sum" "${dependent-sum-src}/dependent-sum"
         { };
 
-      # Copied from https://github.com/NixOS/nixpkgs/blob/2e672ed71afb9d0cea962b694ddb4e63a9ee00eb/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix#L109
-      hlint = (hself.callCabal2nix "hlint" hlint_3_3_1-src { }).overrideScope
-        (self: super: {
-          ghc-lib-parser = overrideCabal self.ghc-lib-parser_9_0_1_20210324 {
-            doHaddock = false;
-          };
-          ghc-lib-parser-ex = self.ghc-lib-parser-ex_9_0_0_4;
-        });
+      hlint = hself.callCabal2nix "hlint" hlint_3_3_1-src { };
+
+      ghc-lib-parser = hself.ghc-lib-parser_9_0_1_20210324;
+
+      ghc-lib-parser-ex = hself.ghc-lib-parser-ex_9_0_0_4;
 
       # Disable plugins
       haskell-language-server =

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -1,0 +1,103 @@
+# nix version of cabal-ghc901.project
+{ pkgs }:
+
+let
+  removePluginPackages = hpkgs:
+    removeAttrs hpkgs [
+      "hls-tactics-plugin"
+      "hls-brittany-plugin"
+      "hls-stylish-haskell-plugin"
+      "hls-fourmolu-plugin"
+      "hls-splice-plugin"
+      "hls-ormolu-plugin"
+    ];
+  hpkgsOverride = hself: hsuper:
+    with pkgs.haskell.lib;
+    let
+      lsp-src = pkgs.fetchFromGitHub {
+        owner = "anka-213";
+        repo = "lsp";
+        rev = "tag-ghc-9.0.1-without-pr-326";
+        sha256 = "lW/EdBnvKPLE2+CGE/grIekOu+U/Wh6zMCN4xhJDtPY=";
+      };
+
+      dependent-sum-src = pkgs.fetchFromGitHub {
+        owner = "anka-213";
+        repo = "dependent-sum";
+        rev = "8cf4c7fbc3bfa2be475a17bb7c94a1e1e9a830b5";
+        sha256 = "WtxTB6ufTZC6SxOtGSfhlO4mY0y9eWejMSa0yUJ7dHQ=";
+      };
+      hlint_3_3_1-src = builtins.fetchTarball {
+        url =
+          "https://hackage.haskell.org/package/hlint-3.3.1/hlint-3.3.1.tar.gz";
+        sha256 = "03vb4s4w8k5vp5cjzg7m2bsinbjz1j2aqx4q06syq4r5vb3ai5yq";
+      };
+    in {
+      blaze-textual = hself.callCabal2nix "blaze-textual"
+        (pkgs.fetchFromGitHub {
+          owner = "jwaldmann";
+          repo = "blaze-textual";
+          rev = "d8ee6cf80e27f9619d621c936bb4bda4b99a183f";
+          sha256 = "C0dIzf64fBaY8mlhMm1kCQC5Jc1wKBtNO2Y24k7YPUw=";
+        }) { };
+
+      czipwith = hself.callCabal2nix "czipwith" (pkgs.fetchFromGitHub {
+        owner = "mithrandi";
+        repo = "czipwith";
+        rev = "b6245884ae83e00dd2b5261762549b37390179f8";
+        sha256 = "2uSoGyrxT/OstRcpx55kwP4JwjPbWLxD72LajeyQV0E=";
+      }) { };
+
+      hie-bios = hself.callCabal2nix "hie-bios" (pkgs.fetchFromGitHub {
+        owner = "jneira";
+        repo = "hie-bios";
+        rev = "9b1445ab5efcabfad54043fc9b8e50e9d8c5bbf3";
+        sha256 = "8ct7t3xIxIAoC+f8VO5e5+QKrd5L5Zu1eButSaE+1Uk=";
+      }) { };
+
+      ghc-api-compat = hself.callCabal2nix "ghc-api-compat"
+        (pkgs.fetchFromGitHub {
+          owner = "hsyl20";
+          repo = "ghc-api-compat";
+          rev = "8fee87eac97a538dbe81ff1ab18cff10f2f9fa15";
+          sha256 = "byehvdxQxhNk5ZQUXeFHjAZpAze4Ct9261ro4c5acZk=";
+        }) { };
+
+      th-extras = hself.callCabal2nix "th-extras" (pkgs.fetchFromGitHub {
+        owner = "anka-213";
+        repo = "th-extras";
+        rev = "57a97b4df128eb7b360e8ab9c5759392de8d1659";
+        sha256 = "Qtha1ge/C0L+uFcV2dZ5xpG59DCxQT7LuK/OYfiM4Pk=";
+      }) { };
+
+      lsp = hself.callCabal2nix "lsp" "${lsp-src}/lsp" { };
+      lsp-types = hself.callCabal2nix "lsp-types" "${lsp-src}/lsp-types" { };
+      lsp-test = hself.callCabal2nix "lsp-test" "${lsp-src}/lsp-test" { };
+
+      dependent-sum =
+        hself.callCabal2nix "dependent-sum" "${dependent-sum-src}/dependent-sum"
+        { };
+
+      # Copied from https://github.com/NixOS/nixpkgs/blob/2e672ed71afb9d0cea962b694ddb4e63a9ee00eb/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix#L109
+      hlint = (hself.callCabal2nix "hlint" hlint_3_3_1-src { }).overrideScope
+        (self: super: {
+          ghc-lib-parser = overrideCabal self.ghc-lib-parser_9_0_1_20210324 {
+            doHaddock = false;
+          };
+          ghc-lib-parser-ex = self.ghc-lib-parser-ex_9_0_0_4;
+        });
+
+      # Disable plugins
+      haskell-language-server =
+        appendConfigureFlags hsuper.haskell-language-server [
+          "-brittany"
+          "-eval"
+          "-fourmolu"
+          "-ormolu"
+          "-splice"
+          "-stylishhaskell"
+          "-tactic"
+          "-refineImports"
+        ];
+    };
+in { tweakHpkgs = hpkgs: (removePluginPackages hpkgs).extend hpkgsOverride; }

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -10,6 +10,8 @@ let
     "hls-splice-plugin"
     "hls-ormolu-plugin"
     "hls-eval-plugin"
+    "hls-class-plugin"
+    "hls-refine-imports-plugin"
   ];
 
   hpkgsOverride = hself: hsuper:
@@ -103,12 +105,14 @@ let
         hself.callCabal2nixWithOptions "haskell-language-server" ./.
         (pkgs.lib.concatStringsSep " " [
           "-f-brittany"
+          "-f-class"
           "-f-eval"
           "-f-fourmolu"
           "-f-ormolu"
           "-f-splice"
           "-f-stylishhaskell"
           "-f-tactic"
+          "-f-refineImports"
         ]) { };
 
       # YOLO

--- a/flake.nix
+++ b/flake.nix
@@ -185,8 +185,8 @@
               ++ (with hpkgs; [
                 cabal-install
                 hlint
-                ormolu
-                stylish-haskell
+                # ormolu
+                # stylish-haskell
                 opentelemetry-extra
               ]);
 

--- a/flake.nix
+++ b/flake.nix
@@ -175,13 +175,12 @@
           hpkgs.shellFor {
             doBenchmark = true;
             packages = p:
-              with lib;
-              # we can remove sources attrs from hpkgs to exclude HLS plugins,
-              # so hpkgs may not be the superset of hlsSources
-              pipe (attrNames hlsSources) [
-                (xs: map (name: if hpkgs ? name then p.${name} else null) xs)
-                (xs: remove null xs)
-              ];
+              with builtins;
+              map (name: p.${name}) (attrNames
+                (if hpkgs.ghc.version == "9.0.1" then
+                  removeAttrs hlsSources ghc901Config.disabledPlugins
+                else
+                  hlsSources));
             buildInputs = [ gmp zlib ncurses capstone tracy (gen-hls-changelogs hpkgs) ]
               ++ (with hpkgs; [
                 cabal-install

--- a/flake.nix
+++ b/flake.nix
@@ -195,7 +195,7 @@
               export LD_LIBRARY_PATH=${gmp}/lib:${zlib}/lib:${ncurses}/lib:${capstone}/lib
               export DYLD_LIBRARY_PATH=${gmp}/lib:${zlib}/lib:${ncurses}/lib:${capstone}/lib
               export PATH=$PATH:$HOME/.local/bin
-              ${(pre-commit-check hpkgs).shellHook}
+              ${if hpkgs.ghc.version != "9.0.1" then (pre-commit-check hpkgs).shellHook else ""}
             '';
           };
         # Create a hls executable

--- a/flake.nix
+++ b/flake.nix
@@ -179,7 +179,7 @@
               # we can remove sources attrs from hpkgs to exclude HLS plugins,
               # so hpkgs may not be the superset of hlsSources
               pipe (attrNames hlsSources) [
-                (xs: map (name: p.${name} or null) xs)
+                (xs: map (name: if hpkgs ? name then p.${name} else null) xs)
                 (xs: remove null xs)
               ];
             buildInputs = [ gmp zlib ncurses capstone tracy (gen-hls-changelogs hpkgs) ]

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -94,6 +94,11 @@ extra-deps:
   commit: ca23431a8dfa013992f9164ccc882a3277361f17
 # https://github.com/diagrams/active/pull/36
 
+# benchmark dependency
+- github: berberman/operational
+  commit: 0e062895678f49fd673ae493371262cfb8c5ab56
+# https://github.com/HeinrichApfelmus/operational/pull/26
+
 configure-options:
   ghcide:
       - --disable-library-for-ghci


### PR DESCRIPTION
As discussed in https://github.com/haskell/haskell-language-server/issues/1871#issuecomment-859990650, this PR attempts to maintain a nix configuration that works for ghc 9.0.1. It's still work in progress, see the CI for results.