### PR TITLE
Disable hls tests for win and ghc-9.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
         # run the tests without parallelism to avoid running out of memory
         run: cabal test ghcide --test-options="-j1 --rerun-update" || cabal test ghcide --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test ghcide --test-options="-j1 --rerun"
 
-      - if: ${{ needs.pre_job.outputs.should_skip != 'true' && matrix.test }}
+      - if: ${{ needs.pre_job.outputs.should_skip != 'true' && matrix.test && !(matrix.os == 'windows-latest' && matrix.ghc == '9.0.1')}}
         name: Test func-test suite
         env:
           HLS_TEST_EXE: hls

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -133,14 +133,12 @@ hlintTests = testGroup "hlint suggestions" [
         testRefactor "ApplyRefact1.hs" "Redundant bracket"
             ("{-# LANGUAGE LambdaCase #-}" : expectedLambdaCase)
 
-    , ignoreInEnv [HostOS Windows, GhcVer GHC90] "Test make execution does not terminate for windows and ghc-9.0" $
-      expectFailBecause "apply-refact doesn't work with cpp" $
+    , expectFailBecause "apply-refact doesn't work with cpp" $
       testCase "apply hints works with CPP via -XCPP argument" $ runHlintSession "cpp" $ do
         testRefactor "ApplyRefact3.hs" "Redundant bracket"
             expectedCPP
 
-    , ignoreInEnv [HostOS Windows, GhcVer GHC90] "Test make execution does not terminate for windows and ghc-9.0" $
-      expectFailBecause "apply-refact doesn't work with cpp" $
+    , expectFailBecause "apply-refact doesn't work with cpp" $
       testCase "apply hints works with CPP via language pragma" $ runHlintSession "" $ do
         testRefactor "ApplyRefact3.hs" "Redundant bracket"
             ("{-# LANGUAGE CPP #-}" : expectedCPP)


### PR DESCRIPTION
* The job is being flaky since i added it, it usually hangs until is cancelled
* Let's see if we can workaround it only disabling hls tests 