### PR TITLE
STM debouncer

### DIFF
--- a/ghcide/src/Development/IDE/Core/Debouncer.hs
+++ b/ghcide/src/Development/IDE/Core/Debouncer.hs
@@ -11,7 +11,6 @@ module Development.IDE.Core.Debouncer
 import           Control.Concurrent.Async
 import           Control.Concurrent.STM
 import           Control.Concurrent.STM.Stats (atomicallyNamed)
-import           Control.Exception
 import           Control.Monad                (join, void)
 import           Data.Hashable
 import           GHC.Conc                     (unsafeIOToSTM)
@@ -49,8 +48,9 @@ asyncRegisterEvent d delay k fire = join $ atomicallyNamed "debouncer - register
                 join $ atomicallyNamed "debouncer - sleep" $ do
                     (s,act) <- readTVar var
                     unsafeIOToSTM $ sleep s
-                    STM.delete k d
-                    return act
+                    return $ do
+                        atomically (STM.delete k d)
+                        act
 
 -- | Debouncer used in the DAML CLI compiler that emits events immediately.
 noopDebouncer :: Debouncer k


### PR DESCRIPTION
8th? instalment of #2357. This one not only makes the debouncer lock-less but also potentially more efficient.

The debouncer associates delayed actions with project files. It works by waiting for a short _delay_ before executing the action. If a new action is registered for this file before the _delay_ is over, the old action is throw away and the delay restarts.

The old implementation does this using `async`, and a new thread is spawned on every reset. 

This PR replaces threads by STM transactions. Associating an action starts an STM transaction that reads the `TVar` and then sleeps for the `delay`. Reassociating a new action writes to the `TVar` causing any long-lived transactions to `retry`.

STM transactions should be more lightweight than threads but I don't expect this to make a huge difference in practice and wouldn't oppose to reverting the change.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2466"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

