### PR TITLE
Remove step `setup ide cache` after checking cache dirs are empty in each run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,20 +138,6 @@ jobs:
           sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
                      src/**/*.hs exe/*.hs
 
-      # this is only safe if the test environment is isolated
-      - name: setup ide cache
-        run: |
-          set +e
-          export XDG_CACHE_HOME=$RUNNER_TEMP/cache
-          ls -la ~/.cache/ghcide
-          ls -la ~/.cache/hie-bios
-          ls -la $XDG_CACHE_HOME/ghcide
-          ls -la $XDG_CACHE_HOME/hie-bios
-          rm -rf ~/.cache/ghcide
-          rm -rf ~/.cache/hie-bios
-          rm -rf $XDG_CACHE_HOME/ghcide
-          rm -rf $XDG_CACHE_HOME/hie-bios
-
       - if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
         name: Build
         # Retry it three times to workaround compiler segfaults in windows


### PR DESCRIPTION
* From https://github.com/haskell/haskell-language-server/pull/2294#discussion_r736345131

> jobs should start in a clean state, the unique cache which should be restored is the explicit one in the workflow, did you check those folders were populated with info?

Will check in this pr and then remove the job step as afaiu it is not neccessary. Let me know if you know os supect there is some way to make those dirs persist between jobs (without a explicit cache step)

Workflow checking dirs: https://github.com/haskell/haskell-language-server/runs/4008204940

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2305"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

