### PR TITLE
Expose runtime metrics via EKG

### DIFF
--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -65,11 +65,7 @@ jobs:
         run: cabal v2-build hls-graph --flags="embed-files stm-stats"
 
       - name: Build `ghcide` with flags
-        run: cabal v2-build ghcide --flags="ghc-patched-unboxed-bytecode test-exe executable bench-exe"
-
-      - if: matrix.ghc == '8.10.7'
-        name: Build `ghcide` with ekg
-        run: cabal v2-build ghcide --flags="ekg"
+        run: cabal v2-build ghcide --flags="ghc-patched-unboxed-bytecode test-exe executable bench-exe ekg"
 
       # we have to clean up warnings for 9.0 and 9.2 before enable -WAll
       - if: matrix.ghc != '9.0.2' && matrix.ghc != '9.2.2'

--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Build `ghcide` with flags
         run: cabal v2-build ghcide --flags="ghc-patched-unboxed-bytecode test-exe executable bench-exe"
 
+      - if: matrix.ghc == '8.10.7'
+        name: Build `ghcide` with ekg
+        run: cabal v2-build ghcide --flags="ekg"
+
       # we have to clean up warnings for 9.0 and 9.2 before enable -WAll
       - if: matrix.ghc != '9.0.2' && matrix.ghc != '9.2.2'
         name: Build with pedantic (-WError)

--- a/cabal.project
+++ b/cabal.project
@@ -53,7 +53,10 @@ constraints:
   ghc-lib-parser-ex -auto,
   stylish-haskell +ghc-lib
 
- source-repository-package
+-- This is benign and won't affect our ability to release to Hackage,
+-- because we only depend on `ekg-json` when a non-default flag
+-- is turned on.
+source-repository-package
   type:git
   location: https://github.com/vshabanov/ekg-json
   tag: 00ebe7211c981686e65730b7144fbf5350462608

--- a/cabal.project
+++ b/cabal.project
@@ -53,6 +53,12 @@ constraints:
   ghc-lib-parser-ex -auto,
   stylish-haskell +ghc-lib
 
+ source-repository-package
+  type:git
+  location: https://github.com/vshabanov/ekg-json
+  tag: 00ebe7211c981686e65730b7144fbf5350462608
+  -- https://github.com/tibbe/ekg-json/pull/12
+
 allow-newer:
   -- ghc-9.2
   ----------
@@ -70,3 +76,11 @@ allow-newer:
   -- for shake-bench
   Chart:lens,
   Chart-diagrams:lens,
+
+  -- for ekg
+  ekg-core:base,
+  ekg-wai:base,
+
+  -- for shake-bench
+  Chart-diagrams:diagrams-core,
+  SVGFonts:diagrams-core

--- a/cabal.project
+++ b/cabal.project
@@ -82,7 +82,9 @@ allow-newer:
 
   -- for ekg
   ekg-core:base,
+  ekg-core:ghc-prim,
   ekg-wai:base,
+  ekg-wai:time,
 
   -- for shake-bench
   Chart-diagrams:diagrams-core,

--- a/cabal.project
+++ b/cabal.project
@@ -58,8 +58,8 @@ constraints:
 -- is turned on.
 source-repository-package
   type:git
-  location: https://github.com/vshabanov/ekg-json
-  tag: 00ebe7211c981686e65730b7144fbf5350462608
+  location: https://github.com/pepeiborra/ekg-json
+  tag: 7a0af7a8fd38045fd15fb13445bdcc7085325460
   -- https://github.com/tibbe/ekg-json/pull/12
 
 allow-newer:

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -225,6 +225,35 @@ If you don't want to use [nix](https://nixos.org/guides/install-nix.html), you c
 
 See the [tutorial](./plugin-tutorial.md) on writing a plugin in HLS.
 
