### PR TITLE
[ghcide-bench] preserve threading details in eventlogs

### DIFF
--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -307,7 +307,7 @@ benchRules build MkBenchRules{..} = do
         let exePath    = build </> "binaries" </> ver </> executableName
             exeExtraArgs =
                 [ "+RTS"
-                , "-l-au"
+                , "-l"
                 , "-S" <> outGc]
              ++ concat
                 [[ "-h"


### PR DESCRIPTION
We need the log of threading operations so that eventlog-to-tracy can
produe a valid trace. Without it, eventlog-to-tracy will generate an
invalid trace where all the spans are impossibly on the same thread and
tracy may/will crash