### PR TITLE
Streamline code for getDocumentationTryGhc

### DIFF
--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -998,19 +998,19 @@ getDocsBatch
   :: HscEnv
   -> Module  -- ^ a moudle where the names are in scope
   -> [Name]
-  -> IO (Map.Map Name (Either String (Maybe HsDocString, Map.Map Int HsDocString)))
+  -> IO (Map.Map Name (Either T.Text (Maybe HsDocString, Map.Map Int HsDocString)))
 getDocsBatch hsc_env _mod _names = do
     ((_warns,errs), res) <- initTc hsc_env HsSrcFile False _mod fakeSpan $ Map.fromList <$> traverse findNameInfo _names
     case res of
         Just x  -> return $ fun x
         Nothing -> throwErrors errs
   where
-    fun :: Map.Map Name (Either GetDocsFailure c) -> Map.Map Name (Either String c)
+    fun :: Map.Map Name (Either GetDocsFailure c) -> Map.Map Name (Either T.Text c)
     fun =
       Map.map fun1
      where
-      fun1 :: Either GetDocsFailure c -> Either String c
-      fun1 = first $ T.unpack . showGhc
+      fun1 :: Either GetDocsFailure c -> Either T.Text c
+      fun1 = first showGhc
 
     throwErrors = liftIO . throwIO . mkSrcErr
 

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -991,11 +991,12 @@ mkDetailsFromIface session iface linkable = do
     initIfaceLoad hsc' (typecheckIface iface)
   return (HomeModInfo iface details linkable)
 
-fakeSpan :: RealSrcSpan
-fakeSpan = realSrcLocSpan $ mkRealSrcLoc (Util.fsLit "<ghcide>") 1 1
-
 initTypecheckEnv :: HscEnv -> Module -> TcRn r -> IO (Messages, Maybe r)
 initTypecheckEnv hsc_env mod = initTc hsc_env HsSrcFile False mod fakeSpan
+  where
+    fakeSpan :: RealSrcSpan
+    fakeSpan = realSrcLocSpan $ mkRealSrcLoc (Util.fsLit "<ghcide>") 1 1
+
 
 getDocsNonInteractive'
     :: Name

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -39,7 +39,6 @@ import           Development.IDE.GHC.Error
 import           Development.IDE.GHC.Orphans       ()
 import           Development.IDE.GHC.Util
 import           Development.IDE.GHC.Warnings
-import           Development.IDE.Spans.Common
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
@@ -75,7 +74,7 @@ import           Control.Lens                      hiding (List)
 import           Control.Monad.Except
 import           Control.Monad.Extra
 import           Control.Monad.Trans.Except
-import           Data.Bifunctor                    (first, second)
+import           Data.Bifunctor                    (second)
 import qualified Data.ByteString                   as BS
 import qualified Data.DList                        as DL
 import           Data.IORef
@@ -104,6 +103,7 @@ import           Data.Functor
 import qualified Data.HashMap.Strict               as HashMap
 import           Data.Map                          (Map)
 import           Data.Tuple.Extra                  (dupe)
+import           Data.Either.Extra                 (maybeToEither)
 import           Data.Unique                       as Unique
 import           Development.IDE.Core.Tracing      (withTrace)
 import           Development.IDE.GHC.Compat.Util   (emptyUDFM, plusUDFM_C)
@@ -998,20 +998,11 @@ getDocsBatch
   :: HscEnv
   -> Module  -- ^ a moudle where the names are in scope
   -> [Name]
-  -> IO (Either ErrorMessages (Map.Map Name (Either T.Text (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))))
+  -> IO (Either ErrorMessages (Map.Map Name (Either GetDocsFailure (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))))
 getDocsBatch hsc_env _mod _names = do
     ((_warns,errs), res) <- initTc hsc_env HsSrcFile False _mod fakeSpan $ Map.fromList <$> traverse findNameInfo _names
