### PR TITLE
Parallel fuzzy filtering

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.4.2.0
+version:            1.4.2.1
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -64,6 +64,7 @@ library
         hiedb == 0.4.1.*,
         lsp-types >= 1.3.0.1 && < 1.4,
         lsp == 1.2.*,
+        monoid-subclasses,
         mtl,
         network-uri,
         optparse-applicative,
@@ -208,6 +209,8 @@ library
         Development.IDE.Plugin.Completions.Logic
         Development.IDE.Session.VersionCheck
         Development.IDE.Types.Action
+        Text.Fuzzy.Parallel
+
     ghc-options: -Wall -Wno-name-shadowing -Wincomplete-uni-patterns -Wno-unticked-promoted-constructors
 
     if flag(ghc-patched-unboxed-bytecode)

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.4.2.1
+version:            1.4.2.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -87,6 +87,7 @@ library
         unordered-containers >= 0.2.10.0,
         utf8-string,
         vector,
+        vector-algorithms,
         hslogger,
         Diff ^>=0.4.0,
         vector,

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -544,9 +544,9 @@ getCompletions plId ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls, qu
       filtModNameCompls =
         map mkModCompl
           $ mapMaybe (T.stripPrefix enteredQual)
-          $ Fuzzy.simpleFilter chunkSize maxC fullPrefix allModNamesAsNS
+          $ Fuzzy.simpleFilter chunkSize fullPrefix allModNamesAsNS
 
-      filtCompls = map Fuzzy.original $ Fuzzy.filter chunkSize maxC prefixText ctxCompls "" "" label False
+      filtCompls = map Fuzzy.original $ Fuzzy.filter chunkSize prefixText ctxCompls "" "" label False
         where
 
           mcc = case maybe_parsed of
@@ -593,7 +593,7 @@ getCompletions plId ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls, qu
 
       filtListWith f list =
         [ f label
-        | label <- Fuzzy.simpleFilter chunkSize maxC fullPrefix list
+        | label <- Fuzzy.simpleFilter chunkSize fullPrefix list
         , enteredQual `T.isPrefixOf` label
         ]
 
@@ -621,7 +621,8 @@ getCompletions plId ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls, qu
     -> return []
     | otherwise -> do
         -- assumes that nubOrdBy is stable
-        let uniqueFiltCompls = nubOrdBy uniqueCompl filtCompls
+        -- nubOrd is very slow - take 10x the maximum configured
+        let uniqueFiltCompls = nubOrdBy uniqueCompl $ take (maxC*10) filtCompls
         let compls = map (mkCompl plId ideOpts) uniqueFiltCompls
         return $ filtModNameCompls
               ++ filtKeywordCompls

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -12,12 +12,13 @@ import qualified Data.Text                    as T
 
 import           Data.Aeson                   (FromJSON, ToJSON)
 import           Data.Text                    (Text)
-import           Development.IDE.Spans.Common
 import           Development.IDE.GHC.Compat
+import           Development.IDE.Spans.Common
 import           GHC.Generics                 (Generic)
 import           Ide.Plugin.Config            (Config)
+import qualified Ide.Plugin.Config            as Config
 import           Ide.Plugin.Properties
-import           Ide.PluginUtils              (usePropertyLsp)
+import           Ide.PluginUtils              (getClientConfig, usePropertyLsp)
 import           Ide.Types                    (PluginId)
 import           Language.LSP.Server          (MonadLsp)
 import           Language.LSP.Types           (CompletionItemKind (..), Uri)
@@ -46,11 +47,13 @@ getCompletionsConfig pId =
   CompletionsConfig
     <$> usePropertyLsp #snippetsOn pId properties
     <*> usePropertyLsp #autoExtendOn pId properties
+    <*> (Config.maxCompletions <$> getClientConfig)
 
 
 data CompletionsConfig = CompletionsConfig {
   enableSnippets   :: Bool,
-  enableAutoExtend :: Bool
+  enableAutoExtend :: Bool,
+  maxCompletions   :: Int
 }
 
 data ExtendImport = ExtendImport

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -1,7 +1,6 @@
 -- | Parallel versions of 'filter' and 'simpleFilter'
 module Text.Fuzzy.Parallel
-(
-    filter,
+(   filter,
     simpleFilter,
     -- reexports
     Fuzzy(..),
@@ -10,16 +9,14 @@ module Text.Fuzzy.Parallel
 
 import           Control.Monad.ST            (runST)
 import           Control.Parallel.Strategies (Eval, Strategy, evalTraversable,
-                                              parListChunk, parTraversable,
-                                              rseq, using)
+                                              parTraversable, rseq, using)
 import           Data.Function               (on)
-import           Data.List                   (sortOn)
-import           Data.Maybe                  (catMaybes)
 import           Data.Monoid.Textual         (TextualMonoid)
 import           Data.Ord                    (Down (Down))
 import           Data.Vector                 (Vector, (!))
 import qualified Data.Vector                 as V
-import qualified Data.Vector.Algorithms.Heap as VA
+-- need to use a stable sort
+import qualified Data.Vector.Algorithms.Tim  as VA
 import           Prelude                     hiding (filter)
 import           Text.Fuzzy                  (Fuzzy (..), match)
 
@@ -43,7 +40,7 @@ filter chunkSize maxRes pattern ts pre post extract caseSen = runST $ do
              `using`
              parVectorChunk chunkSize (evalTraversable forceScore)))
   v' <- V.unsafeThaw v
