### PR TITLE
CI: organizing bootstraping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,8 @@ defaults: &defaults
   steps:
     - checkout
     - run:
-        name: Write provided stack.yaml with predictable name
-        command: cp ${STACK_FILE} stack-build.txt
-
-    - run:
-        name: Figure out resolver for better caching
-        command: grep '^resolver:' stack-build.txt > resolver.txt
+        name: Save resolver field into file
+        command: grep '^resolver:' ${STACK_FILE} > resolver.txt
 
     - restore_cache:
         keys:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,9 @@
 name: Benchmark
 
+defaults:
+  run:
+    shell: bash
+
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}
@@ -72,17 +76,14 @@ jobs:
     - run: cabal configure --enable-benchmarks --max-backjumps 12000
 
     - name: Build
-      shell: bash
       run: cabal build ghcide:benchHist
 
     - name: Bench init
-      shell: bash
       run: cabal bench ghcide:benchHist  -j --benchmark-options="all-binaries"
 
     # tar is required to preserve file permissions
     # compression speeds up upload/download nicely
     - name: tar workspace
-      shell: bash
       run: tar -czf workspace.tar.gz * .git
 
     - name: tar cabal
@@ -142,11 +143,9 @@ jobs:
         tar xzf cabal.tar.gz --directory ~/.cabal
 
     - name: Bench
-      shell: bash
       run: cabal bench ghcide:benchHist  -j --benchmark-options="${{ matrix.example }}"
 
     - name: Display results
-      shell: bash
       run: |
         column -s, -t < ghcide/bench-results/unprofiled/${{ matrix.example }}/results.csv | tee ghcide/bench-results/unprofiled/${{ matrix.example }}/results.txt
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,8 +36,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
 
     - run: git fetch origin master # check the master branch for benchmarking
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,11 +52,6 @@ jobs:
         cabal-version: ${{ matrix.cabal }}
         enable-stack: false
 
-    - name: Platform config
-      run: |
-        echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
-        echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
-
     - name: Cache Cabal
       uses: actions/cache@v2
       with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,6 +34,9 @@ jobs:
         os: [ubuntu-latest]
         cabal: ['3.6']
 
+    # This code is fitted to the strategy: assumes Linux is used ... etc,
+    # change of the strategy may require changing the bootstrapping/run code
+
     steps:
     - uses: actions/checkout@v2
 
@@ -45,38 +48,10 @@ jobs:
         cabal-version: ${{ matrix.cabal }}
         enable-stack: false
 
-    - if: runner.os == 'Windows'
-      name: (Windows) Platform config
-      run: |
-        echo "CABAL_STORE_DIR=$SYSTEMDRIVE\\SR" >> $GITHUB_ENV
-        echo "CABAL_PKGS_DIR=~\\AppData\\cabal\\packages" >> $GITHUB_ENV
-    - if: ( runner.os == 'Linux' ) || ( runner.os == 'macOS' )
-      name: (Linux,macOS) Platform config
+    - name: Platform config
       run: |
         echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
         echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