-    pure $ case res of
-        Just x  -> pure $ fun x
-        Nothing -> Left errs
-  where
-    fun :: Map.Map Name (Either GetDocsFailure c) -> Map.Map Name (Either T.Text c)
-    fun =
-      Map.map fun1
-     where
-      fun1 :: Either GetDocsFailure c -> Either T.Text c
-      fun1 = first showGhc
-
+    pure $ maybeToEither errs res
+ where
     findNameInfo :: Name -> IOEnv (Env TcGblEnv TcLclEnv) (Name, Either GetDocsFailure (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))
     findNameInfo name =
         case nameModule_maybe name of

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1029,7 +1029,7 @@ getDocsNonInteractive' name =
 -- | Non-interactive modification of 'GHC.Runtime.Eval.getDocs'.
 --   The interactive paths create problems in ghc-lib builds
 ---  and lead to fun errors like "Cannot continue after interface file error".
-getDocsNonInteractive :: HscEnv -> Module -> Name -> IO (Either ErrorMessages (Name, Either GetDocsFailure (Maybe HsDocString, Maybe (Map.Map Int HsDocString))))
+getDocsNonInteractive :: HscEnv -> Module -> Name -> IO (Either GHC.ErrorMessages (Name, Either GetDocsFailure (Maybe HsDocString, Maybe (Map.Map Int HsDocString))))
 getDocsNonInteractive hsc_env mod name = do
     ((_warns,errs), res) <- initTypecheckEnv hsc_env mod $ getDocsNonInteractive' name
     pure $ maybeToEither errs res
@@ -1041,7 +1041,7 @@ getDocsBatch
   -> Module  -- ^ a moudle where the names are in scope
   -> [Name]
   --  2021-11-18: NOTE: Map Int would become IntMap if next GHCs.
-  -> IO (Either ErrorMessages (Map.Map Name (Either GetDocsFailure (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))))
+  -> IO (Either GHC.ErrorMessages (Map.Map Name (Either GetDocsFailure (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))))
   -- ^ Return a 'Map' of 'Name's to 'Either' (no docs messages) (general doc body & arg docs)
 getDocsBatch hsc_env mod names = do
     ((_warns,errs), res) <- initTypecheckEnv hsc_env mod $ Map.fromList <$> traverse getDocsNonInteractive' names

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -998,11 +998,11 @@ getDocsBatch
   :: HscEnv
   -> Module  -- ^ a moudle where the names are in scope
   -> [Name]
-  -> IO [(Name, Either String (Maybe HsDocString, Map.Map Int HsDocString))]
+  -> IO (Map.Map Name (Either String (Maybe HsDocString, Map.Map Int HsDocString)))
 getDocsBatch hsc_env _mod _names = do
     ((_warns,errs), res) <- initTc hsc_env HsSrcFile False _mod fakeSpan $ traverse findNameInfo _names
     case res of
-        Just x  -> return $ fun x
+        Just x  -> return $ Map.fromList $ fun x
         Nothing -> throwErrors errs
   where
     fun :: [(Name, Either GetDocsFailure c)] -> [(Name, Either String c)]

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1000,17 +1000,17 @@ getDocsBatch
   -> [Name]
   -> IO (Map.Map Name (Either String (Maybe HsDocString, Map.Map Int HsDocString)))
 getDocsBatch hsc_env _mod _names = do
-    ((_warns,errs), res) <- initTc hsc_env HsSrcFile False _mod fakeSpan $ traverse findNameInfo _names
+    ((_warns,errs), res) <- initTc hsc_env HsSrcFile False _mod fakeSpan $ Map.fromList <$> traverse findNameInfo _names
     case res of
-        Just x  -> return $ Map.fromList $ fun x
+        Just x  -> return $ fun x
         Nothing -> throwErrors errs
   where
-    fun :: [(Name, Either GetDocsFailure c)] -> [(Name, Either String c)]
+    fun :: Map.Map Name (Either GetDocsFailure c) -> Map.Map Name (Either String c)
     fun =
-      map fun1
+      Map.map fun1
      where
