### PR TITLE
Bump up shake-bench version

### DIFF
--- a/shake-bench/shake-bench.cabal
+++ b/shake-bench/shake-bench.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          shake-bench
-version:       0.1.0.0
+version:       0.1.0.1
 synopsis:      Build rules for historical benchmarking
 license:       Apache-2.0
 license-file:  LICENSE


### PR DESCRIPTION
* to make progress the hackage release script

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2178"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

https://github.com/jneira/haskell-language-server/runs/3556360579?check_suite_focus=true
```
Run # This will throw an error if there is any difference cause we have to bump up the package version
diff -r -x '*.md' -x data ./incoming/shake-bench-0.1.0.0/shake-bench.cabal ./current/shake-bench-0.1.0.0/shake-bench.cabal
23,25c23
<         diagrams-contrib,
<         diagrams-core,
<         diagrams-lib,
```
