### PR TITLE
Remove .stack-work from circleci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,17 +22,17 @@ defaults: &defaults
 
     - run:
         name: Stack setup
-        command: stack -j 2 --stack-yaml=${STACK_FILE} setup
+        command: stack -j2 --stack-yaml=${STACK_FILE} setup
 
     - run:
         name: Build (we need the exe for tests)
         # need j1, else ghc-lib-parser triggers OOM
-        command: stack -j 1 --stack-yaml=${STACK_FILE} install --no-terminal
+        command: stack -j1 --stack-yaml=${STACK_FILE} install --no-terminal
         no_output_timeout: 30m
 
     - run:
         name: Build Testsuite without running it
-        command: stack -j 1 --stack-yaml=${STACK_FILE} build --test --no-run-tests --no-terminal
+        command: stack -j1 --stack-yaml=${STACK_FILE} build --test --no-run-tests --no-terminal
         no_output_timeout: 30m
 
     - store_artifacts:
@@ -43,11 +43,6 @@ defaults: &defaults
         key: v4-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
         paths: &cache_paths
           - ~/.stack
-
-    - run:
-        name: Build including tests
-        command: stack --stack-yaml=${STACK_FILE} test --no-run-tests --no-terminal
-        no_output_timeout: 120m
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults: &defaults
 
     - restore_cache:
         keys:
-          - v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+          - v4-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
 
     - run:
         name: Stack upgrade
@@ -40,7 +40,7 @@ defaults: &defaults
         destination: bin
 
     - save_cache:
-        key: v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+        key: v4-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
         paths: &cache_paths
           - ~/.stack
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,9 @@ defaults: &defaults
 
     - restore_cache:
         keys:
-          - v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
-          - v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
-          - v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+          - v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
+          - v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+          - v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
 
     - run:
         name: Stack upgrade
@@ -46,11 +46,9 @@ defaults: &defaults
         destination: bin
 
     - save_cache:
-        key: v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+        key: v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
         paths: &cache_paths
           - ~/.stack
-          - ~/build/.stack-work
-          - ~/build/ghcide/.stack-work
 
     - run:
         name: Build including tests
@@ -58,7 +56,7 @@ defaults: &defaults
         no_output_timeout: 120m
 
     - save_cache:
-        key: v2-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
+        key: v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
         paths: *cache_paths
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,8 @@ defaults: &defaults
         name: Figure out resolver for better caching
         command: grep '^resolver:' stack-build.txt > resolver.txt
 
-    - run:
-        name: Create a composite cabal file for changes detection
-        command: find . -name "*.cabal" | grep -v -e "stack-work" -e "dist-newstyle" -e "submodules" -e "testdata" | sort | xargs cat > all-cabal.txt
-
     - restore_cache:
         keys:
-          - v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
-          - v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
           - v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
 
     - run:
@@ -54,10 +48,6 @@ defaults: &defaults
         name: Build including tests
         command: stack --stack-yaml=${STACK_FILE} test --no-run-tests --no-terminal
         no_output_timeout: 120m
-
-    - save_cache:
-        key: v3-stack-cache-{{ .Environment.HIE_CACHE }}-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
-        paths: *cache_paths
 
 version: 2
 jobs:

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -75,8 +75,6 @@ extra-deps:
   # https://github.com/haskell/lsp/pull/332
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
     - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.10.3.yaml
+++ b/stack-8.10.3.yaml
@@ -75,8 +75,6 @@ extra-deps:
   # https://github.com/haskell/lsp/pull/332
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.10.4.yaml
+++ b/stack-8.10.4.yaml
@@ -77,8 +77,6 @@ extra-deps:
   # - hlint-3.3@sha256:4218ad6e03050f5d68aeba0e025f5f05e366c8fd49657f2a19df04ee31b2bb23,4154
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.10.5.yaml
+++ b/stack-8.10.5.yaml
@@ -79,8 +79,6 @@ extra-deps:
   # - hlint-3.3@sha256:4218ad6e03050f5d68aeba0e025f5f05e366c8fd49657f2a19df04ee31b2bb23,4154
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -124,8 +124,6 @@ flags:
 
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -113,8 +113,6 @@ extra-deps:
   # https://github.com/haskell/lsp/pull/332
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
     - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -92,8 +92,6 @@ extra-deps:
   # https://github.com/haskell/lsp/pull/332
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
     - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -89,8 +89,6 @@ extra-deps:
   # https://github.com/haskell/lsp/pull/332
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
     - --disable-library-for-ghci
   haskell-language-server:

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -102,8 +102,6 @@ extra-deps:
   commit: 16e19aaf34e286f3d27b3988c61040823ec66537
 
 configure-options:
-  $targets:
-      - --enable-executable-dynamic
   ghcide:
       - --disable-library-for-ghci
   haskell-language-server:


### PR DESCRIPTION
* From #2038
* Build times are close to having `.stack-work` and we avoid issues with conflicts in the linker phase 
  * https://app.circleci.com/pipelines/github/jneira/haskell-language-server/644/workflows/ba2d76ab-341b-4bb0-a2df-109a677878e2