### PR TITLE
contributing: add implicit-hie gen-hie > hie.yaml note

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -113,16 +113,32 @@ $ cabal run haskell-language-server:func-test -- -p "hlint enables"
 
 ## Using HLS on HLS code
 
-[HLS project configuration guidelines](../configuration.md#configuring-your-project-build) also apply to the HLS project itself.
+Project source code should load without `hie.yaml` setup.
 
-Note: HLS implicitly detects HLS codebase as a Stack project (see [hie-bios implicit configuration documentation](https://github.com/haskell/hie-bios/blob/master/README.md#implicit-configuration)).
-If you want HLS to use Cabal, you need to create an `hie.yaml` file:
+In other cases:
+
+1. Check if `hie.yaml` (& `hie.yml`) files left from previous configurations.
+
+2. If the main project needs special configuration, note that other internal subprojects probably also would need configuration.
+
+To create an explicit configuration for all projects - use [implicit-hie](https://github.com/Avi-D-coder/implicit-hie) generator directly:
+
+```shell
+gen-hie > hie.yaml  # into the main HLS directory
+```
+
+that configuration should help.
+
+3. Inspect & tune configuration explicitly.
+
+[Configuring project build](../configuration.md#configuring-your-project-build) applies to HLS project source code loading just as to any other.
+
+Note: HLS may implicitly detect codebase as a Stack project (see [hie-bios implicit configuration documentation](https://github.com/haskell/hie-bios/blob/master/README.md#implicit-configuration)). To use Cabal, try creating an `hie.yaml` file:
+
 ```yaml
 cradle:
   cabal:
 ```
-
-Also note that the `install/` subdirectory is a different project, so if you want to work on this part of the code, you may also have to create an `install/hie.yaml` file.
 
 ### Manually testing your hacked HLS
 If you want to test HLS while hacking on it, follow the steps below.


### PR DESCRIPTION
On my setups, the `gen-hie` tool was found to be irreplaceable.

Mainline documentation currently directs people to read lengthy HLS docs on cradle & then directs reading HIE-Bios docs on it & says to make all `hie.yaml` by hand. For every project person wants to contribute to.

<details><summary> & currently that means: </summary>

</p>

```yaml
cradle:
  cabal:
    - path: "./ghcide/src"
      component: "lib:ghcide"

    - path: "./ghcide/session-loader"
      component: "lib:ghcide"

    - path: "./ghcide/test/preprocessor/Main.hs"
      component: "ghcide:exe:ghcide-test-preprocessor"

    - path: "./ghcide/bench/hist/Main.hs"
      component: "ghcide:bench:benchHist"

    - path: "./ghcide/bench/lib/Main.hs"
      component: "ghcide:bench:benchHist"

    - path: "./ghcide/bench/hist/Experiments/Types.hs"
      component: "ghcide:bench:benchHist"

    - path: "./ghcide/bench/lib/Experiments/Types.hs"
      component: "ghcide:bench:benchHist"

    - path: "./ghcide/exe/Main.hs"
      component: "ghcide:exe:ghcide"

    - path: "./ghcide/exe/Arguments.hs"
      component: "ghcide:exe:ghcide"

    - path: "./ghcide/test/cabal"
      component: "ghcide:test:ghcide-tests"

    - path: "./ghcide/test/exe"
      component: "ghcide:test:ghcide-tests"

    - path: "./ghcide/test/src"
      component: "ghcide:test:ghcide-tests"

    - path: "./ghcide/bench/lib"
      component: "ghcide:test:ghcide-tests"

    - path: "./ghcide/bench/lib/Main.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/bench/exe/Main.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/test/src/Main.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/bench/lib/Development/IDE/Test/Diagnostic.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/bench/lib/Experiments.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/bench/lib/Experiments/Types.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/bench/exe/Development/IDE/Test/Diagnostic.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/bench/exe/Experiments.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/bench/exe/Experiments/Types.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/test/src/Development/IDE/Test/Diagnostic.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/test/src/Experiments.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./ghcide/test/src/Experiments/Types.hs"
      component: "ghcide:exe:ghcide-bench"

    - path: "./src"
      component: "lib:haskell-language-server"

    - path: "./exe/Main.hs"
      component: "haskell-language-server:exe:haskell-language-server"

    - path: "./exe/Plugins.hs"
      component: "haskell-language-server:exe:haskell-language-server"

    - path: "./exe/Wrapper.hs"
      component: "haskell-language-server:exe:haskell-language-server-wrapper"

    - path: "./test/functional"
      component: "haskell-language-server:test:func-test"

    - path: "./test/utils"
      component: "haskell-language-server:test:func-test"

    - path: "./test/wrapper"
      component: "haskell-language-server:test:wrapper-test"

    - path: "./hie-compat/src-ghc86"
      component: "lib:hie-compat"

    - path: "./hie-compat/src-ghc88"
      component: "lib:hie-compat"

    - path: "./hie-compat/src-reexport"
      component: "lib:hie-compat"

    - path: "./hie-compat/src-ghc810"
      component: "lib:hie-compat"

    - path: "./hie-compat/src-reexport"
      component: "lib:hie-compat"

    - path: "./hie-compat/src-reexport-ghc9"
      component: "lib:hie-compat"

    - path: "./hie-compat/src-reexport-ghc9"
      component: "lib:hie-compat"

    - path: "./hls-graph/src"
      component: "lib:hls-graph"

    - path: "./hls-plugin-api/src"
      component: "lib:hls-plugin-api"

    - path: "./hls-test-utils/src"
      component: "lib:hls-test-utils"

    - path: "./plugins/hls-brittany-plugin/src"
      component: "lib:hls-brittany-plugin"

    - path: "./plugins/hls-brittany-plugin/test"
      component: "hls-brittany-plugin:test:tests"

    - path: "./plugins/hls-call-hierarchy-plugin/src"
      component: "lib:hls-call-hierarchy-plugin"

    - path: "./plugins/hls-call-hierarchy-plugin/test"
      component: "hls-call-hierarchy-plugin:test:tests"

    - path: "./plugins/hls-class-plugin/src"
      component: "lib:hls-class-plugin"

    - path: "./plugins/hls-class-plugin/test"
      component: "hls-class-plugin:test:tests"

    - path: "./plugins/hls-eval-plugin/src"
      component: "lib:hls-eval-plugin"

    - path: "./plugins/hls-eval-plugin/test"
      component: "hls-eval-plugin:test:tests"

    - path: "./plugins/hls-explicit-imports-plugin/src"
      component: "lib:hls-explicit-imports-plugin"

    - path: "./plugins/hls-explicit-imports-plugin/test"
      component: "hls-explicit-imports-plugin:test:tests"

    - path: "./plugins/hls-floskell-plugin/src"
      component: "lib:hls-floskell-plugin"

    - path: "./plugins/hls-floskell-plugin/test"
      component: "hls-floskell-plugin:test:tests"

    - path: "./plugins/hls-fourmolu-plugin/src"
      component: "lib:hls-fourmolu-plugin"

    - path: "./plugins/hls-fourmolu-plugin/test"
      component: "hls-fourmolu-plugin:test:tests"

    - path: "./plugins/hls-haddock-comments-plugin/src"
      component: "lib:hls-haddock-comments-plugin"

    - path: "./plugins/hls-haddock-comments-plugin/test"
      component: "hls-haddock-comments-plugin:test:tests"

    - path: "./plugins/hls-hlint-plugin/test"
      component: "hls-hlint-plugin:test:tests"

    - path: "./plugins/hls-module-name-plugin/src"
      component: "lib:hls-module-name-plugin"

    - path: "./plugins/hls-module-name-plugin/test"
      component: "hls-module-name-plugin:test:tests"

    - path: "./plugins/hls-ormolu-plugin/src"
      component: "lib:hls-ormolu-plugin"

    - path: "./plugins/hls-ormolu-plugin/test"
      component: "hls-ormolu-plugin:test:tests"

    - path: "./plugins/hls-pragmas-plugin/src"
      component: "lib:hls-pragmas-plugin"

    - path: "./plugins/hls-pragmas-plugin/test"
      component: "hls-pragmas-plugin:test:tests"

    - path: "./plugins/hls-refine-imports-plugin/src"
      component: "lib:hls-refine-imports-plugin"

    - path: "./plugins/hls-refine-imports-plugin/test"
      component: "hls-refine-imports-plugin:test:tests"

    - path: "./plugins/hls-rename-plugin/src"
      component: "lib:hls-rename-plugin"

    - path: "./plugins/hls-rename-plugin/test"
      component: "hls-rename-plugin:test:tests"

    - path: "./plugins/hls-retrie-plugin/src"
      component: "lib:hls-retrie-plugin"

    - path: "./plugins/hls-splice-plugin/src"
      component: "lib:hls-splice-plugin"

    - path: "./plugins/hls-splice-plugin/test"
      component: "hls-splice-plugin:test:tests"

    - path: "./plugins/hls-stylish-haskell-plugin/src"
      component: "lib:hls-stylish-haskell-plugin"

    - path: "./plugins/hls-stylish-haskell-plugin/test"
      component: "hls-stylish-haskell-plugin:test:tests"

    - path: "./plugins/hls-tactics-plugin/src"
      component: "lib:hls-tactics-plugin"

    - path: "./plugins/hls-tactics-plugin/test"
      component: "hls-tactics-plugin:test:tests"
```

</details>

While contributor just wants to make project to load into running HLS - to study through the code & be able to navigate the whole project to study how things are done.

Patch advises trying a cradle generator, or using it as possible starting point. It helped me for years in complex project setups. It helped me even in my own projects with complex setups.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2341"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

