### PR TITLE
[skip circleci] Add option to effectively cancel prev runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,9 @@ defaults:
   run:
     shell: bash
 
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,13 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.0
         with:
-          cancel_others: true
+          cancel_others: false
           paths_ignore: '["**/docs/**", "**.md", "**/LICENSE", "install/**", "**.nix", "flake.lock", "**/README.md", "FUNDING.yml"]'
       # If we only change ghcide downstream packages we have not test ghcide itself
       - id: skip_ghcide_check
         uses: fkirc/skip-duplicate-actions@v3.4.0
         with:
+          cancel_others: false
           paths_ignore: '["hls-test-utils/**", "plugins/**", "src/**", "exe/**", "test/**", "shake-bench/**"]'
       - if: steps.skip_check.outputs.should_skip == 'true'
         name: Skip circleci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ defaults:
   run:
     shell: bash
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
* Without using skip-duplicate-actions which is failing due to github access permission. 
* See https://github.com/fkirc/skip-duplicate-actions/issues/103 and https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency
* We can keep skip-duplicate-actions, as it is cancelling and skipping using other criteria. But i suspect it can only cancel others if the branch source of the pr belongs to this repo

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2310"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

