### PR TITLE
[skip ci] Separate features from demos

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -13,7 +13,7 @@ You can watch demos for some of these features [below](#demos).
 - [Integration with](#retrie-integration) [retrie](https://hackage.haskell.org/package/retrie), a powerful, easy-to-use codemodding tool
 - [Code lenses for explicit import lists](#explicit-import-lists)
 - [Generate functions from type signatures, and intelligently complete holes](#wingman) using [Wingman (tactics)](https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-tactics-plugin)
-- [Integration with](#hlint) [hlint](https://github.com/ndmitchell/hlint), the most used haskell linter, to show diagnostics and apply hints via [apply-refact](https://github.com/mpickering/apply-refact)
+- [Integration](#hlint) with [hlint](https://github.com/ndmitchell/hlint), the most used haskell linter, to show diagnostics and apply hints via [apply-refact](https://github.com/mpickering/apply-refact)
 - [Module name suggestions](#module-names) for insertion or correction
 - [Call hierarchy support](#call-hierarchy)
 


### PR DESCRIPTION
* Correlated pr in vscode: https://github.com/haskell/vscode-haskell/pull/491
* As commented with @michaelpj there we will remove demos from vscode and the readme will link this one

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2307"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