-
-    # Needs to be before Cache Cabal so the cache can detect changes to the modified cabal.project file
-    - if: matrix.ghc == '9.0.1'
-      name: (GHC 9.0.1) Use modified `cabal.project`
-      run: |
-        cp cabal-ghc901.project cabal.project
-    - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
-      name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults
-      run: |
-        echo "package floskell" >> cabal.project
-        echo "  ghc-options: -O0" >> cabal.project
-
-    # Shorten binary names as a workaround for filepath length limits in Windows,
-    # but since tests are hardcoded on this workaround -
-    # all platforms (in 2021-12-07) need it.
-    - name: Workaround shorten binary names
-      run: |
-        sed -i.bak -e 's/haskell-language-server/hls/g' \
-                   -e 's/haskell_language_server/hls/g' \
-                   haskell-language-server.cabal cabal.project
-        sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
-                   src/**/*.hs exe/*.hs
 
     - name: Cache Cabal
       uses: actions/cache@v2

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
 
     - run: git fetch origin master # check the master branch for benchmarking
 
@@ -44,6 +46,39 @@ jobs:
         ghc-version  : ${{ matrix.ghc   }}
         cabal-version: ${{ matrix.cabal }}
         enable-stack: false
+
+    - if: runner.os == 'Windows'
+      name: (Windows) Platform config
+      run: |
+        echo "CABAL_STORE_DIR=$SYSTEMDRIVE\\SR" >> $GITHUB_ENV
+        echo "CABAL_PKGS_DIR=~\\AppData\\cabal\\packages" >> $GITHUB_ENV
+    - if: ( runner.os == 'Linux' ) || ( runner.os == 'macOS' )
+      name: (Linux,macOS) Platform config
+      run: |
+        echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
+        echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
+
+    # Needs to be before Cache Cabal so the cache can detect changes to the modified cabal.project file
+    - if: matrix.ghc == '9.0.1'
+      name: (GHC 9.0.1) Use modified `cabal.project`
+      run: |
+        cp cabal-ghc901.project cabal.project
+    - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
+      name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults
+      run: |
+        echo "package floskell" >> cabal.project
+        echo "  ghc-options: -O0" >> cabal.project
+
+    # Shorten binary names as a workaround for filepath length limits in Windows,
+    # but since tests are hardcoded on this workaround -
+    # all platforms (in 2021-12-07) need it.
+    - name: Workaround shorten binary names
+      run: |
+        sed -i.bak -e 's/haskell-language-server/hls/g' \
+                   -e 's/haskell_language_server/hls/g' \
+                   haskell-language-server.cabal cabal.project
+        sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
+                   src/**/*.hs exe/*.hs
 
     - name: Cache Cabal
       uses: actions/cache@v2
@@ -105,6 +140,7 @@ jobs:
       matrix:
         ghc: ['8.10.7']
         os: [ubuntu-latest]
+        cabal: ['3.6']
         example: ['cabal', 'lsp-types']
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
+
     - uses: haskell/actions/setup@v1
       with:
         ghc-version  : ${{ matrix.ghc   }}
@@ -161,8 +160,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
 
       - name: Create source tarball
         run: |

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -1,8 +1,21 @@
 name: Caching
 
 # Docs on the workflow:
-# 1. GitHub cache scoping goes: main branch -> PR main branch -> PR. (essentially in a tree fashion). That is why it is useful to build caches on `master` - to generate & keep the main project state & they would be shared to the whole tree.
-# 2. GitHub has a 10G default limit of cache pool per repo. HLS is a big project & monorepo of many projects, so to keep cache useful - the main branch state caches should be preserved & their storage preferred to the PRs, since PRs from internal branches - would count into 10G pool, but would be available only inside of the PR scope, which can bork cache fore the whole community. That is short story why `dist-newstyle` (especially full) - is not includded into `master` cache.
+# 1. GitHub cache scoping goes:
+#   [main branch -> PR main branch -> PR. (essentially in a tree fashion)](https://web.archive.org/web/20211125171853/https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).
+#   Building & keeping caches on `master` allows
+#   to share the main project state cache be shared to the whole tree.
+# 2. GitHub has a [default 10G cache pool limit](https://web.archive.org/web/20211125171853/https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy) per repo.
+#   HLS is a big monorepo codebase, which means easy cache pool
+#   invalidation & exhaustion because of the pool limit.
+#   To keep caches useful - the main state of the main branch should remain
+#   & so keep caching in the repo well below the limit.
+#   that means preferring main branch to the PR caches
+#   (especially internal branch ones), since PRs from internal branches -
+#   count into the repo 10G pool, while that cache gets used only inside of the PR,
+#   while exhausting the pool would bork cache for the rest of the community.
+#   That is a short story why `dist-newstyle` (especially full) currently is not
+#   includded into `master` or PR caches.
 
 defaults:
   run:

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -30,9 +30,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    # Try to save snapshot every day at 08:25 UTC (~00:25 in California)
-    - cron: "25 8 * * *"
 
 jobs:
   pre_job:

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -64,8 +64,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
 
       - uses: haskell/actions/setup@v1
         with:

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -55,6 +55,7 @@ jobs:
     needs: pre_job
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         ghc: ["9.0.1", '8.10.7', '8.10.6', "8.8.4", "8.6.5"]
         os: [ubuntu-latest, macOS-latest, windows-latest]

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -92,17 +92,6 @@ jobs:
           echo "package floskell" >> cabal.project
           echo "  ghc-options: -O0" >> cabal.project
 
-      # Shorten binary names as a workaround for filepath length limits in Windows,
-      # but since tests are hardcoded on this workaround -
-      # all platforms (in 2021-12-07) need it.
-      - name: Workaround shorten binary names
-        run: |
-          sed -i.bak -e 's/haskell-language-server/hls/g' \
-                     -e 's/haskell_language_server/hls/g' \
-                     haskell-language-server.cabal cabal.project
-          sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
-                     src/**/*.hs exe/*.hs
-
       - name: Cache Cabal
         uses: actions/cache@v2
         env:

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -32,6 +32,7 @@ on:
       - master
 
 jobs:
+
   pre_job:
     runs-on: ubuntu-latest
     outputs:
@@ -50,7 +51,7 @@ jobs:
           cancel_others: false
           paths_ignore: '["hls-test-utils/**", "plugins/**", "src/**", "exe/**", "test/**", "shake-bench/**"]'
 
-  deps:
+  caching:
     if: needs.pre_job.outputs.should_skip != 'true'
     needs: pre_job
     runs-on: ${{ matrix.os }}
@@ -65,33 +66,44 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+
       - uses: haskell/actions/setup@v1
         with:
-          ghc-version  : ${{ matrix.ghc   }}
+          ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
 
-      - if: matrix.os == 'windows-latest'
-        name: Set some window specific things
+      - if: runner.os == 'Windows'
+        name: (Windows) Platform config
         run: |
           echo "CABAL_STORE_DIR=$SYSTEMDRIVE\\SR" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~\\AppData\\cabal\\packages" >> $GITHUB_ENV
-
-      - if: matrix.os != 'windows-latest'
-        name: Set some linux/macOS specific things
+      - if: ( runner.os == 'Linux' ) || ( runner.os == 'macOS' )
+        name: (Linux,macOS) Platform config
         run: |
           echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
 
       # Needs to be before Cache Cabal so the cache can detect changes to the modified cabal.project file
       - if: matrix.ghc == '9.0.1'
-        name: Use modified cabal.project for ghc9
-        run: cp cabal-ghc901.project cabal.project
-
-      - if: matrix.ghc == '8.8.4' && matrix.os == 'windows-latest'
-        name: Modify cabal.project to workaround segfaults for ghc-8.8.4 and windows
+        name: (GHC 9.0.1) Use modified `cabal.project`
+        run: |
+          cp cabal-ghc901.project cabal.project
+      - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
+        name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults
         run: |
           echo "package floskell" >> cabal.project
           echo "  ghc-options: -O0" >> cabal.project
+
+      # Shorten binary names as a workaround for filepath length limits in Windows,
+      # but since tests are hardcoded on this workaround -
+      # all platforms (in 2021-12-07) need it.
+      - name: Workaround shorten binary names
+        run: |
+          sed -i.bak -e 's/haskell-language-server/hls/g' \
+                     -e 's/haskell_language_server/hls/g' \
+                     haskell-language-server.cabal cabal.project
+          sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
+                     src/**/*.hs exe/*.hs
 
       - name: Cache Cabal
         uses: actions/cache@v2
@@ -108,15 +120,6 @@ jobs:
             v2-${{ runner.os }}-${{ matrix.ghc }}
 
       - run: cabal update
-
-      # Need this to work around filepath length limits in Windows
-      - name: Shorten binary names
-        run: |
-          sed -i.bak -e 's/haskell-language-server/hls/g' \
-                     -e 's/haskell_language_server/hls/g' \
-                     haskell-language-server.cabal cabal.project
-          sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
-                     src/**/*.hs exe/*.hs
 
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
       - name: Build

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
 
       - uses: actions/checkout@v2
-        with:
-          submodules: true
 
       - uses: haskell/actions/setup@v1
         with:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,8 +44,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
+
     - uses: cachix/install-nix-action@v16
       with:
         install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
@@ -79,8 +78,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
+
     - uses: cachix/install-nix-action@v16
       with:
         install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
 
       - uses: haskell/actions/setup@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,36 +76,44 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+
       - uses: haskell/actions/setup@v1
         with:
           ghc-version  : ${{ matrix.ghc   }}
           cabal-version: ${{ matrix.cabal }}
 
-      - run: ./fmt.sh
-        name: "HLint via ./fmt.sh"
-
-      - if: matrix.os == 'windows-latest'
-        name: Set some window specific things
+      - if: runner.os == 'Windows'
+        name: (Windows) Platform config
         run: |
           echo "CABAL_STORE_DIR=$SYSTEMDRIVE\\SR" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~\\AppData\\cabal\\packages" >> $GITHUB_ENV
-
-      - if: matrix.os != 'windows-latest'
-        name: Set some linux/macOS specific things
+      - if: ( runner.os == 'Linux' ) || ( runner.os == 'macOS' )
+        name: (Linux,macOS) Platform config
         run: |
           echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
 
       # Needs to be before Cache Cabal so the cache can detect changes to the modified cabal.project file
       - if: matrix.ghc == '9.0.1'
-        name: Use modified cabal.project for ghc9
-        run: cp cabal-ghc901.project cabal.project
-
-      - if: matrix.ghc == '8.8.4' && matrix.os == 'windows-latest'
-        name: Modify cabal.project to workaround segfaults for ghc-8.8.4 and windows
+        name: (GHC 9.0.1) Use modified `cabal.project`
+        run: |
+          cp cabal-ghc901.project cabal.project
+      - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
+        name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults
         run: |
           echo "package floskell" >> cabal.project
           echo "  ghc-options: -O0" >> cabal.project
+
+      # Shorten binary names as a workaround for filepath length limits in Windows,
+      # but since tests are hardcoded on this workaround -
+      # all platforms (in 2021-12-07) need it.
+      - name: Workaround shorten binary names
+        run: |
+          sed -i.bak -e 's/haskell-language-server/hls/g' \
+                     -e 's/haskell_language_server/hls/g' \
+                     haskell-language-server.cabal cabal.project
+          sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
+                     src/**/*.hs exe/*.hs
 
       - name: Cache Cabal
         uses: actions/cache@v2
@@ -123,14 +131,9 @@ jobs:
 
       - run: cabal update
 
-      # Need this to work around filepath length limits in Windows
-      - name: Shorten binary names
+      - name: "HLint via ./fmt.sh"
         run: |
-          sed -i.bak -e 's/haskell-language-server/hls/g' \
-                     -e 's/haskell_language_server/hls/g' \
-                     haskell-language-server.cabal cabal.project
-          sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
-                     src/**/*.hs exe/*.hs
+          ./fmt.sh
 
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
       - name: Build


### PR DESCRIPTION
Be free at merging #2444, I would rebase this to whatever needed.

---

Using the same bootstrapping process so workflows have the same setup & so can share the caches between them.

<sub>(A work derived from #2427)</sub>

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2446"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