+## Measuring, benchmarking and tracing
+
+### Metrics
+
+HLS opens a metrics server on port 8000 exposing GC and ghcide metrics. The ghcide metrics currently exposed are:
+
+- `ghcide.values_count`- count of build results in the store
+- `ghcide.database_count` - count of build keys in the store (these two would be the same in the absence of GC)
+- `ghcide.build_count` - build count. A key is GC'ed if it is dirty and older than 100 builds
+- `ghcide.dirty_keys_count` - non transitive count of dirty build keys
+- `ghcide.indexing_pending_count` - count of items in the indexing queue
+- `ghcide.exports_map_count` - count of identifiers in the exports map.
+
+### Benchmarks
+
+If you are touching performance sensitive code, take the time to run a differential
+benchmark between HEAD and master using the benchHist script. This assumes that
+"master" points to the upstream master.
+
+Run the benchmarks with `cabal bench ghcide`.
+
+It should take around 25 minutes and the results will be stored in the `ghcide/bench-results` folder. To interpret the results, see the comments in the `ghcide/bench/hist/Main.hs` module.
+
+More details in [bench/README](../../ghcide/bench/README.md)
+
+### Tracing
+
+HLS records opentelemetry eventlog traces via [opentelemetry](https://hackage.haskell.org/package/opentelemetry). To generate the traces, build with `-eventlog` and run with `+RTS -l`. To visualize the traces, install [Tracy](https://github.com/wolfpld/tracy) and use [eventlog-to-tracy](https://hackage.haskell.org/package/opentelemetry-extra) to open the generated eventlog.
+
 ## Adding support for a new editor
 
 Adding support for new editors is fairly easy if the editor already has good support for generic LSP-based extensions.

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -252,7 +252,7 @@ More details in [bench/README](../../ghcide/bench/README.md)
 
 ### Tracing
 
-HLS records opentelemetry eventlog traces via [opentelemetry](https://hackage.haskell.org/package/opentelemetry). To generate the traces, build with `-eventlog` and run with `+RTS -l`. To visualize the traces, install [Tracy](https://github.com/wolfpld/tracy) and use [eventlog-to-tracy](https://hackage.haskell.org/package/opentelemetry-extra) to open the generated eventlog.
+HLS records opentelemetry [eventlog traces](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/runtime_control.html#rts-eventlog) via [opentelemetry](https://hackage.haskell.org/package/opentelemetry). To generate the traces, build with `-eventlog` and run with `+RTS -l`. To visualize the traces, install [Tracy](https://github.com/wolfpld/tracy) and use [eventlog-to-tracy](https://hackage.haskell.org/package/opentelemetry-extra) to open the generated eventlog.
 
 ## Adding support for a new editor
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -229,7 +229,7 @@ See the [tutorial](./plugin-tutorial.md) on writing a plugin in HLS.
 
 ### Metrics
 
-HLS opens a metrics server on port 8000 exposing GC and ghcide metrics. The ghcide metrics currently exposed are:
+When ghcide is built with the `ekg` flag, HLS opens a metrics server on port 8999 exposing GC and ghcide metrics. The ghcide metrics currently exposed are:
 
 - `ghcide.values_count`- count of build results in the store
 - `ghcide.database_count` - count of build keys in the store (these two would be the same in the absence of GC)

--- a/ghcide/.hlint.yaml
+++ b/ghcide/.hlint.yaml
@@ -111,6 +111,7 @@
     - Development.IDE.GHC.Util
     - Development.IDE.Import.FindImports
     - Development.IDE.LSP.Outline
+    - Development.IDE.Main
     - Development.IDE.Spans.Calculate
     - Development.IDE.Spans.Documentation
     - Development.IDE.Spans.Common
@@ -123,6 +124,7 @@
     - Development.IDE.Plugin.Completions.Logic
     - Development.IDE.Types.Location
     - Main
+    - Arguments
 
 - flags:
   - default: false

--- a/ghcide/.hlint.yaml
+++ b/ghcide/.hlint.yaml
@@ -111,7 +111,6 @@
     - Development.IDE.GHC.Util
     - Development.IDE.Import.FindImports
     - Development.IDE.LSP.Outline
-    - Development.IDE.Main
     - Development.IDE.Spans.Calculate
     - Development.IDE.Spans.Documentation
     - Development.IDE.Spans.Common
@@ -123,8 +122,6 @@
     - Development.IDE.Plugin.Completions
     - Development.IDE.Plugin.Completions.Logic
     - Development.IDE.Types.Location
-    - Main
-    - Arguments
 
 - flags:
   - default: false

--- a/ghcide/exe/Arguments.hs
+++ b/ghcide/exe/Arguments.hs
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE CPP #-}
 module Arguments(Arguments(..), getArguments) where
 
 import           Development.IDE      (IdeState)
@@ -19,6 +20,9 @@ data Arguments = Arguments
     ,argsVerbose                    :: Bool
     ,argsCommand                    :: Command
     ,argsConservativeChangeTracking :: Bool
+#ifdef MONITORING_EKG
+    ,argsMonitoringPort             :: Int
+#endif
     }
 
 getArguments :: IdePlugins IdeState -> IO Arguments
@@ -40,6 +44,9 @@ arguments plugins = Arguments
       <*> switch (short 'd' <> long "verbose" <> help "Include internal events in logging output")
       <*> (commandP plugins <|> lspCommand <|> checkCommand)
       <*> switch (long "conservative-change-tracking" <> help "disable reactive change tracking (for testing/debugging)")
+#ifdef MONITORING_EKG
+      <*> option auto (long "monitoring-port" <> metavar "PORT" <> value 8999 <> showDefault <> help "Port to use for monitoring")
+#endif
       where
           checkCommand = Check <$> many (argument str (metavar "FILES/DIRS..."))
           lspCommand = LSP <$ flag' True (long "lsp" <> help "Start talking to an LSP client")

--- a/ghcide/exe/Arguments.hs
+++ b/ghcide/exe/Arguments.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE CPP #-}
 module Arguments(Arguments(..), getArguments) where
 
 import           Development.IDE      (IdeState)
@@ -20,9 +19,7 @@ data Arguments = Arguments
     ,argsVerbose                    :: Bool
     ,argsCommand                    :: Command
     ,argsConservativeChangeTracking :: Bool
-#ifdef MONITORING_EKG
     ,argsMonitoringPort             :: Int
-#endif
     }
 
 getArguments :: IdePlugins IdeState -> IO Arguments
@@ -44,9 +41,7 @@ arguments plugins = Arguments
       <*> switch (short 'd' <> long "verbose" <> help "Include internal events in logging output")
       <*> (commandP plugins <|> lspCommand <|> checkCommand)
       <*> switch (long "conservative-change-tracking" <> help "disable reactive change tracking (for testing/debugging)")
-#ifdef MONITORING_EKG
-      <*> option auto (long "monitoring-port" <> metavar "PORT" <> value 8999 <> showDefault <> help "Port to use for monitoring")
-#endif
+      <*> option auto (long "monitoring-port" <> metavar "PORT" <> value 8999 <> showDefault <> help "Port to use for EKG monitoring (if the binary is built with EKG)")
       where
           checkCommand = Check <$> many (argument str (metavar "FILES/DIRS..."))
           lspCommand = LSP <$ flag' True (long "lsp" <> help "Start talking to an LSP client")

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -149,8 +149,5 @@ main = withTelemetryLogger $ \telemetryLogger -> do
                 }
 #ifdef MONITORING_EKG
         , IDEMain.argsMonitoring = OpenTelemetry.monitoring <> EKG.monitoring logger argsMonitoringPort
