### PR TITLE
hls-call-hierarchy-plugin: Update `ghc` dependency

### DIFF
--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -29,7 +29,7 @@ library
     , bytestring
     , containers
     , extra
-    , ghc
+    , ghc                   >=9.2.1
     , ghcide                ^>=1.4.1 || ^>= 1.5.0
     , hiedb
     , hls-plugin-api        ^>=1.2


### PR DESCRIPTION
The latest version of `hls-call-hierarchy-plugin` calls [`occNameSpace`](https://hackage.haskell.org/package/ghc-9.2.1/docs/GHC-Types-Name-Occurrence.html#v:occNameSpace) which does not exist in [earlier versions](https://hackage.haskell.org/package/ghc-8.10.2/docs/GHC-Types-Name-Occurrence.html#v:occNameSpace).

```
Building library for hls-call-hierarchy-plugin-1.0.1.1..
[1 of 4] Compiling Ide.Plugin.CallHierarchy.Types ( src/Ide/Plugin/CallHierarchy/Types.hs, dist/build/Ide/Plugin/CallHierarchy/Types.o, dist/build/Ide/Plugin/CallHierarchy/Types.dyn_o )
[2 of 4] Compiling Ide.Plugin.CallHierarchy.Query ( src/Ide/Plugin/CallHierarchy/Query.hs, dist/build/Ide/Plugin/CallHierarchy/Query.o, dist/build/Ide/Plugin/CallHierarchy/Query.dyn_o )

src/Ide/Plugin/CallHierarchy/Query.hs:78:23: error:
    Variable not in scope:
      occNameSpace :: OccName.OccName -> OccName.NameSpace
   |
78 |     let o = toNsChar (occNameSpace symName) : occNameString symName
   |                       ^^^^^^^^^^^^

src/Ide/Plugin/CallHierarchy/Query.hs:78:47: error:
    Variable not in scope: occNameString :: OccName.OccName -> [Char]
   |
78 |     let o = toNsChar (occNameSpace symName) : occNameString symName
   |                                               ^^^^^^^^^^^^^

src/Ide/Plugin/CallHierarchy/Query.hs:80:26: error:
    • Variable not in scope: moduleUnit :: Module -> Unit
    • Perhaps you meant one of these:
        ‘moduleUnitId’ (imported from Development.IDE.GHC.Compat),
        ‘moduleInfo’ (imported from Development.IDE.GHC.Compat)
   |
80 |         u = unitString $ moduleUnit symModule
   |                          ^^^^^^^^^^
```
(Building with `ghc-8.10-6`)

This affects `hls-call-hierarchy-plugin >=1.0.1.1`, but not earlier versions.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2367"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

