### PR TITLE
Add fix for import placement

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -21,10 +21,12 @@ module Development.IDE.Plugin.CodeAction
 import           Control.Applicative                               ((<|>))
 import           Control.Arrow                                     (second,
                                                                     (>>>))
-import           Control.Monad                                     (guard, join)
+import           Control.Monad                                     (foldM,
+                                                                    guard, join)
 import           Control.Monad.IO.Class
 import           Data.Char
 import qualified Data.DList                                        as DL
+import           Data.Either.Extra                                 (fromEither)
 import           Data.Function
 import           Data.Functor
 import qualified Data.HashMap.Strict                               as Map
@@ -1323,12 +1325,32 @@ findNextPragmaPosition contents = Just ((lineNumber, 0), 0)
     contents' = T.lines contents
 
 afterPragma :: T.Text -> [T.Text] -> Int -> Int
-afterPragma name contents lineNum = lastLineWithPrefix (checkPragma name) contents lineNum
+afterPragma name = lastLineWithPrefixMulti (checkPragma name)
 
 lastLineWithPrefix :: (T.Text -> Bool) -> [T.Text] -> Int -> Int
 lastLineWithPrefix p contents lineNum = max lineNum next
   where
-    next = maybe lineNum succ $ listToMaybe . reverse $ findIndices p contents
+    next = maybe lineNum succ $ listToMaybe $ reverse $ findIndices p contents
+
+-- | Accounts for the case where the LANGUAGE or OPTIONS_GHC
+-- pragma spans multiple lines or just a single line
+lastLineWithPrefixMulti :: (T.Text -> Bool) -> [T.Text] -> Int -> Int
+lastLineWithPrefixMulti p contents lineNum = max lineNum next
+  where
+    mIndex = listToMaybe . reverse $ findIndices p contents
+    next = case mIndex of
+      Nothing    -> 0
+      Just index -> getEndOfPragmaBlock index $ drop index contents
+
+getEndOfPragmaBlock :: Int -> [T.Text] -> Int
+getEndOfPragmaBlock start contents = lineNumber
+  where
+    lineNumber = fromEither lineNum
+    lineNum = foldM go start contents
+    go pos txt
+      | endOfBlock txt = Left $ pos + 1
+      | otherwise = Right $ pos + 1
+    endOfBlock txt = T.dropWhile (/= '}') (T.dropWhile (/= '-') txt) == "}"
 
 checkPragma :: T.Text -> T.Text -> Bool
 checkPragma name = check

--- a/ghcide/test/data/import-placement/AfterMultilineOptsPragma.expected.hs
+++ b/ghcide/test/data/import-placement/AfterMultilineOptsPragma.expected.hs
@@ -1,0 +1,15 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards, 
+   OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wall,
+  -Wno-unused-imports #-}
+import Data.Monoid
+
+   
+
+class Semigroup a => SomeData a
+
+-- | a comment
+instance SomeData All

--- a/ghcide/test/data/import-placement/AfterMultilineOptsPragma.hs
+++ b/ghcide/test/data/import-placement/AfterMultilineOptsPragma.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards, 
+   OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wall,
+  -Wno-unused-imports #-}
+
+   
+
+class Semigroup a => SomeData a
+
+-- | a comment
+instance SomeData All

--- a/ghcide/test/data/import-placement/AfterMultilinePragma.expected.hs
+++ b/ghcide/test/data/import-placement/AfterMultilinePragma.expected.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE RecordWildCards, 
+   OverloadedStrings #-}
+import Data.Monoid
+   
+
+class Semigroup a => SomeData a
+
+-- | a comment
+instance SomeData All

--- a/ghcide/test/data/import-placement/AfterMultilinePragma.hs
+++ b/ghcide/test/data/import-placement/AfterMultilinePragma.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE RecordWildCards, 
+   OverloadedStrings #-}
+   
+
+class Semigroup a => SomeData a
+
+-- | a comment
+instance SomeData All

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -857,7 +857,9 @@ watchedFilesTests = testGroup "watched files"
 
 insertImportTests :: TestTree
 insertImportTests = testGroup "insert import"
-  [ checkImport "above comment at top of module" "CommentAtTop.hs" "CommentAtTop.expected.hs" "import Data.Monoid"
+  [ checkImport "after multiline pragmas and opts no module or imports" "AfterMultilineOptsPragma.hs" "AfterMultilineOptsPragma.expected.hs" "import Data.Monoid" 
+  , checkImport "after multiline pragma no module or imports" "AfterMultilinePragma.hs" "AfterMultilinePragma.expected.hs" "import Data.Monoid"
+  , checkImport "above comment at top of module" "CommentAtTop.hs" "CommentAtTop.expected.hs" "import Data.Monoid"
   , checkImport "above multiple comments below" "CommentAtTopMultipleComments.hs" "CommentAtTopMultipleComments.expected.hs" "import Data.Monoid"
   , checkImport "above curly brace comment" "CommentCurlyBraceAtTop.hs" "CommentCurlyBraceAtTop.expected.hs" "import Data.Monoid"
   , checkImport "above multi-line comment" "MultiLineCommentAtTop.hs" "MultiLineCommentAtTop.expected.hs" "import Data.Monoid"


### PR DESCRIPTION
This is related to #2401 and #2392 but with imports in ghcide. 

So it's only an issue when the file doesn't have any existing imports or a module declaration already - in those cases it relies on the ParsedSource type from the GHC parsing.

But in the case where neither of those are in the file it would fall back on the same logic as in the pragma plugin, and so had the same bug when there was multiline LANGUAGE or OPTS_GHC pragmas, like:

Before:
{-# LANGUAGE RecordWildCards,
   OverloadedStrings #-}

After:
{-# LANGUAGE RecordWildCards,
    Import Data.Monoid
    OverloadedStrings #-}

This fixes that issue. It works for all the cases except for the issue raised in #2392, if there's an OPTIONS_GHC pragma later in the file the import will be incorrectly added under that.

I think it's probably better to wait for the parser to deal with that case instead of trying to do the same thing in two places, and I can adapt this solution to use that then. 



<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2402"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

