### PR TITLE
Generate custom source tarball 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,9 +155,41 @@ jobs:
       with:
         name: haskell-language-server-wrapper-${{ runner.OS }}${{env.EXE_EXT}}.${{ steps.compress_wrapper_binary.outputs.extension }}
         path: ${{ steps.compress_wrapper_binary.outputs.path }}
+  
+  # generates a custom tarball with sources, used by `ghcup compile hls` 
+  src-tar:
+    needs: build
+    runs-on: ubuntu-18.04
+    
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      
+      - name: "Create source tarball"
+        run: |
+          mkdir src-dist
+          git archive --prefix=haskell-language-server-${{ github.event.release.tag_name }}/ \
+                      --format=tar.gz \
+                      -o src-dist/haskell-language-server.tar.gz \
+                      HEAD
+      
+      - uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: src-dist/haskell-language-server.tar.gz
+          asset_name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
+          asset_content_type: application/gzip
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
+          path: src-dist/haskell-language-server.tar.gz
+      
   # this generates .gz tarfiles containing binaries for all GHC versions and OS's
-  # and a custom tarball with sources, used by ghcup
+  # used by `ghcup install hls`
   tar:
     needs: build
     runs-on: ubuntu-18.04
@@ -181,19 +213,6 @@ jobs:
             gzip -d *.gz
           fi
           tar -czpf haskell-language-server.tar.gz *
-      
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      
-      - name: "Create source tarball"
-        if: matrix.os == 'Linux'
-        run: |
-          mkdir src-dist
-          git archive --prefix=haskell-language-server-${{ github.event.release.tag_name }}/ \
-                      --format=tar.gz \
-                      -o src-dist/haskell-language-server.tar.gz \
-                      HEAD
 
       - uses: actions/upload-release-asset@v1.0.2
         env:
@@ -204,28 +223,13 @@ jobs:
           asset_name: haskell-language-server-${{ matrix.os }}-${{ github.event.release.tag_name }}.tar.gz
           asset_content_type: application/gzip
 
-      - uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: src-dist/haskell-language-server.tar.gz
-          asset_name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
-          asset_content_type: application/gzip
-
       - uses: actions/upload-artifact@v2
         with:
           name: haskell-language-server-${{ matrix.os }}-${{ github.event.release.tag_name }}.tar.gz
           path: bin/haskell-language-server.tar.gz
 
-      - if: matrix.os == 'Linux'
-        uses: actions/upload-artifact@v2
-        with:
-          name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
-          path: src-dist/haskell-language-server.tar.gz
-
   sha256sum:
-    needs: tar
+    needs: [tar, src-tar]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
     types: [created]
 
 jobs:
-
   build:
     runs-on: ${{ matrix.os }}
 
@@ -157,8 +156,8 @@ jobs:
         name: haskell-language-server-wrapper-${{ runner.OS }}${{env.EXE_EXT}}.${{ steps.compress_wrapper_binary.outputs.extension }}
         path: ${{ steps.compress_wrapper_binary.outputs.path }}
 
-  # this generates .gz tarfiles containing all the GHC versions for
-  # macOS and Linux, used by ghcup
+  # this generates .gz tarfiles containing binaries for all GHC versions and OS's
+  # and a custom tarball with sources, used by ghcup
   tar:
     needs: build
     runs-on: ubuntu-18.04
@@ -183,6 +182,14 @@ jobs:
           fi
           tar -czpf haskell-language-server.tar.gz *
 
+      - name: "Create source tarball"
+        if: matrix.os == 'Linux'
+        run: |
+          git archive --prefix=haskell-language-server-${{ github.event.release.tag_name }}/ \
+                      --format=tar.gz \
+                      -o src/haskell-language-server.tar.gz \
+                      HEAD
+
       - uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -192,10 +199,25 @@ jobs:
           asset_name: haskell-language-server-${{ matrix.os }}-${{ github.event.release.tag_name }}.tar.gz
           asset_content_type: application/gzip
 
+      - uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: src/haskell-language-server.tar.gz
+          asset_name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
+          asset_content_type: application/gzip
+
       - uses: actions/upload-artifact@v2
         with:
           name: haskell-language-server-${{ matrix.os }}-${{ github.event.release.tag_name }}.tar.gz
           path: bin/haskell-language-server.tar.gz
+
+      - if: matrix.os == 'Linux'
+        uses: actions/upload-artifact@v2
+        with:
+          name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
+          path: src/haskell-language-server.tar.gz
 
   sha256sum:
     needs: tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,13 +181,18 @@ jobs:
             gzip -d *.gz
           fi
           tar -czpf haskell-language-server.tar.gz *
-
+      
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      
       - name: "Create source tarball"
         if: matrix.os == 'Linux'
         run: |
+          mkdir src-dist
           git archive --prefix=haskell-language-server-${{ github.event.release.tag_name }}/ \
                       --format=tar.gz \
-                      -o src/haskell-language-server.tar.gz \
+                      -o src-dist/haskell-language-server.tar.gz \
                       HEAD
 
       - uses: actions/upload-release-asset@v1.0.2
@@ -204,7 +209,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: src/haskell-language-server.tar.gz
+          asset_path: src-dist/haskell-language-server.tar.gz
           asset_name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
           asset_content_type: application/gzip
 
