### PR TITLE
hls-fourmolu-plugin: Update ghcide dependency

### DIFF
--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -26,7 +26,7 @@ library
     , fourmolu        ^>=0.3 || ^>=0.4
     , ghc
     , ghc-boot-th
-    , ghcide          >=1.2  && <1.6
+    , ghcide          ^>=1.5.0
     , hls-plugin-api  >=1.1  && <1.3
     , lens
     , lsp


### PR DESCRIPTION
Similar to #2368

It will also need a revision on hackage

```
src/Ide/Plugin/Fourmolu.hs:18:1: error:
    Could not find module ‘Development.IDE.GHC.Compat.Util’
    Perhaps you meant
      Development.IDE.GHC.Compat (from ghcide-1.4.2.2)
      Development.IDE.GHC.Util (from ghcide-1.4.2.2)
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
18 | import qualified Development.IDE.GHC.Compat.Util as S
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2370"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

