### PR TITLE
Update flake to use fourmolu plugin in GHC 9

### DIFF
--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -6,27 +6,19 @@ let
     "hls-tactics-plugin"
     "hls-brittany-plugin"
     "hls-stylish-haskell-plugin"
-    "hls-fourmolu-plugin"
   ];
 
   hpkgsOverride = hself: hsuper:
     with pkgs.haskell.lib;
     {
-
-      # Released on hackage, but not in nixpkgs yet
-      primitive-extras = hself.callCabal2nix "primitive-extras" (pkgs.fetchFromGitHub {
-        owner = "metrix-ai";
-        repo = "primitive-extras";
-        rev = "c758d7366b99d85889cb13425fc0140879f8b936";
-        sha256 = "sha256-vTT7svbM7IkhyxYx2xQ8p1ptoYe+ndcMN5+j9qx++7E=";
-      }) { };
+      fourmolu = hself.fourmolu_0_4_0_0;
+      primitive-extras = hself.primitive-extras_0_10_1_2;
 
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =
         hself.callCabal2nixWithOptions "haskell-language-server" ./.
         (pkgs.lib.concatStringsSep " " [
           "-f-brittany"
-          "-f-fourmolu"
           "-f-stylishhaskell"
           "-f-tactic"
         ]) { };

--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638249621,
-        "narHash": "sha256-5sm83bBBg/U6rALZy/IwITtYY4rJJ5mn4z1Tt5W8FT8=",
+        "lastModified": 1639357775,
+        "narHash": "sha256-mJJFCPqZi1ZO3CvgEfN2nFAYv4uAJSRnTKzLFi61+WA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af21d41260846fb9c9840a75e310e56dfe97d6a3",
+        "rev": "c473cc8714710179df205b153f4e9fa007107ff9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,8 @@
             with haskell.lib; {
               # Patches don't apply
               github = overrideCabal hsuper.github (drv: { patches = []; });
+              # GHCIDE requires hie-bios >=0.8 && <0.9.0
+              hie-bios = hself.hie-bios_0_8_0;
               # We need an older version
               hiedb = hself.hiedb_0_4_1_0;
 

--- a/myst-parser.nix
+++ b/myst-parser.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "myst-parser";
-  version = "0.15.1";
+  version = "0.16.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "00qnpkfjrn7bqbazm20n3zcci05803cfncvrlvk0rhsbdjiphg3w";
+    sha256 = "14lzbhciw7ksi219lrcy9afglmg5mx0rmfvrr2x8ssghv4kf8cdy";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Ref: #297

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2482"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