-  VA.partialSortBy (compare `on` (Down . score)) v' maxRes
+  VA.sortBy (compare `on` (Down . score)) v'
   v'' <- V.unsafeFreeze v'
   return $ take maxRes $ V.toList v''
 

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -1,0 +1,60 @@
+-- | Parallel versions of 'filter' and 'simpleFilter'
+module Text.Fuzzy.Parallel
+(
+    filter,
+    simpleFilter,
+    -- reexports
+    Fuzzy(..),
+    match
+) where
+
+import           Control.Parallel.Strategies (Eval, evalTraversable,
+                                              parListChunk, rseq, using)
+import           Data.List                   (sortOn)
+import           Data.Maybe                  (catMaybes)
+import           Data.Monoid.Textual         (TextualMonoid)
+import           Data.Ord                    (Down (Down))
+import           Prelude                     hiding (filter)
+import           Text.Fuzzy                  (Fuzzy (..), match)
+
+-- | Evaluation that forces the 'score' field
+forceScore :: TextualMonoid s => Fuzzy t s -> Eval(Fuzzy t s)
+forceScore it@Fuzzy{score} = do
+  score' <- rseq score
+  return it{score = score'}
+
+-- | The function to filter a list of values by fuzzy search on the text extracted from them.
+--
+-- >>> filter "ML" [("Standard ML", 1990),("OCaml",1996),("Scala",2003)] "<" ">" fst False
+-- [Fuzzy {original = ("Standard ML",1990), rendered = "standard <m><l>", score = 4},Fuzzy {original = ("OCaml",1996), rendered = "oca<m><l>", score = 4}]
+{-# INLINABLE filter #-}
+filter :: (TextualMonoid s)
+       => Int      -- ^ Chunk size. 1000 works well.
+       -> s        -- ^ Pattern.
+       -> [t]      -- ^ The list of values containing the text to search in.
+       -> s        -- ^ The text to add before each match.
+       -> s        -- ^ The text to add after each match.
+       -> (t -> s) -- ^ The function to extract the text from the container.
+       -> Bool     -- ^ Case sensitivity.
+       -> [Fuzzy t s] -- ^ The list of results, sorted, highest score first.
+filter chunkSize pattern ts pre post extract caseSen =
+  sortOn (Down . score)
+         (catMaybes
+             (map (\t -> match pattern t pre post extract caseSen) ts
+             `using`
+             parListChunk chunkSize (evalTraversable forceScore)))
+
+-- | Return all elements of the list that have a fuzzy
+-- match against the pattern. Runs with default settings where
+-- nothing is added around the matches, as case insensitive.
+--
+-- >>> simpleFilter "vm" ["vim", "emacs", "virtual machine"]
+-- ["vim","virtual machine"]
+{-# INLINABLE simpleFilter #-}
+simpleFilter :: (TextualMonoid s)
+             => Int -- ^ Chunk size. 1000 works well.
+             -> s   -- ^ Pattern to look for.
+             -> [s] -- ^ List of texts to check.
+             -> [s] -- ^ The ones that match.
+simpleFilter chunk pattern xs =
+  map original $ filter chunk pattern xs mempty mempty id False

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -8,28 +8,28 @@ module Text.Fuzzy.Parallel
     match
 ) where
 
-import           Control.Parallel.Strategies (Eval, evalTraversable,
-                                              parListChunk, rseq, using)
+import           Control.Monad.ST            (runST)
+import           Control.Parallel.Strategies (Eval, Strategy, evalTraversable,
+                                              parListChunk, parTraversable,
+                                              rseq, using)
+import           Data.Function               (on)
 import           Data.List                   (sortOn)
 import           Data.Maybe                  (catMaybes)
 import           Data.Monoid.Textual         (TextualMonoid)
 import           Data.Ord                    (Down (Down))
+import           Data.Vector                 (Vector, (!))
+import qualified Data.Vector                 as V
+import qualified Data.Vector.Algorithms.Heap as VA
 import           Prelude                     hiding (filter)
 import           Text.Fuzzy                  (Fuzzy (..), match)
 
--- | Evaluation that forces the 'score' field
-forceScore :: TextualMonoid s => Fuzzy t s -> Eval(Fuzzy t s)
-forceScore it@Fuzzy{score} = do
-  score' <- rseq score
-  return it{score = score'}
-
 -- | The function to filter a list of values by fuzzy search on the text extracted from them.
 --
--- >>> filter "ML" [("Standard ML", 1990),("OCaml",1996),("Scala",2003)] "<" ">" fst False
--- [Fuzzy {original = ("Standard ML",1990), rendered = "standard <m><l>", score = 4},Fuzzy {original = ("OCaml",1996), rendered = "oca<m><l>", score = 4}]
-{-# INLINABLE filter #-}
+-- >>> length $ filter 1000 200 "ML" (concat $ replicate 10000 [("Standard ML", 1990),("OCaml",1996),("Scala",2003)]) "<" ">" fst False
+-- 200
 filter :: (TextualMonoid s)
        => Int      -- ^ Chunk size. 1000 works well.
+       -> Int      -- ^ Max results
        -> s        -- ^ Pattern.
        -> [t]      -- ^ The list of values containing the text to search in.
        -> s        -- ^ The text to add before each match.
@@ -37,12 +37,15 @@ filter :: (TextualMonoid s)
        -> (t -> s) -- ^ The function to extract the text from the container.
        -> Bool     -- ^ Case sensitivity.
        -> [Fuzzy t s] -- ^ The list of results, sorted, highest score first.
-filter chunkSize pattern ts pre post extract caseSen =
-  sortOn (Down . score)
-         (catMaybes
-             (map (\t -> match pattern t pre post extract caseSen) ts
+filter chunkSize maxRes pattern ts pre post extract caseSen = runST $ do
+  let v = (V.catMaybes
+             (V.map (\t -> match pattern t pre post extract caseSen) (V.fromList ts)
              `using`
-             parListChunk chunkSize (evalTraversable forceScore)))
+             parVectorChunk chunkSize (evalTraversable forceScore)))
+  v' <- V.unsafeThaw v
+  VA.partialSortBy (compare `on` (Down . score)) v' maxRes
+  v'' <- V.unsafeFreeze v'
+  return $ take maxRes $ V.toList v''
 
 -- | Return all elements of the list that have a fuzzy
 -- match against the pattern. Runs with default settings where
@@ -53,8 +56,40 @@ filter chunkSize pattern ts pre post extract caseSen =
 {-# INLINABLE simpleFilter #-}
 simpleFilter :: (TextualMonoid s)
              => Int -- ^ Chunk size. 1000 works well.
+             -> Int -- ^ Max results
              -> s   -- ^ Pattern to look for.
              -> [s] -- ^ List of texts to check.
              -> [s] -- ^ The ones that match.
-simpleFilter chunk pattern xs =
-  map original $ filter chunk pattern xs mempty mempty id False
+simpleFilter chunk maxRes pattern xs =
+  map original $ filter chunk maxRes pattern xs mempty mempty id False
+
+--------------------------------------------------------------------------------
+
+-- | Divides a vector in chunks, applies the strategy in parallel to each chunk.
+parVectorChunk :: Int -> Strategy a -> Vector a -> Eval (Vector a)
+parVectorChunk chunkSize st v =
+    V.concat <$> parTraversable (evalTraversable st) (chunkVector chunkSize v)
+
+-- >>> chunkVector 3 (V.fromList [0..10])
+-- >>> chunkVector 3 (V.fromList [0..11])
+-- >>> chunkVector 3 (V.fromList [0..12])
+-- [[0,1,2],[3,4,5],[6,7,8],[9,10]]
+-- [[0,1,2],[3,4,5],[6,7,8],[9,10,11]]
+-- [[0,1,2],[3,4,5],[6,7,8],[9,10,11],[12]]
+chunkVector :: Int -> Vector a -> [Vector a]
+chunkVector chunkSize v = do
+    let indices = pairwise $ [0, chunkSize .. l-1] ++ [l]
+        l = V.length v
+    [V.fromListN (h-l) [v ! j | j <- [l .. h-1]]
+            | (l,h) <- indices]
+
+pairwise :: [a] -> [(a,a)]
+pairwise []       = []
+pairwise [_]      = []
+pairwise (x:y:xs) = (x,y) : pairwise (y:xs)
+
+-- | Evaluation that forces the 'score' field
+forceScore :: TextualMonoid s => Fuzzy t s -> Eval(Fuzzy t s)
+forceScore it@Fuzzy{score} = do
+  score' <- rseq score
+  return it{score = score'}

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -38,7 +38,7 @@ filter :: (TextualMonoid s)
        -> Bool     -- ^ Case sensitivity.
        -> [Fuzzy t s] -- ^ The list of results, sorted, highest score first.
 filter chunkSize maxRes pattern ts pre post extract caseSen = runST $ do
-  let v = (V.catMaybes
+  let v = (V.mapMaybe id
              (V.map (\t -> match pattern t pre post extract caseSen) (V.fromList ts)
              `using`
              parVectorChunk chunkSize (evalTraversable forceScore)))


### PR DESCRIPTION
Following #2215  and #2217 this is another performance improvement to completions driven by the large Sigma codebase.

On every completion attempt we need to match the prefix against all the identifiers in the project, with a cost of O(Identifiers*C) where C is the average number of characters per identifier. This PR parallelises the matching and uses vectors to reduce the amount of allocations and enable in-place sorting of the results.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2225"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

