### PR TITLE
Add fix for placement after multiline pragma

### DIFF
--- a/plugins/hls-pragmas-plugin/test/Main.hs
+++ b/plugins/hls-pragmas-plugin/test/Main.hs
@@ -27,7 +27,10 @@ tests =
 codeActionTests :: TestTree
 codeActionTests =
   testGroup "code actions"
-  [ codeActionTest "adds LANGUAGE with no other pragmas at start ignoring later INLINE pragma" "AddPragmaIgnoreInline" [("Add \"TupleSections\"", "Contains TupleSections code action")]
+  [ codeActionTest "add pragma after mix of multi line lang and opts pragmas" "MultiLangOptsMix" [("Add \"TupleSections\"", "Contains TupleSections code action")]
+  , codeActionTest "add LANGUAGE pragma after multi line options_ghc" "AfterMultiOptionsPragma" [("Add \"TupleSections\"", "Contains TupleSections code action")]
+  , codeActionTest "add LANGUAGE pragma after multi line lang pragma" "PragmaAfterMultilinePragma" [("Add \"BangPatterns\"", "Contains BangPatterns code action")]
+  , codeActionTest "adds LANGUAGE with no other pragmas at start ignoring later INLINE pragma" "AddPragmaIgnoreInline" [("Add \"TupleSections\"", "Contains TupleSections code action")]
   , codeActionTest "adds LANGUAGE after shebang preceded by other LANGUAGE and GHC_OPTIONS" "AddPragmaAfterShebangPrecededByLangAndOptsGhc" [("Add \"TupleSections\"", "Contains TupleSections code action")]
   , codeActionTest "adds LANGUAGE after shebang with other Language preceding shebang" "AddPragmaAfterShebangPrecededByLangAndOptsGhc" [("Add \"TupleSections\"", "Contains TupleSections code action")]
   , codeActionTest "adds LANGUAGE before Doc comments after interchanging pragmas" "BeforeDocInterchanging" [("Add \"NamedFieldPuns\"", "Contains NamedFieldPuns code action")]

--- a/plugins/hls-pragmas-plugin/test/testdata/AfterMultiOptionsPragma.expected.hs
+++ b/plugins/hls-pragmas-plugin/test/testdata/AfterMultiOptionsPragma.expected.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE  OverloadedStrings #-}
+{-# OPTIONS_GHC -Wall 
+, -Wno-unused-imports, 
+ -freverse-errors #-}
+{-# LANGUAGE TupleSections #-}
+
+data Something = Something {
+    foo :: !String,
+    bar :: !Int
+}
+
+tupleSection = (1, ) <$> Just 2
+
+{-# INLINE addOne #-}
+addOne :: Int -> Int 
+addOne x = x + 1
+
+{-# INLINE subOne #-}
+subOne :: Int -> Int
+subOne x = x - 1

--- a/plugins/hls-pragmas-plugin/test/testdata/AfterMultiOptionsPragma.hs
+++ b/plugins/hls-pragmas-plugin/test/testdata/AfterMultiOptionsPragma.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE  OverloadedStrings #-}
+{-# OPTIONS_GHC -Wall 
+, -Wno-unused-imports, 
+ -freverse-errors #-}
+
+data Something = Something {
+    foo :: !String,
+    bar :: !Int
+}
+
+tupleSection = (1, ) <$> Just 2
+
+{-# INLINE addOne #-}
+addOne :: Int -> Int 
+addOne x = x + 1
+
+{-# INLINE subOne #-}
+subOne :: Int -> Int
+subOne x = x - 1

--- a/plugins/hls-pragmas-plugin/test/testdata/MultiLangOptsMix.expected.hs
+++ b/plugins/hls-pragmas-plugin/test/testdata/MultiLangOptsMix.expected.hs
@@ -1,0 +1,25 @@
+{-# OPTIONS_GHC -Wall 
+, -Wno-unused-imports, 
+ -freverse-errors #-}
+{-# LANGUAGE RecordWildCards, 
+   OverloadedStrings,
+   BangPatterns #-}
+{-# OPTIONS_GHC
+    -freverse-errors
+  #-}
+{-# LANGUAGE TupleSections #-}
+
+data Something = Something {
+    foo :: !String,
+    bar :: !Int
+}
+
+tupleSection = (1, ) <$> Just 2
+
+{-# INLINE addOne #-}
+addOne :: Int -> Int 
+addOne x = x + 1
+
+{-# INLINE subOne #-}
+subOne :: Int -> Int
+subOne x = x - 1

--- a/plugins/hls-pragmas-plugin/test/testdata/MultiLangOptsMix.hs
+++ b/plugins/hls-pragmas-plugin/test/testdata/MultiLangOptsMix.hs
@@ -1,0 +1,24 @@
+{-# OPTIONS_GHC -Wall 
+, -Wno-unused-imports, 
+ -freverse-errors #-}
+{-# LANGUAGE RecordWildCards, 
+   OverloadedStrings,
+   BangPatterns #-}
+{-# OPTIONS_GHC
+    -freverse-errors
+  #-}
+
+data Something = Something {
+    foo :: !String,
+    bar :: !Int
+}
+
+tupleSection = (1, ) <$> Just 2
+
+{-# INLINE addOne #-}
+addOne :: Int -> Int 
+addOne x = x + 1
+
+{-# INLINE subOne #-}
+subOne :: Int -> Int
+subOne x = x - 1

--- a/plugins/hls-pragmas-plugin/test/testdata/PragmaAfterMultilinePragma.expected.hs
+++ b/plugins/hls-pragmas-plugin/test/testdata/PragmaAfterMultilinePragma.expected.hs
@@ -1,0 +1,18 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE RecordWildCards, 
+   OverloadedStrings #-}
+{-# LANGUAGE BangPatterns #-}
+
+data Metaprogram = Metaprogram
+  { mp_name             :: !Text
+  , mp_known_by_auto    :: !Bool
+  , mp_show_code_action :: !Bool
+  , mp_program          :: !(TacticsM ())
+  }
+  deriving stock Generic
+{-# ANN Metaprogram "hello" #-}
+
+instance NFData Metaprogram where
+  rnf (!(Metaprogram !_ !_ !_ !_)) = ()

--- a/plugins/hls-pragmas-plugin/test/testdata/PragmaAfterMultilinePragma.hs
+++ b/plugins/hls-pragmas-plugin/test/testdata/PragmaAfterMultilinePragma.hs
@@ -1,0 +1,17 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE RecordWildCards, 
+   OverloadedStrings #-}
+
+data Metaprogram = Metaprogram
+  { mp_name             :: !Text
+  , mp_known_by_auto    :: !Bool
+  , mp_show_code_action :: !Bool
+  , mp_program          :: !(TacticsM ())
+  }
+  deriving stock Generic
+{-# ANN Metaprogram "hello" #-}
+
+instance NFData Metaprogram where
+  rnf (!(Metaprogram !_ !_ !_ !_)) = ()


### PR DESCRIPTION
This is in reference to the issue mentioned in #2392 pr.

It adds a fix for the case where LANGUAGE or OPTIONS_GHC pragmas span multiple lines - where previously it was assuming that they were all single line pragmas.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2401"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

