### PR TITLE
Show build graph statistics in ghcide-bench

### DIFF
--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -26,6 +26,7 @@ import           Control.Exception.Safe          (IOException, handleAny, try)
 import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import           Data.Aeson                      (Value (Null), toJSON)
+import           Data.Either                     (fromRight)
 import           Data.List
 import           Data.Maybe
 import qualified Data.Text                       as T
@@ -496,10 +497,10 @@ runBench runSess b = handleAny (\e -> print e >> return badRun)
           (userWaits, delayedWork) = fromMaybe (0,0) result
 
       rulesTotal <- length <$> getStoredKeys
-      rulesBuilt <- length <$> getBuildKeysBuilt
-      rulesChanged <- length <$> getBuildKeysChanged
-      rulesVisited <- length <$> getBuildKeysVisited
-      edgesTotal   <- getBuildEdgesCount
+      rulesBuilt <- either (const 0) length <$> getBuildKeysBuilt
+      rulesChanged <- either (const 0) length <$> getBuildKeysChanged
+      rulesVisited <- either (const 0) length <$> getBuildKeysVisited
+      edgesTotal   <- fromRight 0 <$> getBuildEdgesCount
 
       return BenchRun {..}
 

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -31,6 +31,11 @@ import           Data.Maybe
 import qualified Data.Text                       as T
 import           Data.Version
 import           Development.IDE.Plugin.Test
+import           Development.IDE.Test            (getBuildEdgesCount,
+                                                  getBuildKeysBuilt,
+                                                  getBuildKeysChanged,
+                                                  getBuildKeysVisited,
+                                                  getStoredKeys)
 import           Development.IDE.Test.Diagnostic
 import           Development.Shake               (CmdOption (Cwd, FileStdout),
                                                   cmd_)
@@ -323,6 +328,11 @@ runBenchmarksFun dir allBenchmarks = do
         , "userTime"
         , "delayedTime"
         , "totalTime"
+        , "buildRulesBuilt"
+        , "buildRulesChanged"
+        , "buildRulesVisited"
+        , "buildRulesTotal"
+        , "buildEdges"
         ]
       rows =
         [ [ name,
@@ -332,7 +342,12 @@ runBenchmarksFun dir allBenchmarks = do
             show runSetup',
             show userWaits,
             show delayedWork,
-            show runExperiment
+            show runExperiment,
+            show rulesBuilt,
+            show rulesChanged,
+            show rulesVisited,
+            show rulesTotal,
+            show edgesTotal
           ]
           | (Bench {name, samples}, BenchRun {..}) <- results,
             let runSetup' = if runSetup < 0.01 then 0 else runSetup
@@ -352,7 +367,12 @@ runBenchmarksFun dir allBenchmarks = do
             showDuration runSetup',
             showDuration userWaits,
             showDuration delayedWork,
-            showDuration runExperiment
+            showDuration runExperiment,
+            show rulesBuilt,
+            show rulesChanged,
+            show rulesVisited,
+            show rulesTotal,
+            show edgesTotal
           ]
           | (Bench {name, samples}, BenchRun {..}) <- results,
             let runSetup' = if runSetup < 0.01 then 0 else runSetup
@@ -398,11 +418,16 @@ data BenchRun = BenchRun
     runExperiment :: !Seconds,
     userWaits     :: !Seconds,
     delayedWork   :: !Seconds,
+    rulesBuilt    :: !Int,
+    rulesChanged  :: !Int,
+    rulesVisited  :: !Int,
+    rulesTotal    :: !Int,
+    edgesTotal    :: !Int,
     success       :: !Bool
   }
 
 badRun :: BenchRun
-badRun = BenchRun 0 0 0 0 0 False
+badRun = BenchRun 0 0 0 0 0 0 0 0 0 0 False
 
 waitForProgressStart :: Session ()
 waitForProgressStart = void $ do
@@ -469,6 +494,12 @@ runBench runSess b = handleAny (\e -> print e >> return badRun)
       (runExperiment, result) <- duration $ loop 0 0 samples
       let success = isJust result
           (userWaits, delayedWork) = fromMaybe (0,0) result
