### PR TITLE
[benchmarks] Fix edit and "after edit" experiments

### DIFF
--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -74,10 +74,10 @@ experiments =
         isJust <$> getHover doc (fromJust identifierP),
       ---------------------------------------------------------------------------------------
       bench "edit" $ \docs -> do
-        forM_ docs $ \DocumentPositions{..} ->
+        forM_ docs $ \DocumentPositions{..} -> do
           changeDoc doc [charEdit stringLiteralP]
-        -- wait for a fresh build start
-        waitForProgressStart
+          -- wait for a fresh build start
+          waitForProgressStart
         -- wait for the build to be finished
         waitForProgressDone
         return True,
@@ -121,8 +121,9 @@ experiments =
         ( \docs -> do
             unless (any (isJust . identifierP) docs) $
                 error "None of the example modules is suitable for this experiment"
-            forM_ docs $ \DocumentPositions{..} ->
+            forM_ docs $ \DocumentPositions{..} -> do
                 forM_ identifierP $ \p -> changeDoc doc [charEdit p]
+                waitForProgressStart
             waitForProgressDone
         )
         ( \docs -> not . null . catMaybes <$> forM docs (\DocumentPositions{..} ->
@@ -139,8 +140,9 @@ experiments =
                 forM_ identifierP $ \p -> changeDoc doc [charEdit p]
         )
         ( \docs -> do
-            forM_ docs $ \DocumentPositions{..} ->
+            forM_ docs $ \DocumentPositions{..} -> do
               changeDoc doc [charEdit stringLiteralP]
+              waitForProgressStart
             waitForProgressDone
             not . null . catMaybes <$> forM docs (\DocumentPositions{..} -> do
               forM identifierP $ \p ->
@@ -160,8 +162,9 @@ experiments =
             liftIO $ appendFile (fromJust $ uriToFilePath hieYamlUri) "##\n"
             sendNotification SWorkspaceDidChangeWatchedFiles $ DidChangeWatchedFilesParams $
                 List [ FileEvent hieYamlUri FcChanged ]
-            forM_ docs $ \DocumentPositions{..} ->
+            forM_ docs $ \DocumentPositions{..} -> do
               changeDoc doc [charEdit stringLiteralP]
+              waitForProgressStart
             waitForProgressDone
             not . null . catMaybes <$> forM docs (\DocumentPositions{..} -> do
               forM identifierP $ \p ->


### PR DESCRIPTION
When the example includes >1 modules (like the Cabal example), this is the sequence of events:
```
--> didChange A.hs
--> didChange B.hs
<-- [ProgressDone (abort the previous progress, if any)]
<-- ProgressStart (for A.hs change)
<-- ProgressDone (aborted)
<-- ProgressStart (for B.hs change)
<-- ProgressDone
```

The edit and "after edit" experiments usually want to wait until the final set of diagnostics is produced. Currently the edit experiment waits for one progress start and one progress done, while the "after edit" experiments wait for one progress done. This is only correct if there is only one module in the example. When there are two or more, as seen above, it's not enough. The experiment needs to ignore the aborted progress done events and wait until the last progress done event.

This PR makes changes to wait for one progress start event per module and then wait for one progress done event after changing the last module.