-      fun1 :: ((Name, Either GetDocsFailure c) -> (Name, Either String c))
-      fun1 = fmap (first $ T.unpack . showGhc)
+      fun1 :: Either GetDocsFailure c -> Either String c
+      fun1 = first $ T.unpack . showGhc
 
     throwErrors = liftIO . throwIO . mkSrcErr
 

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1014,6 +1014,7 @@ getDocsBatch hsc_env _mod _names = do
                 }
                 <- loadModuleInterface "getModuleInterface" mod
               pure . (name,) $
+                --  2021-11-17: NOTE: one does not simply check into Mordor (not 1 mode)
                 if isNothing mb_doc_hdr && Map.null dmap && Map.null amap
                 then Left $ NoDocsInIface mod $ isCompiled name
                 else Right (Map.lookup name dmap, Map.lookup name amap)

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -694,7 +694,7 @@ mergeEnvs :: HscEnv -> [ModSummary] -> [HomeModInfo] -> [HscEnv] -> IO HscEnv
 mergeEnvs env extraModSummaries extraMods envs = do
     prevFinderCache <- concatFC <$> mapM (readIORef . hsc_FC) envs
     let ims  = map (Compat.installedModule (homeUnitId_ $ hsc_dflags env) . moduleName . ms_mod) extraModSummaries
-        ifrs = zipWith (\ms -> InstalledFound (ms_location ms)) extraModSummaries ims
+        ifrs = zipWith (InstalledFound . ms_location) extraModSummaries ims
     newFinderCache <- newIORef $
             foldl'
                 (\fc (im, ifr) -> Compat.extendInstalledModuleEnv fc im ifr) prevFinderCache
@@ -996,6 +996,7 @@ getDocsBatch
   :: HscEnv
   -> Module  -- ^ a moudle where the names are in scope
   -> [Name]
+  --  2021-11-18: NOTE: Map Int would become IntMap if next GHCs.
   -> IO (Either ErrorMessages (Map.Map Name (Either GetDocsFailure (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))))
   -- ^ Return a 'Map' of 'Name's to 'Either' (no docs messages) (general doc body & arg docs)
 getDocsBatch hsc_env _mod _names = do

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -27,6 +27,7 @@ module Development.IDE.GHC.Compat.Outputable (
     mkWarnMsg,
     mkSrcErr,
     srcErrorMessages,
+    Messages
     ) where
 
 

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -49,7 +49,7 @@ import           GHC.Driver.Session
 import           GHC.Driver.Types                as HscTypes
 import           GHC.Types.Name.Reader           (GlobalRdrEnv)
 import           GHC.Types.SrcLoc
-import           GHC.Utils.Error                 as Err hiding (mkWarnMsg)
+import           GHC.Utils.Error                 hiding (mkWarnMsg)
 import qualified GHC.Utils.Error                 as Err
 import           GHC.Utils.Outputable            as Out
 #else

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -27,7 +27,8 @@ module Development.IDE.GHC.Compat.Outputable (
     mkWarnMsg,
     mkSrcErr,
     srcErrorMessages,
-    Messages
+    Messages,
+    ErrorMessages
     ) where
 
 

--- a/ghcide/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/ghcide/src/Development/IDE/LSP/HoverDefinition.hs
@@ -24,14 +24,14 @@ import           Language.LSP.Types
 
 import qualified Data.Text                      as T
 
-gotoDefinition :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (ResponseResult TextDocumentDefinition))
-hover          :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (Maybe Hover))
+gotoDefinition     :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (ResponseResult TextDocumentDefinition))
+hover              :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (Maybe Hover))
 gotoTypeDefinition :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (ResponseResult TextDocumentTypeDefinition))
