### PR TITLE
Update ghcide dependency for various plugins

### DIFF
--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -41,7 +41,7 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  ^>=1.4 || ^>=1.5
+    , ghcide                  ^>=1.5.0
     , hls-graph
     , hls-plugin-api          ^>=1.2
     , hspec                   <2.8

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -29,7 +29,7 @@ library
     , containers
     , ghc
     , ghc-exactprint
-    , ghcide          >=1.2  && <1.6
+    , ghcide          ^>=1.5.0
     , hls-plugin-api  >=1.1  && <1.3
     , lens
     , lsp

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -26,7 +26,7 @@ library
     , fourmolu        ^>=0.3 || ^>=0.4
     , ghc
     , ghc-boot-th
-    , ghcide          >=1.2  && <1.6
+    , ghcide          ^>=1.5.0
     , hls-plugin-api  >=1.1  && <1.3
     , lens
     , lsp

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -55,7 +55,7 @@ library
     , extra
     , filepath
     , ghc-exactprint        >=0.6.3.4
-    , ghcide                ^>=1.4 || ^>=1.5
+    , ghcide                ^>=1.5.0
     , hashable
     , hlint
     , hls-plugin-api        >=1.1     && <1.3

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -24,7 +24,7 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          >=1.2   && <1.6
+    , ghcide          ^>=1.5.0
     , hls-plugin-api  >=1.1   && <1.3
     , lens
     , lsp

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -23,7 +23,7 @@ library
     , directory
     , extra
     , ghc
-    , ghcide                >=1.2     && <1.6
+    , ghcide                ^>=1.5.0
     , hashable
     , hls-plugin-api        >=1.1     && <1.3
     , lsp

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -38,7 +38,7 @@ library
     , foldl
     , ghc
     , ghc-exactprint
-    , ghcide                >=1.2  && <1.6
+    , ghcide                ^>=1.5.0
     , hls-plugin-api        >=1.1  && <1.3
     , lens
     , lsp

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -24,7 +24,7 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide           >=1.2  && <1.6
+    , ghcide           ^>=1.5.0
     , hls-plugin-api   >=1.1  && <1.3
     , lsp-types
     , stylish-haskell  ^>=0.12 || ^>=0.13

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -82,7 +82,7 @@ library
     , ghc-boot-th
     , ghc-exactprint
     , ghc-source-gen        ^>=0.4.1
-    , ghcide                ^>=1.4.1 || ^>=1.5
+    , ghcide                ^>=1.5.0
     , hls-graph
     , hls-plugin-api        >=1.1     && <1.3
     , hyphenation


### PR DESCRIPTION
`hls-class-plugin-1.0.1.1` imports `Development.IDE.GHC.Compat.Util`, which doesn't exist until `ghcide-1.5.0`

```
Building library for hls-class-plugin-1.0.1.1..
[1 of 1] Compiling Ide.Plugin.Class ( src/Ide/Plugin/Class.hs, dist/build/Ide/Plugin/Class.o, dist/build/Ide/Plugin/Class.dyn_o )

src/Ide/Plugin/Class.hs:27:1: error:
    Could not find module ‘Development.IDE.GHC.Compat.Util’
    Perhaps you meant
      Development.IDE.GHC.Compat (from ghcide-1.4.2.2)
      Development.IDE.GHC.Util (from ghcide-1.4.2.2)
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
27 | import           Development.IDE.GHC.Compat.Util
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2368"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

