### PR TITLE
Use dependent-sum from hackage

### DIFF
--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -28,7 +28,7 @@ jobs:
                   "hls-call-hierarchy-plugin",
                   "haskell-language-server"]
         # Uncomment 9.0.1 when ghcide is buildable
-        ghc: [ # "9.0.1",
+        ghc: [ "9.0.1",
               "8.10.7",
               "8.8.4",
               "8.6.5"]

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -33,23 +33,9 @@ package *
   ghc-options: -haddock
   test-show-details: direct
 
-source-repository-package
-  type: git
-  location: https://github.com/mokus0/th-extras
-  tag: 0d050b24ec5ef37c825b6f28ebd46787191e2a2d
--- https://github.com/mokus0/th-extras/issues/10
-
-
-source-repository-package
-  type: git
-  location: https://github.com/fendor/dependent-sum
-  tag: 5de03c38b0de4945f4e9bce1b026110e69dc8118
-  subdir: dependent-sum-template
--- https://github.com/obsidiansystems/dependent-sum/pull/59
-
 write-ghc-environment-files: never
 
-index-state: 2021-11-23T21:12:30Z
+index-state: 2021-11-29T08:11:07Z
 
 constraints:
   -- These plugins don't work on GHC9 yet

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -34,7 +34,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2021-11-23T21:12:30Z
+index-state: 2021-11-29T08:11:07Z
 
 constraints:
   -- These plugins doesn't work on GHC92 yet

--- a/cabal.project
+++ b/cabal.project
@@ -38,7 +38,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2021-11-23T21:12:30Z
+index-state: 2021-11-29T08:11:07Z
 
 constraints:
     hyphenation +embed


### PR DESCRIPTION
* Updating hackage index and remove obsolete source-repository-packages
* Will backport changes to 1.5.1-hackage
* Hackage check workflow here: https://github.com/jneira/haskell-language-server/actions/runs/1515454378

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2412"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

