### PR TITLE
Fix reverse dep. tracking for alwaysRerun rules

### DIFF
--- a/hls-graph/src/Development/IDE/Graph/Internal/Action.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Action.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE ConstraintKinds #-}
 
 module Development.IDE.Graph.Internal.Action
 ( ShakeValue
@@ -19,23 +19,23 @@ module Development.IDE.Graph.Internal.Action
 
 import           Control.Concurrent.Async
 import           Control.Exception
-import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
 import           Data.IORef
 import           Development.IDE.Graph.Classes
 import           Development.IDE.Graph.Internal.Database
+import           Development.IDE.Graph.Internal.Rules    (RuleResult)
 import           Development.IDE.Graph.Internal.Types
 import           System.Exit
-import Development.IDE.Graph.Internal.Rules (RuleResult)
 
 type ShakeValue a = (Show a, Typeable a, Eq a, Hashable a, NFData a)
 
+-- | Always rerun this rule when dirty, regardless of the dependencies.
 alwaysRerun :: Action ()
 alwaysRerun = do
     ref <- Action $ asks actionDeps
-    liftIO $ writeIORef ref Nothing
+    liftIO $ modifyIORef ref (AlwaysRerunDeps [] <>)
 
 -- No-op for now
 reschedule :: Double -> Action ()
@@ -48,23 +48,23 @@ parallel xs = do
     a <- Action ask
     deps <- liftIO $ readIORef $ actionDeps a
     case deps of
-        Nothing ->
+        UnknownDeps ->
             -- if we are already in the rerun mode, nothing we do is going to impact our state
             liftIO $ mapConcurrently (ignoreState a) xs
-        Just deps -> do
+        deps -> do
             (newDeps, res) <- liftIO $ unzip <$> mapConcurrently (usingState a) xs
-            liftIO $ writeIORef (actionDeps a) $ (deps ++) <$> concatMapM id newDeps
+            liftIO $ writeIORef (actionDeps a) $ mconcat $ deps : newDeps
             pure res
     where
         usingState a x = do
-            ref <- newIORef $ Just []
+            ref <- newIORef mempty
             res <- runReaderT (fromAction x) a{actionDeps=ref}
             deps <- readIORef ref
             pure (deps, res)
 
 ignoreState :: SAction -> Action b -> IO b
 ignoreState a x = do
-    ref <- newIORef Nothing
+    ref <- newIORef mempty
     runReaderT (fromAction x) a{actionDeps=ref}
 
 actionFork :: Action a -> (Async a -> Action b) -> Action b
@@ -73,7 +73,7 @@ actionFork act k = do
     deps <- liftIO $ readIORef $ actionDeps a
     let db = actionDatabase a
     case deps of
-        Nothing -> do
+        UnknownDeps -> do
             -- if we are already in the rerun mode, nothing we do is going to impact our state
             [res] <- liftIO $ withAsync (ignoreState a act) $ \as -> runActions db [k as]
             return res
@@ -116,12 +116,10 @@ apply ks = do
     db <- Action $ asks actionDatabase
     (is, vs) <- liftIO $ build db ks
     ref <- Action $ asks actionDeps
-    deps <- liftIO $ readIORef ref
-    whenJust deps $ \deps ->
-        liftIO $ writeIORef ref $ Just $ is ++ deps
+    liftIO $ modifyIORef ref (ResultDeps is <>)
     pure vs
 
 runActions :: Database -> [Action a] -> IO [a]
 runActions db xs = do
-    deps <- newIORef Nothing
+    deps <- newIORef mempty
     runReaderT (fromAction $ parallel xs) $ SAction db deps


### PR DESCRIPTION
When I ported reverse dependencies from Shake[1] I missed an important
detail. While Shake models `alwaysRerun` as a dependency on an actual rule
(AlwaysRerun), hls-graph models it by setting `actionDeps` to
`Nothing`. This is important difference - it means dependencies are not computed for
these rules, and therefore reverse dependency tracking doesn't do
anything, which breaks correctness of dirty rebuilds.

This commit adds dependency tracking for `alwaysRerun` rules, and fixes
reverse dependency tracking. The alternative would be to follow the
Shake approach but I'm not sure what other implications this might have.

[1] - https://github.com/ndmitchell/shake/pull/802

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2298"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

