### PR TITLE
Fix several hlint issues related with the use of parsed module without comments

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -701,34 +701,34 @@ Here are the summary of changes:
 Haskell Language Server 1.1.0 has finally come! Many thanks to all contributors -- since the last release, we have merged over 100 PRs!
 As always, there are many internal bug fixes and performance improvements in ghcide. Apart from that,
 
-* Wingman gets many enhancements, thanks to @isovector for this epic work!
-  * Wingman actions can now be bound to editor hotkeys
-  * Experimental support for "jump to next unsolved hole"
-  * Improved layout algorithm --- don't reflow instances, or break do-blocks
-  * Wingman can now deal with GADTs, rank-n types and pattern synonyms
-  * Wingman now respects user-written bindings on the left side of the equals sign
-  * Significantly more-natural synthesized code when dealing with newtypes, infix operators, records and strings
-  * Improved user experience --- less waiting, and friendly errors for when things go wrong
-* hlint plugin not working in some cases gets fixed
-* annoying log message "haskell-lsp:incoming message parse error" gets fixed in `lsp-1.2`
-* eval plugin now supports `it` variable, like GHCi
-* verbose message "No cradle found for ... Proceeding with implicit cradle" is GONE
-* type lenses plugin now has its custom config `mode` (enum) [`always`] to control its working mode:
-  * `always`: always displays type signature lenses of global bindings
-  * `exported`: similar to `always`, but only displays for exported global bindings
-  * `diagnostics`: follows diagnostic messages produced by GHC
-* top-level LSP option `completionSnippetsOn` and `maxNumberOfProblems` are deprecated
-* completions plugin now has its custom config:
-  * `autoExtendOn` (boolean) [`true`]: whether to enable auto extending import lists
-  * `snippetsOn` (boolean) [`true`]: wheter to enable completion snippets, taking the place of `completionSnippetsOn`
-* Wingman has its custom config:
-  * `timeout_duration` (integer) [`2`]: the timeout for Wingman actions, in seconds
-  * `features` (string) [`""`]: feature set used by Wingman (See [the README of Wingman](https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-tactics-plugin#readme))
-  * `max_use_ctor_actions` (integer) [`5`]: maximum number of `Use constructor <x>` code actions that can appear
-  * `hole_severity` (enum) [`none`]: the severity to use when showing hole diagnostics
-* LSP symbols of typeclass and type families are more appropriate
-* test suite of plugins are reorganized, which no longer need to be run with `test-server` executable
-* two new packages `hls-test-utils` and `hls-stylish-haskell-plugin` are extracted
+- Wingman gets many enhancements, thanks to @isovector for this epic work!
+  - Wingman actions can now be bound to editor hotkeys
+  - Experimental support for "jump to next unsolved hole"
+  - Improved layout algorithm --- don't reflow instances, or break do-blocks
+  - Wingman can now deal with GADTs, rank-n types and pattern synonyms
+  - Wingman now respects user-written bindings on the left side of the equals sign
+  - Significantly more-natural synthesized code when dealing with newtypes, infix operators, records and strings
+  - Improved user experience --- less waiting, and friendly errors for when things go wrong
+- hlint plugin not working in some cases gets fixed
+- annoying log message "haskell-lsp:incoming message parse error" gets fixed in `lsp-1.2`
+- eval plugin now supports `it` variable, like GHCi
+- verbose message "No cradle found for ... Proceeding with implicit cradle" is GONE
+- type lenses plugin now has its custom config `mode` (enum) [`always`] to control its working mode:
+  - `always`: always displays type signature lenses of global bindings
+  - `exported`: similar to `always`, but only displays for exported global bindings
+  - `diagnostics`: follows diagnostic messages produced by GHC
+- top-level LSP option `completionSnippetsOn` and `maxNumberOfProblems` are deprecated
+- completions plugin now has its custom config:
+  - `autoExtendOn` (boolean) [`true`]: whether to enable auto extending import lists
+  - `snippetsOn` (boolean) [`true`]: wheter to enable completion snippets, taking the place of `completionSnippetsOn`
+- Wingman has its custom config:
+  - `timeout_duration` (integer) [`2`]: the timeout for Wingman actions, in seconds
+  - `features` (string) [`""`]: feature set used by Wingman (See [the README of Wingman](https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-tactics-plugin#readme))
+  - `max_use_ctor_actions` (integer) [`5`]: maximum number of `Use constructor <x>` code actions that can appear
+  - `hole_severity` (enum) [`none`]: the severity to use when showing hole diagnostics
+- LSP symbols of typeclass and type families are more appropriate
+- test suite of plugins are reorganized, which no longer need to be run with `test-server` executable
+- two new packages `hls-test-utils` and `hls-stylish-haskell-plugin` are extracted
 
 This version uses `lsp-1.2.0`, `hls-plugin-api-1.1.0`, and `ghcide-1.2.0.2`.
 

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -237,14 +237,14 @@ getIdeas nfp = do
   where moduleEx :: ParseFlags -> Action (Maybe (Either ParseError ModuleEx))
 #ifndef HLINT_ON_GHC_LIB
         moduleEx _flags = do
-          mbpm <- getParsedModule nfp
+          mbpm <- getParsedModuleWithComments nfp
           return $ createModule <$> mbpm
           where createModule pm = Right (createModuleEx anns modu)
                   where anns = pm_annotations pm
                         modu = pm_parsed_source pm
 #else
         moduleEx flags = do
-          mbpm <- getParsedModule nfp
+          mbpm <- getParsedModuleWithComments nfp
           -- If ghc was not able to parse the module, we disable hlint diagnostics
           if isNothing mbpm
               then return Nothing

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -131,7 +131,7 @@ suggestionsTests =
         doc <- openDoc "IgnoreAnn.hs" "haskell"
         expectNoMoreDiagnostics 3 doc "hlint"
 
-    , knownBrokenForHlintOnRawGhc "[#838] hlint plugin doesn't honour HLINT annotations" $
+    , knownBrokenForHlintOnRawGhc "[#638] hlint plugin doesn't honour HLINT annotations" $
       testCase "hlint diagnostics ignore hints honouring HLINT annotations" $ runHlintSession "" $ do
         doc <- openDoc "IgnoreAnnHlint.hs" "haskell"
         expectNoMoreDiagnostics 3 doc "hlint"

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -131,8 +131,7 @@ suggestionsTests =
         doc <- openDoc "IgnoreAnn.hs" "haskell"
         expectNoMoreDiagnostics 3 doc "hlint"
 
-    , knownBrokenForHlintOnRawGhc "[#638] hlint plugin doesn't honour HLINT annotations" $
-      testCase "hlint diagnostics ignore hints honouring HLINT annotations" $ runHlintSession "" $ do
+    , testCase "hlint diagnostics ignore hints honouring HLINT annotations" $ runHlintSession "" $ do
         doc <- openDoc "IgnoreAnnHlint.hs" "haskell"
         expectNoMoreDiagnostics 3 doc "hlint"
 
@@ -158,8 +157,7 @@ suggestionsTests =
         liftIO $ not (hasApplyAll thirdLine) @? "Unexpected apply all code action"
         liftIO $ hasApplyAll multiLine @? "Missing apply all code action"
 
-    , knownBrokenForHlintOnRawGhc "[#2042] maybe hlint is ignoring pragmas" $
-      testCase "hlint should warn about unused extensions" $ runHlintSession "unusedext" $ do
+    , testCase "hlint should warn about unused extensions" $ runHlintSession "unusedext" $ do
         doc <- openDoc "UnusedExtension.hs" "haskell"
         diags@(unusedExt:_) <- waitForDiagnosticsFromSource doc "hlint"
 
@@ -174,8 +172,7 @@ suggestionsTests =
         waitForAllProgressDone
         -- hlint will report a parse error if PatternSynonyms is enabled
         expectNoMoreDiagnostics 3 doc "hlint"
-    , knownBrokenForHlintOnRawGhc "[#2280] maybe hlint is ignoring pragmas" $
-      testCase "hlint should not warn about redundant irrefutable pattern with LANGUAGE Strict" $ runHlintSession "" $ do
+    , testCase "hlint should not warn about redundant irrefutable pattern with LANGUAGE Strict" $ runHlintSession "" $ do
         doc <- openDoc "StrictData.hs" "haskell"
 
         waitForAllProgressDone


### PR DESCRIPTION
* The plugin was not using the `getParsedModuleWithComments` so it was missing all info encoded in comments: pragmas, directives, etc and causing several issues

* Fixes #638
* Fixes #2042
* Fixes #2280

I was suspecting this so i added the regression tests in #2321 with the intent of fixing them in a ongoing pr, this one.

(I've included a minor correction of bullet lists suggested by markdown linting)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2366"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

