### PR TITLE
Add support for install hls from hackage using ghc 9.0.1

### DIFF
--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -119,7 +119,7 @@ jobs:
           path: ${{ steps.generate-dist-tarball.outputs.path }}
 
   upload-candidate:
-    if: ! contains(github.head_ref, 'check')
+    if: ${{ !contains(github.head_ref, 'check') }}
     needs: check-and-upload-tarballs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -21,7 +21,7 @@ jobs:
                   "hls-splice-plugin", "hls-tactics-plugin",
                   "hls-call-hierarchy-plugin",
                   "haskell-language-server"]
-        ghc: ["8.10.7", "8.8.4", "8.6.5"]
+        ghc: ["9.0.1", "8.10.7", "8.8.4", "8.6.5"]
 
     steps:
 
@@ -119,6 +119,7 @@ jobs:
           path: ${{ steps.generate-dist-tarball.outputs.path }}
 
   upload-candidate:
+    if: ! contains(github.head_ref, 'check')
     needs: check-and-upload-tarballs
     runs-on: ubuntu-latest
     steps:

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -59,7 +59,7 @@ index-state: 2021-10-04T02:41:06Z
 
 constraints:
   -- These plugins don't work on GHC9 yet
-  haskell-language-server +force-plugins -brittany -class -stylishhaskell -tactic
+  haskell-language-server +ignore-plugins-ghc-bounds -brittany -class -stylishhaskell -tactic
 
 allow-newer:
     floskell:base,

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -58,8 +58,8 @@ write-ghc-environment-files: never
 index-state: 2021-10-04T02:41:06Z
 
 constraints:
-    -- These plugins don't work on GHC9 yet
-    haskell-language-server -brittany -class -stylishhaskell -tactic
+  -- These plugins don't work on GHC9 yet
+  haskell-language-server -brittany -class -stylishhaskell -tactic
 
 allow-newer:
     floskell:base,

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -59,7 +59,7 @@ index-state: 2021-10-04T02:41:06Z
 
 constraints:
   -- These plugins don't work on GHC9 yet
-  haskell-language-server -brittany -class -stylishhaskell -tactic
+  haskell-language-server +force-plugins -brittany -class -stylishhaskell -tactic
 
 allow-newer:
     floskell:base,

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -53,11 +53,6 @@ write-ghc-environment-files: never
 
 index-state: 2021-09-29T21:38:47Z
 
-constraints:
-    -- These plugins doesn't work on GHC9 yet
-    haskell-language-server -brittany -class -fourmolu -splice -stylishhaskell -tactic -refineImports -callhierarchy -retrie
-
-
 allow-newer:
   Cabal,
   base,

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -53,6 +53,10 @@ write-ghc-environment-files: never
 
 index-state: 2021-09-29T21:38:47Z
 
+constraints:
+  -- These plugins doesn't work on GHC92 yet
+  haskell-language-server +force-plugins -brittany -class -fourmolu -splice -stylishhaskell -tactic -refineImports -callhierarchy -retrie
+
 allow-newer:
   Cabal,
   base,

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -55,7 +55,7 @@ index-state: 2021-09-29T21:38:47Z
 
 constraints:
   -- These plugins doesn't work on GHC92 yet
-  haskell-language-server +force-plugins -brittany -class -fourmolu -splice -stylishhaskell -tactic -refineImports -callhierarchy -retrie
+  haskell-language-server +ignore-plugins-ghc-bounds -brittany -class -fourmolu -splice -stylishhaskell -tactic -refineImports -callhierarchy -retrie
 
 allow-newer:
   Cabal,

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -86,7 +86,7 @@ library
 -- - Bulk flags should be default:False
 -- - Individual flags should be default:True
 
-flag force-plugins
+flag ignore-plugins-ghc-bounds
   description: Force the inclusion of plugins even if they are not buildable by default with a specific ghc version
   default:     False
   manual:      True
@@ -189,12 +189,12 @@ common example-plugins
                  Ide.Plugin.Example2
 
 common class
