### PR TITLE
Handle re-exported modules when constructing ExportsMap

### DIFF
--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -16,7 +16,6 @@ import           Control.Concurrent.Strict       (modifyVar, newVar)
 import           Control.DeepSeq                 (force)
 import           Control.Exception               (evaluate, mask, throwIO)
 import           Control.Monad.Extra             (eitherM, join, mapMaybeM)
-import           Control.Monad.IO.Class
 import           Data.Either                     (fromRight)
 import           Data.Set                        (Set)
 import qualified Data.Set                        as Set
@@ -81,11 +80,11 @@ newHscEnvEqWithImportPaths envImportPaths hscEnv deps = do
                 | d        <- depends
                 , Just pkg <- [lookupPackageConfig d hscEnv]
                 , (modName, maybeOtherPkgMod) <- unitExposedModules pkg
-                , m <- pure $ case maybeOtherPkgMod of
-                    -- When module is re-exported from another package,
-                    -- the origin module is represented by value in Just
-                    Just otherPkgMod -> otherPkgMod
-                    Nothing -> mkModule (unitInfoId pkg) modName
+                , let m = case maybeOtherPkgMod of
+                        -- When module is re-exported from another package,
+                        -- the origin module is represented by value in Just
+                        Just otherPkgMod -> otherPkgMod
+                        Nothing -> mkModule (unitInfoId pkg) modName
                 ]
 
             doOne m = do

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -76,22 +76,25 @@ newHscEnvEqWithImportPaths envImportPaths hscEnv deps = do
         -- compute the package imports
         let pkgst   = unitState hscEnv
             depends = explicitUnits pkgst
-            targets =
-                [ (pkg, mn)
+            modules =
+                [ m
                 | d        <- depends
                 , Just pkg <- [lookupPackageConfig d hscEnv]
-                , (mn, _)  <- unitExposedModules pkg
+                , (modName, maybeOtherPkgMod) <- unitExposedModules pkg
+                , m <- pure $ case maybeOtherPkgMod of
+                    -- When module is re-exported from another package,
+                    -- the origin module is represented by value in Just
+                    Just otherPkgMod -> otherPkgMod
+                    Nothing -> mkModule (unitInfoId pkg) modName
                 ]
 
-            doOne (pkg, mn) = do
-                modIface <- liftIO $ initIfaceLoad hscEnv $ loadInterface
-                    ""
-                    (mkModule (unitInfoId pkg) mn)
-                    (ImportByUser NotBoot)
+            doOne m = do
+                modIface <- initIfaceLoad hscEnv $
+                    loadInterface "" m (ImportByUser NotBoot)
                 return $ case modIface of
                     Maybes.Failed    _r -> Nothing
                     Maybes.Succeeded mi -> Just mi
-        modIfaces <- mapMaybeM doOne targets
+        modIfaces <- mapMaybeM doOne modules
         return $ createExportsMap modIfaces
 
     -- similar to envPackageExports, evaluated lazily


### PR DESCRIPTION
Attempt at fixing https://github.com/haskell/haskell-language-server/issues/2451 based on @pepeiborra 's suggestion: https://github.com/haskell/haskell-language-server/issues/2451#issuecomment-991637640

This fixes the issue for me with GHC 8.10.7, let's see how it fares in CI..

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2468"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

