### PR TITLE
Wingman: Use awareness of skolems when filtering GADT data constructors

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/AbstractLSP/TacticActions.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/AbstractLSP/TacticActions.hs
@@ -17,7 +17,6 @@ import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.ExactPrint
 import           Generics.SYB.GHC (mkBindListT, everywhereM')
 import           GhcPlugins (occName)
-import           System.Timeout (timeout)
 import           Wingman.AbstractLSP.Types
 import           Wingman.CaseSplit
 import           Wingman.GHC (liftMaybe, isHole, pattern AMatch, unXPat)

--- a/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
@@ -59,7 +59,8 @@ destructMatches
 destructMatches use_field_puns f scrut t jdg = do
   let hy = jEntireHypothesis jdg
       g  = jGoal jdg
-  case tacticsGetDataCons $ unCType t of
+  skolems <- gets ts_skolems
+  case tacticsGetDataCons skolems $ unCType t of
     Nothing -> cut -- throwError $ GoalMismatch "destruct" g
     Just (dcs, apps) ->
       fmap unzipTrace $ for dcs $ \dc -> do
@@ -93,11 +94,11 @@ destructMatches use_field_puns f scrut t jdg = do
 
 ------------------------------------------------------------------------------
 -- | Generate just the 'Match'es for a case split on a specific type.
-destructionFor :: Hypothesis a -> Type -> Maybe [LMatch GhcPs (LHsExpr GhcPs)]
+destructionFor :: S.Set TyVar -> Hypothesis a -> Type -> Maybe [LMatch GhcPs (LHsExpr GhcPs)]
 -- TODO(sandy): In an ideal world, this would be the same codepath as
 -- 'destructMatches'. Make sure to change that if you ever change this.
-destructionFor hy t = do
-  case tacticsGetDataCons t of
+destructionFor skolems hy t = do
+  case tacticsGetDataCons skolems t of
     Nothing -> Nothing
     Just ([], _) -> Nothing
     Just (dcs, apps) -> do

--- a/plugins/hls-tactics-plugin/src/Wingman/EmptyCase.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/EmptyCase.hs
@@ -68,7 +68,9 @@ emptyCaseInteraction = Interaction $
             range = realSrcSpanToRange $ unTrack ss
         matches <-
           liftMaybe $
-            destructionFor
+          -- TODO(sandy): This needs a judgment in order to correctly compute
+          -- the skolems! But we don't have a judgement yet :(
+            destructionFor mempty
               (foldMap (hySingleton . occName . fst) bindings)
               ty
         edits <- liftMaybe $ hush $
@@ -149,7 +151,9 @@ emptyCaseScrutinees state nfp = do
           . fmap (scrutinzedType <=< sequence)
           . traverse (typeCheck (hscEnv $ untrackedStaleValue hscenv) tcg')
           $ scrutinee
-      case null $ tacticsGetDataCons ty of
+      -- TODO(sandy): This needs a judgment in order to correctly compute the
+      -- skolems! But we don't have a judgement yet :(
+      case null $ tacticsGetDataCons mempty ty of
         True -> pure empty
         False ->
           case ss of

--- a/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/GHC.hs
@@ -112,7 +112,6 @@ tacticsDataConCantMatch :: Set TyVar -> [Type] -> DataCon -> Bool
 --                  where T is the dcRepTyCon for the data con
 tacticsDataConCantMatch skolems tys con
   | null inst_theta   = False   -- Common
-  | all isTyVarTy tys = False   -- Also common
   | otherwise         = typesCantMatch (concatMap predEqs inst_theta)
   where
     (_, inst_theta, _) = dataConInstSig con tys
@@ -134,7 +133,9 @@ tacticsDataConCantMatch skolems tys con
         cant_match :: Type -> Type -> Bool
         cant_match t1 t2 = case tcUnifyTysFG (isSkolem skolems) [t1] [t2] of
           SurelyApart -> True
-          _           -> False
+          -- Still contains skolems, so it's actually surely apart.
+          MaybeApart _ -> True
+          Unifiable _ -> False
 
 ------------------------------------------------------------------------------
 -- | Instantiate all of the quantified type variables in a type with fresh

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
@@ -6,6 +6,7 @@ import           Control.Lens hiding (Context)
 import           Data.Bool
 import           Data.Char
 import           Data.Coerce
+import           Data.Foldable (toList)
 import           Data.Generics.Product (field)
 import           Data.Map (Map)
 import qualified Data.Map as M
@@ -473,3 +474,17 @@ isAlreadyDestructed _ = False
 expandDisallowed :: Provenance -> Provenance
 expandDisallowed (DisallowedPrv _ prv) = expandDisallowed prv
 expandDisallowed prv                   = prv
+
+
+------------------------------------------------------------------------------
+-- | Compute the skolems in scope for a given judgement.
+skolemsForJudgment :: Judgement -> Set TyVar
+skolemsForJudgment jdg
+  = S.fromList
+  $ foldMap (tyCoVarsOfTypeWellScoped . unCType)
+  $ (:) (jGoal jdg)
+  $ fmap hi_type
+  $ toList
+  $ hyByName
+  $ jHypothesis jdg
+

--- a/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Machinery.hs
@@ -93,16 +93,9 @@ runTactic
     -> TacticsM ()  -- ^ Tactic to use
     -> IO (Either [TacticError] RunTacticResults)
 runTactic duration ctx jdg t = do
-    let skolems = S.fromList
-                $ foldMap (tyCoVarsOfTypeWellScoped . unCType)
-                $ (:) (jGoal jdg)
-                $ fmap hi_type
-                $ toList
-                $ hyByName
-                $ jHypothesis jdg
-        tacticState =
+    let tacticState =
           defaultTacticState
-            { ts_skolems = skolems
+            { ts_skolems = skolemsForJudgment jdg
             }
 
     let stream = hoistListT (flip runReaderT ctx . unExtractM)
@@ -414,9 +407,9 @@ getCurrentDefinitions = do
 -- data constructor in the domain to the same in the codomain. This function
 -- returns 'Just' when all the lookups succeeded, and a non-empty value if the
 -- homomorphism *is not* possible.
-uncoveredDataCons :: Type -> Type -> Maybe (S.Set (Uniquely DataCon))
-uncoveredDataCons domain codomain = do
-  (g_dcs, _) <- tacticsGetDataCons codomain
-  (hi_dcs, _) <- tacticsGetDataCons domain
+uncoveredDataCons :: S.Set TyVar -> Type -> Type -> Maybe (S.Set (Uniquely DataCon))
+uncoveredDataCons skolems domain codomain = do
+  (g_dcs, _) <- tacticsGetDataCons skolems codomain
+  (hi_dcs, _) <- tacticsGetDataCons skolems domain
   pure $ S.fromList (coerce hi_dcs) S.\\ S.fromList (coerce g_dcs)
 

--- a/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/AutoSpec.hs
@@ -88,4 +88,5 @@ spec = do
     mkShowMessageTest Auto ""  2 8 "MessageForallA"      TacticErrors
     mkShowMessageTest Auto ""  7 8 "MessageCantUnify"    TacticErrors
     mkShowMessageTest Auto "" 12 8 "MessageNotEnoughGas" NotEnoughGas
+    mkShowMessageTest Auto ""  7 8 "MessageRespectGADTSkolem" TacticErrors
 

--- a/plugins/hls-tactics-plugin/test/golden/MessageRespectGADTSkolem.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MessageRespectGADTSkolem.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE GADTs #-}
+
+data Foo a where
+  Foo :: Foo Int
+
+test :: Foo as
+test = _
+


### PR DESCRIPTION
GHC provides `dataConCannotMatch`, which WIngman was using to filter out GADT data constructors which don't typecheck. But GHC doesn't do any reasoning about skolems in this function, so it assumes it can just unify any type variables that are present. This is entirely wrong --- skolems are definitely apart for all of Wingman's purposes.

Fixes #2171