### PR TITLE
Nix: Add HLS as buildInput (flake, nix-shell)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -206,6 +206,7 @@
                 # ormolu
                 # stylish-haskell
                 opentelemetry-extra
+                haskell-language-server
               ]);
 
             src = null;


### PR DESCRIPTION
So I don't know what is the status quo/strategy regarding Nix shell providing, but just in case, I'm opening this PR.

I was surprised that neither `nix-shell` nor `nix develop` provide HLS itself (a prepackaged built, not the one being hacked). It means even after `nix-shell`ing or `nix develop`ing, one must also install HLS by some other means.

This PR thus adds it.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2313"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

