### PR TITLE
add dependabot: add Actions CI merge requests automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  # NOTE: Dependabot official configuration documentation:
+  # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem
+
+  # Maintain dependencies for internal GitHub Actions CI for pull requests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot would weekly check updates for project's [.github/workflows/*](https://github.com/haskell/actions/blob/main/.github/workflows/workflow.yml) & send-in information & patch updates as PRs to be merged ([like these](https://github.com/haskell-nix/hnix-store/pull/169)).

PR to CI configuration run CI with changes applied, which is a self-test.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

