### PR TITLE
Set bounds for retrie by ghc

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -71,7 +71,6 @@ library
         prettyprinter-ansi-terminal,
         prettyprinter,
         regex-tdfa >= 1.3.1.0,
-        retrie,
         rope-utf16-splay,
         safe,
         safe-exceptions,
@@ -109,6 +108,13 @@ library
     else
       build-depends:
         unix
+
+    if impl(ghc < 8.8 )
+      build-depends:
+        retrie < 1.0.0.0
+    else
+      build-depends:
+        retrie >= 1.0.0.0
 
     if impl(ghc < 8.10.5)
         build-depends:


### PR DESCRIPTION
* To be backported to 1.3.0-hackage (See #1990)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2175"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

