### PR TITLE
Caching process update

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,12 +47,12 @@ jobs:
     - run: git fetch origin master # check the master branch for benchmarking
 
     - uses: haskell/actions/setup@v1
+      id: HaskEnvSetup
       with:
         ghc-version  : ${{ matrix.ghc   }}
         cabal-version: ${{ matrix.cabal }}
         enable-stack: false
 
-    - name: Cache Cabal
     - name: Linux Platform config
       run: |
         echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
@@ -65,16 +65,26 @@ jobs:
         INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
         echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+    - name: Hackage sources cache
       uses: actions/cache@v2
+      env:
+        cache-name: hackage-sources
       with:
-        path: |
-          ~/.cabal/packages
-          ~/.cabal/store
-        key: v2-${{ runner.os }}-${{ matrix.ghc }}-bench-${{ hashFiles('cabal.project') }}
+        path: ${{ env.CABAL_PKGS_DIR }}
+        key:          ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+        restore-keys: ${{ env.cache-name }}-
+
+    - name: Compiled deps cache
+      uses: actions/cache@v2
+      env:
+        cache-name: compiled-deps
+      with:
+        path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
+        key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project') }}
         restore-keys: |
-            v2-${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
-            v2-${{ runner.os }}-${{ matrix.ghc }}-bench-
-            v2-${{ runner.os }}-${{ matrix.ghc }}
+              ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
+              ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
+              ${{ env.cache-name }}-${{ runner.os }}-
 
     - run: cabal update
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,6 +53,10 @@ jobs:
         enable-stack: false
 
     - name: Cache Cabal
+    - name: Linux Platform config
+      run: |
+        echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
+
       uses: actions/cache@v2
       with:
         path: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,6 +57,15 @@ jobs:
       run: |
         echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
 
+    # All workflows which distinquishes cache on `cabal.project` needs this.
+    - name: Workaround shorten binary names
+      run: |
+        sed -i.bak -e 's/haskell-language-server/hls/g' \
+                    -e 's/haskell_language_server/hls/g' \
+                    haskell-language-server.cabal cabal.project
+        sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
+                    src/**/*.hs exe/*.hs
+
     - name: Retrieving `cabal.project` Hackage timestamp
       run: |
         # Form: index-state: 2021-11-29T08:11:08Z

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,6 +57,14 @@ jobs:
       run: |
         echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
 
+    - name: Retrieving `cabal.project` Hackage timestamp
+      run: |
+        # Form: index-state: 2021-11-29T08:11:08Z
+        INDEX_STATE_ENTRY=$(grep index-state cabal.project)
+        # Form: 2021-11-29T08-11-08Z
+        INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
+        echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
+
       uses: actions/cache@v2
       with:
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
       with:
         ghc-version  : ${{ matrix.ghc   }}
         cabal-version: ${{ matrix.cabal }}
+        enable-stack: false
 
     # some alpines come with integer-simple instead of integer-gmp
     - name: Force integer-simple

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -31,6 +31,9 @@ on:
     branches:
       - master
 
+env:
+  cabalBuild: "v2-build all --enable-tests --enable-benchmarks"
+
 jobs:
 
   pre_job:
@@ -128,6 +131,16 @@ jobs:
 
       - run: cabal update
 
+      - name: Download all sources
+        run: |
+          cabal $cabalBuild --only-download
+
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
-      - name: Build
-        run: cabal build --only-dependencies || cabal build --only-dependencies || cabal build --only-dependencies
+      # This build agenda in not to have successful code,
+      # but to cache what can be cached, so step is fault tolerant & would always succseed.
+      # 2021-12-11: NOTE: Building all targets, since
+      # current Cabal does not allow `all --enable-tests --enable-benchmarks --only-dependencies`
+      - name: Build all targets; try 3 times
+        continue-on-error: true
+        run: |
+          cabal $cabalBuild || cabal $cabalBuild || cabal $cabalBuild

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -94,6 +94,14 @@ jobs:
           echo "  ghc-options: -O0" >> cabal.project
 
       - name: Cache Cabal
+      - name: Retrieving `cabal.project` Hackage timestamp
+        run: |
+          # Form: index-state: 2021-11-29T08:11:08Z
+          INDEX_STATE_ENTRY=$(grep index-state cabal.project)
+          # Form: 2021-11-29T08-11-08Z
+          INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
+          echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
+
         uses: actions/cache@v2
         env:
           cache-name: cache-cabal

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -95,6 +95,18 @@ jobs:
           echo "package floskell" >> cabal.project
           echo "  ghc-options: -O0" >> cabal.project
 
+      # Shorten binary names as a workaround for filepath length limits in Windows,
+      # but since tests are hardcoded on this workaround -
+      # all platforms (in 2021-12-07) need it.
+      # All workflows which distinquishes cache on `cabal.project` needs this.
+      - name: Workaround shorten binary names
+        run: |
+          sed -i.bak -e 's/haskell-language-server/hls/g' \
+                     -e 's/haskell_language_server/hls/g' \
+                     haskell-language-server.cabal cabal.project
+          sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
+                     src/**/*.hs exe/*.hs
+
       - name: Retrieving `cabal.project` Hackage timestamp
         run: |
           # Form: index-state: 2021-11-29T08:11:08Z

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -66,20 +66,19 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: haskell/actions/setup@v1
+        id: HaskEnvSetup
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc-version  : ${{ matrix.ghc   }}
           cabal-version: ${{ matrix.cabal }}
           enable-stack: false
 
       - if: runner.os == 'Windows'
         name: (Windows) Platform config
         run: |
-          echo "CABAL_STORE_DIR=$SYSTEMDRIVE\\SR" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~\\AppData\\cabal\\packages" >> $GITHUB_ENV
       - if: ( runner.os == 'Linux' ) || ( runner.os == 'macOS' )
         name: (Linux,macOS) Platform config
         run: |
-          echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
 
       # Needs to be before Cache Cabal so the cache can detect changes to the modified cabal.project file
@@ -93,7 +92,6 @@ jobs:
           echo "package floskell" >> cabal.project
           echo "  ghc-options: -O0" >> cabal.project
 
-      - name: Cache Cabal
       - name: Retrieving `cabal.project` Hackage timestamp
         run: |
           # Form: index-state: 2021-11-29T08:11:08Z
@@ -102,18 +100,31 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      # 2021-12-02: NOTE: Cabal Hackage source tree storage does not depend on OS or GHC really,
+      # but can depend on `base`.
+      # But this caching is happens only inside `master` for `master` purposes of compiling the deps
+      # so having a shared pool here that depends only on Hackage pin & does not depend on `base` is "good enough"
+      # & used such because it preserves 10% of a global cache storage pool.
+      - name: Hackage sources cache
         uses: actions/cache@v2
         env:
-          cache-name: cache-cabal
+          cache-name: hackage-sources
         with:
-          path: |
-            ${{ env.CABAL_PKGS_DIR }}
-            ${{ env.CABAL_STORE_DIR }}
-          key: v2-${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
+          path: ${{ env.CABAL_PKGS_DIR }}
+          key:          ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+          restore-keys: ${{ env.cache-name }}-
+
+      - name: Compiled deps cache
+        uses: actions/cache@v2
+        env:
+          cache-name: compiled-deps
+        with:
+          path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project') }}
           restore-keys: |
-            v2-${{ runner.os }}-${{ matrix.ghc }}-bench-${{ hashFiles('cabal.project') }}
-            v2-${{ runner.os }}-${{ matrix.ghc }}-build-
-            v2-${{ runner.os }}-${{ matrix.ghc }}
+                ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
+                ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
+                ${{ env.cache-name }}-${{ runner.os }}-
 
       - run: cabal update
 

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
+          enable-stack: false
 
       - if: runner.os == 'Windows'
         name: (Windows) Platform config

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -49,12 +49,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: haskell/actions/setup@v1
+        id: HaskEnvSetup
         with:
           ghc-version  : ${{ matrix.ghc   }}
           cabal-version: ${{ matrix.cabal }}
           enable-stack: false
 
-      - name: Cache Cabal
       - name: Linux Platform config
         run: |
           echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
@@ -67,18 +67,26 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      - name: Hackage sources cache
         uses: actions/cache@v2
         env:
-          cache-name: cache-cabal
+          cache-name: hackage-sources
         with:
-          path: |
-            ~/.cabal/packages
-            ~/.cabal/store
-          key: v2-${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
+          path: ${{ env.CABAL_PKGS_DIR }}
+          key:          ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+          restore-keys: ${{ env.cache-name }}-
+
+      - name: Compiled deps cache
+        uses: actions/cache@v2
+        env:
+          cache-name: compiled-deps
+        with:
+          path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project') }}
           restore-keys: |
-            v2-${{ runner.os }}-${{ matrix.ghc }}-bench-${{ hashFiles('cabal.project') }}
-            v2-${{ runner.os }}-${{ matrix.ghc }}-build-
-            v2-${{ runner.os }}-${{ matrix.ghc }}
+                ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
+                ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
+                ${{ env.cache-name }}-${{ runner.os }}-
 
       - name: "Run cabal check"
         run: |

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -59,6 +59,14 @@ jobs:
         run: |
           echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
 
+      - name: Retrieving `cabal.project` Hackage timestamp
+        run: |
+          # Form: index-state: 2021-11-29T08:11:08Z
+          INDEX_STATE_ENTRY=$(grep index-state cabal.project)
+          # Form: 2021-11-29T08-11-08Z
+          INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
+          echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
+
         uses: actions/cache@v2
         env:
           cache-name: cache-cabal

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           ghc-version  : ${{ matrix.ghc   }}
           cabal-version: ${{ matrix.cabal }}
+          enable-stack: false
 
       - name: Cache Cabal
         uses: actions/cache@v2

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -55,6 +55,10 @@ jobs:
           enable-stack: false
 
       - name: Cache Cabal
+      - name: Linux Platform config
+        run: |
+          echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
+
         uses: actions/cache@v2
         env:
           cache-name: cache-cabal

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           ghc-version  : ${{ matrix.ghc   }}
           cabal-version: ${{ matrix.cabal }}
+          enable-stack: false
 
       - if: runner.os == 'Windows'
         name: (Windows) Platform config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: haskell/actions/setup@v1
+        id: HaskEnvSetup
         with:
           ghc-version  : ${{ matrix.ghc   }}
           cabal-version: ${{ matrix.cabal }}
@@ -84,12 +85,10 @@ jobs:
       - if: runner.os == 'Windows'
         name: (Windows) Platform config
         run: |
-          echo "CABAL_STORE_DIR=$SYSTEMDRIVE\\SR" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~\\AppData\\cabal\\packages" >> $GITHUB_ENV
       - if: ( runner.os == 'Linux' ) || ( runner.os == 'macOS' )
         name: (Linux,macOS) Platform config
         run: |
-          echo "CABAL_STORE_DIR=~/.cabal/store" >> $GITHUB_ENV
           echo "CABAL_PKGS_DIR=~/.cabal/packages" >> $GITHUB_ENV
 
       # Needs to be before Cache Cabal so the cache can detect changes to the modified cabal.project file
@@ -114,7 +113,6 @@ jobs:
           sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
                      src/**/*.hs exe/*.hs
 
-      - name: Cache Cabal
       - name: Retrieving `cabal.project` Hackage timestamp
         run: |
           # Form: index-state: 2021-11-29T08:11:08Z
@@ -123,18 +121,26 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      - name: Hackage sources cache
         uses: actions/cache@v2
         env:
-          cache-name: cache-cabal
+          cache-name: hackage-sources
         with:
-          path: |
-            ${{ env.CABAL_PKGS_DIR }}
-            ${{ env.CABAL_STORE_DIR }}
-          key: v2-${{ runner.os }}-${{ matrix.ghc }}-build-${{ hashFiles('cabal.project') }}
+          path: ${{ env.CABAL_PKGS_DIR }}
+          key:          ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+          restore-keys: ${{ env.cache-name }}-
+
+      - name: Compiled deps cache
+        uses: actions/cache@v2
+        env:
+          cache-name: compiled-deps
+        with:
+          path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project') }}
           restore-keys: |
-            v2-${{ runner.os }}-${{ matrix.ghc }}-bench-${{ hashFiles('cabal.project') }}
-            v2-${{ runner.os }}-${{ matrix.ghc }}-build-
-            v2-${{ runner.os }}-${{ matrix.ghc }}
+                ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
+                ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
+                ${{ env.cache-name }}-${{ runner.os }}-
 
       - run: cabal update
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,9 +102,7 @@ jobs:
           echo "package floskell" >> cabal.project
           echo "  ghc-options: -O0" >> cabal.project
 
-      # Shorten binary names as a workaround for filepath length limits in Windows,
-      # but since tests are hardcoded on this workaround -
-      # all platforms (in 2021-12-07) need it.
+      # All workflows which distinquishes cache on `cabal.project` needs this.
       - name: Workaround shorten binary names
         run: |
           sed -i.bak -e 's/haskell-language-server/hls/g' \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,14 @@ jobs:
                      src/**/*.hs exe/*.hs
 
       - name: Cache Cabal
+      - name: Retrieving `cabal.project` Hackage timestamp
+        run: |
+          # Form: index-state: 2021-11-29T08:11:08Z
+          INDEX_STATE_ENTRY=$(grep index-state cabal.project)
+          # Form: 2021-11-29T08-11-08Z
+          INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
+          echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
+
         uses: actions/cache@v2
         env:
           cache-name: cache-cabal


### PR DESCRIPTION
* New code included & shares all source code that may be needed.

* New config includes & shares all compiled deps that may be needed in workflows.

* New config stores the source code separately, which means it gets stored one time.

Before this cache stored per Platform/GHC - the sources & compiled results
together. It is while sources not depend on platform or GHC, as sources are
platform & GHC agnostic. Because they were always bundled together
& sources took ~1/2-2/3 of that storage - cache stored multiple duplicates of the same
source code.

`caching` workflow now downloads, builds & shares all sources & all dependencies for all targets.

`dist-newstyle` so far is not included in to the cache, (what to cache from them can be looked into in the next updates).

---

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2467"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

