### PR TITLE
Let cabal-ghc901.project be cabal.project.local

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
     - if: ${{ matrix.ghc == '9.0.1' }}
       name: Use modified cabal.project for ghc9
-      run: cp cabal-ghc901.project cabal.project
+      run: cp cabal-ghc901.project.local cabal.project.local
 
     - name: Shorten binary names
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
       # Needs to be before Cache Cabal so the cache can detect changes to the modified cabal.project file
       - if: ${{ needs.pre_job.outputs.should_skip != 'true' && matrix.ghc == '9.0.1' }}
         name: Use modified cabal.project for ghc9
-        run: cp cabal-ghc901.project cabal.project
+        run: cp cabal-ghc901.project.local cabal.project.local
 
       - if: ${{ needs.pre_job.outputs.should_skip != 'true' && matrix.ghc == '8.8.4' && matrix.os == 'windows-latest' }}
         name: Modify cabal.project to workaround segfaults for ghc-8.8.4 and windows

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# Used for ci setup in the gitlab mirror of the project: 
+# Used for ci setup in the gitlab mirror of the project:
 # https://gitlab.haskell.org/haskell/haskell-language-server/-/pipelines
 variables:
   # Commit of ghc/ci-images repository from which to pull Docker images
@@ -9,21 +9,17 @@ variables:
 .default_matrix: &default_matrix
   matrix:
     - GHC_VERSION: 8.8.4
-      CABAL_PROJECT: cabal.project
     - GHC_VERSION: 8.10.7
-      CABAL_PROJECT: cabal.project
     - GHC_VERSION: 9.0.1
-      CABAL_PROJECT: cabal-ghc901.project
+      LOCAL_CABAL_PROJECT: cabal-ghc901.project.local
 
 .m1_matrix: &m1_matrix
   matrix:
     - GHC_VERSION: 8.10.7
-      CABAL_PROJECT: cabal.project
 
 .arm_matrix: &arm_matrix
   matrix:
     - GHC_VERSION: 8.10.7
-      CABAL_PROJECT: cabal.project
 
 
 workflow:
@@ -93,7 +89,6 @@ build-aarch64-darwin:
         --keep CI_PROJECT_DIR \
         --keep MACOSX_DEPLOYMENT_TARGET \
         --keep GHC_VERSION \
-        --keep CABAL_PROJECT \
         --keep CABAL_INSTALL_VERSION \
         --run "$1" 2>&1
     }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,6 +89,7 @@ build-aarch64-darwin:
         --keep CI_PROJECT_DIR \
         --keep MACOSX_DEPLOYMENT_TARGET \
         --keep GHC_VERSION \
+        --keep LOCAL_CABAL_PROJECT \
         --keep CABAL_INSTALL_VERSION \
         --run "$1" 2>&1
     }

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -30,6 +30,10 @@ export BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=yes
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
+if [[ ! -z "$LOCAL_CABAL_PROJECT" ]]; then
+    cp $LOCAL_CABAL_PROJECT cabal.project.local
+fi
+
 # some alpines need workaround
 if ghc --info | grep -q integer-simple ; then
 	echo -e 'package blaze-textual\n    flags: +integer-simple' >> cabal.project.local

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -30,10 +30,6 @@ export BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=yes
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
-if [[ -n "$CABAL_PROJECT" ]]; then
-    CABAL_PROJECT="cabal.project"
-fi
-
 if [[ -n "$LOCAL_CABAL_PROJECT" ]]; then
     run cp "$LOCAL_CABAL_PROJECT" cabal.project.local
 fi
@@ -46,7 +42,6 @@ fi
 run cabal v2-install exe:haskell-language-server exe:haskell-language-server-wrapper \
 	-O2 \
     -w "ghc-$GHC_VERSION" \
-	--project-file "$CABAL_PROJECT" \
     --installdir="$CI_PROJECT_DIR/out" \
     --install-method=copy \
     --overwrite-policy=always \

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -30,7 +30,7 @@ export BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=yes
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
-if [[ -n "$LOCAL_CABAL_PROJECT" ]]; then
+if [[ -n "${LOCAL_CABAL_PROJECT-}" ]]; then
     run cp "$LOCAL_CABAL_PROJECT" cabal.project.local
 fi
 

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -31,7 +31,7 @@ export BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=yes
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
 if [[ -n "$LOCAL_CABAL_PROJECT" ]]; then
-    cp $LOCAL_CABAL_PROJECT cabal.project.local
+    run cp "$LOCAL_CABAL_PROJECT" cabal.project.local
 fi
 
 # some alpines need workaround

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -30,7 +30,7 @@ export BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=yes
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
-if [[ ! -z "$LOCAL_CABAL_PROJECT" ]]; then
+if [[ -n "$LOCAL_CABAL_PROJECT" ]]; then
     cp $LOCAL_CABAL_PROJECT cabal.project.local
 fi
 

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -30,6 +30,10 @@ export BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=yes
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
+if [[ -n "$CABAL_PROJECT" ]]; then
+    CABAL_PROJECT="cabal.project"
+fi
+
 if [[ -n "$LOCAL_CABAL_PROJECT" ]]; then
     run cp "$LOCAL_CABAL_PROJECT" cabal.project.local
 fi

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -1,3 +1,5 @@
+-- this can be used copied as cabal.project.local
+-- or directly with `cabal build --project-file=cabal-ghc901.project`
 packages:
          ./
          ./hie-compat
