### PR TITLE
Add ghc-8.10.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,11 @@ jobs:
       - STACK_FILE: "stack-8.10.6.yaml"
     <<: *defaults
 
+  ghc-8.10.7:
+    environment:
+      - STACK_FILE: "stack-8.10.7.yaml"
+    <<: *defaults
+
   ghc-9.0.1:
     environment:
       - STACK_FILE: "stack-9.0.1.yaml"
@@ -115,5 +120,6 @@ workflows:
       - ghc-8.10.4
       - ghc-8.10.5
       - ghc-8.10.6
+      - ghc-8.10.7
       - ghc-9.0.1
       - ghc-default

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: ["9.0.1", '8.10.6', "8.10.5", "8.10.4", "8.10.3", "8.10.2", "8.8.4", "8.8.3", "8.6.5", "8.6.4"]
+        ghc: ["9.0.1", '8.10.7', '8.10.6', "8.10.5", "8.10.4", "8.10.3", "8.10.2", "8.8.4", "8.8.3", "8.6.5", "8.6.4"]
         os: [ubuntu-latest, macOS-latest]
         include:
           # only test supported ghc major versions
@@ -41,7 +41,7 @@ jobs:
             ghc: '9.0.1'
             test: true
           - os: ubuntu-latest
-            ghc: '8.10.6'
+            ghc: '8.10.7'
             test: true
           - os: ubuntu-latest
             ghc: '8.8.4'
@@ -53,12 +53,16 @@ jobs:
             ghc: '9.0.1'
             test: true
           - os: windows-latest
-            ghc: '8.10.6'
+            ghc: '8.10.7'
             test: true
           - os: windows-latest
             ghc: '8.6.5'
             test: true
           # only build rest of supported ghc versions for windows
+          - os: windows-latest
+            ghc: '8.10.7'
+          - os: windows-latest
+            ghc: '8.10.6'
           - os: windows-latest
             ghc: '8.10.5'
           - os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,8 +60,6 @@ jobs:
             test: true
           # only build rest of supported ghc versions for windows
           - os: windows-latest
-            ghc: '8.10.7'
-          - os: windows-latest
             ghc: '8.10.6'
           - os: windows-latest
             ghc: '8.10.5'

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -13,7 +13,7 @@ description:
     A library for building Haskell IDE's on top of the GHC API.
 homepage:           https://github.com/haskell/haskell-language-server/tree/master/ghcide#readme
 bug-reports:        https://github.com/haskell/haskell-language-server/issues
-tested-with:        GHC == 8.6.4 || == 8.6.5 || == 8.8.3 || == 8.8.4 || == 8.10.2 || == 8.10.3 || == 8.10.4 || == 8.10.5 || == 8.10.6 || == 9.0.1
+tested-with:        GHC == 8.6.4 || == 8.6.5 || == 8.8.3 || == 8.8.4 || == 8.10.2 || == 8.10.3 || == 8.10.4 || == 8.10.5 || == 8.10.6 || == 8.10.7 || == 9.0.1
 extra-source-files: README.md CHANGELOG.md
                     test/data/**/*.project
                     test/data/**/*.cabal

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -289,7 +289,7 @@ typecheckParentsAction nfp = do
       Just rs -> do
         liftIO $ (log $ "Typechecking reverse dependencies for " ++ show nfp ++ ": " ++ show revs)
           `catch` \(e :: SomeException) -> log (show e)
-        () <$ uses GetModIface rs
+        void $ uses GetModIface rs
 
 -- | Note that some keys have been modified and restart the session
 --   Only valid if the virtual file system was initialised by LSP, as that

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -55,6 +55,9 @@ extra-deps:
   # - ghc-lib-parser-ex-9.0.0.4@sha256:8282b11c3797fc8ba225b245e736cc9a0745d9c48d0f9fea7f9bffb5c9997709,3642
   # - hlint-3.3@sha256:4218ad6e03050f5d68aeba0e025f5f05e366c8fd49657f2a19df04ee31b2bb23,4154
 