-#ifdef MONITORING_EKG
 #endif
-#endif
-
         }

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -Wno-dodgy-imports #-} -- GHC no longer exports def in GHC 8.6 and above
-{-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Main(main) where
@@ -20,6 +19,8 @@ import           Development.IDE.Core.Rules        (mainRule)
 import qualified Development.IDE.Core.Rules        as Rules
 import           Development.IDE.Core.Tracing      (withTelemetryLogger)
 import qualified Development.IDE.Main              as IDEMain
+import qualified Development.IDE.Monitoring.OpenTelemetry as OpenTelemetry
+import qualified Development.IDE.Monitoring.EKG    as EKG
 import qualified Development.IDE.Plugin.HLS.GhcIde as GhcIde
 import           Development.IDE.Types.Logger      (Logger (Logger),
                                                     LoggingColumn (DataColumn, PriorityColumn),
@@ -42,11 +43,6 @@ import           System.Environment                (getExecutablePath)
 import           System.Exit                       (exitSuccess)
 import           System.IO                         (hPutStrLn, stderr)
 import           System.Info                       (compilerVersion)
-
-#ifdef MONITORING_EKG
-import qualified Development.IDE.Monitoring.OpenTelemetry as OpenTelemetry
-import qualified Development.IDE.Monitoring.EKG as EKG
-#endif
 
 data Log
   = LogIDEMain IDEMain.Log
@@ -147,7 +143,5 @@ main = withTelemetryLogger $ \telemetryLogger -> do
                 , optCheckProject = pure $ checkProject config
                 , optRunSubset = not argsConservativeChangeTracking
                 }
-#ifdef MONITORING_EKG
         , IDEMain.argsMonitoring = OpenTelemetry.monitoring <> EKG.monitoring logger argsMonitoringPort
-#endif
         }

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -48,6 +48,8 @@ library
         dependent-map,
         dependent-sum,
         dlist,
