### PR TITLE
Fix excessive interface recompilation caused by the Tactics plugin

### DIFF
--- a/plugins/hls-tactics-plugin/src/Wingman/StaticPlugin.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/StaticPlugin.hs
@@ -13,6 +13,7 @@ import Development.IDE.GHC.Compat.Util
 import GHC.LanguageExtensions.Type (Extension(EmptyCase, QuasiQuotes))
 import Generics.SYB
 import Ide.Types
+import Plugins (purePlugin)
 
 staticPlugin :: DynFlagsModifications
 staticPlugin = mempty
@@ -66,8 +67,12 @@ allowEmptyCaseButWithWarning =
 #if __GLASGOW_HASKELL__ >= 808
 metaprogrammingPlugin :: StaticPlugin
 metaprogrammingPlugin =
-    StaticPlugin $ PluginWithArgs (defaultPlugin { parsedResultAction = worker })  []
+    StaticPlugin $ PluginWithArgs pluginDefinition  []
   where
+    pluginDefinition = defaultPlugin
+        { parsedResultAction = worker
+        , pluginRecompile = purePlugin
+        }
     worker :: Monad m => [CommandLineOption] -> ModSummary -> HsParsedModule -> m HsParsedModule
     worker _ _ pm = pure $ pm { hpm_module = addMetaprogrammingSyntax $ hpm_module pm }
 #endif


### PR DESCRIPTION
The Tactics HLS plugin installs a GHC plugin that forces the recompilation checker to bail out, since the plugin uses the default "RecompileAlways" strategy. 

As found in #2151 this is very bad, causing `.hi` and `.hie` files to be regenerated unnecessarily, indexed, etc.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2282"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