+
+      rulesTotal <- length <$> getStoredKeys
+      rulesBuilt <- length <$> getBuildKeysBuilt
+      rulesChanged <- length <$> getBuildKeysChanged
+      rulesVisited <- length <$> getBuildKeysVisited
+      edgesTotal   <- getBuildEdgesCount
 
       return BenchRun {..}
 

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -446,6 +446,7 @@ executable ghcide-bench
         extra,
         filepath,
         ghcide,
+        hls-plugin-api,
         lens,
         lsp-test,
         lsp-types,
@@ -454,11 +455,13 @@ executable ghcide-bench
         safe-exceptions,
         hls-graph,
         shake,
+        tasty-hunit,
         text
     hs-source-dirs: bench/lib bench/exe test/src
     ghc-options: -threaded -Wall -Wno-name-shadowing -rtsopts
     main-is: Main.hs
     other-modules:
+        Development.IDE.Test
         Development.IDE.Test.Diagnostic
         Experiments
         Experiments.Types

--- a/ghcide/src/Development/IDE/Plugin/Test.hs
+++ b/ghcide/src/Development/IDE/Plugin/Test.hs
@@ -11,33 +11,40 @@ module Development.IDE.Plugin.Test
   , blockCommandId
   ) where
 
-import           Control.Concurrent              (threadDelay)
-import           Control.Concurrent.Extra        (readVar)
+import           Control.Concurrent                   (threadDelay)
+import           Control.Concurrent.Extra             (readVar)
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.STM
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Bifunctor
-import           Data.CaseInsensitive            (CI, original)
-import qualified Data.HashMap.Strict             as HM
-import           Data.Maybe                      (isJust)
+import           Data.CaseInsensitive                 (CI, original)
+import qualified Data.HashMap.Strict                  as HM
+import           Data.Maybe                           (isJust)
 import           Data.String
-import           Data.Text                       (Text, pack)
-import           Development.IDE.Core.OfInterest (getFilesOfInterest)
+import           Data.Text                            (Text, pack)
+import           Development.IDE.Core.OfInterest      (getFilesOfInterest)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Service
 import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Compat
-import           Development.IDE.Graph          (Action)
-import           Development.IDE.Graph.Database (shakeLastBuildKeys)
+import           Development.IDE.Graph                (Action)
+import qualified Development.IDE.Graph                as Graph
+import           Development.IDE.Graph.Database       (ShakeDatabase,
+                                                       shakeGetBuildEdges,
+                                                       shakeGetBuildStep,
+                                                       shakeGetCleanKeys)
+import           Development.IDE.Graph.Internal.Types (Result (resultBuilt, resultChanged, resultVisited),
+                                                       Step (Step))
+import qualified Development.IDE.Graph.Internal.Types as Graph
 import           Development.IDE.Types.Action
-import           Development.IDE.Types.HscEnvEq  (HscEnvEq (hscEnv))
-import           Development.IDE.Types.Location  (fromUri)
-import           GHC.Generics                    (Generic)
-import           Ide.Plugin.Config               (CheckParents)
+import           Development.IDE.Types.HscEnvEq       (HscEnvEq (hscEnv))
+import           Development.IDE.Types.Location       (fromUri)
+import           GHC.Generics                         (Generic)
+import           Ide.Plugin.Config                    (CheckParents)
 import           Ide.Types
-import qualified Language.LSP.Server             as LSP
+import qualified Language.LSP.Server                  as LSP
 import           Language.LSP.Types
 import           System.Time.Extra
 
@@ -48,7 +55,10 @@ data TestRequest
     | GetShakeSessionQueueCount      -- ^ :: Number
     | WaitForShakeQueue -- ^ Block until the Shake queue is empty. Returns Null
     | WaitForIdeRule String Uri      -- ^ :: WaitForIdeRuleResult
