### PR TITLE
Fix rerun log cache handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,14 +138,14 @@ jobs:
 
       - name: Set test options
         run: |
-          echo "TEST_OPTS=-j1 --rerun-update --rerun-filter failures,exceptions,new" >> $GITHUB_ENV
+          echo "TEST_OPTS=-j1 --rerun-update --rerun-filter failures,exceptions" >> $GITHUB_ENV
 
       - name: Cache test log bewteen attempts of the same run
         uses: actions/cache@v2
         env:
           cache-name: cache-test-log
         with:
-          path: .tasty-rerun-log
+          path: "**/.tasty-rerun-log*"
           key: v1-${{ runner.os }}-${{ matrix.ghc }}-test-log-${{ github.sha }}
 
       - if: needs.pre_job.outputs.should_skip_ghcide != 'true' && matrix.test
@@ -172,7 +172,7 @@ jobs:
         # all functional test cases simultaneously which causes way too many hls
         # instances to be spun up for the poor github actions runner to handle
 
-        run: cabal test wrapper-test --test-options="$TEST_OPTS" || cabal test wrapper-test --test-options="$TEST_OPTS" || cabal test wrapper-test --test-options="$TEST_OPTS"
+        run: cabal test wrapper-test --test-options="$TEST_OPTS --rerun-log-file .tasty-rerun-log-wrapper" || cabal test wrapper-test --test-options="$TEST_OPTS  --rerun-log-file .tasty-rerun-log-wrapper" || cabal test wrapper-test --test-options="$TEST_OPTS  --rerun-log-file .tasty-rerun-log-wrapper"
 
       - if: matrix.test && matrix.ghc != '9.0.1'
         name: Test hls-brittany-plugin


### PR DESCRIPTION
* The cache of tasty logs to not repeat succesful tests between attempts of the same run was not working correctly
* `new` makes rerun all tests again, as succesful one in one attempt are "new" for the next one
* Logs are saved in each package root dir, so the cache should be `**./.tasty-rerun-log*`
* `func-tests` and `wrapper-tests` are from the same hls top level package so at least one of them needs a specific name (did it for wrapper tests)
* I've checked a second rerun does not run any effective test here: https://github.com/jneira/haskell-language-server/actions/runs/1550353254

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2450"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

