### PR TITLE
Makes local record field completion respects the fields sharing one single type signature

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -20,7 +20,6 @@ import           Data.List.Extra                          as List hiding
 import qualified Data.Map                                 as Map
 
 import           Data.Maybe                               (fromMaybe, isJust,
-                                                           listToMaybe,
                                                            mapMaybe)
 import qualified Data.Text                                as T
 import qualified Text.Fuzzy.Parallel                      as Fuzzy
@@ -502,7 +501,7 @@ findRecordCompl uri pmod mn DataDecl {tcdLName, tcdDataDefn} = result
             --
             -- is encoded as @[[arg1, arg2], [arg3], [arg4]]@
             -- Hence, we must concat nested arguments into one to get all the fields.
-            = concatMap (rdrNameFieldOcc . unLoc) cd_fld_names
+            = map (rdrNameFieldOcc . unLoc) cd_fld_names
         -- XConDeclField
         extract _ = []
 findRecordCompl _ _ _ _ = []

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -480,7 +480,7 @@ findRecordCompl uri pmod mn DataDecl {tcdLName, tcdDataDefn} = result
                         (showGhc . unLoc $ con_name) field_labels mn doc Nothing
                  | ConDeclH98{..} <- unLoc <$> dd_cons tcdDataDefn
                  , Just  con_details <- [getFlds con_args]
-                 , let field_names = mapMaybe extract con_details
+                 , let field_names = concatMap extract con_details
                  , let field_labels = showGhc . unLoc <$> field_names
                  , (not . List.null) field_labels
                  ]
@@ -493,11 +493,18 @@ findRecordCompl uri pmod mn DataDecl {tcdLName, tcdDataDefn} = result
                              _           -> Nothing
 
         extract ConDeclField{..}
-             -- TODO: Why is cd_fld_names a list?
-            | Just fld_name <- rdrNameFieldOcc . unLoc <$> listToMaybe cd_fld_names = Just fld_name
-            | otherwise = Nothing
+            -- NOTE: 'cd_fld_names' is grouped so that the fields
+            -- sharing the same type declaration to fit in the same group; e.g.
+            --
+            -- @
+            --   data Foo = Foo {arg1, arg2 :: Int, arg3 :: Int, arg4 :: Bool}
+            -- @
+            --
+            -- is encoded as @[[arg1, arg2], [arg3], [arg4]]@
+            -- Hence, we must concat nested arguments into one to get all the fields.
+            = concatMap (rdrNameFieldOcc . unLoc) cd_fld_names
         -- XConDeclField
-        extract _ = Nothing
+        extract _ = []
 findRecordCompl _ _ _ _ = []
 
 ppr :: Outputable a => a -> T.Text

--- a/test/testdata/completion/FieldsSharingSignature.hs
+++ b/test/testdata/completion/FieldsSharingSignature.hs
@@ -1,0 +1,1 @@
+data Foo = MkFoo { arg1, arg2, arg3 :: Int, arg4 :: Int, arg5 :: Double }

--- a/test/testdata/completion/hie.yaml
+++ b/test/testdata/completion/hie.yaml
@@ -4,3 +4,4 @@ cradle:
       - "Completion"
       - "Context"
       - "DupRecFields"
+      - "FieldsSharingSignature"


### PR DESCRIPTION
Currently, HLS generates wrong completion snippets for a record with some fields sharing the same type signature.
For example, consider the following:

```hs
data Foo = Foo { arg1, arg2 :: Int, arg3 :: Int, arg4 :: Bool }
```

Above, `arg1, arg2` shares the same `Int` signature and this is a completely legitimate definition.
If this is defined in a local module, the current HLS generates the following record snippet for `Foo`, which lacks `arg2`:

```hs
Foo { arg1 = _arg1, arg3 = _arg3, arg4 = _arg4 }
```

The base cause of this seems as follows.
HLS handles record snippets for datatypes in a local module via parsed modules (`findRecordCompl` logic), especially from the `RecCon` constructor.
In `RecCon`, field information is stored as a list of `ConDeclField`s, which stores field label information in `cd_fld_names` field.
This `cd_fld_names` is *a list of* `LFieldOcc`s, and it seems that this nested structure reflects the signature-sharing relation.
The current implementation in HLS, however, picks only the first element of `cd_fld_names`, resulting in the incomplete completion snippet.

This PR aims at fixing this issue by just returning lists as-is.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2439"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

