### PR TITLE
Add formatting plugin for cabal files which uses cabal-fmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,6 +254,11 @@ jobs:
         name: Test hls-explicit-record-fields-plugin test suite
         run: cabal test hls-explicit-record-fields-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-explicit-record-fields-plugin --test-options="$TEST_OPTS"
 
+      ## version needs to be limited since the tests depend on cabal-fmt which only builds using specific ghc versions
+      - if: matrix.test && matrix.ghc == '8.10.7'
+        name: Test hls-cabal-fmt-plugin test suite
+        run: cabal test hls-cabal-fmt-plugin --test-options="$TEST_OPTS" || cabal test hls-cabal-fmt-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-cabal-fmt-plugin --test-options="$TEST_OPTS"
+
   test_post_job:
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,7 +257,7 @@ jobs:
       ## version needs to be limited since the tests depend on cabal-fmt which only builds using specific ghc versions
       - if: matrix.test && matrix.ghc == '8.10.7'
         name: Test hls-cabal-fmt-plugin test suite
-        run: cabal test hls-cabal-fmt-plugin --test-options="$TEST_OPTS" || cabal test hls-cabal-fmt-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-cabal-fmt-plugin --test-options="$TEST_OPTS"
+        run: cabal test hls-cabal-fmt-plugin --flag=isolateTests --test-options="$TEST_OPTS" || cabal test hls-cabal-fmt-plugin --flag=isolateTests --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-cabal-fmt-plugin --flag=isolateTests --test-options="$TEST_OPTS"
 
   test_post_job:
     if: always()

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 # Plugins
 /plugins/hls-alternate-number-format-plugin @drsooch
 /plugins/hls-brittany-plugin @fendor
+/plugins/hls-cabal-fmt-plugin @VeryMilkyJoe @fendor
 /plugins/hls-call-hierarchy-plugin @July541
 /plugins/hls-class-plugin @Ailrun
 /plugins/hls-eval-plugin

--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,7 @@ packages:
          ./ghcide/test
          ./hls-plugin-api
          ./hls-test-utils
+         ./plugins/hls-cabal-fmt-plugin
          ./plugins/hls-tactics-plugin
          ./plugins/hls-brittany-plugin
          ./plugins/hls-stylish-haskell-plugin

--- a/docs/features.md
+++ b/docs/features.md
@@ -107,6 +107,13 @@ Format your code with various Haskell code formatters.
 | Ormolu          | `hls-ormolu-plugin`          |
 | Stylish Haskell | `hls-stylish-haskell-plugin` |
 
