### PR TITLE
Fix regression in GhcSessionDeps

### DIFF
--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -252,10 +252,6 @@ type instance RuleResult GetModIfaceFromDiskAndIndex = HiFileResult
 -- | Get a module interface details, either from an interface file or a typechecked module
 type instance RuleResult GetModIface = HiFileResult
 
--- | Get a module interface details, without the Linkable
--- For better early cuttoff
-type instance RuleResult GetModIfaceWithoutLinkable = HiFileResult
-
 -- | Get the contents of a file, either dirty (if the buffer is modified) or Nothing to mean use from disk.
 type instance RuleResult GetFileContents = (FileVersion, Maybe Text)
 
@@ -429,11 +425,6 @@ data GetModIface = GetModIface
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetModIface
 instance NFData   GetModIface
-
-data GetModIfaceWithoutLinkable = GetModIfaceWithoutLinkable
-    deriving (Eq, Show, Typeable, Generic)
-instance Hashable GetModIfaceWithoutLinkable
-instance NFData   GetModIfaceWithoutLinkable
 
 data IsFileOfInterest = IsFileOfInterest
     deriving (Eq, Show, Typeable, Generic)

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -688,13 +688,11 @@ loadGhcSession ghcSessionDepsConfig = do
 
 data GhcSessionDepsConfig = GhcSessionDepsConfig
     { checkForImportCycles :: Bool
-    , forceLinkables       :: Bool
     , fullModSummary       :: Bool
     }
 instance Default GhcSessionDepsConfig where
   def = GhcSessionDepsConfig
     { checkForImportCycles = True
-    , forceLinkables = False
     , fullModSummary = False
     }
 
@@ -712,12 +710,7 @@ ghcSessionDepsDefinition GhcSessionDepsConfig{..} env file = do
                 else uses_ GetModSummaryWithoutTimestamps (file:deps)
 
             depSessions <- map hscEnv <$> uses_ GhcSessionDeps deps
-            let uses_th_qq =
-                    xopt LangExt.TemplateHaskell dflags || xopt LangExt.QuasiQuotes dflags
-                dflags = ms_hspp_opts ms
-            ifaces <- if uses_th_qq || forceLinkables
-                        then uses_ GetModIface deps
-                        else uses_ GetModIfaceWithoutLinkable deps
+            ifaces <- uses_ GetModIface deps
 
             let inLoadOrder = map hirHomeMod ifaces
             session' <- liftIO $ mergeEnvs hsc mss inLoadOrder depSessions

--- a/ghcide/test/data/THLoading/A.hs
+++ b/ghcide/test/data/THLoading/A.hs
@@ -1,0 +1,5 @@
+module A where
+import B (bar)
+
+foo :: ()
+foo = bar

--- a/ghcide/test/data/THLoading/B.hs
+++ b/ghcide/test/data/THLoading/B.hs
@@ -1,0 +1,4 @@
+module B where
+
+bar :: ()
+bar = ()

--- a/ghcide/test/data/THLoading/THA.hs
+++ b/ghcide/test/data/THLoading/THA.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE TemplateHaskell #-}
+module THA where
+import Language.Haskell.TH
+import A (foo)
+
+th_a :: DecsQ
+th_a = [d| a = foo |]

--- a/ghcide/test/data/THLoading/THB.hs
+++ b/ghcide/test/data/THLoading/THB.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+module THB where
+import THA
+
+$th_a

--- a/ghcide/test/data/THLoading/hie.yaml
+++ b/ghcide/test/data/THLoading/hie.yaml
@@ -1,0 +1,1 @@
+cradle: {direct: {arguments: ["-Wmissing-signatures", "-package template-haskell", "THA", "THB", "A", "B"]}}

--- a/ghcide/test/data/THLoading/hie.yaml
+++ b/ghcide/test/data/THLoading/hie.yaml
@@ -1,1 +1,1 @@
-cradle: {direct: {arguments: ["-Wmissing-signatures", "-package template-haskell", "THA", "THB", "A", "B"]}}
+cradle: {direct: {arguments: ["-package template-haskell", "THA", "THB", "A", "B"]}}

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4061,7 +4061,7 @@ thLoadingTest :: TestTree
 thLoadingTest = testCase "Loading linkables" $ runWithExtraFiles "THLoading" $ \dir -> do
     let thb = dir </> "THB.hs"
     _ <- openDoc thb "haskell"
-    expectDiagnostics [ ( thb, [(DsWarning, (4, 0), "Top-level binding with no type signature: a :: ()")] ) ]
+    expectNoMoreDiagnostics 1
 
 
 -- | test that TH is reevaluated on typecheck

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4018,6 +4018,7 @@ thTests =
         _ <- createDoc "B.hs" "haskell" sourceB
         return ()
     , thReloadingTest False
+    , thLoadingTest
     , ignoreInWindowsBecause "Broken in windows" $ thReloadingTest True
     -- Regression test for https://github.com/haskell/haskell-language-server/issues/891
     , thLinkingTest False
@@ -4054,6 +4055,14 @@ thTests =
     _ <- openDoc cPath "haskell"
     expectDiagnostics [ ( cPath, [(DsWarning, (3, 0), "Top-level binding with no type signature: a :: A")] ) ]
     ]
+
+-- | Test that all modules have linkables
+thLoadingTest :: TestTree
+thLoadingTest = testCase "Loading linkables" $ runWithExtraFiles "THLoading" $ \dir -> do
+    let thb = dir </> "THB.hs"
+    _ <- openDoc thb "haskell"
+    expectDiagnostics [ ( thb, [(DsWarning, (4, 0), "Top-level binding with no type signature: a :: ()")] ) ]
+
 
 -- | test that TH is reevaluated on typecheck
 thReloadingTest :: Bool -> TestTree

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -540,8 +540,7 @@ runGetSession st nfp = liftIO $ runAction "eval" st $ do
     ((_, res),_) <- liftIO $ loadSessionFun fp
     let env = fromMaybe (error $ "Unknown file: " <> fp) res
         ghcSessionDepsConfig = def
-            { forceLinkables = True
-            , checkForImportCycles = False
+            { checkForImportCycles = False
             , fullModSummary = True
             }
     res <- fmap hscEnvWithImportPaths <$> ghcSessionDepsDefinition ghcSessionDepsConfig env nfp


### PR DESCRIPTION
We cannot use GetModIfaceWithoutLinkable since the session might be reused later to load a module that needs linkables

Note that this does not have any effects on performance, since GetModIfaceWithoutLinkable is just a synonym for GetModIface that removes the linkable

Fixes #2379

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2380"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

