### PR TITLE
Partial sort of fuzzy filtering results

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.4.2.2
+version:            1.4.2.3
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -544,9 +544,9 @@ getCompletions plId ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls, qu
       filtModNameCompls =
         map mkModCompl
           $ mapMaybe (T.stripPrefix enteredQual)
-          $ Fuzzy.simpleFilter chunkSize fullPrefix allModNamesAsNS
+          $ Fuzzy.simpleFilter chunkSize maxC fullPrefix allModNamesAsNS
 
-      filtCompls = map Fuzzy.original $ Fuzzy.filter chunkSize prefixText ctxCompls "" "" label False
+      filtCompls = map Fuzzy.original $ Fuzzy.filter chunkSize maxC prefixText ctxCompls "" "" label False
         where
 
           mcc = case maybe_parsed of
@@ -593,7 +593,7 @@ getCompletions plId ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls, qu
 
       filtListWith f list =
         [ f label
-        | label <- Fuzzy.simpleFilter chunkSize fullPrefix list
+        | label <- Fuzzy.simpleFilter chunkSize maxC fullPrefix list
         , enteredQual `T.isPrefixOf` label
         ]
 
@@ -621,8 +621,7 @@ getCompletions plId ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls, qu
     -> return []
     | otherwise -> do
         -- assumes that nubOrdBy is stable
-        -- nubOrd is very slow - take 10x the maximum configured
-        let uniqueFiltCompls = nubOrdBy uniqueCompl $ take (maxC*10) filtCompls
+        let uniqueFiltCompls = nubOrdBy uniqueCompl filtCompls
         let compls = map (mkCompl plId ideOpts) uniqueFiltCompls
         return $ filtModNameCompls
               ++ filtKeywordCompls

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -20,18 +20,6 @@ import           Prelude                     hiding (filter)
 import           Text.Fuzzy                  (Fuzzy (..), match)
 
 -- | The function to filter a list of values by fuzzy search on the text extracted from them.
---
--- >>> map (\x -> score <$> match ("lookup"::String) x "" "" id False) ["splitLookup"::String, "lookupInput"]
--- WAS WAS WAS WAS NOW [Just 58,Just 120]
--- WAS WAS WAS NOW [Just 58,Just 120]
--- WAS WAS NOW [Just 58,Just 120]
--- WAS NOW [Just 58,Just 120]
--- NOW [Just 58,Just 120]
--- >>> take 10 $ iterate (\(tot, cur) -> let cur' = 2*cur + 1 in (tot + cur', cur')) (0,0)
--- NOW [(0,0),(1,1),(4,3),(11,7),(26,15),(57,31),(120,63),(247,127),(502,255),(1013,511)]
-
--- >>> length $ filter 1000 200 "ML" (concat $ replicate 10000 [("Standard ML", 1990),("OCaml",1996),("Scala",2003)]) "<" ">" fst False
--- 200
 filter :: (TextualMonoid s)
        => Int      -- ^ Chunk size. 1000 works well.
        -> Int      -- ^ Max. number of results wanted
@@ -110,8 +98,6 @@ pairwise [_]      = []
 pairwise (x:y:xs) = (x,y) : pairwise (y:xs)
 
 -- | A stable partial sort ascending by score. O(N) best case, O(wanted*N) worst case
---- >>> partialSortByAscScore 3 5 $ V.fromList $ map (\x -> Fuzzy x x (length x)) ["A","B","ABCDE","ABBC"]
--- [Fuzzy {original = "ABCDE", rendered = "ABCDE", score = 5},Fuzzy {original = "ABBC", rendered = "ABBC", score = 4},Fuzzy {original = "A", rendered = "A", score = 1}]
 partialSortByAscScore :: TextualMonoid s
             => Int  -- ^ Number of items needed
             -> Int  -- ^ Value of a perfect score

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -79,10 +79,8 @@ parVectorChunk chunkSize st v =
 -- [[0,1,2],[3,4,5],[6,7,8],[9,10,11],[12]]
 chunkVector :: Int -> Vector a -> [Vector a]
 chunkVector chunkSize v = do
-    let indices = chunkIndices chunkSize (0,l)
-        l = V.length v
-    [V.fromListN (h-l+1) [v ! j | j <- [l .. h]]
-            | (l,h) <- indices]
+    let indices = chunkIndices chunkSize (0,V.length v)
+    [V.slice l (h-l+1) v | (l,h) <- indices]
 
 -- >>> chunkIndices 3 (0,9)
 -- >>> chunkIndices 3 (0,10)
@@ -114,6 +112,7 @@ partialSortByAscScore wantedCount perfectScore v = loop 0 (SortState minBound pe
   loop index st@SortState{..} acc
     | foundCount == wantedCount = reverse acc
     | index == l
+-- ProgressCancelledException
     = if bestScoreSeen < scoreWanted
         then loop 0 st{scoreWanted = bestScoreSeen, bestScoreSeen = minBound} acc
         else reverse acc

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -16,7 +16,6 @@ import qualified Data.Vector                 as V
 -- need to use a stable sort
 import           Data.Bifunctor              (second)
 import           Data.Maybe                  (fromJust)
-import qualified Data.Monoid.Factorial       as T
 import           Prelude                     hiding (filter)
 import           Text.Fuzzy                  (Fuzzy (..), match)
 

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4508,7 +4508,9 @@ otherCompletionTests = [
 
 packageCompletionTests :: [TestTree]
 packageCompletionTests =
-  [ testSessionWait "fromList" $ do
+  [ testSession' "fromList" $ \dir -> do
+        liftIO $ writeFile (dir </> "hie.yaml")
+            "cradle: {direct: {arguments: [-hide-all-packages, -package, base, A]}}"
         doc <- createDoc "A.hs" "haskell" $ T.unlines
             [ "{-# OPTIONS_GHC -Wunused-binds #-}",
                 "module A () where",
@@ -4524,9 +4526,8 @@ packageCompletionTests =
               ]
         liftIO $ take 3 (sort compls') @?=
           map ("Defined in "<>)
-              [ "'Data.IntMap"
-              , "'Data.IntMap.Lazy"
-              , "'Data.IntMap.Strict"
+              [ "'Data.List.NonEmpty"
+              , "'GHC.Exts"
               ]
 
   , testSessionWait "Map" $ do
@@ -4627,7 +4628,7 @@ projectCompletionTests =
                 <- compls
               , _label == "anidentifier"
               ]
-        liftIO $ compls' @?= ["Defined in 'A"], 
+        liftIO $ compls' @?= ["Defined in 'A"],
       testSession' "auto complete project imports" $ \dir-> do
         liftIO $ writeFile (dir </> "hie.yaml")
             "cradle: {direct: {arguments: [\"-Wmissing-signatures\", \"ALocalModule\", \"B\"]}}"


### PR DESCRIPTION
This improves the performance of completions by around 25% on a large project (>500k identifiers) and also removes the use of unsafe primitives in the previous in-place solution

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2240"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

