### PR TITLE
ghcide: Add flags to toggle building each executable

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -217,6 +217,10 @@ library
       exposed-modules:
         Development.IDE.GHC.Compat.CPP
 
+flag test-exe
+    description: Build the ghcide-test-preprocessor executable
+    default: True
+
 executable ghcide-test-preprocessor
     default-language: Haskell2010
     hs-source-dirs: test/preprocessor
@@ -224,6 +228,9 @@ executable ghcide-test-preprocessor
     main-is: Main.hs
     build-depends:
         base == 4.*
+
+    if !flag(test-exe)
+        buildable: False
 
 benchmark benchHist
     type: exitcode-stdio-1.0
@@ -262,6 +269,10 @@ benchmark benchHist
         shake,
         text,
         yaml
+
+flag executable
+    description: Build the ghcide executable
+    default: True
 
 executable ghcide
     default-language:   Haskell2010
@@ -321,6 +332,9 @@ executable ghcide
         TupleSections
         TypeApplications
         ViewPatterns
+
+    if !flag(executable)
+        buildable: False
 
 test-suite ghcide-tests
     type: exitcode-stdio-1.0
@@ -404,6 +418,10 @@ test-suite ghcide-tests
         TypeApplications
         ViewPatterns
 
+flag bench-exe
+    description: Build the ghcide-bench executable
+    default: True
+
 executable ghcide-bench
     default-language: Haskell2010
     build-tool-depends:
@@ -448,3 +466,6 @@ executable ghcide-bench
         TupleSections
         TypeApplications
         ViewPatterns
+
+    if !flag(bench-exe)
+        buildable: False


### PR DESCRIPTION
This package is a transient dependency of `haskell-language-server`.
However, only the library is needed. These three flags give the option for
those who do not need the executables to disable them.

`executable`:
* Toggles the `ghcide` executable
* enabled by default.

`test-exe`:
* Toggles the `ghcide-test-preprocessor` executable
* disabled by default

`bench-exe`:
* Toggles the `ghcide-bench` executable
* disabled by default

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

