### PR TITLE
Completions from non-imported modules

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -21,6 +21,7 @@ import           GHC                        ()
 import           GhcPlugins
 import           Retrie.ExactPrint          (Annotated)
 import qualified StringBuffer               as SB
+import           Unique                     (getKey)
 
 
 -- Orphan instances for types from the GHC API.
@@ -162,3 +163,6 @@ instance (NFData HsModule) where
 instance (NFData (HsModule a)) where
 #endif
   rnf = rwhnf
+
+instance Show OccName where show = prettyPrint
+instance Hashable OccName where hashWithSalt s n = hashWithSalt s (getKey $ getUnique n)

--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -51,6 +51,8 @@ instance Hashable GhcPlugins.InstalledUnitId where
   hashWithSalt salt = hashWithSalt salt . installedUnitIdString
 #else
 instance Show InstalledUnitId where show = prettyPrint
+deriving instance Ord SrcSpan
+deriving instance Ord UnhelpfulSpanReason
 #endif
 
 instance NFData SB.StringBuffer where rnf = rwhnf

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -837,7 +837,7 @@ suggestExtendImport exportsMap (L _ HsModule {hsmodImports}) Diagnostic{_range=_
             -- fallback to using GHC suggestion even though it is not always correct
           | otherwise
           = Just IdentInfo
-                { name = binding
+                { name = mkVarOcc $ T.unpack binding
                 , rendered = binding
                 , parent = Nothing
                 , isDatacon = False

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -11,7 +11,9 @@ module Development.IDE.Plugin.CodeAction
     iePluginDescriptor,
     typeSigsPluginDescriptor,
     bindingsPluginDescriptor,
-    fillHolePluginDescriptor
+    fillHolePluginDescriptor,
+    newImport,
+    newImportToEdit
     -- * For testing
     , matchRegExMultipleImports
     ) where

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -23,17 +23,20 @@ import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error                    (rangeToSrcSpan)
 import           Development.IDE.GHC.ExactPrint               (Annotated (annsA),
-                                                               GetAnnotatedParsedSource (GetAnnotatedParsedSource))
+                                                               GetAnnotatedParsedSource (GetAnnotatedParsedSource),
+                                                               astA)
 import           Development.IDE.GHC.Util                     (prettyPrint)
 import           Development.IDE.Graph
 import           Development.IDE.Graph.Classes
+import           Development.IDE.Plugin.CodeAction            (newImport,
+                                                               newImportToEdit)
 import           Development.IDE.Plugin.CodeAction.ExactPrint
 import           Development.IDE.Plugin.Completions.Logic
 import           Development.IDE.Plugin.Completions.Types
 import           Development.IDE.Types.HscEnvEq               (HscEnvEq (envPackageExports),
                                                                hscEnv)
 import           Development.IDE.Types.Location
-import           GHC.Exts                                     (toList)
+import           GHC.Exts                                     (fromList, toList)
 import           GHC.Generics
 import           Ide.Plugin.Config                            (Config)
 import           Ide.Types
@@ -136,7 +139,7 @@ getCompletionsLSP ide plId
             binds <- fromMaybe (mempty, zeroMapping) <$> useWithStaleFast GetBindings npath
             exportsMapIO <- fmap(envPackageExports . fst) <$> useWithStaleFast GhcSession npath
             exportsMap <- mapM liftIO exportsMapIO
-            let exportsCompItems = foldMap (map fromIdentInfo . Set.toList) . Map.elems . getExportsMap <$> exportsMap
+            let exportsCompItems = foldMap (map (fromIdentInfo uri) . Set.toList) . Map.elems . getExportsMap <$> exportsMap
                 exportsCompls = mempty{unqualCompls = fromMaybe [] exportsCompItems}
             let compls = (fst <$> localCompls) <> (fst <$> nonLocalCompls) <> (Just exportsCompls)
             pure (opts, fmap (,pm,binds) compls)
@@ -194,10 +197,19 @@ extendImportHandler' ideState ExtendImport {..}
       let df = ms_hspp_opts msrModSummary
           wantedModule = mkModuleName (T.unpack importName)
           wantedQual = mkModuleName . T.unpack <$> importQual
-      imp <- liftMaybe $ find (isWantedModule wantedModule wantedQual) msrImports
-      fmap (nfp,) $ liftEither $
-        rewriteToWEdit df doc (annsA ps) $
-          extendImport (T.unpack <$> thingParent) (T.unpack newThing) imp
+          existingImport = find (isWantedModule wantedModule wantedQual) msrImports
+      case existingImport of
+        Just imp -> do
+            fmap (nfp,) $ liftEither $
+              rewriteToWEdit df doc (annsA ps) $
+                extendImport (T.unpack <$> thingParent) (T.unpack newThing) imp
+        Nothing -> do
+            let n = newImport importName (Just it) importQual False
+                it = case thingParent of
+                  Nothing -> newThing
+                  Just p  -> p <> "(" <> newThing <> ")"
+            t <- liftMaybe $ snd <$> newImportToEdit n (astA ps)
+            return (nfp, WorkspaceEdit {_changes=Just (fromList [(doc,List [t])]), _documentChanges=Nothing, _changeAnnotations=Nothing})
   | otherwise =
     mzero
 

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -141,7 +141,7 @@ getCompletionsLSP ide plId
             exportsMap <- mapM liftIO exportsMapIO
             let exportsCompItems = foldMap (map (fromIdentInfo uri) . Set.toList) . Map.elems . getExportsMap <$> exportsMap
                 exportsCompls = mempty{unqualCompls = fromMaybe [] exportsCompItems}
-            let compls = (fst <$> localCompls) <> (fst <$> nonLocalCompls) <> (Just exportsCompls)
+            let compls = (fst <$> localCompls) <> (fst <$> nonLocalCompls) <> Just exportsCompls
             pure (opts, fmap (,pm,binds) compls)
         case compls of
           Just (cci', parsedMod, bindMap) -> do

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -13,6 +13,8 @@ import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Maybe
 import           Data.Aeson
+import qualified Data.HashMap.Strict                          as Map
+import qualified Data.HashSet                                 as Set
 import           Data.List                                    (find)
 import           Data.Maybe
 import qualified Data.Text                                    as T
@@ -33,6 +35,7 @@ import           Development.IDE.Plugin.CodeAction            (newImport,
 import           Development.IDE.Plugin.CodeAction.ExactPrint
 import           Development.IDE.Plugin.Completions.Logic
 import           Development.IDE.Plugin.Completions.Types
+import           Development.IDE.Types.Exports
 import           Development.IDE.Types.HscEnvEq               (HscEnvEq (envPackageExports),
                                                                hscEnv)
 import           Development.IDE.Types.Location
@@ -46,9 +49,6 @@ import qualified Language.LSP.VFS                             as VFS
 #if MIN_VERSION_ghc(9,0,0)
 import           GHC.Tc.Module                                (tcRnImportDecls)
 #else
-import qualified Data.HashMap.Strict                          as Map
-import qualified Data.HashSet                                 as Set
-import           Development.IDE.Types.Exports
 import           TcRnDriver                                   (tcRnImportDecls)
 #endif
 

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -140,7 +140,7 @@ getCompletionsLSP ide plId
             exportsMapIO <- fmap(envPackageExports . fst) <$> useWithStaleFast GhcSession npath
             exportsMap <- mapM liftIO exportsMapIO
             let exportsCompItems = foldMap (map (fromIdentInfo uri) . Set.toList) . Map.elems . getExportsMap <$> exportsMap
-                exportsCompls = mempty{unqualCompls = fromMaybe [] exportsCompItems}
+                exportsCompls = mempty{anyQualCompls = fromMaybe [] exportsCompItems}
             let compls = (fst <$> localCompls) <> (fst <$> nonLocalCompls) <> Just exportsCompls
             pure (opts, fmap (,pm,binds) compls)
         case compls of
@@ -204,7 +204,8 @@ extendImportHandler' ideState ExtendImport {..}
               rewriteToWEdit df doc (annsA ps) $
                 extendImport (T.unpack <$> thingParent) (T.unpack newThing) imp
         Nothing -> do
-            let n = newImport importName (Just it) importQual False
+            let n = newImport importName sym importQual False
+                sym = if isNothing importQual then Just it else Nothing
                 it = case thingParent of
                   Nothing -> newThing
                   Just p  -> p <> "(" <> newThing <> ")"

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -606,7 +606,7 @@ getCompletions plId ideOpts CC {allModNamesAsNS, unqualCompls, qualCompls, impor
     | "{-# " `T.isPrefixOf` fullLine
     -> return $ filtPragmaCompls (pragmaSuffix fullLine)
     | otherwise -> do
-        let uniqueFiltCompls = nubOrdOn (\x -> (insertText x, importedFrom x) ) filtCompls
+        let uniqueFiltCompls = nubOrdOn (\x -> (label x, importedFrom x, compKind x) ) filtCompls
         compls <- mapM (mkCompl plId ideOpts) uniqueFiltCompls
         return $ filtModNameCompls
               ++ filtKeywordCompls

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -606,7 +606,7 @@ getCompletions plId ideOpts CC {allModNamesAsNS, unqualCompls, qualCompls, impor
     | "{-# " `T.isPrefixOf` fullLine
     -> return $ filtPragmaCompls (pragmaSuffix fullLine)
     | otherwise -> do
-        let uniqueFiltCompls = nubOrdOn insertText filtCompls
+        let uniqueFiltCompls = nubOrdOn (\x -> (insertText x, importedFrom x) ) filtCompls
         compls <- mapM (mkCompl plId ideOpts) uniqueFiltCompls
         return $ filtModNameCompls
               ++ filtKeywordCompls

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -9,6 +9,7 @@ module Development.IDE.Plugin.Completions.Logic (
 , cacheDataProducer
 , localCompletionsForParsedModule
 , getCompletions
+, fromIdentInfo
 ) where
 
 import           Control.Applicative
@@ -19,6 +20,7 @@ import           Data.List.Extra                          as List hiding
 import qualified Data.Map                                 as Map
 
 import           Data.Maybe                               (fromMaybe, isJust,
+                                                           isNothing,
                                                            listToMaybe,
                                                            mapMaybe)
 import qualified Data.Text                                as T
@@ -49,6 +51,7 @@ import           Development.IDE.Plugin.Completions.Types
 import           Development.IDE.Spans.Common
 import           Development.IDE.Spans.Documentation
 import           Development.IDE.Spans.LocalBindings
+import           Development.IDE.Types.Exports
 import           Development.IDE.Types.HscEnvEq
 import           Development.IDE.Types.Options
 import           GhcPlugins                               (flLabel, unpackFS)
@@ -302,6 +305,25 @@ mkPragmaCompl label insertText =
     Nothing Nothing Nothing Nothing Nothing (Just insertText) (Just Snippet)
     Nothing Nothing Nothing Nothing Nothing Nothing
 
+fromIdentInfo :: Uri -> IdentInfo -> CompItem
+fromIdentInfo doc IdentInfo{..} = CI
+  { compKind= occNameToComKind Nothing name
+  , insertText=rendered
+  , importedFrom=Right moduleNameText
+  , typeText=Nothing
+  , label=rendered
+  , isInfix=Nothing
+  , docs=emptySpanDoc
+  , isTypeCompl= not isDatacon && isUpper (T.head rendered)
+  , additionalTextEdits= Just $
+        ExtendImport
+          { doc,
+            thingParent = parent,
+            importName = moduleNameText,
+            importQual = Nothing,
+            newThing = rendered
+          }
+  }
 
 cacheDataProducer :: Uri -> HscEnvEq -> Module -> GlobalRdrEnv-> GlobalRdrEnv -> [LImportDecl GhcPs] -> IO CachedCompletions
 cacheDataProducer uri env curMod globalEnv inScopeEnv limports = do
@@ -606,13 +628,26 @@ getCompletions plId ideOpts CC {allModNamesAsNS, unqualCompls, qualCompls, impor
     | "{-# " `T.isPrefixOf` fullLine
     -> return $ filtPragmaCompls (pragmaSuffix fullLine)
     | otherwise -> do
-        let uniqueFiltCompls = nubOrdOn (\x -> (label x, importedFrom x, compKind x) ) filtCompls
+        -- assumes that nubOrdBy is stable
+        let uniqueFiltCompls = nubOrdBy uniqueCompl filtCompls
         compls <- mapM (mkCompl plId ideOpts) uniqueFiltCompls
         return $ filtModNameCompls
               ++ filtKeywordCompls
               ++ map (toggleSnippets caps config) compls
 
-
+uniqueCompl :: CompItem -> CompItem -> Ordering
+uniqueCompl x y =
+  case compare (label x, importedFrom x, compKind x)
+               (label y, importedFrom y, compKind y) of
+    EQ ->
+      -- preserve completions for duplicate record fields where the only difference is in the type
+      -- remove redundant completions with less type info
+      if typeText x == typeText y
+        || isNothing (typeText x)
+        || isNothing (typeText y)
+        then EQ
+        else compare (insertText x) (insertText y)
+    other -> other
 -- ---------------------------------------------------------------------
 -- helper functions for pragmas
 -- ---------------------------------------------------------------------

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -7,20 +7,23 @@ module Development.IDE.Plugin.Completions.Types (
 ) where
 
 import           Control.DeepSeq
-import qualified Data.Map                     as Map
-import qualified Data.Text                    as T
+import qualified Data.Map                      as Map
+import qualified Data.Text                     as T
 import           SrcLoc
 
-import           Data.Aeson                   (FromJSON, ToJSON)
-import           Data.Text                    (Text)
+import           Data.Aeson                    (FromJSON, ToJSON)
+import           Data.Char                     (isUpper)
+import           Data.Maybe                    (isJust)
+import           Data.Text                     (Text)
 import           Development.IDE.Spans.Common
-import           GHC.Generics                 (Generic)
-import           Ide.Plugin.Config            (Config)
+import           Development.IDE.Types.Exports
+import           GHC.Generics                  (Generic)
+import           Ide.Plugin.Config             (Config)
 import           Ide.Plugin.Properties
-import           Ide.PluginUtils              (usePropertyLsp)
-import           Ide.Types                    (PluginId)
-import           Language.LSP.Server          (MonadLsp)
-import           Language.LSP.Types           (CompletionItemKind, Uri)
+import           Ide.PluginUtils               (usePropertyLsp)
+import           Ide.Types                     (PluginId)
+import           Language.LSP.Server           (MonadLsp)
+import           Language.LSP.Types            (CompletionItemKind (..), Uri)
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/LSP/Completions.hs
 
@@ -76,6 +79,23 @@ data CompItem = CI
   , additionalTextEdits :: Maybe ExtendImport
   }
   deriving (Eq, Show)
+
+fromIdentInfo :: IdentInfo -> CompItem
+fromIdentInfo IdentInfo{..} = CI
+  { compKind=
+      if isDatacon
+        then CiConstructor
+        else if isJust parent then CiProperty else CiFunction
+  , insertText=rendered
+  , importedFrom=Right moduleNameText
+  , typeText=Nothing
+  , label=rendered
+  , isInfix=Nothing
+  , docs=emptySpanDoc
+  , isTypeCompl= not isDatacon && isUpper (T.head rendered)
+  -- TODO Extend imports
+  , additionalTextEdits=Nothing
+  }
 
 -- Associates a module's qualifier with its members
 newtype QualCompls

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -80,8 +80,8 @@ data CompItem = CI
   }
   deriving (Eq, Show)
 
-fromIdentInfo :: IdentInfo -> CompItem
-fromIdentInfo IdentInfo{..} = CI
+fromIdentInfo :: Uri -> IdentInfo -> CompItem
+fromIdentInfo doc IdentInfo{..} = CI
   { compKind=
       if isDatacon
         then CiConstructor
@@ -93,8 +93,14 @@ fromIdentInfo IdentInfo{..} = CI
   , isInfix=Nothing
   , docs=emptySpanDoc
   , isTypeCompl= not isDatacon && isUpper (T.head rendered)
-  -- TODO Extend imports
-  , additionalTextEdits=Nothing
+  , additionalTextEdits= Just $
+        ExtendImport
+          { doc,
+            thingParent = parent,
+            importName = moduleNameText,
+            importQual = Nothing,
+            newThing = rendered
+          }
   }
 
 -- Associates a module's qualifier with its members

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -7,23 +7,20 @@ module Development.IDE.Plugin.Completions.Types (
 ) where
 
 import           Control.DeepSeq
-import qualified Data.Map                      as Map
-import qualified Data.Text                     as T
+import qualified Data.Map                     as Map
+import qualified Data.Text                    as T
 import           SrcLoc
 
-import           Data.Aeson                    (FromJSON, ToJSON)
-import           Data.Char                     (isUpper)
-import           Data.Maybe                    (isJust)
-import           Data.Text                     (Text)
+import           Data.Aeson                   (FromJSON, ToJSON)
+import           Data.Text                    (Text)
 import           Development.IDE.Spans.Common
-import           Development.IDE.Types.Exports
-import           GHC.Generics                  (Generic)
-import           Ide.Plugin.Config             (Config)
+import           GHC.Generics                 (Generic)
+import           Ide.Plugin.Config            (Config)
 import           Ide.Plugin.Properties
-import           Ide.PluginUtils               (usePropertyLsp)
-import           Ide.Types                     (PluginId)
-import           Language.LSP.Server           (MonadLsp)
-import           Language.LSP.Types            (CompletionItemKind (..), Uri)
+import           Ide.PluginUtils              (usePropertyLsp)
+import           Ide.Types                    (PluginId)
+import           Language.LSP.Server          (MonadLsp)
+import           Language.LSP.Types           (CompletionItemKind (..), Uri)
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/LSP/Completions.hs
 
@@ -79,29 +76,6 @@ data CompItem = CI
   , additionalTextEdits :: Maybe ExtendImport
   }
   deriving (Eq, Show)
-
-fromIdentInfo :: Uri -> IdentInfo -> CompItem
-fromIdentInfo doc IdentInfo{..} = CI
-  { compKind=
-      if isDatacon
-        then CiConstructor
-        else if isJust parent then CiProperty else CiFunction
-  , insertText=rendered
-  , importedFrom=Right moduleNameText
-  , typeText=Nothing
-  , label=rendered
-  , isInfix=Nothing
-  , docs=emptySpanDoc
-  , isTypeCompl= not isDatacon && isUpper (T.head rendered)
-  , additionalTextEdits= Just $
-        ExtendImport
-          { doc,
-            thingParent = parent,
-            importName = moduleNameText,
-            importQual = Nothing,
-            newThing = rendered
-          }
-  }
 
 -- Associates a module's qualifier with its members
 newtype QualCompls

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -91,18 +91,21 @@ instance Monoid QualCompls where
 data CachedCompletions = CC
   { allModNamesAsNS   :: [T.Text] -- ^ All module names in scope.
                                 -- Prelude is a single module
-  , unqualCompls      :: [CompItem]  -- ^ All Possible completion items
+  , unqualCompls      :: [CompItem]  -- ^ Unqualified completion items
   , qualCompls        :: QualCompls    -- ^ Completion items associated to
                                 -- to a specific module name.
+  , anyQualCompls     :: [Maybe T.Text -> CompItem] -- ^ Items associated to any qualifier
   , importableModules :: [T.Text] -- ^ All modules that may be imported.
-  } deriving Show
+  }
+
+instance Show CachedCompletions where show _ = "<cached completions>"
 
 instance NFData CachedCompletions where
     rnf = rwhnf
 
 instance Monoid CachedCompletions where
-    mempty = CC mempty mempty mempty mempty
+    mempty = CC mempty mempty mempty mempty mempty
 
 instance Semigroup CachedCompletions where
-    CC a b c d <> CC a' b' c' d' =
-        CC (a<>a') (b<>b') (c<>c') (d<>d')
+    CC a b c d e <> CC a' b' c' d' e' =
+        CC (a<>a') (b<>b') (c<>c') (d<>d') (e<>e')

--- a/ghcide/src/Development/IDE/Types/Exports.hs
+++ b/ghcide/src/Development/IDE/Types/Exports.hs
@@ -136,4 +136,4 @@ unpackAvail mn
   | otherwise = const []
   where
     !mod = pack $ moduleNameString mn
-    f id@IdentInfo {..} = (rendered, [id])
+    f id@IdentInfo {..} = (pack (prettyPrint name), [id])

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -3979,8 +3979,9 @@ completionTest name src pos expected = testSessionWait name $ do
     let compls' = [ (_label, _kind, _insertText, _additionalTextEdits) | CompletionItem{..} <- compls]
     liftIO $ do
         let emptyToMaybe x = if T.null x then Nothing else Just x
-        sortOn (Lens.view Lens._1) compls' @?=
-            sortOn (Lens.view Lens._1) [ (l, Just k, emptyToMaybe t, at) | (l,k,t,_,_,at) <- expected]
+        sortOn (Lens.view Lens._1) (take (length expected) compls') @?=
+            sortOn (Lens.view Lens._1)
+              [ (l, Just k, emptyToMaybe t, at) | (l,k,t,_,_,at) <- expected]
         forM_ (zip compls expected) $ \(CompletionItem{..}, (_,_,_,expectedSig, expectedDocs, _)) -> do
             when expectedSig $
                 assertBool ("Missing type signature: " <> T.unpack _label) (isJust _detail)
@@ -4362,7 +4363,7 @@ otherCompletionTests = [
       _ <- waitForDiagnostics
       compls <- getCompletions docA $ Position 2 4
       let compls' = [txt | CompletionItem {_insertText = Just txt, ..} <- compls, _label == "member"]
-      liftIO $ compls' @?= ["member ${1:Foo}", "member ${1:Bar}"],
+      liftIO $ take 2 compls' @?= ["member ${1:Foo}", "member ${1:Bar}"],
 
     testSessionWait "maxCompletions" $ do
         doc <- createDoc "A.hs" "haskell" $ T.unlines

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4459,6 +4459,21 @@ globalCompletionTests =
               ]
         liftIO $ take 3 compls' @?=
           map Just ["fromList ${1:([Item l])}", "fromList", "fromList"]
+  , testGroup "auto import snippets"
+    [ completionCommandTest
+            "import Data.Sequence"
+            ["module A where", "foo :: Seq"]
+            (Position 1 9)
+            "Seq"
+            ["module A where", "import Data.Sequence (Seq)", "foo :: Seq"]
+
+    , completionCommandTest
+            "qualified import"
+            ["module A where", "foo :: Seq.Seq"]
+            (Position 1 13)
+            "Seq"
+            ["module A where", "import qualified Data.Sequence as Seq", "foo :: Seq.Seq"]
+    ]
   ]
 
 highlightTests :: TestTree

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -121,9 +121,6 @@ instance Ord CType where
 instance Show CType where
   show  = unsafeRender . unCType
 
-instance Show OccName where
-  show  = unsafeRender
-
 instance Show Name where
   show  = unsafeRender
 


### PR DESCRIPTION
Provide completions for non-imported modules and automatically inserts new imports when necessary. The identifiers are extracted from the exports map, which no longer includes entries from `*.Internal` modules. 

Things left for future work:

- Qualified imports
- Better display of completion suggestions by default

This partially closes #1327

https://user-images.githubusercontent.com/26626/127127619-d92ba213-65d8-409c-a73d-35bbe13cc759.mov