@@ -6,11 +8,11 @@ packages:
          ./ghcide
          ./hls-plugin-api
          ./hls-test-utils
-        -- ./plugins/hls-tactics-plugin
-        -- ./plugins/hls-brittany-plugin
-        -- ./plugins/hls-stylish-haskell-plugin
-        -- ./plugins/hls-fourmolu-plugin
-        -- ./plugins/hls-class-plugin
+         ./plugins/hls-tactics-plugin
+         ./plugins/hls-brittany-plugin
+         ./plugins/hls-stylish-haskell-plugin
+         ./plugins/hls-fourmolu-plugin
+         ./plugins/hls-class-plugin
          ./plugins/hls-eval-plugin
          ./plugins/hls-explicit-imports-plugin
          ./plugins/hls-refine-imports-plugin
@@ -72,4 +74,20 @@ allow-newer:
     floskell:ghc-prim,
     -- for shake-bench
     Chart-diagrams:diagrams-core,
-    SVGFonts:diagrams-core
+    SVGFonts:diagrams-core,
+
+    -- This is needed to allow cabal find a build plan
+    -- for stylish-haskell, fourmolu and brittany
+    -- (even if they are not being built due to flags)
+    butcher:base,
+    data-tree-print:base,
+    multistate:base,
+    brittany:base,
+    brittany:ghc,
+    brittany:ghc-boot-th,
+    hls-brittany-plugin:brittany,
+
+    stylish-haskell:Cabal,
+    stylish-haskell:ghc-lib-parser,
+
+    fourmolu:ghc-lib-parser

--- a/cabal-ghc901.project.local
+++ b/cabal-ghc901.project.local
@@ -1,39 +1,5 @@
--- this can be used copied as cabal.project.local
--- or directly with `cabal build --project-file=cabal-ghc901.project`
-packages:
-         ./
-         ./hie-compat
-         ./shake-bench
-         ./hls-graph
-         ./ghcide
-         ./hls-plugin-api
-         ./hls-test-utils
-         ./plugins/hls-tactics-plugin
-         ./plugins/hls-brittany-plugin
-         ./plugins/hls-stylish-haskell-plugin
-         ./plugins/hls-fourmolu-plugin
-         ./plugins/hls-class-plugin
-         ./plugins/hls-eval-plugin
-         ./plugins/hls-explicit-imports-plugin
-         ./plugins/hls-refine-imports-plugin
-         ./plugins/hls-hlint-plugin
-         ./plugins/hls-rename-plugin
-         ./plugins/hls-retrie-plugin
-         ./plugins/hls-haddock-comments-plugin
-         ./plugins/hls-splice-plugin
-         ./plugins/hls-floskell-plugin
-         ./plugins/hls-pragmas-plugin
-         ./plugins/hls-module-name-plugin
-         ./plugins/hls-ormolu-plugin
-         ./plugins/hls-call-hierarchy-plugin
-
+-- this has to be copied as cabal.project.local
 with-compiler: ghc-9.0.1
-
-tests: true
-
-package *
-  ghc-options: -haddock
-  test-show-details: direct
 
 source-repository-package
   type: git
@@ -61,10 +27,6 @@ source-repository-package
   location: https://github.com/HeinrichApfelmus/operational
   tag: 16e19aaf34e286f3d27b3988c61040823ec66537
 
-write-ghc-environment-files: never
-
-index-state: 2021-09-16T07:00:23Z
-
 constraints:
     -- These plugins don't work on GHC9 yet
     haskell-language-server -brittany -class -fourmolu -stylishhaskell -tactic
@@ -72,9 +34,6 @@ constraints:
 allow-newer:
     floskell:base,
     floskell:ghc-prim,
-    -- for shake-bench
-    Chart-diagrams:diagrams-core,
-    SVGFonts:diagrams-core,
 
     -- This is needed to allow cabal find a build plan
     -- for stylish-haskell, fourmolu and brittany

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -1,4 +1,4 @@
-# nix version of cabal-ghc901.project
+# nix version of cabal-ghc901.project.local
 { pkgs }:
 
 let


### PR DESCRIPTION
* The intent of the change is let users do `cp cabal-ghc901.project cabal.project.local` to make the workflow smoother
  * but the file can be used in its own as before
* To do so the packages should be uncommented (as they are so in main cabal.project) and the packages without support for ghc-9 should be make buildable with `allow-newer` (thanks to @gbaz for the suggestion)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2241"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

