### PR TITLE
avoid double rebuilds for FOIs

### DIFF
--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -8,6 +8,7 @@
 --   open in the editor. The rule is 'IsFileOfInterest'
 module Development.IDE.Core.OfInterest(
     ofInterestRules,
+    getFilesOfInterest,
     getFilesOfInterestUntracked,
     addFileOfInterest,
     deleteFileOfInterest,
@@ -56,6 +57,11 @@ ofInterestRules = do
 
 ------------------------------------------------------------
 -- Exposed API
+
+getFilesOfInterest :: IdeState -> IO( HashMap NormalizedFilePath FileOfInterestStatus)
+getFilesOfInterest state = do
+    OfInterestVar var <- getIdeGlobalState state
+    readVar var
 
 -- | Set the files-of-interest - not usually necessary or advisable.
 --   The LSP client will keep this information up to date.


### PR DESCRIPTION
With VSCode I get a WatchedFile notification immediately after of the TextDocumentDidChange notification, triggering a second rebuild unnecessarily. 

To avoid this, let's filter out WatchedFile events for files of interest

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2266"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