-documentHighlight :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (List DocumentHighlight))
-gotoDefinition = request "Definition" getDefinition (InR $ InL $ List []) (InR . InL . List)
-gotoTypeDefinition = request "TypeDefinition" getTypeDefinition (InR $ InL $ List []) (InR . InL . List)
-hover          = request "Hover"      getAtPoint     Nothing      foundHover
-documentHighlight = request "DocumentHighlight" highlightAtPoint (List []) List
+documentHighlight  :: IdeState -> TextDocumentPositionParams -> LSP.LspM c (Either ResponseError (List DocumentHighlight))
+gotoDefinition     = request "Definition"        getDefinition     (InR $ InL $ List []) (InR . InL . List)
+gotoTypeDefinition = request "TypeDefinition"    getTypeDefinition (InR $ InL $ List []) (InR . InL . List)
+hover              = request "Hover"             getAtPoint        Nothing                     foundHover
+documentHighlight  = request "DocumentHighlight" highlightAtPoint  (List [])             List
 
 references :: IdeState -> ReferenceParams -> LSP.LspM c (Either ResponseError (List Location))
 references ide (ReferenceParams (TextDocumentIdentifier uri) pos _ _ _) = liftIO $

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -396,7 +396,9 @@ defRowToSymbolInfo _ = Nothing
 
 pointCommand :: HieASTs t -> Position -> (HieAST t -> a) -> [a]
 pointCommand hf pos getter =
-    catMaybes $ M.elems $ flip M.mapWithKey (getAsts hf) $ \fs ast ->
+    catMaybes $ M.elems $ M.mapWithKey findInfo (getAsts hf)
+ where
+   findInfo fs ast =
       -- Since GHC 9.2:
       -- getAsts :: Map HiePath (HieAst a)
       -- type HiePath = LexialFastString
@@ -409,7 +411,6 @@ pointCommand hf pos getter =
       -- backwards compatibility.
       let smallestRange = selectSmallestContaining (sp $ coerce fs) ast in
       fmap getter smallestRange
- where
    sloc fs = mkRealSrcLoc fs (line+1) (cha+1)
    sp fs = mkRealSrcSpan (sloc fs) (sloc fs)
    line = _line pos

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -387,7 +387,7 @@ defRowToSymbolInfo (DefRow{..}:.(modInfoSrcFile -> Just srcFile))
 defRowToSymbolInfo _ = Nothing
 
 pointCommand :: HieASTs t -> Position -> (HieAST t -> a) -> [a]
-pointCommand hf pos k =
+pointCommand hf pos getter =
     catMaybes $ M.elems $ flip M.mapWithKey (getAsts hf) $ \fs ast ->
       -- Since GHC 9.2:
       -- getAsts :: Map HiePath (HieAst a)
@@ -399,9 +399,8 @@ pointCommand hf pos k =
       --
       -- 'coerce' here to avoid an additional function for maintaining
       -- backwards compatibility.
-      case selectSmallestContaining (sp $ coerce fs) ast of
-        Nothing   -> Nothing
-        Just ast' -> Just $ k ast'
+      let smallestRange = selectSmallestContaining (sp $ coerce fs) ast in
+      fmap getter smallestRange
  where
    sloc fs = mkRealSrcLoc fs (line+1) (cha+1)
    sp fs = mkRealSrcSpan (sloc fs) (sloc fs)

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -209,12 +209,12 @@ atPoint
   -> Maybe (Maybe Range, [T.Text])
 atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ pointCommand hf pos hoverInfo
   where
-    -- Hover info for values/data
+    -- | Get hover info for values/data
     hoverInfo ast = (Just range, prettyNames ++ pTypes)
       where
         pTypes
-          | Prelude.length names == 1 = dropEnd1 $ map wrapHaskell prettyTypes
-          | otherwise = map wrapHaskell prettyTypes
+          | Prelude.length names == 1 = dropEnd1 $ map wrapHaskell prettyConcreteTypes
+          | otherwise = map wrapHaskell prettyConcreteTypes
 
         range = realSrcSpanToRange $ nodeSpan ast
 
@@ -242,10 +242,12 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
               version = T.pack $ showVersion (unitPackageVersion conf)
           pure $ " *(" <> pkgName <> "-" <> version <> ")*"
 