+        ekg-wai,
+        ekg-core,
         exceptions,
         extra >= 1.7.4,
         enummapset,

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -30,6 +30,11 @@ flag ghc-patched-unboxed-bytecode
     default:     False
     manual:      True
 
+flag ekg
+    description: Enable EKG monitoring of the build graph and other metrics on port 8999
+    default:     False
+    manual:      True
+
 library
     default-language:   Haskell2010
     build-depends:
@@ -48,8 +53,6 @@ library
         dependent-map,
         dependent-sum,
         dlist,
-        ekg-wai,
-        ekg-core,
         exceptions,
         extra >= 1.7.4,
         enummapset,
@@ -200,6 +203,8 @@ library
         Development.IDE.Types.KnownTargets
         Development.IDE.Types.Location
         Development.IDE.Types.Logger
+        Development.IDE.Types.Monitoring
+        Development.IDE.Monitoring.OpenTelemetry
         Development.IDE.Types.Options
         Development.IDE.Types.Shake
         Development.IDE.Plugin
@@ -237,6 +242,14 @@ library
     if impl(ghc < 8.10)
       exposed-modules:
         Development.IDE.GHC.Compat.CPP
+
+    if flag(ekg)
+        build-depends:
+            ekg-wai,
+            ekg-core,
+        cpp-options:   -DMONITORING_EKG
+        exposed-modules:
+            Development.IDE.Monitoring.EKG
 
 flag test-exe
     description: Build the ghcide-test-preprocessor executable
@@ -358,6 +371,11 @@ executable ghcide
 
     if !flag(executable)
         buildable: False
+    if flag(ekg)
+        build-depends:
+            ekg-wai,
+            ekg-core,
+        cpp-options:   -DMONITORING_EKG
 
 test-suite ghcide-tests
     type: exitcode-stdio-1.0

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -187,6 +187,7 @@ library
         Development.IDE.GHC.Util
         Development.IDE.Import.DependencyInformation
         Development.IDE.Import.FindImports
+        Development.IDE.Monitoring.EKG
         Development.IDE.LSP.HoverDefinition
         Development.IDE.LSP.LanguageServer
         Development.IDE.LSP.Outline
@@ -248,8 +249,6 @@ library
             ekg-wai,
             ekg-core,
         cpp-options:   -DMONITORING_EKG
-        exposed-modules:
-            Development.IDE.Monitoring.EKG
 
 flag test-exe
     description: Build the ghcide-test-preprocessor executable

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -38,10 +38,11 @@ import           Control.Monad
 import qualified Development.IDE.Core.FileExists as FileExists
 import qualified Development.IDE.Core.OfInterest as OfInterest
 import           Development.IDE.Core.Shake      hiding (Log)
+import           Development.IDE.Core.Shake
 import qualified Development.IDE.Core.Shake      as Shake
 import           Development.IDE.Types.Shake     (WithHieDb)
 import           System.Environment              (lookupEnv)
-
+import           System.Metrics
 
 data Log
   = LogShake Shake.Log
@@ -68,8 +69,9 @@ initialise :: Recorder (WithPriority Log)
            -> IdeOptions
            -> WithHieDb
            -> IndexQueue
+           -> Maybe Store
            -> IO IdeState
-initialise recorder defaultConfig mainRule lspEnv logger debouncer options withHieDb hiedbChan = do
+initialise recorder defaultConfig mainRule lspEnv logger debouncer options withHieDb hiedbChan metrics = do
     shakeProfiling <- do
         let fromConf = optShakeProfiling options
         fromEnv <- lookupEnv "GHCIDE_BUILD_PROFILING"
@@ -86,6 +88,7 @@ initialise recorder defaultConfig mainRule lspEnv logger debouncer options withH
         withHieDb
         hiedbChan
         (optShakeOptions options)
