### PR TITLE
enable the PR gitpod badge and drop the label

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -54,9 +54,9 @@ github:
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
     addComment: false
     # add a "Review in Gitpod" button to pull requests (defaults to false)
-    addBadge: false
+    addBadge: true
     # add a label once the prebuild is ready to pull requests (defaults to false)
-    addLabel: prebuilt-in-gitpod
+    addLabel: false
 
 vscode:
   extensions:


### PR DESCRIPTION
Let's try out a gitpod integration that adds a button to the PR description

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2167"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