-        prettyTypes = map (("_ :: "<>) . prettyType) types
         prettyType t = case kind of
           HieFresh -> showGhc t
           HieFromDisk full_file -> showGhc $ hieTypeToIface $ recoverFullType t (hie_types full_file)
+
+        -- | Local inferred most concrete type signature.
+        prettyConcreteTypes = map (("_ :: "<>) . prettyType) types
 
         definedAt name =
           -- do not show "at <no location info>" and similar messages

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -40,6 +40,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
 import           Data.Coerce                          (coerce)
+import           Data.Set                             (Set)
 import qualified Data.HashMap.Strict                  as HM
 import qualified Data.Map.Strict                      as M
 import           Data.Maybe
@@ -163,8 +164,12 @@ documentHighlight hf rf pos = pure highlights
       n <- ns
       ref <- fromMaybe [] (M.lookup (Right n) rf)
       pure $ makeHighlight ref
+
+    makeHighlight :: (RealSrcSpan, IdentifierDetails a) -> DocumentHighlight
     makeHighlight (sp,dets) =
       DocumentHighlight (realSrcSpanToRange sp) (Just $ highlightType $ identInfo dets)
+
+    highlightType :: Set ContextInfo -> DocumentHighlightKind
     highlightType s =
       if any (isJust . getScopeFromContext) s
         then HkWrite

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -40,7 +40,7 @@ showGhc = showSD . ppr
 showSD :: SDoc -> T.Text
 showSD = T.pack . unsafePrintSDoc
 
--- | Print name dropping unique tagging.
+-- | Print the name, dropping the unique tagging from it.
 showNameWithoutUniques :: Outputable a => a -> T.Text
 showNameWithoutUniques = T.pack . printNameWithoutUniques
 

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -97,9 +97,7 @@ spanDocToMarkdownForTest
   = haddockToMarkdown . H.toRegular . H._doc . H.parseParas Nothing
 
 -- Simple (and a bit hacky) conversion from Haddock markup to Markdown
-haddockToMarkdown
-  :: H.DocH String String -> String
-
+haddockToMarkdown :: H.DocH String String -> String
 haddockToMarkdown H.DocEmpty
   = ""
 haddockToMarkdown (H.DocAppend d1 d2)

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -40,6 +40,7 @@ showGhc = showSD . ppr
 showSD :: SDoc -> T.Text
 showSD = T.pack . unsafePrintSDoc
 
+-- | Print name dropping unique tagging.
 showNameWithoutUniques :: Outputable a => a -> T.Text
 showNameWithoutUniques = T.pack . printNameWithoutUniques
 

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -69,14 +69,11 @@ getDocumentationTryGhc env mod n = fromJust . Map.lookup n <$> getDocumentations
 
 getDocumentationsTryGhc :: HscEnv -> Module -> [Name] -> IO (Map.Map Name SpanDoc)
 getDocumentationsTryGhc env mod names = do
-  res <- fun
+  res <- getDocsBatch env mod names
   case res of
     Left _    -> return mempty -- catchSrcErrors (hsc_dflags env) "docs"
     Right res -> sequenceA $ Map.mapWithKey unwrap res
   where
-    fun :: IO (Either ErrorMessages (Map.Map Name (Either T.Text (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))))
-    fun = getDocsBatch env mod names
-
     unwrap :: Name -> Either a (Maybe HsDocString, b) -> IO SpanDoc
     unwrap name a = extractDocString a <$> getSpanDocUris name
      where

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -72,10 +72,10 @@ getDocumentationsTryGhc env mod names = do
   res <- fun
   case res of
       Left _    -> return []
-      Right res -> zipWithM unwrap (fmap snd res) names
+      Right res -> zipWithM unwrap (fmap snd $ Map.toList res) names
   where