+        metrics
           $ do
             addIdeGlobal $ GlobalIdeOptions options
             ofInterestRules (cmapWithPrio LogOfInterest recorder)

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -18,30 +18,30 @@ module Development.IDE.Core.Service(
     Log(..),
     ) where
 
-import           Control.Applicative             ((<|>))
+import           Control.Applicative              ((<|>))
 import           Development.IDE.Core.Debouncer
-import           Development.IDE.Core.FileExists (fileExistsRules)
-import           Development.IDE.Core.OfInterest hiding (Log, LogShake)
+import           Development.IDE.Core.FileExists  (fileExistsRules)
+import           Development.IDE.Core.OfInterest  hiding (Log, LogShake)
 import           Development.IDE.Graph
-import           Development.IDE.Types.Logger    as Logger (Logger,
-                                                            Pretty (pretty),
-                                                            Priority (Debug),
-                                                            Recorder,
-                                                            WithPriority,
-                                                            cmapWithPrio)
-import           Development.IDE.Types.Options   (IdeOptions (..))
+import           Development.IDE.Types.Logger     as Logger (Logger,
+                                                             Pretty (pretty),
+                                                             Priority (Debug),
+                                                             Recorder,
+                                                             WithPriority,
+                                                             cmapWithPrio)
+import           Development.IDE.Types.Options    (IdeOptions (..))
 import           Ide.Plugin.Config
-import qualified Language.LSP.Server             as LSP
-import qualified Language.LSP.Types              as LSP
+import qualified Language.LSP.Server              as LSP
+import qualified Language.LSP.Types               as LSP
 
 import           Control.Monad
-import qualified Development.IDE.Core.FileExists as FileExists
-import qualified Development.IDE.Core.OfInterest as OfInterest
-import           Development.IDE.Core.Shake      hiding (Log)
-import qualified Development.IDE.Core.Shake      as Shake
-import           Development.IDE.Types.Shake     (WithHieDb)
-import           System.Environment              (lookupEnv)
-import           System.Metrics
+import qualified Development.IDE.Core.FileExists  as FileExists
+import qualified Development.IDE.Core.OfInterest  as OfInterest
+import           Development.IDE.Core.Shake       hiding (Log)
+import qualified Development.IDE.Core.Shake       as Shake
+import           Development.IDE.Types.Monitoring (Monitoring)
+import           Development.IDE.Types.Shake      (WithHieDb)
+import           System.Environment               (lookupEnv)
 
 data Log
   = LogShake Shake.Log
@@ -68,7 +68,7 @@ initialise :: Recorder (WithPriority Log)
            -> IdeOptions
            -> WithHieDb
            -> IndexQueue
-           -> Maybe Store
+           -> Monitoring
            -> IO IdeState
 initialise recorder defaultConfig mainRule lspEnv logger debouncer options withHieDb hiedbChan metrics = do
     shakeProfiling <- do

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -38,7 +38,6 @@ import           Control.Monad
 import qualified Development.IDE.Core.FileExists as FileExists
 import qualified Development.IDE.Core.OfInterest as OfInterest
 import           Development.IDE.Core.Shake      hiding (Log)
-import           Development.IDE.Core.Shake
 import qualified Development.IDE.Core.Shake      as Shake
 import           Development.IDE.Types.Shake     (WithHieDb)
 import           System.Environment              (lookupEnv)

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -363,6 +363,7 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
                     log Warning LogOnlyPartialGhc9Support
                 server <- fmap join $ for argsMonitoringPort $ \p -> do
                     store <- Monitoring.newStore
+                    Monitoring.registerGcMetrics store
                     let startServer = Monitoring.forkServerWith store "localhost" (fromIntegral p)
                     -- this can fail if the port is busy, throwing an async exception back to us
                     -- to handle that, wrap the server thread in an async

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP            #-}
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Development.IDE.Main
@@ -63,6 +62,9 @@ import           Development.IDE.LSP.LanguageServer    (runLanguageServer)
 import qualified Development.IDE.LSP.LanguageServer    as LanguageServer
 import           Development.IDE.Main.HeapStats        (withHeapStats)
 import qualified Development.IDE.Main.HeapStats        as HeapStats
