### PR TITLE
Build with lsp 1.2.0.1

### DIFF
--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -67,15 +67,6 @@ source-repository-package
   subdir: dependent-sum-template
 -- https://github.com/obsidiansystems/dependent-sum/pull/57
 
-source-repository-package
-  type: git
-  location: https://github.com/anka-213/lsp
-  tag: tag-ghc-9.0.1-without-pr-326
-  subdir: lsp-types
-  subdir: lsp
-  subdir: lsp-test
--- https://github.com/haskell/lsp/pull/312
-
 -- benchmark dependency
 source-repository-package
   type: git
@@ -84,7 +75,7 @@ source-repository-package
 
 write-ghc-environment-files: never
 
-index-state: 2021-07-14T20:31:09Z
+index-state: 2021-08-01T00:00:00Z
 
 constraints:
     -- These plugins doesn't work on GHC9 yet

--- a/cabal.project
+++ b/cabal.project
@@ -37,7 +37,7 @@ source-repository-package
 
 write-ghc-environment-files: never
 
-index-state: 2021-07-14T20:31:09Z
+index-state: 2021-08-01T00:00:00Z
 
 constraints:
     -- Diagrams doesn't support optparse-applicative >= 0.16 yet
@@ -85,20 +85,3 @@ allow-newer:
     these:base,
     time-compat:base
 
-source-repository-package
-  type: git
-  location: https://github.com/haskell/lsp.git
-  tag: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-  subdir: lsp-types
-
-source-repository-package
-  type: git
-  location: https://github.com/haskell/lsp.git
-  tag: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-  subdir: lsp-test
-
-source-repository-package
-  type: git
-  location: https://github.com/haskell/lsp.git
-  tag: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-  subdir: lsp

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -36,7 +36,10 @@ import           Development.Shake               (CmdOption (Cwd, FileStdout),
                                                   cmd_)
 import           Experiments.Types
 import           Language.LSP.Test
-import           Language.LSP.Types
+import           Language.LSP.Types              hiding
+                                                 (SemanticTokenAbsolute (length, line),
+                                                  SemanticTokenRelative (length),
+                                                  SemanticTokensEdit (_start))
 import           Language.LSP.Types.Capabilities
 import           Numeric.Natural
 import           Options.Applicative

--- a/ghcide/src/Development/IDE/Core/PositionMapping.hs
+++ b/ghcide/src/Development/IDE/Core/PositionMapping.hs
@@ -30,7 +30,8 @@ import           Data.Bifunctor
 import           Data.List
 import qualified Data.Text           as T
 import qualified Data.Vector.Unboxed as V
-import           Language.LSP.Types
+import           Language.LSP.Types  (Position (Position), Range (Range),
+                                      TextDocumentContentChangeEvent (TextDocumentContentChangeEvent))
 
 -- | Either an exact position, or the range of text that was substituted
 data PositionResult a

--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -22,7 +22,13 @@ import           Development.IDE.GHC.Error      (rangeToRealSrcSpan,
                                                  realSrcSpanToRange)
 import           Development.IDE.Types.Location
 import           Language.LSP.Server            (LspM)
