### PR TITLE
Update link to supported platforms by ghcup

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,7 @@ If you are using [`ghcup`](https://www.haskell.org/ghcup/) to manage your instal
 ghcup install hls
 ```
 
-You can check if HLS is available for your platorm via ghcup here: <https://gitlab.haskell.org/haskell/ghcup-hs#supported-platforms>.
+You can check if HLS is available for your platorm via ghcup here: <https://haskell.org/ghcup/install/#supported-platforms>.
 
 You can also install HLS from source without checking out the code manually:
 ```bash


### PR DESCRIPTION
`ghcup` documentation moved entirely to the haskell.org website. So I noticed that the previous link to supported platforms doesn't work anymore.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2293"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