-    fun :: IO (Either [FileDiagnostic] [(Name, Either String (Maybe HsDocString, Map.Map Int HsDocString))])
-    fun = catchSrcErrors (hsc_dflags env) "docs" $ Map.toList <$> getDocsBatch env mod names
+    fun :: IO (Either [FileDiagnostic] (Map.Map Name (Either String (Maybe HsDocString, Map.Map Int HsDocString))))
+    fun = catchSrcErrors (hsc_dflags env) "docs" $ getDocsBatch env mod names
 
     unwrap (Right (Just docs, _)) n = SpanDocString docs <$> getUris n
     unwrap _ n                      = mkSpanDocText n

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -74,7 +74,7 @@ getDocumentationsTryGhc env mod names = do
     Left _    -> return mempty -- catchSrcErrors (hsc_dflags env) "docs"
     Right res -> fmap Map.fromList $ sequenceA $ uncurry unwrap <$> Map.toList res
   where
-    fun :: IO (Either ErrorMessages (Map.Map Name (Either T.Text (Maybe HsDocString, Map.Map Int HsDocString))))
+    fun :: IO (Either ErrorMessages (Map.Map Name (Either T.Text (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))))
     fun = getDocsBatch env mod names
 
     unwrap :: Name -> Either a (Maybe HsDocString, b) -> IO (Name, SpanDoc)

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -75,7 +75,7 @@ getDocumentationsTryGhc env mod names = do
       Left _    -> return mempty
       Right res -> fmap Map.fromList $ sequenceA $ uncurry unwrap <$> Map.toList res
   where
-    fun :: IO (Either [FileDiagnostic] (Map.Map Name (Either String (Maybe HsDocString, Map.Map Int HsDocString))))
+    fun :: IO (Either [FileDiagnostic] (Map.Map Name (Either T.Text (Maybe HsDocString, Map.Map Int HsDocString))))
     fun = catchSrcErrors (hsc_dflags env) "docs" $ getDocsBatch env mod names
 
     unwrap :: Name -> Either a (Maybe HsDocString, b) -> IO (Name, SpanDoc)

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -44,16 +44,16 @@ mkDocMap env rm this_mod =
      k <- foldrM getType (tcg_type_env this_mod) names
      pure $ DKMap d k
   where
-    getDocs n map
-      | maybe True (mod ==) $ nameModule_maybe n = pure map -- we already have the docs in this_docs, or they do not exist
+    getDocs n mapToSpanDoc
+      | maybe True (mod ==) $ nameModule_maybe n = pure mapToSpanDoc -- we already have the docs in this_docs, or they do not exist
       | otherwise = do
       doc <- getDocumentationTryGhc env mod n
-      pure $ extendNameEnv map n doc
-    getType n map
+      pure $ extendNameEnv mapToSpanDoc n doc
+    getType n mapToTyThing
       | isTcOcc $ occName n = do
         kind <- lookupKind env mod n
-        pure $ maybe map (extendNameEnv map n) kind
-      | otherwise = pure map
+        pure $ maybe mapToTyThing (extendNameEnv mapToTyThing n) kind
+      | otherwise = pure mapToTyThing
     names = rights $ S.toList idents
     idents = M.keysSet rm
     mod = tcg_mod this_mod

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -65,21 +65,21 @@ lookupKind env mod =
     fmap (fromRight Nothing) . catchSrcErrors (hsc_dflags env) "span" . lookupName env mod
 
 getDocumentationTryGhc :: HscEnv -> Module -> Name -> IO SpanDoc
-getDocumentationTryGhc env mod n = fmap head ((fmap . fmap) snd $ getDocumentationsTryGhc env mod [n])
+getDocumentationTryGhc env mod n = fmap head ((fmap . fmap) snd $ fmap Map.toList $ getDocumentationsTryGhc env mod [n])
 
-getDocumentationsTryGhc :: HscEnv -> Module -> [Name] -> IO [(Name, SpanDoc)]
+getDocumentationsTryGhc :: HscEnv -> Module -> [Name] -> IO (Map.Map Name SpanDoc)
 getDocumentationsTryGhc env mod names = do
   res <- fun
   case res of