-    | GetLastBuildKeys               -- ^ :: [String]
+    | GetBuildKeysVisited        -- ^ :: [(String]
+    | GetBuildKeysBuilt          -- ^ :: [(String]
+    | GetBuildKeysChanged        -- ^ :: [(String]
+    | GetBuildEdgesCount         -- ^ :: Int
     | GarbageCollectDirtyKeys CheckParents Age    -- ^ :: [String] (list of keys collected)
     | GetStoredKeys                  -- ^ :: [String] (list of keys in store)
     | GetFilesOfInterest             -- ^ :: [FilePath]
@@ -98,9 +108,18 @@ testRequestHandler s (WaitForIdeRule k file) = liftIO $ do
     success <- runAction ("WaitForIdeRule " <> k <> " " <> show file) s $ parseAction (fromString k) nfp
     let res = WaitForIdeRuleResult <$> success
     return $ bimap mkResponseError toJSON res
-testRequestHandler s GetLastBuildKeys = liftIO $ do
-    keys <- shakeLastBuildKeys $ shakeDb s
+testRequestHandler s GetBuildKeysBuilt = liftIO $ do
+    keys <- getDatabaseKeys resultBuilt $ shakeDb s
     return $ Right $ toJSON $ map show keys
+testRequestHandler s GetBuildKeysChanged = liftIO $ do
+    keys <- getDatabaseKeys resultChanged $ shakeDb s
+    return $ Right $ toJSON $ map show keys
+testRequestHandler s GetBuildKeysVisited = liftIO $ do
+    keys <- getDatabaseKeys resultVisited $ shakeDb s
+    return $ Right $ toJSON $ map show keys
+testRequestHandler s GetBuildEdgesCount = liftIO $ do
+    count <- shakeGetBuildEdges $ shakeDb s
+    return $ Right $ toJSON count
 testRequestHandler s (GarbageCollectDirtyKeys parents age) = do
     res <- liftIO $ runAction "garbage collect dirty" s $ garbageCollectDirtyKeysOlderThan age parents
     return $ Right $ toJSON $ map show res
@@ -110,6 +129,14 @@ testRequestHandler s GetStoredKeys = do
 testRequestHandler s GetFilesOfInterest = do
     ff <- liftIO $ getFilesOfInterest s
     return $ Right $ toJSON $ map fromNormalizedFilePath $ HM.keys ff
+
+getDatabaseKeys :: (Graph.Result -> Step)
+    -> ShakeDatabase
+    -> IO [Graph.Key]
+getDatabaseKeys field db = do
+    keys <- shakeGetCleanKeys db
+    step <- shakeGetBuildStep db
+    return [ k | (k, res) <- keys, field res == Step step]
 
 mkResponseError :: Text -> ResponseError
 mkResponseError msg = ResponseError InvalidRequest msg Nothing

--- a/ghcide/test/src/Development/IDE/Test.hs
+++ b/ghcide/test/src/Development/IDE/Test.hs
@@ -21,7 +21,6 @@ module Development.IDE.Test
   , standardizeQuotes
   , flushMessages
   , waitForAction
-  , getLastBuildKeys
   , getInterfaceFilesDir
   , garbageCollectDirtyKeys
   , getFilesOfInterest
@@ -30,7 +29,7 @@ module Development.IDE.Test
   , getStoredKeys
   , waitForCustomMessage
   , waitForGC
-  ) where
+  ,getBuildKeysBuilt,getBuildKeysVisited,getBuildKeysChanged,getBuildEdgesCount) where
 
 import           Control.Applicative.Combinators
 import           Control.Lens                    hiding (List)
@@ -197,8 +196,17 @@ waitForAction :: String -> TextDocumentIdentifier -> Session WaitForIdeRuleResul
 waitForAction key TextDocumentIdentifier{_uri} =
     callTestPlugin (WaitForIdeRule key _uri)
 
-getLastBuildKeys :: Session [T.Text]
-getLastBuildKeys = callTestPlugin GetLastBuildKeys
+getBuildKeysBuilt :: Session [T.Text]
+getBuildKeysBuilt = callTestPlugin GetBuildKeysBuilt
+
+getBuildKeysVisited :: Session [T.Text]
+getBuildKeysVisited = callTestPlugin GetBuildKeysVisited
+
+getBuildKeysChanged :: Session [T.Text]
+getBuildKeysChanged = callTestPlugin GetBuildKeysChanged
+
+getBuildEdgesCount :: Session Int
+getBuildEdgesCount = callTestPlugin GetBuildEdgesCount
 
 getInterfaceFilesDir :: TextDocumentIdentifier -> Session FilePath
 getInterfaceFilesDir TextDocumentIdentifier{_uri} = callTestPlugin (GetInterfaceFilesDir _uri)

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -38,8 +38,6 @@ library
     Development.IDE.Graph.Classes
     Development.IDE.Graph.Database
     Development.IDE.Graph.Rule
-
-  other-modules:
     Development.IDE.Graph.Internal.Action
     Development.IDE.Graph.Internal.Options
     Development.IDE.Graph.Internal.Rules
@@ -55,6 +53,7 @@ library
 
   hs-source-dirs:     src
   build-depends:
+    , aeson
     , async
     , base >=4.12 && <5
     , bytestring

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -49,7 +49,7 @@ import           Development.IDE                 (IdeState, noLogging)
 import           Development.IDE.Graph           (ShakeOptions (shakeThreads))
 import           Development.IDE.Main
 import qualified Development.IDE.Main            as Ghcide
-import           Development.IDE.Plugin.Test     (TestRequest (GetLastBuildKeys, WaitForIdeRule, WaitForShakeQueue),
+import           Development.IDE.Plugin.Test     (TestRequest (GetBuildKeysBuilt, WaitForIdeRule, WaitForShakeQueue),
                                                   WaitForIdeRuleResult (ideResultSuccess))
 import           Development.IDE.Types.Options
 import           GHC.IO.Handle
@@ -242,7 +242,7 @@ waitForTypecheck :: TextDocumentIdentifier -> Session (Either ResponseError Bool
 waitForTypecheck tid = fmap ideResultSuccess <$> waitForAction "typecheck" tid
 
 getLastBuildKeys :: Session (Either ResponseError [T.Text])
-getLastBuildKeys = callTestPlugin GetLastBuildKeys
+getLastBuildKeys = callTestPlugin GetBuildKeysBuilt
 
 sendConfigurationChanged :: Value -> Session ()
 sendConfigurationChanged config =


### PR DESCRIPTION
This adds 5 new columns to the benchmark outputs:

- buildRulesBuilt   - for which the value didn't change
- buildRulesChanged - for which the value did change
- buildRulesVisited - for which the value was not even recomputed
- buildRulesTotal   - including the rules that were not visited in the last build
- buildEdges        - total number of edges in the build graph

Example output:
```
cabal exec cabal run ghcide-bench -- -- -s "edit" --samples 2 --no-clean --example-module Distribution/Simple.hs
Up to date
Config {verbosity = Normal, shakeProfiling = Nothing, otMemoryProfiling = Nothing, outputCSV = "results.csv", buildTool = Cabal, ghcideOptions = [], matches = ["edit"], repetitions = Just 2, ghcide = "ghcide", timeoutLsp = 60, example = Example {exampleName = "name", exampleDetails = Right (ExamplePackage {packageName = "Cabal", packageVersion = Version {versionBranch = [3,4,0,0], versionTags = []}}), exampleModules = ["Distribution/Simple.hs"], exampleExtraArgs = []}}
starting test
Setting up document contents took 1.95s
Running edit benchmark
0.00s
0.17s
name | success | samples | startup | setup | userTime | delayedTime | totalTime | buildRulesBuilt | buildRulesChanged | buildRulesVisited | buildRulesTotal | buildEdges
---- | ------- | ------- | ------- | ----- | -------- | ----------- | --------- | --------------- | ----------------- | ----------------- | --------------- | ----------
edit | True    | 2       | 1.98s   | 0.00s | 0.17s    | 1.61s       | 1.78s     | 8               | 7                 | 1219              | 6345            | 148658   
```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2343"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