+Format your cabal files with a cabal code formatter.
+
+| Formatter       | Provided by                  |
+|-----------------|------------------------------|
+| cabal-fmt       | `hls-cabal-fmt-plugin`       |
+
+
 ## Document symbols
 
 Provided by: `ghcide`

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -46,6 +46,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-pragmas-plugin`                | 1    |                          |
 | `hls-refactor-plugin`               | 1    | 9.4                      |
 | `hls-alternate-number-plugin`       | 2    |                          |
+| `hls-cabal-fmt-plugin`              | 2    |                          |
 | `hls-class-plugin`                  | 2    |                          |
 | `hls-change-type-signature-plugin`  | 2    |                          |
 | `hls-eval-plugin`                   | 2    | 9.4                      |

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -205,6 +205,16 @@ flag dynamic
   default:     True
   manual:      True
 
+flag cabalfmt
+  description: Enable cabal-fmt plugin
+  default:     True
+  manual:      True
+
+common cabalfmt
+  if flag(cabalfmt)
+    build-depends: hls-cabal-fmt-plugin ^>= 0.1.0.0
+    cpp-options: -Dhls_cabalfmt
+
 common class
   if flag(class)
     build-depends: hls-class-plugin ^>= 1.1

--- a/hls-plugin-api/src/Ide/Plugin/Config.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Config.hs
@@ -47,11 +47,12 @@ data CheckParents
 -- will be surprises relating to config options being ignored, initially though.
 data Config =
   Config
-    { checkParents       :: CheckParents
-    , checkProject       :: !Bool
-    , formattingProvider :: !T.Text
-    , maxCompletions     :: !Int
-    , plugins            :: !(Map.Map T.Text PluginConfig)
+    { checkParents            :: CheckParents
+    , checkProject            :: !Bool
+    , formattingProvider      :: !T.Text
+    , cabalFormattingProvider :: !T.Text
+    , maxCompletions          :: !Int
+    , plugins                 :: !(Map.Map T.Text PluginConfig)
     } deriving (Show,Eq)
 
 instance Default Config where
@@ -62,6 +63,7 @@ instance Default Config where
     , formattingProvider          = "ormolu"
     -- , formattingProvider          = "floskell"
     -- , formattingProvider          = "stylish-haskell"
+    , cabalFormattingProvider     = "cabal-fmt"
     , maxCompletions              = 40
     , plugins                     = Map.empty
     }
@@ -78,6 +80,7 @@ parseConfig defValue = A.withObject "Config" $ \v -> do
         <$> (o .:? "checkParents" <|> v .:? "checkParents") .!= checkParents defValue
         <*> (o .:? "checkProject" <|> v .:? "checkProject") .!= checkProject defValue
         <*> o .:? "formattingProvider"                      .!= formattingProvider defValue
+        <*> o .:? "cabalFormattingProvider"                 .!= cabalFormattingProvider defValue
         <*> o .:? "maxCompletions"                          .!= maxCompletions defValue
         <*> o .:? "plugin"                                  .!= plugins defValue
 

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -403,14 +403,15 @@ instance PluginMethod Request TextDocumentCompletion where
 
 instance PluginMethod Request TextDocumentFormatting where
   pluginEnabled STextDocumentFormatting msgParams pluginDesc conf =
-    pluginResponsible uri pluginDesc && PluginId (formattingProvider conf) == pid
+    pluginResponsible uri pluginDesc
+      && (PluginId (formattingProvider conf) == pid || PluginId (cabalFormattingProvider conf) == pid)
     where
       uri = msgParams ^. J.textDocument . J.uri
       pid = pluginId pluginDesc
 
 instance PluginMethod Request TextDocumentRangeFormatting where
   pluginEnabled _ msgParams pluginDesc conf = pluginResponsible uri pluginDesc
-      && PluginId (formattingProvider conf) == pid
+      && (PluginId (formattingProvider conf) == pid || PluginId (cabalFormattingProvider conf) == pid)
     where
       uri = msgParams ^. J.textDocument . J.uri
       pid = pluginId pluginDesc

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -17,9 +17,11 @@ module Test.Hls
     goldenGitDiff,
     goldenWithHaskellDoc,
     goldenWithHaskellDocFormatter,
+    goldenWithCabalDocFormatter,
     def,
     runSessionWithServer,
     runSessionWithServerFormatter,
+    runSessionWithCabalServerFormatter,
     runSessionWithServer',
     waitForProgressDone,
     waitForAllProgressDone,
@@ -70,6 +72,7 @@ import           Development.IDE.Types.Options
 import           GHC.IO.Handle
 import           GHC.Stack                       (emptyCallStack)
 import           Ide.Plugin.Config               (Config, PluginConfig,
+                                                  cabalFormattingProvider,
                                                   formattingProvider, plugins)
 import           Ide.PluginUtils                 (idePluginsToPluginDesc,
                                                   pluginDescToIdePlugins)
@@ -130,15 +133,30 @@ goldenWithHaskellDoc plugin title testDataDir path desc ext act =
     act doc
     documentContents doc
 
+
+runSessionWithServer :: PluginDescriptor IdeState -> FilePath -> Session a -> IO a
+runSessionWithServer plugin = runSessionWithServer' [plugin] def def fullCaps
+
+runSessionWithServerFormatter :: PluginDescriptor IdeState -> String -> PluginConfig -> FilePath -> Session a -> IO a
+runSessionWithServerFormatter plugin formatter conf =
+  runSessionWithServer'
+    [plugin]
+    def
+      { formattingProvider = T.pack formatter
+      , plugins = M.singleton (T.pack formatter) conf
+      }
+    def
+    fullCaps
+
 goldenWithHaskellDocFormatter
-  :: PluginDescriptor IdeState
-  -> String
+  :: PluginDescriptor IdeState -- ^ Formatter plugin to be used
+  -> String -- ^ Name of the formatter to be used
   -> PluginConfig
-  -> TestName
-  -> FilePath
-  -> FilePath
-  -> FilePath
-  -> FilePath
+  -> TestName -- ^ Title of the test
+  -> FilePath -- ^ Directory of the test data to be used
+  -> FilePath -- ^ Path to the testdata to be used within the directory
+  -> FilePath -- ^ Additional suffix to be appended to the output file
+  -> FilePath -- ^ Extension of the output file
   -> (TextDocumentIdentifier -> Session ())
   -> TestTree
 goldenWithHaskellDocFormatter plugin formatter conf title testDataDir path desc ext act =
@@ -151,15 +169,33 @@ goldenWithHaskellDocFormatter plugin formatter conf title testDataDir path desc 
     act doc
     documentContents doc
 
-runSessionWithServer :: PluginDescriptor IdeState -> FilePath -> Session a -> IO a
-runSessionWithServer plugin = runSessionWithServer' [plugin] def def fullCaps
+goldenWithCabalDocFormatter
+  :: PluginDescriptor IdeState -- ^ Formatter plugin to be used
+  -> String -- ^ Name of the formatter to be used
+  -> PluginConfig
+  -> TestName -- ^ Title of the test
+  -> FilePath -- ^ Directory of the test data to be used
+  -> FilePath -- ^ Path to the testdata to be used within the directory
+  -> FilePath -- ^ Additional suffix to be appended to the output file
+  -> FilePath -- ^ Extension of the output file
+  -> (TextDocumentIdentifier -> Session ())
+  -> TestTree
+goldenWithCabalDocFormatter plugin formatter conf title testDataDir path desc ext act =
+  goldenGitDiff title (testDataDir </> path <.> desc <.> ext)
+  $ runSessionWithCabalServerFormatter plugin formatter conf testDataDir
+  $ TL.encodeUtf8 . TL.fromStrict
+  <$> do
+    doc <- openDoc (path <.> ext) "cabal"
+    void waitForBuildQueue
+    act doc
+    documentContents doc
 
-runSessionWithServerFormatter :: PluginDescriptor IdeState -> String -> PluginConfig -> FilePath -> Session a -> IO a
-runSessionWithServerFormatter plugin formatter conf =
+runSessionWithCabalServerFormatter :: PluginDescriptor IdeState -> String -> PluginConfig -> FilePath -> Session a -> IO a
+runSessionWithCabalServerFormatter plugin formatter conf =
   runSessionWithServer'
     [plugin]
     def
-      { formattingProvider = T.pack formatter
+      { cabalFormattingProvider = T.pack formatter
       , plugins = M.singleton (T.pack formatter) conf
       }
     def

--- a/plugins/hls-cabal-fmt-plugin/LICENSE
+++ b/plugins/hls-cabal-fmt-plugin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 The Haskell IDE team
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
+++ b/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
@@ -1,0 +1,51 @@
+cabal-version:      2.4
+name:               hls-cabal-fmt-plugin
+version:            0.1.0.0
+synopsis:           Integration with the cabal-fmt code formatter
+description:
+  Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
+
+license:            Apache-2.0
+license-file:       LICENSE
+author:             The Haskell IDE Team
+copyright:          The Haskell IDE Team
+maintainer:         jana.chadt@nets.at
+category:           Development
+build-type:         Simple
+extra-source-files: LICENSE
+
+common warnings
+  ghc-options: -Wall
+
+library
+  import:           warnings
+  exposed-modules:  Ide.Plugin.CabalFmt
+  hs-source-dirs:   src
+  build-depends:
+    , base            >=4.12 && <5
+    , directory
+    , filepath
+    , ghcide          ^>=1.7 || ^>=1.8
+    , hls-plugin-api  ^>=1.5
+    , lens
+    , lsp-types
+    , process
+    , text
+    , transformers
+
+  default-language: Haskell2010
+
+test-suite tests
+  import:             warnings
+  type:               exitcode-stdio-1.0
+  default-language:   Haskell2010
+  hs-source-dirs:     test
+  main-is:            Main.hs
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base
+    , filepath
+    , hls-cabal-fmt-plugin
+    , hls-test-utils        ^>=1.4
+
+  build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.6

--- a/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
+++ b/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
@@ -14,6 +14,12 @@ category:           Development
 build-type:         Simple
 extra-source-files: LICENSE
 
+flag isolateTests
+  description: Should tests search for 'cabal-fmt' on the $PATH or shall we install it via build-tool-depends?
+  -- By default, search on the PATH
+  default:     False
+  manual:      True
+
 common warnings
   ghc-options: -Wall
 
@@ -44,8 +50,10 @@ test-suite tests
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N
   build-depends:
     , base
+    , directory
     , filepath
     , hls-cabal-fmt-plugin
     , hls-test-utils        ^>=1.4
 
-  build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.6
+  if flag(isolateTests)
+    build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.6

--- a/plugins/hls-cabal-fmt-plugin/src/Ide/Plugin/CabalFmt.hs
+++ b/plugins/hls-cabal-fmt-plugin/src/Ide/Plugin/CabalFmt.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ide.Plugin.CabalFmt where
+
+import           Control.Lens
+import           Control.Monad.IO.Class
+import qualified Data.Text               as T
+import           Development.IDE         hiding (pluginHandlers)
+import           Ide.PluginUtils
+import           Ide.Types
+import           Language.LSP.Types      as J
+import qualified Language.LSP.Types.Lens as J
+import           Prelude                 hiding (log)
+import           System.Directory
+import           System.Exit
+import           System.FilePath
+import           System.Process
+
+data Log
+  = LogProcessInvocationFailure Int
+  | LogReadCreateProcessInfo String [String]
+  | LogInvalidInvocationInfo
+  deriving (Show)
+
+instance Pretty Log where
+  pretty = \case
+    LogProcessInvocationFailure code -> "Invocation of cabal-fmt failed with code" <+> pretty code
+    LogReadCreateProcessInfo stdErrorOut args ->
+      vcat $
+        ["Invocation of cabal-fmt with arguments" <+> pretty args]
+          ++ ["failed with standard error:" <+> pretty stdErrorOut | not (null stdErrorOut)]
+    LogInvalidInvocationInfo -> "Invocation of cabal-fmt with range was called but is not supported."
+
+descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
+descriptor recorder plId =
+  (defaultCabalPluginDescriptor plId)
+    { pluginHandlers = mkFormattingHandlers (provider recorder)
+    }
+
+-- | Formatter provider of cabal fmt.
+-- Formats the given source in either a given Range or the whole Document.
+-- If the provider fails an error is returned that can be displayed to the user.
+provider :: Recorder (WithPriority Log) -> FormattingHandler IdeState
+provider recorder _ (FormatRange _) _ _ _ = do
+  logWith recorder Info LogInvalidInvocationInfo
+  pure $ Left (ResponseError InvalidRequest "You cannot format a text-range using cabal-fmt." Nothing)
+provider recorder _ide FormatText contents nfp opts = liftIO $ do
+  let cabalFmtArgs = [fp, "--indent", show tabularSize]
+  x <- findExecutable "cabal-fmt"
+  case x of
+    Just _ -> do
+      (exitCode, out, err) <-
+        readCreateProcessWithExitCode
+          ( proc "cabal-fmt" cabalFmtArgs
+          )
+            { cwd = Just $ takeDirectory fp
+            }
+          ""
+      log Debug $ LogReadCreateProcessInfo err cabalFmtArgs
+      case exitCode of
+        ExitFailure code -> do
+          log Error $ LogProcessInvocationFailure code
+          pure $ Left (ResponseError UnknownErrorCode "Failed to invoke cabal-fmt" Nothing)
+        ExitSuccess -> do
+          let fmtDiff = makeDiffTextEdit contents (T.pack out)
+          pure $ Right fmtDiff
+    Nothing -> do
+      pure $ Left (ResponseError InvalidRequest "No installation of cabal-fmt could be found. Please install it into your global environment." Nothing)
+  where
+    fp = fromNormalizedFilePath nfp
+    tabularSize = opts ^. J.tabSize
+    log = logWith recorder

--- a/plugins/hls-cabal-fmt-plugin/test/Main.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/Main.hs
@@ -1,33 +1,57 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Main
   ( main
   ) where
 
 import qualified Ide.Plugin.CabalFmt as CabalFmt
+import           System.Directory (findExecutable)
 import           System.FilePath
 import           Test.Hls
 
+data CabalFmtFound = Found | NotFound
+
+isTestIsolated :: Bool
+#if isolateTests
+isTestIsolated = True
+#else
+isTestIsolated = False
+#endif
+
+isCabalFmtFound :: IO CabalFmtFound
+isCabalFmtFound = case isTestIsolated of
+  True -> pure Found
+  False-> do
+    cabalFmt <- findExecutable "cabal-fmt"
+    pure $ maybe NotFound (const Found) cabalFmt
+
 main :: IO ()
-main = defaultTestRunner tests
+main = do
+  foundCabalFmt <- isCabalFmtFound
+  defaultTestRunner (tests foundCabalFmt)
 
 cabalFmtPlugin :: PluginDescriptor IdeState
 cabalFmtPlugin = CabalFmt.descriptor mempty "cabal-fmt"
 
-tests :: TestTree
-tests = testGroup "cabal-fmt"
-  [ cabalFmtGolden "formats a simple document" "simple_testdata" "formatted_document" $ \doc -> do
+tests :: CabalFmtFound -> TestTree
+tests found = testGroup "cabal-fmt"
+  [ cabalFmtGolden found "formats a simple document" "simple_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
 
-  , cabalFmtGolden "formats a document with expand:src comment" "commented_testdata" "formatted_document" $ \doc -> do
+  , cabalFmtGolden found "formats a document with expand:src comment" "commented_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
 
-  , cabalFmtGolden "formats a document with lib information" "lib_testdata" "formatted_document" $ \doc -> do
+  , cabalFmtGolden found "formats a document with lib information" "lib_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 10 True Nothing Nothing Nothing)
   ]
 
-cabalFmtGolden :: TestName -> FilePath -> FilePath -> (TextDocumentIdentifier -> Session ()) -> TestTree
-cabalFmtGolden title path desc = goldenWithCabalDocFormatter cabalFmtPlugin "cabal-fmt" conf title testDataDir path desc "cabal"
+cabalFmtGolden :: CabalFmtFound -> TestName -> FilePath -> FilePath -> (TextDocumentIdentifier -> Session ()) -> TestTree
+cabalFmtGolden NotFound title _ _ _ =
+  testCase title $
+    assertFailure $  "Couldn't find cabal-fmt on PATH or this is not an isolated run. "
+                  <> "Use cabal flag 'isolateTests' to make it isolated or install cabal-fmt locally."
+cabalFmtGolden Found title path desc act = goldenWithCabalDocFormatter cabalFmtPlugin "cabal-fmt" conf title testDataDir path desc "cabal" act
   where
     conf = def
 

--- a/plugins/hls-cabal-fmt-plugin/test/Main.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/Main.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 module Main
   ( main
   ) where
 
 import qualified Ide.Plugin.CabalFmt as CabalFmt
-import           System.Directory (findExecutable)
+import           System.Directory    (findExecutable)
 import           System.FilePath
 import           Test.Hls
 
@@ -36,10 +35,12 @@ cabalFmtPlugin = CabalFmt.descriptor mempty "cabal-fmt"
 
 tests :: CabalFmtFound -> TestTree
 tests found = testGroup "cabal-fmt"
-  [ cabalFmtGolden found "formats a simple document" "simple_testdata" "formatted_document" $ \doc -> do
+  [ knownBrokenOnWindows "Eats newlines between comments" $
+    cabalFmtGolden found "formats a simple document" "simple_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
 
-  , cabalFmtGolden found "formats a document with expand:src comment" "commented_testdata" "formatted_document" $ \doc -> do
+  , knownBrokenOnWindows "expand:src comment bug in cabal-fmt on windows" $
+    cabalFmtGolden found "formats a document with expand:src comment" "commented_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
 
   , cabalFmtGolden found "formats a document with lib information" "lib_testdata" "formatted_document" $ \doc -> do

--- a/plugins/hls-cabal-fmt-plugin/test/Main.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/Main.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main
+  ( main
+  ) where
+
+import qualified Ide.Plugin.CabalFmt as CabalFmt
+import           System.FilePath
+import           Test.Hls
+
+main :: IO ()
+main = defaultTestRunner tests
+
+cabalFmtPlugin :: PluginDescriptor IdeState
+cabalFmtPlugin = CabalFmt.descriptor mempty "cabal-fmt"
+
+tests :: TestTree
+tests = testGroup "cabal-fmt"
+  [ cabalFmtGolden "formats a simple document" "simple_testdata" "formatted_document" $ \doc -> do
+      formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
+
+  , cabalFmtGolden "formats a document with expand:src comment" "commented_testdata" "formatted_document" $ \doc -> do
+      formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
+
+  , cabalFmtGolden "formats a document with lib information" "lib_testdata" "formatted_document" $ \doc -> do
+      formatDoc doc (FormattingOptions 10 True Nothing Nothing Nothing)
+  ]
+
+cabalFmtGolden :: TestName -> FilePath -> FilePath -> (TextDocumentIdentifier -> Session ()) -> TestTree
+cabalFmtGolden title path desc = goldenWithCabalDocFormatter cabalFmtPlugin "cabal-fmt" conf title testDataDir path desc "cabal"
+  where
+    conf = def
+
+testDataDir :: FilePath
+testDataDir = "test" </> "testdata"

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/commented_testdata.cabal
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/commented_testdata.cabal
@@ -1,0 +1,12 @@
+cabal-version:      2.4
+name:               testdata
+version:            0.1.0.0
+author:             Banana
+extra-source-files: CHANGELOG.md
+
+library
+    -- cabal-fmt: expand src
+    exposed-modules:  MyLib
+    build-depends:    base ^>=4.14.1.0
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/commented_testdata.formatted_document.cabal
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/commented_testdata.formatted_document.cabal
@@ -1,0 +1,15 @@
+cabal-version:      2.4
+name:               testdata
+version:            0.1.0.0
+author:             Banana
+extra-source-files: CHANGELOG.md
+
+library
+  -- cabal-fmt: expand src
+  exposed-modules:
+    MyLib
+    MyOtherLib
+
+  build-depends:    base ^>=4.14.1.0
+  hs-source-dirs:   src
+  default-language: Haskell2010

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/hie.yaml
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/hie.yaml
@@ -1,0 +1,3 @@
+cradle:
+  direct:
+    arguments: []

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/lib_testdata.cabal
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/lib_testdata.cabal
@@ -1,0 +1,19 @@
+cabal-version:      2.4
+name:               testdata
+version:                           0.1.0.0
+author:        Gregg
+extra-source-files: CHANGELOG.md
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base   ^>=4.14.1.0
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+executable testdata
+    main-is:          Main.hs
+    build-depends:
+        base                ^>=4.14.1.0,testdata
+    hs-source-dirs:   app
+    default-language:
+        Haskell2010

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/lib_testdata.formatted_document.cabal
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/lib_testdata.formatted_document.cabal
@@ -1,0 +1,20 @@
+cabal-version:      2.4
+name:               testdata
+version:            0.1.0.0
+author:             Gregg
+extra-source-files: CHANGELOG.md
+
+library
+          exposed-modules:  MyLib
+          build-depends:    base ^>=4.14.1.0
+          hs-source-dirs:   src
+          default-language: Haskell2010
+
+executable testdata
+          main-is:          Main.hs
+          build-depends:
+                    , base      ^>=4.14.1.0
+                    , testdata
+          
+          hs-source-dirs:   app
+          default-language: Haskell2010

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/simple_testdata.cabal
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/simple_testdata.cabal
@@ -1,0 +1,36 @@
+cabal-version:      2.4
+name:               testdata
+version:            0.1.0.0
+
+-- A short (one-line) description of the package.
+-- synopsis:
+
+-- A longer description of the package.
+-- description:
+
+-- A URL where users can report bugs.
+-- bug-reports:
+
+-- The license under which the package is released.
+-- license:
+author:             Milky
+
+-- An email address to which users can send suggestions, bug reports, and patches.
+-- maintainer:
+
+-- A copyright notice.
+-- copyright:
+-- category:
+extra-source-files: CHANGELOG.md
+
+executable testdata
+    main-is:          Main.hs
+
+    -- Modules included in this executable, other than Main.
+    -- other-modules:
+
+    -- LANGUAGE extensions used by modules in this package.
+    -- other-extensions:
+    build-depends:    base ^>=4.14.1.0
+    hs-source-dirs:   app
+    default-language: Haskell2010

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/simple_testdata.formatted_document.cabal
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/simple_testdata.formatted_document.cabal
@@ -1,0 +1,36 @@
+cabal-version:      2.4
+name:               testdata
+version:            0.1.0.0
+
+-- A short (one-line) description of the package.
+-- synopsis:
+
+-- A longer description of the package.
+-- description:
+
+-- A URL where users can report bugs.
+-- bug-reports:
+
+-- The license under which the package is released.
+-- license:
+author:             Milky
+
+-- An email address to which users can send suggestions, bug reports, and patches.
+-- maintainer:
+
+-- A copyright notice.
+-- copyright:
+-- category:
+extra-source-files: CHANGELOG.md
+
+executable testdata
+  main-is:          Main.hs
+
+  -- Modules included in this executable, other than Main.
+  -- other-modules:
+
+  -- LANGUAGE extensions used by modules in this package.
+  -- other-extensions:
+  build-depends:    base ^>=4.14.1.0
+  hs-source-dirs:   app
+  default-language: Haskell2010

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/src/MyLib.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/src/MyOtherLib.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/src/MyOtherLib.hs
@@ -1,0 +1,3 @@
+module MyOtherLib where
+
+bar = 2

--- a/src/HlsPlugins.hs
+++ b/src/HlsPlugins.hs
@@ -108,6 +108,10 @@ import qualified Ide.Plugin.Floskell               as Floskell
 import qualified Ide.Plugin.Fourmolu               as Fourmolu
 #endif
 
+#if hls_cabalfmt
+import qualified Ide.Plugin.CabalFmt               as CabalFmt
+#endif
+
 #if hls_ormolu
 import qualified Ide.Plugin.Ormolu                 as Ormolu
 #endif
@@ -150,6 +154,9 @@ idePlugins recorder = pluginDescToIdePlugins allPlugins
 #endif
 #if hls_fourmolu
       let pId = "fourmolu" in Fourmolu.descriptor (pluginRecorder pId) pId:
+#endif
+#if hls_cabalfmt
+      let pId = "cabalfmt" in CabalFmt.descriptor (pluginRecorder pId) pId:
 #endif
 #if hls_tactic
       let pId = "tactics" in Tactic.descriptor (pluginRecorder pId) pId:

--- a/stack-lts19.yaml
+++ b/stack-lts19.yaml
@@ -9,6 +9,7 @@ packages:
   - ./hls-plugin-api
   - ./hls-test-utils
   # - ./shake-bench
+  - ./plugins/hls-cabal-fmt-plugin
   - ./plugins/hls-call-hierarchy-plugin
   - ./plugins/hls-class-plugin
   - ./plugins/hls-haddock-comments-plugin
@@ -41,6 +42,8 @@ ghc-options:
 
 extra-deps:
 - Cabal-3.6.0.0
+# needed for tests of hls-cabal-fmt-plugin
+- cabal-fmt-0.1.6@sha256:54041d50c8148c32d1e0a67aef7edeebac50ae33571bef22312f6815908eac19,3626
 - floskell-0.10.6@sha256:e77d194189e8540abe2ace2c7cb8efafc747ca35881a2fefcbd2d40a1292e036,3819
 - fourmolu-0.6.0.0
 - ghc-lib-9.2.4.20220729

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,7 @@ packages:
 - ./hls-plugin-api
 - ./hls-test-utils
 - ./shake-bench
+- ./plugins/hls-cabal-fmt-plugin
 - ./plugins/hls-call-hierarchy-plugin
 - ./plugins/hls-class-plugin
 # - ./plugins/hls-haddock-comments-plugin
@@ -37,6 +38,8 @@ packages:
 - ./plugins/hls-explicit-record-fields-plugin
 
 extra-deps:
+# needed for tests of hls-cabal-fmt-plugin
+- cabal-fmt-0.1.6@sha256:54041d50c8148c32d1e0a67aef7edeebac50ae33571bef22312f6815908eac19,3626
 - floskell-0.10.6@sha256:e77d194189e8540abe2ace2c7cb8efafc747ca35881a2fefcbd2d40a1292e036,3819
 - hiedb-0.4.2.0
 - implicit-hie-0.1.2.7@sha256:82bbbb1a8c05f99c8af3c16ac53e80c8648d8bf047b25ed5ce45a135bd736907,3122

--- a/test/functional/Format.hs
+++ b/test/functional/Format.hs
@@ -55,7 +55,6 @@ providerTests = testGroup "formatting provider" [
             _ -> assertFailure $ "strange response from formatting provider:" ++ show result
           result -> assertFailure $ "strange response from formatting provider:" ++ show result
 
-
     , requiresOrmoluPlugin . requiresFloskellPlugin $ testCase "can change on the fly" $ runSession hlsCommand fullCaps "test/testdata/format" $ do
         formattedOrmolu <- liftIO $ T.readFile "test/testdata/format/Format.ormolu.formatted.hs"
         formattedFloskell <- liftIO $ T.readFile "test/testdata/format/Format.floskell.formatted.hs"


### PR DESCRIPTION
This allows formatting of cabal files with hls.

~~Currently waiting for merges on [cabal-fmt](https://github.com/phadej/cabal-fmt/pull/33) and [stylish haskell](https://github.com/haskell/stylish-haskell/pull/375).~~ We gave up on this, also it makes maintenance harder as cabal-fmt supports only one Cabal version at a time.

Closes #183 and part of #2964.

Builds on top of #2945 

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2047"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

