### PR TITLE
[hls-graph] clean up databaseDirtySet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,6 @@ jobs:
   test:
     needs: pre_job
     runs-on: ${{ matrix.os }}
-    env:
-      XDG_CACHE_HOME: ${{ runner.temp }}/cache
     strategy:
       fail-fast: true
       matrix:
@@ -141,8 +139,9 @@ jobs:
                      src/**/*.hs exe/*.hs
 
       # this is only safe if the test environment is isolated
-      - name: clean ide cache
+      - name: setup ide cache
         run: |
+          export XDG_CACHE_HOME=$RUNNER_TEMP/cache
           rm -rf ~/.cache/ghcide
           rm -rf ~/.cache/hie-bios
           rm -rf $XDG_CACHE_HOME/ghcide


### PR DESCRIPTION
Another spinoff from #2263 to clean up some of the dirty keys code in his-graph.

When I ported https://github.com/ndmitchell/shake/pull/802/files to hls-graph, I changed the encoding of the dirty set. Instead, `Dirty` became a constructor in the `Status` union. But the `databaseDirtySet` stayed around accidentally, leading to some confusion.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2294"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