-      Left _    -> return []
-      Right res -> sequenceA $ unwrap <$> Map.toList res
+      Left _    -> return mempty
+      Right res -> fmap Map.fromList $ sequenceA $ unwrap <$> Map.toList res
   where
     fun :: IO (Either [FileDiagnostic] (Map.Map Name (Either String (Maybe HsDocString, Map.Map Int HsDocString))))
     fun = catchSrcErrors (hsc_dflags env) "docs" $ getDocsBatch env mod names
 
     unwrap :: (Name,  Either a (Maybe HsDocString, b)) -> IO (Name, SpanDoc)
     unwrap (name, Right (Just docs, _)) = (name,) . SpanDocString docs <$> getUris name
-    unwrap (name, _)                    = (name,) . SpanDocText [] <$> getUris name
+    unwrap (name, _)                    = (name,) . SpanDocText mempty <$> getUris name
 
     -- Get the uris to the documentation and source html pages if they exist
     getUris name = do

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -72,13 +72,13 @@ getDocumentationsTryGhc env mod names = do
   res <- fun
   case res of
     Left _    -> return mempty -- catchSrcErrors (hsc_dflags env) "docs"
-    Right res -> fmap Map.fromList $ sequenceA $ uncurry unwrap <$> Map.toList res
+    Right res -> sequenceA $ Map.mapWithKey unwrap res
   where
     fun :: IO (Either ErrorMessages (Map.Map Name (Either T.Text (Maybe HsDocString, Maybe (Map.Map Int HsDocString)))))
     fun = getDocsBatch env mod names
 
-    unwrap :: Name -> Either a (Maybe HsDocString, b) -> IO (Name, SpanDoc)
-    unwrap name a = (name,) . extractDocString a <$> getSpanDocUris name
+    unwrap :: Name -> Either a (Maybe HsDocString, b) -> IO SpanDoc
+    unwrap name a = extractDocString a <$> getSpanDocUris name
      where
       extractDocString :: Either b1 (Maybe HsDocString, b2) -> SpanDocUris -> SpanDoc
       --  2021-11-17: FIXME: ArgDocs get dropped here - instead propagate them.

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -65,7 +65,8 @@ lookupKind env mod =
     fmap (fromRight Nothing) . catchSrcErrors (hsc_dflags env) "span" . lookupName env mod
 
 getDocumentationTryGhc :: HscEnv -> Module -> Name -> IO SpanDoc
-getDocumentationTryGhc env mod n = fmap head ((fmap . fmap) snd $ fmap Map.toList $ getDocumentationsTryGhc env mod [n])
+--  2021-11-17: FIXME: Code uses batch search for singleton & assumes that search always succeeds.
+getDocumentationTryGhc env mod n = fromJust . Map.lookup n <$> getDocumentationsTryGhc env mod [n]
 
 getDocumentationsTryGhc :: HscEnv -> Module -> [Name] -> IO (Map.Map Name SpanDoc)
 getDocumentationsTryGhc env mod names = do

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -32,6 +32,7 @@ import           System.Directory
 import           System.FilePath
 
 import           Language.LSP.Types             (filePathToUri, getUri)
+import qualified Data.Map                       as Map
 
 mkDocMap
   :: HscEnv
@@ -67,7 +68,7 @@ getDocumentationTryGhc env mod n = head <$> getDocumentationsTryGhc env mod [n]
 
 getDocumentationsTryGhc :: HscEnv -> Module -> [Name] -> IO [SpanDoc]
 getDocumentationsTryGhc env mod names = do
-  res <- catchSrcErrors (hsc_dflags env) "docs" $ (fmap . fmap) snd $ getDocsBatch env mod names
+  res <- catchSrcErrors (hsc_dflags env) "docs" $ (fmap . fmap) snd $ fmap Map.toList $ getDocsBatch env mod names
   case res of
       Left _    -> return []
       Right res -> zipWithM unwrap res names

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -67,7 +67,7 @@ getDocumentationTryGhc env mod n = head <$> getDocumentationsTryGhc env mod [n]
 
 getDocumentationsTryGhc :: HscEnv -> Module -> [Name] -> IO [SpanDoc]
 getDocumentationsTryGhc env mod names = do
