### PR TITLE
Draft: Add POC for HLS loading multiple components on startup

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -37,6 +37,11 @@ source-repository-package
   location: https://github.com/hsyl20/ghc-api-compat
   tag: 8fee87eac97a538dbe81ff1ab18cff10f2f9fa15
 
+source-repository-package
+  type: git
+  location: https://github.com/fendor/hie-bios
+  tag: fe823adfa0e82aa76e098a57cc424c92902e1db8
+
 write-ghc-environment-files: never
 
 index-state: 2021-08-12T12:00:38Z

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -100,7 +100,7 @@ library
         ghc-paths,
         ghc-api-compat,
         cryptohash-sha1 >=0.11.100 && <0.12,
-        hie-bios >= 0.7.1 && < 0.8.0,
+        hie-bios >= 0.8.0 && < 0.9.0,
         implicit-hie-cradle >= 0.3.0.5 && < 0.4,
         base16-bytestring >=0.1.1 && <1.1
     if os(windows)


### PR DESCRIPTION
Powered by hie-bios.

A prototype implementation for loading multiple components on startup using the WIP hie-bios interface: https://github.com/mpickering/hie-bios/pull/301

The main feature is the usage of `cabal show-build-info`, from here: https://github.com/haskell/cabal/pull/7478 
To test out this PR, you have to install the linked cabal executable from source.
NB: currently cabal only supports loading projects where the build-type is `Simple`.

For debugging, take a look at the result of `cabal build all` in your project, which  *currently must* succeed for `show-build-info` to succeed.