### PR TITLE
Minor org to contribution doc

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -5,5 +5,5 @@ Contributing
    :maxdepth: 2
 
    contributing
-   releases
    plugin-tutorial
+   releases


### PR DESCRIPTION
This is a small change, but on reading the Contribution guide was wondering why the theme of Haskell dev is suddenly interrupted by maintenance docs & then continued again.

---

Before this:

-> Contributing to the project
-> Maintenance
-> Example developing of a new plugin

Considering that maintenance questions are not related to the main path of contributors & a meta project
questions for contributors which are promoted to maintainers.

-> Contributing to the project
-> Example developing of a new plugin
-> Maintenance

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2472"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

