### PR TITLE
ghcide: Update dependency on `hls-plugin-api`

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -60,7 +60,7 @@ library
         haddock-library >= 1.8 && < 1.11,
         hashable,
         hie-compat ^>= 0.2.0.0,
-        hls-plugin-api ^>= 1.2.0.0,
+        hls-plugin-api ^>= 1.2.0.2,
         lens,
         hiedb == 0.4.1.*,
         lsp-types >= 1.3.0.1 && < 1.4,


### PR DESCRIPTION
2204a16bfbbdd3f0887cdfdab4b86cbd63ab051a broke backward compatibility between `ghcide` and `hls-plugin-api`

In addition to this PR, the following will need to be revised on hackage:

Versions `1.4.1.0` `1.4.2.0` `1.4.2.1` `1.4.2.2` `1.4.2.3` will need
`hls-plugin-api ^>= 1.2.0.0`
changed to
`hls-plugin-api >= 1.2.0.0 && < 1.2.0.2`

Version `1.5.0` will need
`hls-plugin-api ^>= 1.2.0.0`
changed to
`hls-plugin-api ^>= 1.2.0.2`

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2382"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

