### PR TITLE
Enable dynamic linking in stack builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,9 @@ defaults: &defaults
 
     - restore_cache:
         keys:
-          - stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
-          - stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
-          - stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+          - v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
+          - v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+          - v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
 
     - run:
         name: Stack upgrade
@@ -46,7 +46,7 @@ defaults: &defaults
         destination: bin
 
     - save_cache:
-        key: stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+        key: v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
         paths: &cache_paths
           - ~/.stack
           - ~/build/.stack-work
@@ -58,7 +58,7 @@ defaults: &defaults
         no_output_timeout: 120m
 
     - save_cache:
-        key: stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
+        key: v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
         paths: *cache_paths
 
 version: 2

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -69,6 +69,8 @@ extra-deps:
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
     - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.10.3.yaml
+++ b/stack-8.10.3.yaml
@@ -69,6 +69,8 @@ extra-deps:
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.10.4.yaml
+++ b/stack-8.10.4.yaml
@@ -71,6 +71,8 @@ extra-deps:
   # - hlint-3.3@sha256:4218ad6e03050f5d68aeba0e025f5f05e366c8fd49657f2a19df04ee31b2bb23,4154
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.10.5.yaml
+++ b/stack-8.10.5.yaml
@@ -73,6 +73,8 @@ extra-deps:
   # - hlint-3.3@sha256:4218ad6e03050f5d68aeba0e025f5f05e366c8fd49657f2a19df04ee31b2bb23,4154
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -118,6 +118,8 @@ flags:
 
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -107,6 +107,8 @@ extra-deps:
   - resourcet-1.2.3
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
     - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -86,6 +86,8 @@ extra-deps:
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
     - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -83,6 +83,8 @@ extra-deps:
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
     - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -101,6 +101,8 @@ extra-deps:
   commit: 16e19aaf34e286f3d27b3988c61040823ec66537
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack.yaml
+++ b/stack.yaml
@@ -62,6 +62,8 @@ extra-deps:
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
 
 configure-options:
+  $targets:
+      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:


### PR DESCRIPTION
CircleCI is running OOM during linking (except in the 9.0.1 build for some reason). 

I don't know what has changed, but perhaps we can simply avoid linking at all?

I don't use stack so this change is untested - let's see if it helps.