### PR TITLE
Gives post jobs unique ids

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -154,7 +154,7 @@ jobs:
            ghcide/bench-results/**/*.eventlog
            ghcide/bench-results/**/*.hp
 
-  post_job:
+  bench_summary:
     if: always()
     runs-on: ubuntu-latest
     needs: [pre_job, bench_init, bench_example]

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -102,7 +102,7 @@ jobs:
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server
 
-  post_job:
+  nix_summary:
     if: always()
     runs-on: ubuntu-latest
     needs: [pre_job, develop, build]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
         name: Test hls-hlint-plugin test suite
         run: cabal test hls-hlint-plugin --test-options="-j1 --rerun-update" || cabal test hls-hlint-plugin --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-hlint-plugin --test-options="-j1 --rerun"
 
-  post_job:
+  test_summary:
     if: always()
     runs-on: ubuntu-latest
     needs: [pre_job, test]


### PR DESCRIPTION
* After merging #2297 i've checked the three post_job jobs are not listed for include as required checks, only there is one post_job
* Not sure if it is one of three but each workflow should have its own post_job so this pr gives unique ids to three jobs

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