+# for ghc-api-compat-8.10.6
+allow-newer: true
+
 configure-options:
   ghcide:
       - --disable-library-for-ghci

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2021-06-14
+resolver: lts-18.7
 compiler: ghc-8.10.7
 
 packages:

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -31,42 +31,23 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-  - apply-refact-0.9.3.0
-  - brittany-0.13.1.2
-  - Cabal-3.0.2.0
-  - clock-0.7.2
-  - data-tree-print-0.1.0.2@rev:2
-  - floskell-0.10.5
-  - fourmolu-0.3.0.0
-  - # ghc-api-compat-8.6
-    github: hsyl20/ghc-api-compat
-    commit: 8fee87eac97a538dbe81ff1ab18cff10f2f9fa15
-  - ghc-check-0.5.0.4
-  - ghc-exactprint-0.6.4
-  - ghc-source-gen-0.4.1.0
-  - heapsize-0.3.0
-  - implicit-hie-cradle-0.3.0.5
-  - implicit-hie-0.1.2.6
-  - monad-dijkstra-0.1.1.2
-  # For stylish-haskell-0.12.2.0
-  - optparse-applicative-0.15.1.0
-  - refinery-0.4.0.0
-  - retrie-1.0.0.0
-  - stylish-haskell-0.12.2.0
-  - semigroups-0.18.5
-  - temporary-1.2.1.1
-  - th-compat-0.1.2@sha256:3d55de1adc542c1a870c9ada90da2fbbe5f4e8bcd3eed545a55c3df9311b32a8,2854
-  - bytestring-encoding-0.1.0.0@sha256:460b49779fbf0112e8e2f1753c1ed9131eb18827600c298f4d6bb51c4e8c1c0d,1727
-  - hiedb-0.4.0.0
-  - dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
-  - dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
-  - dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
-  - constraints-extras-0.3.1.0
-  - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
-  - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-  - lsp-1.2.0.1
-  - lsp-types-1.3.0.1
-  - lsp-test-0.14.0.1
+  - brittany-0.13.1.2@sha256:9922614f1df18c63755a37c144033988788e0769fd9c2630b64ed0dfb49462bd,8197
+  - bytestring-encoding-0.1.1.0@sha256:1c3b97eb6345fd7153006211c8272215cd78bb0cf440c41185290822f1e3f2c2,1738
+  - data-tree-print-0.1.0.2@sha256:d845e99f322df70e0c06d6743bf80336f5918d5423498528beb0593a2afc1703,1620
+  - floskell-0.10.5@sha256:77f0bc1569573d9666b10975a5357fef631d32266c071733739393ccae521dab,3803
+  - ghc-api-compat-8.10.6@sha256:cde370b1b4c8a090de1ba6a8e27f65def9af43ca88710b412a6545b876568626,3324
+  - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
+  - hiedb-0.4.0.0@sha256:b6dadd5cefc8c1052bc4b29144f616ca9c22e863a96d8e447d66a4d32c96fd4a,2987
+  - implicit-hie-0.1.2.6@sha256:f50a908979a574a881f753c0f9a5224f023f438b30fdefc5b7fa01803b07a280,2998
+  - implicit-hie-cradle-0.3.0.5@sha256:5f5e575f549b2a9db664be7650b5c3c9226e313bddc46c79e2e83eb349f8e692,2610
+  - lsp-1.2.0.1@sha256:5b37d26fcbf037434e257e953c08513d4cb125ed784d4611038905c72dc0f58c,5431
+  - lsp-test-0.14.0.1@sha256:efce2ddec4183390341db7667e63936954c654a14d809ad7b61e4010a2fde97e,4739
+  - lsp-types-1.3.0.1@sha256:1dc41eb358345c1927fb8f285e7d951869623fe5b695fbbecf2fe6a3cee9fcfd,4646
+  - monad-dijkstra-0.1.1.3@sha256:d2fc098d7c122555e726830a12ae0423ac187f89de9228f32e56e2f6fc2238e1,1900
+  - optparse-applicative-0.15.1.0@sha256:29ff6146aabf54d46c4c8788e8d1eadaea27c94f6d360c690c5f6c93dac4b07e,4810
+  - refinery-0.4.0.0@sha256:fe3a43add8ff1db5cfffee7e7694c86128b1dfe62c541f26e25a8eadf9585610,1663
+  - retrie-1.0.0.0@sha256:82014773115807f649f60fe4a3246911bbccd063a3c846cf5665e71f237bdd2d,4241
+  - stylish-haskell-0.12.2.0@sha256:38f7fd9ca30c9aad34f176dae4564576899e9c197b6b8557b59c5e8c6a622c74,6108
 
   # Enable these when supported by all formatters
   # - ghc-lib-9.0.1.20210324@sha256:c8b9a2541ea3424c8d0e4f80584477d0f35be03f4a47d931152042d5f446c5fc,19279

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,0 +1,100 @@
+resolver: nightly-2021-06-14
+compiler: ghc-8.10.7
+
+packages:
+  - .
+  - ./hie-compat
+  - ./hls-graph
+  - ./ghcide/
+  - ./hls-plugin-api
+  - ./hls-test-utils
+  # - ./shake-bench
+  - ./plugins/hls-call-hierarchy-plugin
+  - ./plugins/hls-class-plugin
+  - ./plugins/hls-haddock-comments-plugin
+  - ./plugins/hls-eval-plugin
+  - ./plugins/hls-explicit-imports-plugin
+  - ./plugins/hls-refine-imports-plugin
+  - ./plugins/hls-hlint-plugin
+  - ./plugins/hls-retrie-plugin
+  - ./plugins/hls-splice-plugin
+  - ./plugins/hls-tactics-plugin
+  - ./plugins/hls-brittany-plugin
+  - ./plugins/hls-stylish-haskell-plugin
+  - ./plugins/hls-floskell-plugin
+  - ./plugins/hls-fourmolu-plugin
+  - ./plugins/hls-pragmas-plugin
+  - ./plugins/hls-module-name-plugin
+  - ./plugins/hls-ormolu-plugin
+
+ghc-options:
+  "$everything": -haddock
+
+extra-deps:
+  - apply-refact-0.9.3.0
+  - brittany-0.13.1.2
+  - Cabal-3.0.2.0
+  - clock-0.7.2
+  - data-tree-print-0.1.0.2@rev:2
+  - floskell-0.10.5
+  - fourmolu-0.3.0.0
+  - # ghc-api-compat-8.6
+    github: hsyl20/ghc-api-compat
+    commit: 8fee87eac97a538dbe81ff1ab18cff10f2f9fa15
+  - ghc-check-0.5.0.4
+  - ghc-exactprint-0.6.4
+  - ghc-source-gen-0.4.1.0
+  - heapsize-0.3.0
+  - implicit-hie-cradle-0.3.0.5
+  - implicit-hie-0.1.2.6
+  - monad-dijkstra-0.1.1.2
+  # For stylish-haskell-0.12.2.0
+  - optparse-applicative-0.15.1.0
+  - refinery-0.4.0.0
+  - retrie-1.0.0.0
+  - stylish-haskell-0.12.2.0
+  - semigroups-0.18.5
+  - temporary-1.2.1.1
+  - th-compat-0.1.2@sha256:3d55de1adc542c1a870c9ada90da2fbbe5f4e8bcd3eed545a55c3df9311b32a8,2854
+  - bytestring-encoding-0.1.0.0@sha256:460b49779fbf0112e8e2f1753c1ed9131eb18827600c298f4d6bb51c4e8c1c0d,1727
+  - hiedb-0.4.0.0
+  - dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
+  - dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
+  - dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
+  - constraints-extras-0.3.1.0
+  - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
+  - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
+  - lsp-1.2.0.1
+  - lsp-types-1.3.0.1
+  - lsp-test-0.14.0.1
+
+  # Enable these when supported by all formatters
+  # - ghc-lib-9.0.1.20210324@sha256:c8b9a2541ea3424c8d0e4f80584477d0f35be03f4a47d931152042d5f446c5fc,19279
+  # - ghc-lib-parser-9.0.1.20210324@sha256:fb680f78d4ab08b5d089a05bda3b84ad857e5edcc2e4ca7c188c0207d369af80
+  # - ghc-lib-parser-ex-9.0.0.4@sha256:8282b11c3797fc8ba225b245e736cc9a0745d9c48d0f9fea7f9bffb5c9997709,3642
+  # - hlint-3.3@sha256:4218ad6e03050f5d68aeba0e025f5f05e366c8fd49657f2a19df04ee31b2bb23,4154
+
+configure-options:
+  ghcide:
+      - --disable-library-for-ghci
+  haskell-language-server:
+      - --disable-library-for-ghci
+  heapsize:
+      - --disable-library-for-ghci
+
+flags:
+  haskell-language-server:
+    pedantic: true
+  retrie:
+    BuildExecutable: false
+  # Stack doesn't support automatic flags.
+  # Until the formatters support ghc-lib-9, we need this flag disabled
+  hls-hlint-plugin:
+    hlint33: false
+  hyphenation:
+    embed: true
+
+nix:
+  packages: [ icu libcxx zlib ]
+
+concurrent-tests: false


