### PR TITLE
Remove custom version of operational

### DIFF
--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -53,12 +53,6 @@ source-repository-package
   subdir: dependent-sum-template
 -- https://github.com/obsidiansystems/dependent-sum/pull/59
 
--- benchmark dependency
-source-repository-package
-  type: git
-  location: https://github.com/HeinrichApfelmus/operational
-  tag: 16e19aaf34e286f3d27b3988c61040823ec66537
-
 write-ghc-environment-files: never
 
 index-state: 2021-09-16T07:00:23Z

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -55,7 +55,7 @@ source-repository-package
 
 write-ghc-environment-files: never
 
-index-state: 2021-09-16T07:00:23Z
+index-state: 2021-09-29T21:38:47Z
 
 constraints:
     -- These plugins don't work on GHC9 yet

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -36,12 +36,6 @@ source-repository-package
   tag: b6245884ae83e00dd2b5261762549b37390179f8
   -- https://github.com/lspitzner/czipwith/pull/2
 
--- benchmark dependency
-source-repository-package
-  type: git
-  location: https://github.com/HeinrichApfelmus/operational
-  tag: 16e19aaf34e286f3d27b3988c61040823ec66537
-
 -- Head of hiedb
 source-repository-package
   type: git
@@ -57,7 +51,7 @@ source-repository-package
 
 write-ghc-environment-files: never
 
-index-state: 2021-09-16T07:00:23Z
+index-state: 2021-09-29T21:38:47Z
 
 constraints:
     -- These plugins doesn't work on GHC9 yet

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -70,6 +70,14 @@ let
 
       monoid-extras = hself.monoid-extras_0_6;
 
+      # Released on hackage, but not in nixpkgs yet
+      operational = hself.callCabal2nix "operational" (pkgs.fetchFromGitHub {
+        owner = "HeinrichApfelmus";
+        repo = "operational";
+        rev = "2b33e0055066cf92a302ee2c32058dfa44ac8882";
+        sha256 = "sha256-nwB4vssm4wUTkVryjQVb3peOwR6js7vdekkbaWedHNI=";
+      }) { };
+
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =
         hself.callCabal2nixWithOptions "haskell-language-server" ./.

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -62,13 +62,6 @@ let
 
       ormolu = hself.ormolu_0_2_0_0;
 
-      operational = hself.callCabal2nix "operational" (pkgs.fetchFromGitHub {
-        owner = "HeinrichApfelmus";
-        repo = "operational";
-        rev = "16e19aaf34e286f3d27b3988c61040823ec66537";
-        sha256 = "P+aocEcqCN8klnW3IMrmIqq6ztBZJxk4sBp1ewN6YaA=";
-      }) { };
-
       diagrams-core = hself.diagrams-core_1_5_0;
 
       diagrams-lib = hself.diagrams-lib_1_4_4;

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -78,13 +78,11 @@ extra-deps:
 - Chart-1.9.3@sha256:640a38463318b070d80a049577e4f0b3322df98290abb7afcf0cb74a4ad5b512,2948
 - Chart-diagrams-1.9.3@sha256:1535d5d0d3febca63138cecfde234315212611c21bb7f4358b2dae8c55c59003,1801
 - statestack-0.3@sha256:be43ce2cd790a4732b88cdc9480458503cb5e307b4f79a502d99d5b3d417730e,1135
+- operational-0.2.4.0
 
 - github: diagrams/active
   commit: ca23431a8dfa013992f9164ccc882a3277361f17
 # https://github.com/diagrams/active/pull/36
-
-- github: HeinrichApfelmus/operational
-  commit: 16e19aaf34e286f3d27b3988c61040823ec66537
 
 # end of shake-bench dpendencies
 


### PR DESCRIPTION
* After a ghc-9.0.1 compat versions has been published in hackage (see https://github.com/HeinrichApfelmus/operational/issues/29)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2249"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

