### PR TITLE
Configuration docs: Typo

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,7 @@ Here is a list of the additional settings currently supported by `haskell-langua
 - Diagnostics on change (`haskell.diagnosticsOnChange`, default true): (currently unused).
 - Completion snippets (`haskell.completionSnippetsOn`, default true): whether to support completion snippets. *Deprecated* as it is equivalent to `haskell.plugin.ghcide-completions.config.snippetsOn`.
 - Liquid Haskell (`haskell.liquidOn`, default false): whether to enable Liquid Haskell support (currently unused until the Liquid Haskell support is functional again, see <https://github.com/haskell/haskell-language-server/issues/367>).
-- Hlint (`haskell.hlintOn`, default true): whether to enable Hlint support. *Deprecated* as it is equivalen to `haskell.plugin.hlint.globalOn`
+- Hlint (`haskell.hlintOn`, default true): whether to enable Hlint support. *Deprecated* as it is equivalent to `haskell.plugin.hlint.globalOn`
 - Max completions (`haskell.maxCompletions`, default 40): maximum number of completions sent to the LSP client.
 - Check project (`haskell.checkProject`, default true): whether to typecheck the entire project on load. As it is activated by default could drive to bad perfomance in large projects.
 - Check parents (`haskell.checkParents`, default `CheckOnSaveAndClose`): when to typecheck reverse dependencies of a file; one of `NeverCheck`, `CheckOnClose`, `CheckOnSaveAndClose`, or `AlwaysCheck`.


### PR DESCRIPTION
Fixed "equivalent"

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

