### PR TITLE
Add rerun workflow

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,14 @@
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_pr_tests:
+    name: rerun_pr_tests
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: estroz/rerun-actions@main
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        comment_id: ${{ github.event.comment.id }}


### PR DESCRIPTION
* to rerun other workflows via pr comments
* see https://github.com/marketplace/actions/rerun-actions

> * rerun-actions should only be run on comment creation. See the below examples for how to do this.
> * the PR either must have an ok-to-test label present on the PR, or the user who writes a command must be an organization member, or repo owner, contributor, or collaborator. 

The action is triggered by adding a comment in the pr with

> The following commands are supported by this action:
>    /rerun-all - rerun all failed workflows.
>    /rerun-workflow <workflow name> - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2181"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

