### PR TITLE
Enable the ghcide test plugin in HLS test suites

### DIFF
--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -66,10 +66,7 @@ main = do
             pluginDescToIdePlugins $
             GhcIde.descriptors
             ++ [Test.blockCommandDescriptor "block-command" | argsTesting]
-
-        ,Main.argsGhcidePlugin = if argsTesting
-            then Test.plugin
-            else mempty
+            ++ [Test.plugin | argsTesting]
 
         ,Main.argsThreads = case argsThreads of 0 -> Nothing ; i -> Just (fromIntegral i)
 

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -51,7 +51,9 @@ main = do
 
     whenJust argsCwd IO.setCurrentDirectory
 
-    Main.defaultMain def
+    let arguments = if argsTesting then Main.testing else def
+
+    Main.defaultMain arguments
         {Main.argCommand = argsCommand
 
         ,Main.argsRules = do
@@ -62,20 +64,13 @@ main = do
             unless argsDisableKick $
                 action kick
 
-        ,Main.argsHlsPlugins =
-            pluginDescToIdePlugins $
-            GhcIde.descriptors
-            ++ [Test.blockCommandDescriptor "block-command" | argsTesting]
-            ++ [Test.plugin | argsTesting]
-
         ,Main.argsThreads = case argsThreads of 0 -> Nothing ; i -> Just (fromIntegral i)
 
-        ,Main.argsIdeOptions = \config  sessionLoader ->
-            let defOptions = defaultIdeOptions sessionLoader
+        ,Main.argsIdeOptions = \config sessionLoader ->
+            let defOptions = Main.argsIdeOptions arguments config sessionLoader
             in defOptions
                 { optShakeProfiling = argsShakeProfiling
                 , optOTMemoryProfiling = IdeOTMemoryProfiling argsOTMemoryProfiling
-                , optTesting = IdeTesting argsTesting
                 , optShakeOptions = (optShakeOptions defOptions){shakeThreads = argsThreads}
                 , optCheckParents = pure $ checkParents config
                 , optCheckProject = pure $ checkProject config

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -141,7 +141,8 @@ runLanguageServer options inH outH getHieDbLoc defaultConfig onConfigurationChan
                         T.pack $ "Fatal error in server thread: " <> show e
                     exitClientMsg
                 handleServerException _ = pure ()
-            _ <- flip forkFinally handleServerException $ runWithDb dbLoc $ \hiedb hieChan -> do
+                logger = ideLogger ide
+            _ <- flip forkFinally handleServerException $ runWithDb logger dbLoc $ \hiedb hieChan -> do
               putMVar dbMVar (hiedb,hieChan)
               forever $ do
                 msg <- readChan clientMsgChan

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -63,7 +63,8 @@ import           Development.IDE.Session               (SessionLoadingOptions,
                                                         setInitialDynFlags)
 import           Development.IDE.Types.Location        (NormalizedUri,
                                                         toNormalizedFilePath')
-import           Development.IDE.Types.Logger          (Logger (Logger))
+import           Development.IDE.Types.Logger          (Logger (Logger),
+                                                        logDebug, logInfo)
 import           Development.IDE.Types.Options         (IdeGhcSession,
                                                         IdeOptions (optCheckParents, optCheckProject, optReportProgress, optRunSubset),
                                                         IdeTesting (IdeTesting),
@@ -251,20 +252,20 @@ defaultMain Arguments{..} = do
             LT.putStrLn $ decodeUtf8 $ A.encodePretty $ pluginsToDefaultConfig argsHlsPlugins
         LSP -> withNumCapabilities (maybe (numProcessors `div` 2) fromIntegral argsThreads) $ do
             t <- offsetTime
-            hPutStrLn stderr "Starting LSP server..."
-            hPutStrLn stderr "If you are seeing this in a terminal, you probably should have run WITHOUT the --lsp option!"
+            logInfo logger "Starting LSP server..."
+            logInfo logger "If you are seeing this in a terminal, you probably should have run WITHOUT the --lsp option!"
             runLanguageServer options inH outH argsGetHieDbLoc argsDefaultHlsConfig argsOnConfigChange (pluginHandlers plugins) $ \env vfs rootPath hiedb hieChan -> do
                 traverse_ IO.setCurrentDirectory rootPath
                 t <- t
-                hPutStrLn stderr $ "Started LSP server in " ++ showDuration t
+                logInfo logger $ T.pack $ "Started LSP server in " ++ showDuration t
 
                 dir <- maybe IO.getCurrentDirectory return rootPath
 
                 -- We want to set the global DynFlags right now, so that we can use
                 -- `unsafeGlobalDynFlags` even before the project is configured
                 _mlibdir <-
-                    setInitialDynFlags dir argsSessionLoadingOptions
-                        `catchAny` (\e -> (hPutStrLn stderr $ "setInitialDynFlags: " ++ displayException e) >> pure Nothing)
+                    setInitialDynFlags logger dir argsSessionLoadingOptions
+                        `catchAny` (\e -> (logDebug logger $ T.pack $ "setInitialDynFlags: " ++ displayException e) >> pure Nothing)
 
 
                 sessionLoader <- loadSessionWithOptions argsSessionLoadingOptions dir
@@ -273,7 +274,7 @@ defaultMain Arguments{..} = do
 
                 -- disable runSubset if the client doesn't support watched files
                 runSubset <- (optRunSubset def_options &&) <$> LSP.runLspT env isWatchSupported
-                hPutStrLn stderr $ "runSubset: " <> show runSubset
+                logDebug logger $ T.pack $ "runSubset: " <> show runSubset
 
                 let options = def_options
                             { optReportProgress = clientSupportsProgress caps
@@ -299,7 +300,7 @@ defaultMain Arguments{..} = do
         Check argFiles -> do
           dir <- IO.getCurrentDirectory
           dbLoc <- getHieDbLoc dir
-          runWithDb dbLoc $ \hiedb hieChan -> do
+          runWithDb logger dbLoc $ \hiedb hieChan -> do
             -- GHC produces messages with UTF8 in them, so make sure the terminal doesn't error
             hSetEncoding stdout utf8
             hSetEncoding stderr utf8
@@ -363,14 +364,14 @@ defaultMain Arguments{..} = do
         Db dir opts cmd -> do
             dbLoc <- getHieDbLoc dir
             hPutStrLn stderr $ "Using hiedb at: " ++ dbLoc
-            mlibdir <- setInitialDynFlags dir def
+            mlibdir <- setInitialDynFlags logger dir def
             case mlibdir of
                 Nothing     -> exitWith $ ExitFailure 1
                 Just libdir -> HieDb.runCommand libdir opts{HieDb.database = dbLoc} cmd
 
         Custom projectRoot (IdeCommand c) -> do
           dbLoc <- getHieDbLoc projectRoot
-          runWithDb dbLoc $ \hiedb hieChan -> do
+          runWithDb logger dbLoc $ \hiedb hieChan -> do
             vfs <- makeVFSHandle
             sessionLoader <- loadSessionWithOptions argsSessionLoadingOptions "."
             let def_options = argsIdeOptions argsDefaultHlsConfig sessionLoader

--- a/ghcide/src/Development/IDE/Plugin/Test.hs
+++ b/ghcide/src/Development/IDE/Plugin/Test.hs
@@ -50,11 +50,9 @@ newtype WaitForIdeRuleResult = WaitForIdeRuleResult { ideResultSuccess::Bool}
 
 plugin :: PluginDescriptor IdeState
 plugin = (defaultPluginDescriptor "test") {
-    pluginHandlers = mkPluginHandler (SCustomMethod "test") (\st pId ->
-        if pId == "test"
-            then testRequestHandler' st
-            else const $ return $ Left $ ResponseError MethodNotFound "" Nothing)
-}
+    pluginHandlers = mkPluginHandler (SCustomMethod "test") $ \st _ ->
+        testRequestHandler' st
+    }
   where
       testRequestHandler' ide req
         | Just customReq <- parseMaybe parseJSON req

--- a/ghcide/src/Development/IDE/Plugin/Test.hs
+++ b/ghcide/src/Development/IDE/Plugin/Test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs              #-}
+{-# LANGUAGE PolyKinds          #-}
 -- | A plugin that adds custom messages for use in tests
 module Development.IDE.Plugin.Test
   ( TestRequest(..)
@@ -18,7 +19,6 @@ import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Bifunctor
 import           Data.CaseInsensitive           (CI, original)
-import           Data.Default                   (def)
 import           Data.Maybe                     (isJust)
 import           Data.String
 import           Data.Text                      (Text, pack)
@@ -27,8 +27,6 @@ import           Development.IDE.Core.Service
 import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Compat
 import           Development.IDE.Graph          (Action)
-import           Development.IDE.LSP.Server
-import qualified Development.IDE.Plugin         as P
 import           Development.IDE.Types.Action
 import           Development.IDE.Types.HscEnvEq (HscEnvEq (hscEnv))
 import           Development.IDE.Types.Location (fromUri)
@@ -50,10 +48,12 @@ data TestRequest
 newtype WaitForIdeRuleResult = WaitForIdeRuleResult { ideResultSuccess::Bool}
     deriving newtype (FromJSON, ToJSON)
 
-plugin :: P.Plugin c
-plugin = def {
-    P.pluginRules = return (),
-    P.pluginHandlers = requestHandler (SCustomMethod "test") testRequestHandler'
+plugin :: PluginDescriptor IdeState
+plugin = (defaultPluginDescriptor "test") {
+    pluginHandlers = mkPluginHandler (SCustomMethod "test") (\st pId ->
+        if pId == "test"
+            then testRequestHandler' st
+            else const $ return $ Left $ ResponseError MethodNotFound "" Nothing)
 }
   where
       testRequestHandler' ide req

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4627,7 +4627,7 @@ projectCompletionTests =
                 <- compls
               , _label == "anidentifier"
               ]
-        liftIO $ compls' @?= ["Defined in 'A"], 
+        liftIO $ compls' @?= ["Defined in 'A"],
       testSession' "auto complete project imports" $ \dir-> do
         liftIO $ writeFile (dir </> "hie.yaml")
             "cradle: {direct: {arguments: [\"-Wmissing-signatures\", \"ALocalModule\", \"B\"]}}"
@@ -5822,7 +5822,7 @@ unitTests = do
                     | i <- [(1::Int)..20]
                 ] ++ Ghcide.descriptors
 
-        testIde def{IDE.argsHlsPlugins = plugins} $ do
+        testIde IDE.testing{IDE.argsHlsPlugins = plugins} $ do
             _ <- createDoc "haskell" "A.hs" "module A where"
             waitForProgressDone
             actualOrder <- liftIO $ readIORef orderRef

--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -10,6 +10,7 @@ module Ide.PluginUtils
     diffText,
     diffText',
     pluginDescToIdePlugins,
+    idePluginsToPluginDesc,
     responseError,
     getClientConfig,
     getPluginConfig,
@@ -24,7 +25,8 @@ module Ide.PluginUtils
     allLspCmdIds',
     installSigUsr1Handler,
     subRange,
-    usePropertyLsp)
+    usePropertyLsp,
+    )
 where
 
 
@@ -149,6 +151,8 @@ pluginDescToIdePlugins :: [PluginDescriptor ideState] -> IdePlugins ideState
 pluginDescToIdePlugins plugins =
     IdePlugins $ map (\p -> (pluginId p, p)) $ nubOrdOn pluginId plugins
 
+idePluginsToPluginDesc :: IdePlugins ideState -> [PluginDescriptor ideState]
+idePluginsToPluginDesc (IdePlugins pp) = map snd pp
 
 -- ---------------------------------------------------------------------
 -- | Returns the current client configuration. It is not wise to permanently

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -46,7 +46,10 @@ import           GHC.Generics
 import           Ide.Plugin.Config
 import           Ide.Plugin.Properties
 import           Language.LSP.Server             (LspM, getVirtualFile)
-import           Language.LSP.Types              hiding (SemanticTokenAbsolute(length, line), SemanticTokenRelative(length), SemanticTokensEdit(_start))
+import           Language.LSP.Types              hiding
+                                                 (SemanticTokenAbsolute (length, line),
+                                                  SemanticTokenRelative (length),
+                                                  SemanticTokensEdit (_start))
 import           Language.LSP.Types.Capabilities (ClientCapabilities (ClientCapabilities),
                                                   TextDocumentClientCapabilities (_codeAction, _documentSymbol))
 import           Language.LSP.Types.Lens         as J (HasChildren (children),
@@ -285,6 +288,10 @@ instance PluginMethod CallHierarchyIncomingCalls where
 instance PluginMethod CallHierarchyOutgoingCalls where
   pluginEnabled _ = pluginEnabledConfig plcCallHierarchyOn
 
+instance PluginMethod CustomMethod where
+  pluginEnabled _ _ _ = True
+  combineResponses _ _ _ _ (x :| _) = x
+
 -- ---------------------------------------------------------------------
 
 -- | Methods which have a PluginMethod instance
@@ -488,8 +495,6 @@ instance HasTracing CallHierarchyOutgoingCallsParams
 -- ---------------------------------------------------------------------
 
 {-# NOINLINE pROCESS_ID #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 pROCESS_ID :: T.Text
 pROCESS_ID = unsafePerformIO getPid
 

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -32,7 +32,7 @@ import           Control.Applicative.Combinators
 import           Control.Concurrent.Async        (async, cancel, wait)
 import           Control.Concurrent.Extra
 import           Control.Exception.Base
-import           Control.Monad                   (unless)
+import           Control.Monad                   (unless, void)
 import           Control.Monad.IO.Class
 import           Data.Aeson                      (Value (Null), toJSON)
 import qualified Data.Aeson                      as A
@@ -97,6 +97,7 @@ goldenWithHaskellDoc plugin title testDataDir path desc ext act =
   $ TL.encodeUtf8 . TL.fromStrict
   <$> do
     doc <- openDoc (path <.> ext) "haskell"
+    void waitForBuildQueue
     act doc
     documentContents doc
 
@@ -116,6 +117,7 @@ goldenWithHaskellDocFormatter plugin formatter title testDataDir path desc ext a
   $ TL.encodeUtf8 . TL.fromStrict
   <$> do
     doc <- openDoc (path <.> ext) "haskell"
+    void waitForBuildQueue
     act doc
     documentContents doc
 

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -53,16 +53,14 @@ import           Ide.Plugin.Config               (Config, formattingProvider)
 import           Ide.PluginUtils                 (idePluginsToPluginDesc, pluginDescToIdePlugins)
 import           Ide.Types
 import           Language.LSP.Test
-import           Language.LSP.Types                hiding
-                                                   (SemanticTokenAbsolute (length, line),
-                                                    SemanticTokenRelative (length),
-                                                    SemanticTokensEdit (_start))
-import           Language.LSP.Types.Capabilities   (ClientCapabilities)
-import           System.Directory                  (getCurrentDirectory,
-                                                    setCurrentDirectory)
-import           System.Environment.Blank          (getEnvDefault)
+import           Language.LSP.Types              hiding
+                                                 (SemanticTokenAbsolute (length, line),
+                                                  SemanticTokenRelative (length),
+                                                  SemanticTokensEdit (_start))
+import           Language.LSP.Types.Capabilities (ClientCapabilities)
+import           System.Directory                (getCurrentDirectory,
+                                                  setCurrentDirectory)
 import           System.FilePath
-import           System.IO.Extra
 import           System.IO.Unsafe                (unsafePerformIO)
 import           System.Process.Extra            (createPipe)
 import           System.Time.Extra
@@ -133,22 +131,6 @@ runSessionWithServerFormatter plugin formatter =
     def
     fullCaps
 
--- | Run an action, with stderr silenced
-silenceStderr :: IO a -> IO a
-silenceStderr action = do
-  showStderr <- getEnvDefault "LSP_TEST_LOG_STDERR" "0"
-  case showStderr of
-    "0" -> withTempFile $ \temp ->
-      bracket (openFile temp ReadWriteMode) hClose $ \h -> do
-        old <- hDuplicate stderr
-        buf <- hGetBuffering stderr
-        h `hDuplicateTo'` stderr
-        action `finally` do
-          old `hDuplicateTo'` stderr
-          hSetBuffering stderr buf
-          hClose old
-    _ -> action
-
 -- | Restore cwd after running an action
 keepCurrentDirectory :: IO a -> IO a
 keepCurrentDirectory = bracket getCurrentDirectory setCurrentDirectory . const
@@ -171,7 +153,7 @@ runSessionWithServer' ::
   FilePath ->
   Session a ->
   IO a
-runSessionWithServer' plugin conf sconf caps root s = withLock lock $ keepCurrentDirectory $ silenceStderr $ do
+runSessionWithServer' plugin conf sconf caps root s = withLock lock $ keepCurrentDirectory $ do
   (inR, inW) <- createPipe
   (outR, outW) <- createPipe
   server <-

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -50,7 +50,7 @@ import           Development.IDE.Plugin.Test     (TestRequest (WaitForIdeRule, W
 import           Development.IDE.Types.Options
 import           GHC.IO.Handle
 import           Ide.Plugin.Config               (Config, formattingProvider)
-import           Ide.PluginUtils                 (pluginDescToIdePlugins)
+import           Ide.PluginUtils                 (idePluginsToPluginDesc, pluginDescToIdePlugins)
 import           Ide.Types
 import           Language.LSP.Test
 import           Language.LSP.Types              hiding
@@ -172,7 +172,7 @@ runSessionWithServer' plugin conf sconf caps root s = withLock lock $ keepCurren
   server <-
     async $
       Ghcide.defaultMain
-        def
+        testing
           { argsHandleIn = pure inR,
             argsHandleOut = pure outW,
             argsDefaultHlsConfig = conf,
@@ -180,7 +180,7 @@ runSessionWithServer' plugin conf sconf caps root s = withLock lock $ keepCurren
             argsIdeOptions = \config sessionLoader ->
               let ideOptions = (argsIdeOptions def config sessionLoader) {optTesting = IdeTesting True}
                in ideOptions {optShakeOptions = (optShakeOptions ideOptions) {shakeThreads = 2}},
-            argsHlsPlugins = pluginDescToIdePlugins $ plugin ++ Ghcide.descriptors
+            argsHlsPlugins = pluginDescToIdePlugins $ plugin ++ idePluginsToPluginDesc (argsHlsPlugins testing)
           }
   x <- runSessionWithHandles inW outR sconf caps root s
   hClose inW

--- a/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE TypeApplications #-}
-
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 module Wingman.Debug
   ( unsafeRender
   , unsafeRender'
@@ -16,7 +17,7 @@ module Wingman.Debug
 
 import           Control.DeepSeq
 import           Control.Exception
-import           Debug.Trace
+import qualified Debug.Trace
 import           Development.IDE.GHC.Compat (PlainGhcException, Outputable(..), SDoc, showSDocUnsafe)
 import           System.IO.Unsafe  (unsafePerformIO)
 
@@ -47,3 +48,15 @@ traceIdX str a = trace (mappend ("!!!" <> str <> ": ") $ show a) a
 traceFX :: String -> (a -> String) -> a -> a
 traceFX str f a = trace (mappend ("!!!" <> str <> ": ") $ f a) a
 
+traceM :: Applicative f => String -> f ()
+trace :: String -> a -> a
+traceShowId :: Show a => a -> a
+#ifdef DEBUG
+traceM = Debug.Trace.traceM
+trace = Debug.Trace.trace
+traceShowId = Debug.Trace.traceShowId
+#else
+traceM _ = pure ()
+trace _ = id
+traceShowId = id
+#endif


### PR DESCRIPTION
The ghcide test plugin installs a `CustomMethod` handler that allows to interact with the build queue and do things like waiting for the queue to be empty. It's installed by the ghcide main driver but not by the HLS test driver. 

This PR refactors things so that it will be installed automatically by the `defaultMain` driver.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2243"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