-  if flag(class) && (impl(ghc < 9.0.1) || flag(force-plugins))
+  if flag(class) && (impl(ghc < 9.0.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-class-plugin ^>=1.0.0.1
     cpp-options: -Dclass
 
 common callHierarchy
-  if flag(callHierarchy) && (impl(ghc < 9.2.1) || flag(force-plugins))
+  if flag(callHierarchy) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-call-hierarchy-plugin ^>=1.0.0.0
     cpp-options: -DcallHierarchy
 
@@ -214,7 +214,7 @@ common importLens
     cpp-options: -DimportLens
 
 common refineImports
-  if flag(refineImports) && (impl(ghc < 9.2.1) || flag(force-plugins))
+  if flag(refineImports) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-refine-imports-plugin ^>=1.0.0.0
     cpp-options: -DrefineImports
 
@@ -224,12 +224,12 @@ common rename
     cpp-options: -Drename
 
 common retrie
-  if flag(retrie) && (impl(ghc < 9.2.1) || flag(force-plugins))
+  if flag(retrie) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-retrie-plugin ^>=1.0.0.1
     cpp-options: -Dretrie
 
 common tactic
-  if flag(tactic) && (impl(ghc < 9.0.1) || flag(force-plugins))
+  if flag(tactic) && (impl(ghc < 9.0.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-tactics-plugin >=1.2.0.0 && <1.5
     cpp-options: -Dtactic
 
@@ -249,19 +249,19 @@ common pragmas
     cpp-options: -Dpragmas
 
 common splice
-  if flag(splice) && (impl(ghc < 9.2.1) || flag(force-plugins))
+  if flag(splice) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-splice-plugin ^>=1.0.0.1
     cpp-options: -Dsplice
 
 -- formatters
 
 common floskell
-  if flag(floskell) && (impl(ghc < 9.0.1) || flag(force-plugins))
+  if flag(floskell) && (impl(ghc < 9.0.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-floskell-plugin ^>=1.0.0.0
     cpp-options: -Dfloskell
 
 common fourmolu
-  if flag(fourmolu) && (impl(ghc < 9.2.1) || flag(force-plugins))
+  if flag(fourmolu) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-fourmolu-plugin ^>=1.0.0.0
     cpp-options: -Dfourmolu
 
@@ -271,12 +271,12 @@ common ormolu
     cpp-options: -Dormolu
 
 common stylishHaskell
-  if flag(stylishHaskell) && (impl(ghc < 9.0.1) || flag(force-plugins))
+  if flag(stylishHaskell) && (impl(ghc < 9.0.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-stylish-haskell-plugin ^>=1.0.0.0
     cpp-options: -DstylishHaskell
 
 common brittany
-  if flag(brittany) && (impl(ghc < 9.0.1) || flag(force-plugins))
+  if flag(brittany) && (impl(ghc < 9.0.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-brittany-plugin ^>=1.0.0.1
     cpp-options: -Dbrittany
 
@@ -440,9 +440,9 @@ test-suite func-test
   if flag(eval)
     cpp-options: -Deval
 -- formatters
-  if flag(floskell) && (impl(ghc < 9.0.1) || flag(force-plugins))
+  if flag(floskell) && (impl(ghc < 9.0.1) || flag(ignore-plugins-ghc-bounds))
     cpp-options: -Dfloskell
-  if flag(fourmolu) && (impl(ghc < 9.2.1) || flag(force-plugins))
+  if flag(fourmolu) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
     cpp-options: -Dfourmolu
   if flag(ormolu)
     cpp-options: -Dormolu

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -87,7 +87,7 @@ library
 -- - Individual flags should be default:True
 
 flag force-plugins
-  description: Force the inclusion of plugins requested with flags
+  description: Force the inclusion of plugins even if they are not buildable by default with a specific ghc version
   default:     False
   manual:      True
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -88,13 +88,8 @@ library
 -- - Bulk flags should be default:False
 -- - Individual flags should be default:True
 
-flag all-plugins
-  description: Enable all non formatter plugins
-  default:     False
-  manual:      True
-
-flag all-formatters
-  description: Enable all fomatters
+flag force-plugins
+  description: Force the inclusion of plugins requested with flags
   default:     False
   manual:      True
 
@@ -196,94 +191,94 @@ common example-plugins
                  Ide.Plugin.Example2
 
 common class
-  if flag(class) || flag(all-plugins)
+  if flag(class) && (impl(ghc < 9.0.1) || flag(force-plugins))
     build-depends: hls-class-plugin ^>=1.0.0.1
     cpp-options: -Dclass
 
 common callHierarchy
-  if flag(callHierarchy) || flag(all-plugins)
+  if flag(callHierarchy) && (impl(ghc < 9.2.1) || flag(force-plugins))
     build-depends: hls-call-hierarchy-plugin ^>=1.0.0.0
     cpp-options: -DcallHierarchy
 
 common haddockComments
-  if flag(haddockComments) || flag(all-plugins)
+  if flag(haddockComments)
     build-depends: hls-haddock-comments-plugin ^>=1.0.0.1
     cpp-options: -DhaddockComments
 
 common eval
-  if flag(eval) || flag(all-plugins)
+  if flag(eval)
     build-depends: hls-eval-plugin ^>=1.2.0.0
     cpp-options: -Deval
 
 common importLens
-  if flag(importLens) || flag(all-plugins)
+  if flag(importLens)
     build-depends: hls-explicit-imports-plugin ^>=1.0.0.1
     cpp-options: -DimportLens
 
 common refineImports
-  if flag(refineImports) || flag(all-plugins)
+  if flag(refineImports) && (impl(ghc < 9.2.1) || flag(force-plugins))
     build-depends: hls-refine-imports-plugin ^>=1.0.0.0
     cpp-options: -DrefineImports
 
 common rename
-  if flag(rename) || flag(all-plugins)
+  if flag(rename)
     build-depends: hls-rename-plugin ^>= 1.0.0.0
     cpp-options: -Drename
 
 common retrie
-  if flag(retrie) || flag(all-plugins)
+  if flag(retrie) && (impl(ghc < 9.2.1) || flag(force-plugins))
     build-depends: hls-retrie-plugin ^>=1.0.0.1
     cpp-options: -Dretrie
 
 common tactic
-  if flag(tactic) || flag(all-plugins)
+  if flag(tactic) && (impl(ghc < 9.0.1) || flag(force-plugins))
     build-depends: hls-tactics-plugin >=1.2.0.0 && <1.5
     cpp-options: -Dtactic
 
 common hlint
-  if flag(hlint) || flag(all-plugins)
+  if flag(hlint)
     build-depends: hls-hlint-plugin ^>=1.0.0.2
     cpp-options: -Dhlint
 
 common moduleName
-  if flag(moduleName) || flag(all-plugins)
+  if flag(moduleName)
     build-depends: hls-module-name-plugin ^>=1.0.0.0
     cpp-options: -DmoduleName
 
 common pragmas
-  if flag(pragmas) || flag(all-plugins)
+  if flag(pragmas)
     build-depends: hls-pragmas-plugin ^>=1.0.0.0
     cpp-options: -Dpragmas
 
 common splice
-  if flag(splice) || flag(all-plugins)
+  if flag(splice) && (impl(ghc < 9.2.1) || flag(force-plugins))
     build-depends: hls-splice-plugin ^>=1.0.0.1
     cpp-options: -Dsplice
 
 -- formatters
 
 common floskell
-  if flag(floskell) || flag(all-formatters)
+  if flag(floskell)
     build-depends: hls-floskell-plugin ^>=1.0.0.0
     cpp-options: -Dfloskell
 
 common fourmolu
-  if flag(fourmolu) || flag(all-formatters)
+  if flag(fourmolu) && (impl(ghc < 9.2.1) || flag(force-plugins))
     build-depends: hls-fourmolu-plugin ^>=1.0.0.0
     cpp-options: -Dfourmolu
 
 common ormolu
-  if flag(ormolu) || flag(all-formatters)
+  if flag(ormolu)
     build-depends: hls-ormolu-plugin ^>=1.0.0.0
     cpp-options: -Dormolu
 
 common stylishHaskell
-  if flag(stylishHaskell) || flag(all-formatters)
+  if flag(stylishHaskell) && (impl(ghc < 9.0.1) || flag(force-plugins))
     build-depends: hls-stylish-haskell-plugin ^>=1.0.0.0
     cpp-options: -DstylishHaskell
 
 common brittany
-  if (flag(brittany) || flag(all-formatters))
+  if flag(brittany) && (impl(ghc < 9.0.1) || flag(force-plugins))
     build-depends: hls-brittany-plugin ^>=1.0.0.1
     cpp-options: -Dbrittany
 
@@ -443,13 +438,13 @@ test-suite func-test
   if flag(pedantic)
     ghc-options: -Werror -Wredundant-constraints
 
-  if flag(callHierarchy) || flag(all-plugins)
+  if flag(callHierarchy)
     cpp-options: -DcallHierarchy
-  if flag(class) || flag(all-plugins)
+  if flag(class)
     cpp-options: -Dclass
-  if flag(haddockComments) || flag(all-plugins)
+  if flag(haddockComments)
     cpp-options: -DhaddockComments
-  if flag(eval) || flag(all-plugins)
+  if flag(eval)
     cpp-options: -Deval
   if flag(importLens) || flag(all-plugins)
     cpp-options: -DimportLens

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -83,8 +83,6 @@ library
   default-extensions: DataKinds, TypeOperators
 
 -- Plugin flags are designed for 'cabal install haskell-language-server':
--- - Packaged plugins should be manual:False
--- - Non packaged plugins and bulk flags should be manual:True
 -- - Bulk flags should be default:False
 -- - Individual flags should be default:True
 
@@ -258,7 +256,7 @@ common splice
 -- formatters
 
 common floskell
-  if flag(floskell)
+  if flag(floskell) && (impl(ghc < 9.0.1) || flag(force-plugins))
     build-depends: hls-floskell-plugin ^>=1.0.0.0
     cpp-options: -Dfloskell
 
@@ -438,42 +436,16 @@ test-suite func-test
   if flag(pedantic)
     ghc-options: -Werror -Wredundant-constraints
 
-  if flag(callHierarchy)
-    cpp-options: -DcallHierarchy
-  if flag(class)
-    cpp-options: -Dclass
-  if flag(haddockComments)
-    cpp-options: -DhaddockComments
+-- Duplicating inclusion plugin conditions until tests are moved to their own packages
   if flag(eval)
     cpp-options: -Deval
-  if flag(importLens) || flag(all-plugins)
-    cpp-options: -DimportLens
-  if flag(rename) || flag(all-plugins)
-    cpp-options: -Drename
-  if flag(retrie) || flag(all-plugins)
-    cpp-options: -Dretrie
-  if flag(tactic) || flag(all-plugins)
-    cpp-options: -Dtactic
-  if flag(hlint) || flag(all-plugins)
-    cpp-options: -Dhlint
-  if flag(moduleName) || flag(all-plugins)
-    cpp-options: -DmoduleName
-  if flag(pragmas) || flag(all-plugins)
-    cpp-options: -Dpragmas
-  if flag(splice) || flag(all-plugins)
-    cpp-options: -Dsplice
-
 -- formatters
-  if flag(floskell) || flag(all-formatters)
+  if flag(floskell) && (impl(ghc < 9.0.1) || flag(force-plugins))
     cpp-options: -Dfloskell
-  if flag(fourmolu) || flag(all-formatters)
+  if flag(fourmolu) && (impl(ghc < 9.2.1) || flag(force-plugins))
     cpp-options: -Dfourmolu
-  if flag(ormolu) || flag(all-formatters)
+  if flag(ormolu)
     cpp-options: -Dormolu
-  if flag(stylishHaskell) || flag(all-formatters)
-    cpp-options: -DstylishHaskell
-  if (flag(brittany) || flag(all-formatters))
-    cpp-options: -Dbrittany
 
 test-suite wrapper-test
   type:               exitcode-stdio-1.0

--- a/test/utils/Test/Hls/Flags.hs
+++ b/test/utils/Test/Hls/Flags.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 -- | Module for disabling tests if their plugins are disabled
-{-# DEPRECATED "To be removed when all plugin tests are in their own packages" #-}
-module Test.Hls.Flags where
+module Test.Hls.Flags {-# DEPRECATED "To be removed when all plugin tests are in their own packages" #-} where
 
 import           Test.Hls (TestTree, ignoreTestBecause)
 

--- a/test/utils/Test/Hls/Flags.hs
+++ b/test/utils/Test/Hls/Flags.hs
@@ -1,27 +1,12 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 -- | Module for disabling tests if their plugins are disabled
+{-# DEPRECATED "To be removed when all plugin tests are in their own packages" #-}
 module Test.Hls.Flags where
 
 import           Test.Hls (TestTree, ignoreTestBecause)
 
 -- * Plugin dependent tests
-
--- | Disable test unless the class flag is set
-requiresClassPlugin           :: TestTree -> TestTree
-#if class
-requiresClassPlugin           = id
-#else
-requiresClassPlugin           = ignoreTestBecause "Class plugin disabled"
-#endif
-
--- | Disable test unless the haddockComments flag is set
-requiresHaddockCommentsPlugin :: TestTree -> TestTree
-#if haddockComments
-requiresHaddockCommentsPlugin = id
-#else
-requiresHaddockCommentsPlugin = ignoreTestBecause "HaddockComments plugin disabled"
-#endif
 
 -- | Disable test unless the eval flag is set
 requiresEvalPlugin            :: TestTree -> TestTree
@@ -30,71 +15,6 @@ requiresEvalPlugin            = id
 #else
 requiresEvalPlugin            = ignoreTestBecause "Eval plugin disabled"
 #endif
-
--- | Disable test unless the importLens flag is set
-requiresImportLensPlugin      :: TestTree -> TestTree
-#if importLens
-requiresImportLensPlugin      = id
-#else
-requiresImportLensPlugin      = ignoreTestBecause "ImportLens plugin disabled"
-#endif
-
--- | Disable test unless the rename flag is set
-requiresRenamePlugin          :: TestTree -> TestTree
-#if rename
-requiresRenamePlugin          = id
-#else
-requiresRenamePlugin          = ignoreTestBecause "Rename plugin disabled"
-#endif
-
--- | Disable test unless the retrie flag is set
-requiresRetriePlugin          :: TestTree -> TestTree
-#if retrie
-requiresRetriePlugin          = id
-#else
-requiresRetriePlugin          = ignoreTestBecause "Retrie plugin disabled"
-#endif
-
--- | Disable test unless the tactic flag is set
-requiresTacticPlugin          :: TestTree -> TestTree
-#if tactic
-requiresTacticPlugin          = id
-#else
-requiresTacticPlugin          = ignoreTestBecause "Tactic plugin disabled"
-#endif
-
--- | Disable test unless the hlint flag is set
-requiresHlintPlugin           :: TestTree -> TestTree
-#if hlint
-requiresHlintPlugin           = id
-#else
-requiresHlintPlugin           = ignoreTestBecause "Hlint plugin disabled"
-#endif
-
--- | Disable test unless the moduleName flag is set
-requiresModuleNamePlugin      :: TestTree -> TestTree
-#if moduleName
-requiresModuleNamePlugin      = id
-#else
-requiresModuleNamePlugin      = ignoreTestBecause "ModuleName plugin disabled"
-#endif
-
--- | Disable test unless the pragmas flag is set
-requiresPragmasPlugin         :: TestTree -> TestTree
-#if pragmas
-requiresPragmasPlugin         = id
-#else
-requiresPragmasPlugin         = ignoreTestBecause "Pragmas plugin disabled"
-#endif
-
--- | Disable test unless the splice flag is set
-requiresSplicePlugin          :: TestTree -> TestTree
-#if splice
-requiresSplicePlugin          = id
-#else
-requiresSplicePlugin          = ignoreTestBecause "Splice plugin disabled"
-#endif
-
 
 -- * Formatters
 -- | Disable test unless the floskell flag is set
@@ -120,20 +40,3 @@ requiresOrmoluPlugin          = id
 #else
 requiresOrmoluPlugin          = ignoreTestBecause "Ormolu plugin disabled"
 #endif
-
--- | Disable test unless the stylishHaskell flag is set
-requiresStylishHaskellPlugin  :: TestTree -> TestTree
-#if stylishHaskell
-requiresStylishHaskellPlugin  = id
-#else
-requiresStylishHaskellPlugin  = ignoreTestBecause "StylishHaskell plugin disabled"
-#endif
-
--- | Disable test unless the brittany flag is set
-requiresBrittanyPlugin        :: TestTree -> TestTree
-#if brittany
-requiresBrittanyPlugin        = id
-#else
-requiresBrittanyPlugin        = ignoreTestBecause "Brittany plugin disabled"
-#endif
-

--- a/test/utils/Test/Hls/Flags.hs
+++ b/test/utils/Test/Hls/Flags.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 -- | Module for disabling tests if their plugins are disabled
-module Test.Hls.Flags {-# DEPRECATED "To be removed when all plugin tests are in their own packages" #-} where
+-- DEPRECATED: To be removed when all plugin tests are in their own packages
+module Test.Hls.Flags where
 
 import           Test.Hls (TestTree, ignoreTestBecause)
 


### PR DESCRIPTION
* As commented in https://github.com/haskell/haskell-language-server/issues/2317#issuecomment-956178685 it is an alternative to make plugin flags automatic to get hls buildable from hackage and ghc-9.0.1
* This pr:
  * Encode explicitly what plugins are buildable for each ghc versions in `haskell-language-server.cabal`, the only config file seen by hackage builds
  * Add a new flag `ignore-plugins-ghc-bounds` to allow custom builds out of hackage force the inclusion of plugins, supposelly adding `allow-newer` or `remote-source-packages` in a `cabal.project`
  * Remove `all-plugins` and `all-formatters` as afaics they are almost useless with actual default values for them and individual plugin flags and being used with `||` in conditions
  * Remove unused plugins conditions in `test-func` as almost all plugins were moved to their own packages. Deprecate the remaining ones as hopefully they will be moved sooner or later
  * Change hackage github workflow to include ghc-9.0.1 and the option to only run the check step, without upload effectively packages 
  * I've added checks for ghc-9.2.1 but they are an aproximation based in the actual `cabal-ghc921-project` which afaiu does not work

This has not been done earlier cause i thought we should "publish" a complete version of hls in hackage. Assuming that it would not take so long to be achieved as it did. 

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2322"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