-  res <- catchSrcErrors (hsc_dflags env) "docs" $ getDocsBatch env mod names
+  res <- catchSrcErrors (hsc_dflags env) "docs" $ (fmap . fmap) snd $ getDocsBatch env mod names
   case res of
       Left _    -> return []
       Right res -> zipWithM unwrap res names

--- a/hie-compat/src-ghc810/Compat/HieAst.hs
+++ b/hie-compat/src-ghc810/Compat/HieAst.hs
@@ -50,7 +50,7 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Data                  ( Data, Typeable )
 import Data.List                  ( foldl1' )
-import Data.Maybe                 ( listToMaybe )
+import Data.Maybe                 ( listToMaybe, fromMaybe )
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Class  ( lift )
 
@@ -506,9 +506,7 @@ instance ToHie (Context (Located Var)) where
       C context (L (RealSrcSpan span) name')
         -> do
         m <- asks name_remapping
-        let name = case lookupNameEnv m (varName name') of
-              Just var -> var
-              Nothing-> name'
+        let name = fromMaybe name' (lookupNameEnv m (varName name'))
         pure
           [Node
             (NodeInfo S.empty [] $
@@ -523,9 +521,7 @@ instance ToHie (Context (Located Name)) where
   toHie c = case c of
       C context (L (RealSrcSpan span) name') -> do
         m <- asks name_remapping
-        let name = case lookupNameEnv m name' of
-              Just var -> varName var
-              Nothing -> name'
+        let name = maybe name' varName (lookupNameEnv m name')
         pure
           [Node
             (NodeInfo S.empty [] $


### PR DESCRIPTION
<sub>at least trying to</sub>

Work towards #2348 & cleaning-up worked-with code on the go.

---

PR solves:
https://github.com/haskell/haskell-language-server/blob/bd0046b7089e32e309f7b29ee6ec1a808ca1db86/ghcide/src/Development/IDE/Spans/Documentation.hs#L64-L67

As `getDocumentationTryGhc` is the main code that retrieves the docs from GHC - the PR provides the element retrieval code.

---

This PR is a stage toward provisioning the argument docs into the LSP interface. PR addressed some underlying code.

---

Initial `master` code conditions:


* `getDocsBatch` had a doc:
https://github.com/haskell/haskell-language-server/blob/854d2c5a1aa3095c93e3f38ef3731be89b4ab09a/ghcide/src/Development/IDE/Core/Compile.hs#L994-L996

* `getDocsBatch` not optimized for batch retrieval, it does 1 element retrieval for every element. (Locates & loads a module interface, retrieves 1 element, locates & loads another module interface, retrieves 1 element ...).

* `getDocumentationsTryGhc` (plural `*s*`) - in the project *had only one use* - in `getDocumentationTryGhc` (single) & so was its implementation.

* So, over the project only (single) (meaning `getDocumentationTryGhc`) was used - & all doc requests to GHC - were 1 element requests, which got wrapped into singleton & processed as a list & by list function down the codepath.
* So `getDocsBatch` both was externally invoked for 1 elem & internally was processing lists per 1 elem. Batch processing optimization is addressed in #2371.

---

The results of the PR:
1. The non-interactive analog of GHCs `getDocs` - `getDocsNonInteractive` is created (for purposes mentioned in the initial doc above) it is designed for (all current requests) case of looking-up an entity.
2. Creation of `getDocsNonInteractive` allows to stop using `getDocumentationsTryGhcs` (plural) for `getDocumentationTryGhc` (single), which makes possible to remove unsafe `head` from the main code path.
3. Optimize the use case currently used everywhere.
3. Code shared between `getDocsNonInteractive` & `getDocsBatch` formed `getDocsNonInteractive'` & `initTypecheckEnv` which self-explained the code.

---

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2349"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