### PR DESCRIPTION
* 8.10.6 did not live much time 😄 
* I am getting error about boot packages locally, building with stack:

```
.....
In the dependencies for ghcide-1.4.1.0:
    directory needed, but this GHC boot package has been pruned (issue #4510); you need to add the
              package explicitly to extra-deps  (latest matching version is 1.3.6.2)
    ghc-boot needed, but this GHC boot package has been pruned (issue #4510); you need to add the
             package explicitly to extra-deps  (latest matching version is 9.0.1)
    process needed, but this GHC boot package has been pruned (issue #4510); you need to add the
            package explicitly to extra-deps  (latest matching version is 1.6.13.2)
    time needed, but this GHC boot package has been pruned (issue #4510); you need to add the
         package explicitly to extra-deps  (latest matching version is 1.12)
needed since ghcide is a build target.
...
Some different approaches to resolving this:

  * Recommended action: try adding the following to your extra-deps in D:\hls\stack-8.10.7.yaml:

- directory-1.3.6.2@sha256:6e5f3e0adfe94483d5754d97d741b7d23a5e085d47176075b1955d4fa78f37aa,2811
- ghc-boot-9.0.1@sha256:dc127d8b4b43eb54167f9befd51b2948e9084b8dfc18b88728148b719fa2287c,2347
- process-1.6.13.2@sha256:9733aa8a27b3e6c0f08a87a5c7287b3b73302d396f68f5655f9990a641368e3e,2845
- time-1.9.3@sha256:8f1b5448722a12a952248b356c9eb366e351226543d9086a2da71270522d5f45,5679

Plan construction failed.
```