-import           Language.LSP.Types
+import           Language.LSP.Types             (DocumentSymbol (..),
+                                                 DocumentSymbolParams (DocumentSymbolParams, _textDocument),
+                                                 List (..), ResponseError,
+                                                 SymbolInformation,
+                                                 SymbolKind (SkConstructor, SkField, SkFile, SkFunction, SkInterface, SkMethod, SkModule, SkObject, SkStruct, SkTypeParameter, SkUnknown),
+                                                 TextDocumentIdentifier (TextDocumentIdentifier),
+                                                 type (|?) (InL), uriToFilePath)
 import           Outputable                     (Outputable, ppr,
                                                  showSDocUnsafe)
 

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -62,7 +62,20 @@ import           HscTypes                                          (ImportedMods
 import           Ide.PluginUtils                                   (subRange)
 import           Ide.Types
 import qualified Language.LSP.Server                               as LSP
-import           Language.LSP.Types
+import           Language.LSP.Types                                (CodeAction (..),
+                                                                    CodeActionContext (CodeActionContext, _diagnostics),
+                                                                    CodeActionKind (CodeActionQuickFix, CodeActionUnknown),
+                                                                    CodeActionParams (CodeActionParams),
+                                                                    Command,
+                                                                    Diagnostic (..),
+                                                                    List (..),
+                                                                    ResponseError,
+                                                                    SMethod (STextDocumentCodeAction),
+                                                                    TextDocumentIdentifier (TextDocumentIdentifier),
+                                                                    TextEdit (TextEdit),
+                                                                    WorkspaceEdit (WorkspaceEdit, _changeAnnotations, _changes, _documentChanges),
+                                                                    type (|?) (InR),
+                                                                    uriToFilePath)
 import           Language.LSP.VFS
 import           Module                                            (moduleEnvElts)
 import           OccName

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/PositionIndexed.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/PositionIndexed.hs
@@ -12,7 +12,8 @@ where
 
 import           Data.Char
 import           Data.List
-import           Language.LSP.Types
+import           Language.LSP.Types (Position (Position),
+                                     Range (Range, _end, _start))
 
 type PositionIndexed a = [(Position, a)]
 

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -206,7 +206,7 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) df pos = listToMaybe $ po
     hoverInfo ast = (Just range, prettyNames ++ pTypes)
       where
         pTypes
-          | length names == 1 = dropEnd1 $ map wrapHaskell prettyTypes
+          | Prelude.length names == 1 = dropEnd1 $ map wrapHaskell prettyTypes
           | otherwise = map wrapHaskell prettyTypes
 
         range = realSrcSpanToRange $ nodeSpan ast

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -60,7 +60,10 @@ import           Development.Shake                        (getDirectoryFilesIO)
 import qualified Experiments                              as Bench
 import           Ide.Plugin.Config
 import           Language.LSP.Test
