### PR TITLE
Allow ormolu 0.2 and fix compatibility with GHC 9

### DIFF
--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -23,12 +23,13 @@ library
     , base            >=4.12  && <5
     , filepath
     , ghc
+    , ghc-api-compat
     , ghc-boot-th
     , ghcide          >=1.2   && <1.5
     , hls-plugin-api  >=1.1   && <1.3
     , lens
     , lsp
-    , ormolu          ^>=0.1.2
+    , ormolu          ^>=0.1.2 || ^>= 0.2
     , text
 
   default-language: Haskell2010


### PR DESCRIPTION
Ormolu 0.2 fixes compatibility with GHC 9. Turns out adding `ghc-api-compat` here is enough for GHC 9 compatibility.

Builds fine and all tests pass.