### PR TITLE
Update installation on ArchLinux - new package

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ To install, download the `haskell-language-server-wrapper` executable for your p
 
 ## Arch Linux
 
-The preferred method of installation for development purposes is to use the [haskell-language-server-bin](https://aur.archlinux.org/packages/haskell-language-server-bin) package from AUR.
+The preferred method of installation for development purposes is to use the [haskell-language-server-static](https://aur.archlinux.org/packages/haskell-language-server-static) package from AUR.
 This package contains statically linked binaries for each supported GHC version and `haskell-language-server-wrapper` for automatic GHC version selection.
 It is updated regularly, requires no additional dependencies, and is independent of other haskell packages you may have on your system, including GHC.
 Its size is relatively large (approx. 900 MB), but if this is a problem for you, during installation you can disable the GHC versions you will not be using by editing the PKGBUILD file.


### PR DESCRIPTION
Fixes https://github.com/haskell/haskell-language-server/issues/2264

In short: the old package was for some reason removed from AUR (it wasn't updated regularly anyway), a kind (and responsive) soul took over and created a new package containing statically build HLS

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2265"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