+import           Development.IDE.Types.Monitoring      (Monitoring)
+import qualified Development.IDE.Monitoring.EKG as EKG
+import qualified Development.IDE.Monitoring.OpenTelemetry as OpenTelemetry
 import           Development.IDE.Plugin                (Plugin (pluginHandlers, pluginModifyDynflags, pluginRules))
 import           Development.IDE.Plugin.HLS            (asGhcIdePlugin)
 import qualified Development.IDE.Plugin.HLS            as PluginHLS
@@ -130,12 +132,6 @@ import           System.Random                         (newStdGen)
 import           System.Time.Extra                     (Seconds, offsetTime,
                                                         showDuration)
 import           Text.Printf                           (printf)
-import Development.IDE.Types.Monitoring (Monitoring)
-import qualified Development.IDE.Monitoring.OpenTelemetry as OpenTelemetry
-
-#ifdef MONITORING_EKG
-import qualified Development.IDE.Monitoring.EKG as EKG
-#endif
 
 data Log
   = LogHeapStats !HeapStats.Log
@@ -275,10 +271,7 @@ defaultArguments recorder logger = Arguments
                 -- the language server tests without the redirection.
                 putStr " " >> hFlush stdout
                 return newStdout
-        , argsMonitoring = OpenTelemetry.monitoring
-#ifdef MONITORING_EKG
-                        <> EKG.monitoring logger 8999
-#endif
+        , argsMonitoring = OpenTelemetry.monitoring <> EKG.monitoring logger 8999
         }
 
 

--- a/ghcide/src/Development/IDE/Monitoring/EKG.hs
+++ b/ghcide/src/Development/IDE/Monitoring/EKG.hs
@@ -13,7 +13,7 @@ monitoring :: Logger -> Int -> IO Monitoring
 monitoring logger port = do
     store <- Monitoring.newStore
     Monitoring.registerGcMetrics store
-    let registerCounter name read = Monitoring.registerGauge name read store
+    let registerCounter name read = Monitoring.registerCounter name read store
         registerGauge name read = Monitoring.registerGauge name read store
         start = do
             server <- do

--- a/ghcide/src/Development/IDE/Monitoring/EKG.hs
+++ b/ghcide/src/Development/IDE/Monitoring/EKG.hs
@@ -1,6 +1,7 @@
 module Development.IDE.Monitoring.EKG(monitoring) where
 import           Control.Concurrent               (killThread)
 import           Control.Concurrent.Async         (async, waitCatch)
+import           Control.Monad                    (forM_)
 import           Data.Text                        (pack)
 import           Development.IDE.Types.Logger     (Logger, logInfo)
 import           Development.IDE.Types.Monitoring (Monitoring (..))
@@ -30,5 +31,7 @@ monitoring logger port = do
                             "Unable to bind monitoring server on port "
                             <> show port <> ":" <> show e
                         return Nothing
-            return $ mapM_ (killThread . Monitoring.serverThreadId) server
+            return $ forM_ server $ \s -> do
+                logInfo logger "Stopping monitoring server"
+                killThread $ Monitoring.serverThreadId s
     return $ Monitoring {..}

--- a/ghcide/src/Development/IDE/Monitoring/EKG.hs
+++ b/ghcide/src/Development/IDE/Monitoring/EKG.hs
@@ -1,0 +1,34 @@
+module Development.IDE.Monitoring.EKG(monitoring) where
+import           Control.Concurrent               (killThread)
+import           Control.Concurrent.Async         (async, waitCatch)
+import           Data.Text                        (pack)
+import           Development.IDE.Types.Logger     (Logger, logInfo)
+import           Development.IDE.Types.Monitoring (Monitoring (..))
+import qualified System.Metrics                   as Monitoring
+import qualified System.Remote.Monitoring.Wai     as Monitoring
+
+-- | Monitoring using EKG
+monitoring :: Logger -> Int -> IO Monitoring
+monitoring logger port = do
+    store <- Monitoring.newStore
+    Monitoring.registerGcMetrics store
+    let registerCounter name read = Monitoring.registerGauge name read store
+        registerGauge name read = Monitoring.registerGauge name read store
+        start = do
+            server <- do
+                let startServer = Monitoring.forkServerWith store "localhost" port
+                -- this can fail if the port is busy, throwing an async exception back to us
+                -- to handle that, wrap the server thread in an async
+                mb_server <- async startServer >>= waitCatch
+                case mb_server of
+                    Right s -> do
+                        logInfo logger $ pack $
+                            "Started monitoring server on port " <> show port
+                        return $ Just s
+                    Left e -> do
+                        logInfo logger $ pack $
+                            "Unable to bind monitoring server on port "
+                            <> show port <> ":" <> show e
+                        return Nothing
+            return $ mapM_ (killThread . Monitoring.serverThreadId) server
+    return $ Monitoring {..}