@@ -217,7 +222,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
-          path: src/haskell-language-server.tar.gz
+          path: src-dist/haskell-language-server.tar.gz
 
   sha256sum:
     needs: tar

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -57,18 +57,24 @@ only one wrapper binary is created per platform, and it should be built with the
 most recent GHC version.
 
 ### ghcup
-It also creates a `haskell-language-server-${os}-${hlsVersion}.tar.gz` tarball with
-the binaries for *all* supported ghc versions, to help downstream publishers in
-the distribution of the release. The most prominent publisher using them is `ghcup`.
-The `tar` job in the workflow file automates the creation of this.
 
-Once all these binaries are present
+It creates a `haskell-language-server-${os}-${hlsVersion}.tar.gz` tarball with
+the binaries for *all* supported ghc versions and a custom source tarball to help
+downstream publishers in the distribution of the release.
+
+The most prominent publisher using them is `ghcup`.
+
+### checksums
+
+The sha256 checksum of all artifacts are listed in the `SHA256SUMS` release file.
 
 ## Distributable binaries
+
 In order to compile a hls binary on one machine and have it run on another, you
 need to make sure there are **no hardcoded paths or data-files**.
 
 ### ghc libdir
+
 One noteable thing which cannot be hardcoded is the **GHC libdir** – this is
 a path to `/usr/local/lib/ghc` or something like that, which was previously
 baked in at compile-time with ghc-paths. Note that with static binaries we
@@ -78,22 +84,24 @@ Therefore, hie-bios provides `getGhcRuntimeLibDir` to obtain this path on the fl
 by consulting the cradle.
 
 ### Static binaries
+
 We use the word "distributable" here because technically only the Linux builds
 are static. They are built by passing `--enable-executable-static` to cabal.
 Static binaries don't really exist on macOS, and there are issues with
 proprietary code being linked in on Windows. However, the `.dylib`s linked on
 macOS are all already provided by the system:
 
-```
+```bash
 $ objdump -macho --dylibs-used  haskell-language-server
 haskell-language-server:
-	/usr/lib/libncurses.5.4.dylib (compatibility version 5.4.0, current version 5.4.0)
-	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
-	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
-	/usr/lib/libcharset.1.dylib (compatibility version 2.0.0, current version 2.0.0)
+  /usr/lib/libncurses.5.4.dylib (compatibility version 5.4.0, current version 5.4.0)
+  /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
+  /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
+  /usr/lib/libcharset.1.dylib (compatibility version 2.0.0, current version 2.0.0)
 ```
 
 ## The GitHub Actions workflow
+
 It just kicks off a matrix of jobs varying across GHC versions and OSs, building
 the binaries with Cabal and extracting them from the dist-newstyle directory.
 The binaries are built with -O2.
@@ -120,19 +128,12 @@ its secure distribution using their hashes. We should only add new ones.*
 
 To manually upload a new binary we should:
 
-- Add the new tar/zip following the name conventions of existing ones
-  - `haskell-language-server-${os}-${ghcVersion}.gz` for `Linux` and `macOS` and `haskell-language-server-Windows-${ghcVersion}.exe.zip` for `Windows`
-  - the binary inside the gz file is named `haskell-language-server-${ghcVersion}` (with the `.exe` extension for `Windows`). Note that the binary name does not contain the `${os}` part.
-- Add the executable to the existing tar `haskell-language-server-${os}-${ghcVersion}.tar.gz` *locally* and upload it under a new name `haskell-language-server-${os}-${ghcVersion}-rev${n}.tar.gz` following the same schema for the binary as the previous one.
-  - `-rev${n}` is the next revision number of the tarball, starting at 1.
-  - we should contact users of the tarball (particularly ghcup) to notify the change
-
-### Windows
-Currently building HLS with GHC 8.8.x on Windows is very flakey and so
-is not included by default in the GitHub Actions build matrix. Instead
-they need to be built and uploaded manually. See [this
-PR](https://github.com/haskell/haskell-language-server/issues/276) for
-more details
+* Add the new tar/zip following the name conventions of existing ones
+  * `haskell-language-server-${os}-${ghcVersion}.gz` for `Linux` and `macOS` and `haskell-language-server-Windows-${ghcVersion}.exe.zip` for `Windows`
+  * the binary inside the gz file is named `haskell-language-server-${ghcVersion}` (with the `.exe` extension for `Windows`). Note that the binary name does not contain the `${os}` part.
+* Add the executable to the existing tar `haskell-language-server-${os}-${ghcVersion}.tar.gz` *locally* and upload it under a new name `haskell-language-server-${os}-${ghcVersion}-rev${n}.tar.gz` following the same schema for the binary as the previous one.
+  * `-rev${n}` is the next revision number of the tarball, starting at 1.
+  * we should contact users of the tarball (particularly ghcup) to notify the change
 
 ## Hackage release workflow
 


### PR DESCRIPTION
* In addition to artifacts automatically generated by github
* Motivation from #2216

 > * autogenerated and would depend on github not messing with the tarball layout (they did so at least twice) for the hash to be stable
 > * depend on the tag (yeah, if you force push, the hash changes too)
 > * have bad tarball names like 1.4.0.tar.gz, causing trouble for ghcup

* Moreover it could include submodules if we return to use them
* Closes #2216

//cc @hasufell 

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2248"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

