### PR TITLE
Use maxBound of uinteger not Int.

### DIFF
--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -48,7 +48,7 @@ moduleOutline ideState DocumentSymbolParams{ _textDocument = TextDocumentIdentif
                    (defDocumentSymbol l :: DocumentSymbol)
                      { _name  = pprText m
                      , _kind  = SkFile
-                     , _range = Range (Position 0 0) (Position maxBound 0) -- _ltop is 0 0 0 0
+                     , _range = Range (Position 0 0) (Position 2147483647 0) -- _ltop is 0 0 0 0
                      }
                  _ -> Nothing
                importSymbols = maybe [] pure $


### PR DESCRIPTION
This is a low effort fix for https://github.com/haskell/vscode-haskell/issues/445 . The lsp spec says 
```
/**
 * Defines an unsigned integer number in the range of 0 to 2^31 - 1.
 */
export type uinteger = number;

interface Position {
	line: uinteger;
	character: uinteger;
}
```

A proper fix would be to create a new type in `lsp-types` for uinteger. 

### Debug info
This check returns `false` https://github.com/microsoft/vscode-languageserver-node/blob/8ad6896d8910214b7a3c8fee8dd175077a743045/client/src/common/client.ts#L1940 and vscode tries to parse it as `SymbolInformation` instead of `DocumentSymbol` and you get the error reported in the above issue.

The check for uinteger is at https://github.com/microsoft/vscode-languageserver-node/blob/8ad6896d8910214b7a3c8fee8dd175077a743045/types/src/main.ts#L3756