-import           Language.LSP.Types                       hiding (mkRange)
+import           Language.LSP.Types                                 hiding
+                                                                    (mkRange, SemanticTokenAbsolute (length, line),
+                                                                     SemanticTokenRelative (length),
+                                                                     SemanticTokensEdit (_start))
 import           Language.LSP.Types.Capabilities
 import qualified Language.LSP.Types.Lens                  as Lsp (diagnostics,
                                                                   message,

--- a/ghcide/test/src/Development/IDE/Test.hs
+++ b/ghcide/test/src/Development/IDE/Test.hs
@@ -36,7 +36,10 @@ import           Development.IDE.Plugin.Test     (TestRequest (..),
 import           Development.IDE.Test.Diagnostic
 import           Language.LSP.Test               hiding (message)
 import qualified Language.LSP.Test               as LspTest
-import           Language.LSP.Types
+import           Language.LSP.Types              hiding
+                                                 (SemanticTokenAbsolute (length, line),
+                                                  SemanticTokenRelative (length),
+                                                  SemanticTokensEdit (_start))
 import           Language.LSP.Types.Lens         as Lsp
 import           System.Directory                (canonicalizePath)
 import           System.Time.Extra

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -49,7 +49,7 @@ library
     , hls-graph             ^>=1.4
     , hslogger
     , lens
-    , lsp                   ^>=1.2
+    , lsp                   ^>=1.2.0.1
     , opentelemetry
     , optparse-applicative
     , process

--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -30,17 +30,19 @@ where
 
 import           Data.Algorithm.Diff
 import           Data.Algorithm.DiffOutput
+import           Data.Containers.ListUtils       (nubOrdOn)
 import qualified Data.HashMap.Strict             as H
 import qualified Data.Text                       as T
-import           Ide.Types
-import           Language.LSP.Types
-import qualified Language.LSP.Types              as J
-import           Language.LSP.Types.Capabilities
-
-import           Data.Containers.ListUtils       (nubOrdOn)
 import           Ide.Plugin.Config
 import           Ide.Plugin.Properties
+import           Ide.Types
 import           Language.LSP.Server
+import           Language.LSP.Types              hiding
+                                                 (SemanticTokenAbsolute (length, line),
+                                                  SemanticTokenRelative (length),
+                                                  SemanticTokensEdit (_start))
+import qualified Language.LSP.Types              as J
+import           Language.LSP.Types.Capabilities
 
 -- ---------------------------------------------------------------------
 

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE BangPatterns         #-}
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DefaultSignatures    #-}
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DefaultSignatures          #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns         #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ViewPatterns               #-}
 
 module Ide.Types
     where
@@ -46,9 +46,21 @@ import           GHC.Generics
 import           Ide.Plugin.Config
 import           Ide.Plugin.Properties
 import           Language.LSP.Server             (LspM, getVirtualFile)
-import           Language.LSP.Types
-import           Language.LSP.Types.Capabilities
-import           Language.LSP.Types.Lens         as J hiding (id)
+import           Language.LSP.Types              hiding (SemanticTokenAbsolute(length, line), SemanticTokenRelative(length), SemanticTokensEdit(_start))
+import           Language.LSP.Types.Capabilities (ClientCapabilities (ClientCapabilities),
+                                                  TextDocumentClientCapabilities (_codeAction, _documentSymbol))
+import           Language.LSP.Types.Lens         as J (HasChildren (children),
+                                                       HasCommand (command),
+                                                       HasContents (contents),
+                                                       HasDeprecated (deprecated),
+                                                       HasEdit (edit),
+                                                       HasKind (kind),
+                                                       HasName (name),
+                                                       HasOptions (..),
+                                                       HasRange (range),
+                                                       HasTextDocument (..),
+                                                       HasTitle (title),
+                                                       HasUri (..))
 import           Language.LSP.VFS
 import           OpenTelemetry.Eventlog
 import           Options.Applicative             (ParserInfo)
@@ -467,7 +479,7 @@ instance HasTracing CallHierarchyOutgoingCallsParams
 -- ---------------------------------------------------------------------
 
 {-# NOINLINE pROCESS_ID #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 pROCESS_ID :: T.Text
 pROCESS_ID = unsafePerformIO getPid

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -47,7 +47,10 @@ import           Ide.Plugin.Config                 (Config, formattingProvider)
 import           Ide.PluginUtils                   (pluginDescToIdePlugins)
 import           Ide.Types
 import           Language.LSP.Test
-import           Language.LSP.Types
+import           Language.LSP.Types                hiding
+                                                   (SemanticTokenAbsolute (length, line),
+                                                    SemanticTokenRelative (length),
+                                                    SemanticTokensEdit (_start))
 import           Language.LSP.Types.Capabilities   (ClientCapabilities)
 import           System.Directory                  (getCurrentDirectory,
                                                     setCurrentDirectory)

--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -32,7 +32,7 @@ library
     , hiedb
     , hls-plugin-api        ^>=1.2
     , lens
-    , lsp
+    , lsp                    >=1.2.0.1
     , sqlite-simple
     , text
     , unordered-containers

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -141,7 +141,9 @@ import           Ide.Plugin.Eval.Util                 (asS, gStrictTry,
                                                        response', timed)
 import           Ide.Types
 import           Language.LSP.Server
-import           Language.LSP.Types
+import           Language.LSP.Types                   hiding
+                                                      (SemanticTokenAbsolute (length, line),
+                                                       SemanticTokenRelative (length))
 import           Language.LSP.Types.Lens              (end, line)
 import           Language.LSP.VFS                     (virtualFileText)
 import           Outputable                           (SDoc, empty, hang, nest,
@@ -153,14 +155,15 @@ import           UnliftIO.Temporary                   (withSystemTempFile)
 import           Util                                 (OverridingBool (Never))
 
 import           IfaceSyn                             (showToHeader)
-import           PprTyThing                           (pprTyThingInContext, pprTypeForUser)
+import           PprTyThing                           (pprTyThingInContext,
+                                                       pprTypeForUser)
 #if MIN_VERSION_ghc(9,0,0)
-import           GHC.Parser.Annotation                (ApiAnns (apiAnnRogueComments))
-import           GHC.Parser.Lexer                     (mkParserFlags)
 import           GHC.Driver.Ways                      (hostFullWays,
                                                        wayGeneralFlags,
                                                        wayUnsetGeneralFlags)
-import           GHC.Types.SrcLoc                     (UnhelpfulSpanReason(UnhelpfulInteractive))
+import           GHC.Parser.Annotation                (ApiAnns (apiAnnRogueComments))
+import           GHC.Parser.Lexer                     (mkParserFlags)
+import           GHC.Types.SrcLoc                     (UnhelpfulSpanReason (UnhelpfulInteractive))
 #else
 import           GhcPlugins                           (interpWays, updateWays,
                                                        wayGeneralFlags,

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -91,7 +91,10 @@ import           Language.Haskell.HLint                             as Hlint hid
 import           Language.LSP.Server                                (ProgressCancellable (Cancellable),
                                                                      sendRequest,
                                                                      withIndefiniteProgress)
-import           Language.LSP.Types
+import           Language.LSP.Types                                 hiding
+                                                                    (SemanticTokenAbsolute (length, line),
+                                                                     SemanticTokenRelative (length),
+                                                                     SemanticTokensEdit (_start))
 import qualified Language.LSP.Types                                 as LSP
 import qualified Language.LSP.Types.Lens                            as LSP
 

--- a/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
+++ b/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
@@ -36,7 +36,10 @@ import           Development.IDE.GHC.Compat (GenLocated (L), getSessionDynFlags,
                                              pm_parsed_source, unLoc)
 import           Ide.Types
 import           Language.LSP.Server
-import           Language.LSP.Types
+import           Language.LSP.Types         hiding
+                                            (SemanticTokenAbsolute (length, line),
+                                             SemanticTokenRelative (length),
+                                             SemanticTokensEdit (_start))
 import           Language.LSP.VFS           (virtualFileText)
 import           System.Directory           (canonicalizePath)
 import           System.FilePath            (dropExtension, splitDirectories,

--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -86,7 +86,10 @@ import           Language.LSP.Server                  (LspM,
                                                        sendNotification,
                                                        sendRequest,
                                                        withIndefiniteProgress)
-import           Language.LSP.Types                   as J
+import           Language.LSP.Types                   as J hiding
+                                                           (SemanticTokenAbsolute (length, line),
+                                                            SemanticTokenRelative (length),
+                                                            SemanticTokensEdit (_start))
 import           Retrie.CPP                           (CPP (NoCPP), parseCPP)
 import           Retrie.ExactPrint                    (fix, relativiseApiAnns,
                                                        transformA, unsafeMkA)

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer.hs
@@ -52,7 +52,10 @@ import           Ide.Types (PluginId)
 import           Language.Haskell.GHC.ExactPrint (Transform)
 import           Language.Haskell.GHC.ExactPrint (modifyAnnsT, addAnnotationsForPretty)
 import           Language.LSP.Server (MonadLsp, sendNotification)
-import           Language.LSP.Types
+import           Language.LSP.Types              hiding
+                                                 (SemanticTokenAbsolute (length, line),
+                                                  SemanticTokenRelative (length),
+                                                  SemanticTokensEdit (_start))
 import           Language.LSP.Types.Capabilities
 import           OccName
 import           Prelude hiding (span)

--- a/plugins/hls-tactics-plugin/src/Wingman/LanguageServer/TacticProviders.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/LanguageServer/TacticProviders.hs
@@ -27,7 +27,10 @@ import           GHC.Generics
 import           GHC.LanguageExtensions.Type (Extension (LambdaCase))
 import           Ide.PluginUtils
 import           Ide.Types
-import           Language.LSP.Types
+import           Language.LSP.Types              hiding
+                                                 (SemanticTokenAbsolute (length, line),
+                                                  SemanticTokenRelative (length),
+                                                  SemanticTokensEdit (_start))
 import           OccName
 import           Prelude hiding (span)
 import           Wingman.Auto

--- a/stack-8.10.2.yaml
+++ b/stack-8.10.2.yaml
@@ -65,14 +65,9 @@ extra-deps:
   - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
 configure-options:
   ghcide:

--- a/stack-8.10.3.yaml
+++ b/stack-8.10.3.yaml
@@ -65,14 +65,9 @@ extra-deps:
   - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
 configure-options:
   ghcide:

--- a/stack-8.10.4.yaml
+++ b/stack-8.10.4.yaml
@@ -61,14 +61,9 @@ extra-deps:
   - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
   # Enable these when supported by all formatters
   # - ghc-lib-9.0.1.20210324@sha256:c8b9a2541ea3424c8d0e4f80584477d0f35be03f4a47d931152042d5f446c5fc,19279

--- a/stack-8.10.5.yaml
+++ b/stack-8.10.5.yaml
@@ -63,14 +63,9 @@ extra-deps:
   - constraints-extras-0.3.1.0
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
   # Enable these when supported by all formatters
   # - ghc-lib-9.0.1.20210324@sha256:c8b9a2541ea3424c8d0e4f80584477d0f35be03f4a47d931152042d5f446c5fc,19279

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -102,14 +102,9 @@ extra-deps:
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
   - resourcet-1.2.3
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
 flags:
   haskell-language-server:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -103,14 +103,9 @@ extra-deps:
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
   - resourcet-1.2.3
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
 configure-options:
   ghcide:

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -82,14 +82,9 @@ extra-deps:
   - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
 configure-options:
   ghcide:

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -79,14 +79,9 @@ extra-deps:
   - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
 configure-options:
   ghcide:

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -54,6 +54,9 @@ extra-deps:
 - refinery-0.4.0.0
 - retrie-1.0.0.0
 - some-1.0.2@sha256:3d460998df32ad7b93bf55657aeae988d97070155e71718b4bc75d0997ce9d62,2244
+- lsp-1.2.0.1
+- lsp-types-1.3.0.0
+- lsp-test-0.14.0.1
 
 # Upstream patches for ghc-9.0.1 compatability
 # Same as in cabal.project
@@ -83,14 +86,6 @@ extra-deps:
   subdirs:
   - dependent-sum-template
 # https://github.com/obsidiansystems/dependent-sum/pull/57
-
-- github: anka-213/lsp
-  commit: e96383ab19534128f12acc70a69fbc15d4f298cc
-  subdirs:
-  - lsp-types
-  - lsp
-  - lsp-test
-# https://github.com/haskell/lsp/pull/312
 
 - github: diagrams/active
   commit: ca23431a8dfa013992f9164ccc882a3277361f17

--- a/stack.yaml
+++ b/stack.yaml
@@ -58,14 +58,9 @@ extra-deps:
   - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-
-  - github: haskell/lsp
-    commit: ef59c28b41ed4c5775f0ab0c1e985839359cec96
-    subdirs:
-    - lsp-types
-    - lsp
-    - lsp-test
-  # https://github.com/haskell/lsp/pull/332
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.0
+  - lsp-test-0.14.0.1
 
 configure-options:
   $targets:


### PR DESCRIPTION
Fix minbounds, remove the source repositories from the cabal and stack project descriptors, and deal with lsp-types-1.3.0.0 new breaking exports.