--- a/ghcide/src/Development/IDE/Monitoring/EKG.hs
+++ b/ghcide/src/Development/IDE/Monitoring/EKG.hs
@@ -1,12 +1,16 @@
+{-# LANGUAGE CPP #-}
 module Development.IDE.Monitoring.EKG(monitoring) where
+
+import           Development.IDE.Types.Monitoring (Monitoring (..))
+import           Development.IDE.Types.Logger     (Logger)
+#ifdef MONITORING_EKG
 import           Control.Concurrent               (killThread)
 import           Control.Concurrent.Async         (async, waitCatch)
 import           Control.Monad                    (forM_)
 import           Data.Text                        (pack)
-import           Development.IDE.Types.Logger     (Logger, logInfo)
-import           Development.IDE.Types.Monitoring (Monitoring (..))
-import qualified System.Metrics                   as Monitoring
+import           Development.IDE.Types.Logger     (logInfo)
 import qualified System.Remote.Monitoring.Wai     as Monitoring
+import qualified System.Metrics                   as Monitoring
 
 -- | Monitoring using EKG
 monitoring :: Logger -> Int -> IO Monitoring
@@ -35,3 +39,10 @@ monitoring logger port = do
                 logInfo logger "Stopping monitoring server"
                 killThread $ Monitoring.serverThreadId s
     return $ Monitoring {..}
+
+#else
+
+monitoring :: Logger -> Int -> IO Monitoring
+monitoring _ _ = mempty
+
+#endif

--- a/ghcide/src/Development/IDE/Monitoring/OpenTelemetry.hs
+++ b/ghcide/src/Development/IDE/Monitoring/OpenTelemetry.hs
@@ -1,0 +1,31 @@
+module Development.IDE.Monitoring.OpenTelemetry (monitoring) where
+
+import           Control.Concurrent.Async         (Async, async, cancel)
+import           Control.Monad                    (forever)
+import           Data.IORef.Extra                 (atomicModifyIORef'_,
+                                                   newIORef, readIORef)
+import           Data.Text.Encoding               (encodeUtf8)
+import           Debug.Trace.Flags                (userTracingEnabled)
+import           Development.IDE.Types.Monitoring (Monitoring (..))
+import           OpenTelemetry.Eventlog           (mkValueObserver, observe)
+import           System.Time.Extra                (Seconds, sleep)
+
+-- | Dump monitoring to the eventlog using the Opentelemetry package
+monitoring :: IO Monitoring
+monitoring
+  | userTracingEnabled = do
+    actions <- newIORef []
+    let registerCounter name read = do
+            observer <- mkValueObserver (encodeUtf8 name)
+            let update = observe observer . fromIntegral =<< read
+            atomicModifyIORef'_ actions (update :)
+        registerGauge = registerCounter
+    let start = do
+            a <- regularly 1 $ sequence_ =<< readIORef actions
+            return (cancel a)
+    return Monitoring{..}
+  | otherwise = mempty
+
+
+regularly :: Seconds -> IO () -> IO (Async ())
+regularly delay act = async $ forever (act >> sleep delay)

--- a/ghcide/src/Development/IDE/Types/Monitoring.hs
+++ b/ghcide/src/Development/IDE/Types/Monitoring.hs
@@ -1,0 +1,30 @@
+module Development.IDE.Types.Monitoring
+(Monitoring(..)
+) where
+
+import           Data.Int
+import           Data.Text                (Text)
+
+-- | An abstraction for runtime monitoring.
+data Monitoring = Monitoring {
+    registerGauge   :: Text -> IO Int64 -> IO (),
+    registerCounter :: Text -> IO Int64 -> IO (),
+    start :: IO (IO ())
+  }
+
+instance Semigroup Monitoring where
+    a <> b = Monitoring {
+        registerGauge   = \n v -> registerGauge a n v >> registerGauge b n v,
+        registerCounter = \n v -> registerCounter a n v >> registerCounter b n v,
+        start = do
+            a' <- start a
+            b' <- start b
+            return $ a' >> b'
+      }
+
+instance Monoid Monitoring where
+    mempty = Monitoring {
+        registerGauge   = \_ _ -> return (),
+        registerCounter = \_ _ -> return (),
+        start = return $ return ()
+      }

--- a/ghcide/src/Development/IDE/Types/Monitoring.hs
+++ b/ghcide/src/Development/IDE/Types/Monitoring.hs
@@ -5,9 +5,11 @@ module Development.IDE.Types.Monitoring
 import           Data.Int
 import           Data.Text                (Text)
 
--- | An abstraction for runtime monitoring.
+-- | An abstraction for runtime monitoring inspired by the 'ekg' package
 data Monitoring = Monitoring {
+    -- | Register an integer-valued metric.
     registerGauge   :: Text -> IO Int64 -> IO (),
+    -- | Register a non-negative, monotonically increasing, integer-valued metric.
     registerCounter :: Text -> IO Int64 -> IO (),
     start :: IO (IO ())
   }

--- a/ghcide/src/Development/IDE/Types/Monitoring.hs
+++ b/ghcide/src/Development/IDE/Types/Monitoring.hs
@@ -11,7 +11,7 @@ data Monitoring = Monitoring {
     registerGauge   :: Text -> IO Int64 -> IO (),
     -- | Register a non-negative, monotonically increasing, integer-valued metric.
     registerCounter :: Text -> IO Int64 -> IO (),
-    start :: IO (IO ())
+    start :: IO (IO ()) -- ^ Start the monitoring system, returning an action which will stop the system.
   }
 
 instance Semigroup Monitoring where

--- a/hls-graph/src/Development/IDE/Graph/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Database.hs
@@ -9,6 +9,7 @@ module Development.IDE.Graph.Database(
     shakeRunDatabaseForKeys,
     shakeProfileDatabase,
     shakeGetBuildStep,
+    shakeGetDatabaseKeys,
     shakeGetDirtySet,
     shakeGetCleanKeys
     ,shakeGetBuildEdges) where
@@ -79,3 +80,8 @@ shakeGetBuildEdges (ShakeDatabase _ _ db) = do
     keys <- getDatabaseValues db
     let ress = mapMaybe (getResult . snd) keys
     return $ sum $ map (length . getResultDepsDefault [] . resultDeps) ress
+
+-- | Returns an approximation of the database keys,
+--   annotated with how long ago (in # builds) they were visited
+shakeGetDatabaseKeys :: ShakeDatabase -> IO [(Key, Int)]
+shakeGetDatabaseKeys (ShakeDatabase _ _ db) = getKeysAndVisitAge db

--- a/hls-graph/src/Development/IDE/Graph/Internal/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Database.hs
@@ -199,7 +199,7 @@ getDirtySet db = do
         calcAgeStatus _         = Nothing
     return $ mapMaybe (secondM calcAgeStatus) dbContents
 
--- | Returns ann approximation of the database keys,
+-- | Returns an approximation of the database keys,
 --   annotated with how long ago (in # builds) they were visited
 getKeysAndVisitAge :: Database -> IO [(Key, Int)]
 getKeysAndVisitAge db = do


### PR DESCRIPTION
Install a metrics server at port 8000 via EKG with the following metrics:

- `ghcide.values_count`- count of build results in the store
- `ghcide.database_count` - count of build keys in the store (these two would be the same in the absence of GC)
- `ghcide.build_count` - build count. A key is GC'ed if it is dirty and older than 100 builds
- `ghcide.dirty_keys_count` - non transitive count of dirty build keys
- `ghcide.indexing_pending_count` - count of items in the indexing queue
- `ghcide.exports_map_count` - count of identifiers in the exports map.


Unfortunately the EKG packages need allow-newer entries for GHC 9. This is also the case for the snap-server packages and dependencies. Since it doesn't look like these are getting resolved in Hackage any time soon, let's hold back on merging this PR for now

Upstream issues:
- https://github.com/tibbe/ekg/issues/85
- https://github.com/tvh/ekg-wai/issues/6

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2267"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

