### PR TITLE
GHCIDE_BUILD_PROFILING env var

### DIFF
--- a/ghcide/exe/Arguments.hs
+++ b/ghcide/exe/Arguments.hs
@@ -31,7 +31,7 @@ arguments :: IdePlugins IdeState -> Parser Arguments
 arguments plugins = Arguments
       <$> optional (strOption $ long "cwd" <> metavar "DIR" <> help "Change to this directory")
       <*> switch (long "version" <> help "Show ghcide and GHC versions")
-      <*> optional (strOption $ long "shake-profiling" <> metavar "DIR" <> help "Dump profiling reports to this directory")
+      <*> optional (strOption $ long "shake-profiling" <> metavar "DIR" <> help "Dump profiling reports to this directory (env var: GHCIDE_BUILD_PROFILING)")
       <*> switch (long "ot-memory-profiling" <> help "Record OpenTelemetry info to the eventlog. Needs the -l RTS flag to have an effect")
       <*> switch (long "test" <> help "Enable additional lsp messages used by the testsuite")
       <*> switch (long "test-no-kick" <> help "Disable kick. Useful for testing cancellation")

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -18,6 +18,7 @@ module Development.IDE.Core.Service(
     updatePositionMapping,
     ) where
 
+import           Control.Applicative             ((<|>))
 import           Development.IDE.Core.Debouncer
 import           Development.IDE.Core.FileExists (fileExistsRules)
 import           Development.IDE.Core.OfInterest
@@ -30,6 +31,7 @@ import qualified Language.LSP.Types              as LSP
 
 import           Control.Monad
 import           Development.IDE.Core.Shake
+import           System.Environment             (lookupEnv)
 
 
 ------------------------------------------------------------
@@ -46,13 +48,17 @@ initialise :: Config
            -> HieDb
            -> IndexQueue
            -> IO IdeState
-initialise defaultConfig mainRule lspEnv logger debouncer options vfs hiedb hiedbChan =
+initialise defaultConfig mainRule lspEnv logger debouncer options vfs hiedb hiedbChan = do
+    shakeProfiling <- do
+        let fromConf = optShakeProfiling options
+        fromEnv <- lookupEnv "GHCIDE_BUILD_PROFILING"
+        return $ fromConf <|> fromEnv
     shakeOpen
         lspEnv
         defaultConfig
         logger
         debouncer
-        (optShakeProfiling options)
+        shakeProfiling
         (optReportProgress options)
         (optTesting options)
         hiedb

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -12,7 +12,6 @@ module Development.IDE.Core.Service(
     getIdeOptions, getIdeOptionsIO,
     IdeState, initialise, shutdown,
     runAction,
-    writeProfile,
     getDiagnostics,
     ideLogger,
     updatePositionMapping,
@@ -70,9 +69,6 @@ initialise defaultConfig mainRule lspEnv logger debouncer options vfs hiedb hied
             ofInterestRules
             fileExistsRules lspEnv vfs
             mainRule
-
-writeProfile :: IdeState -> FilePath -> IO ()
-writeProfile = shakeProfile
 
 -- | Shutdown the Compiler Service.
 shutdown :: IdeState -> IO ()

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -31,7 +31,6 @@ module Development.IDE.Core.Shake(
     GetModificationTime(GetModificationTime, GetModificationTime_, missingFileDiagnostics),
     shakeOpen, shakeShut,
     shakeEnqueue,
-    shakeProfile,
     newSession,
     use, useNoFile, uses, useWithStaleFast, useWithStaleFast', delayedAction,
     FastResult(..),
@@ -550,14 +549,12 @@ shakeSessionInit IdeState{..} = do
     initSession <- newSession shakeExtras shakeDb []
     putMVar shakeSession initSession
 
-shakeProfile :: IdeState -> FilePath -> IO ()
-shakeProfile IdeState{..} = shakeProfileDatabase shakeDb
-
 shakeShut :: IdeState -> IO ()
 shakeShut IdeState{..} = withMVar shakeSession $ \runner -> do
     -- Shake gets unhappy if you try to close when there is a running
     -- request so we first abort that.
     void $ cancelShakeSession runner
+    void $ shakeDatabaseProfile shakeDb
     shakeClose
     progressStop $ progress shakeExtras
 


### PR DESCRIPTION
This is a convenience to generate Shake profiles when running tests.  

I also took the chance to delete some dead code and to force the generation of a profile report before shutdown