### PR TITLE
[skip circleci] Give unique names to post-jobs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -159,7 +159,7 @@ jobs:
            ghcide/bench-results/**/*.eventlog
            ghcide/bench-results/**/*.hp
 
-  post_job:
+  bench_post_job:
     if: always()
     runs-on: ubuntu-latest
     needs: [pre_job, bench_init, bench_example]

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -107,7 +107,7 @@ jobs:
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server
 
-  post_job:
+  nix_post_job:
     if: always()
     runs-on: ubuntu-latest
     needs: [pre_job, develop, build]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,7 +224,7 @@ jobs:
         name: Test hls-hlint-plugin test suite
         run: cabal test hls-hlint-plugin --test-options="-j1 --rerun-update" || cabal test hls-hlint-plugin --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-hlint-plugin --test-options="-j1 --rerun"
 
-  post_job:
+  test_post_job:
     if: always()
     runs-on: ubuntu-latest
     needs: [pre_job, test]


### PR DESCRIPTION
* To try make required checks work
* Before this if some post_job (from nix or bench workflows) was green and the test post_job did not start, the pr was incorrectly mergeable and mergifyio could merge it. This has happened with #2332 and #2321

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2337"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

