### PR TITLE
Fix redundant import actions for names starting with _

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Util.hs
@@ -68,7 +68,9 @@ module Development.IDE.GHC.Compat.Util (
     hGetStringBuffer,
     stringToStringBuffer,
     nextChar,
-    atEnd
+    atEnd,
+    -- * Char
+    is_ident
     ) where
 
 #if MIN_VERSION_ghc(9,0,0)
@@ -81,6 +83,7 @@ import           GHC.Data.FastString
 import           GHC.Data.Maybe
 import           GHC.Data.Pair
 import           GHC.Data.StringBuffer
+import           GHC.Parser.CharClass    (is_ident)
 import           GHC.Types.Unique
 import           GHC.Types.Unique.DFM
 import           GHC.Utils.Fingerprint
@@ -90,6 +93,7 @@ import           GHC.Utils.Panic         hiding (try)
 #else
 import           Bag
 import           BooleanFormula
+import           Ctype                   (is_ident)
 import           EnumSet
 import qualified Exception
 import           FastString

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -24,6 +24,9 @@ import           Control.Arrow                                     (second,
 import           Control.Concurrent.STM.Stats                      (atomically)
 import           Control.Monad                                     (guard, join)
 import           Control.Monad.IO.Class
+#if !MIN_VERSION_ghc(9,0,0)
+import           Ctype                                             (is_ident)
+#endif
 import           Data.Char
 import qualified Data.DList                                        as DL
 import           Data.Function
@@ -57,6 +60,9 @@ import           Development.IDE.Types.Exports
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
 import qualified GHC.LanguageExtensions                            as Lang
+#if MIN_VERSION_ghc(9,0,0)
+import           GHC.Parser.CharClass                              (is_ident)
+#endif
 import           Ide.PluginUtils                                   (subRange)
 import           Ide.Types
 import qualified Language.LSP.Server                               as LSP
@@ -1525,7 +1531,7 @@ rangesForBindingImport _ _ = []
 wrapOperatorInParens :: String -> String
 wrapOperatorInParens x =
   case uncons x of
-    Just (h, _t) -> if isAlpha h then x else "(" <> x <> ")"
+    Just (h, _t) -> if is_ident h then x else "(" <> x <> ")"
     Nothing      -> mempty
 
 smallerRangesForBindingExport :: [LIE GhcPs] -> String -> [Range]

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -24,9 +24,6 @@ import           Control.Arrow                                     (second,
 import           Control.Concurrent.STM.Stats                      (atomically)
 import           Control.Monad                                     (guard, join)
 import           Control.Monad.IO.Class
-#if !MIN_VERSION_ghc(9,0,0)
-import           Ctype                                             (is_ident)
-#endif
 import           Data.Char
 import qualified Data.DList                                        as DL
 import           Data.Function
@@ -60,9 +57,6 @@ import           Development.IDE.Types.Exports
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
 import qualified GHC.LanguageExtensions                            as Lang
-#if MIN_VERSION_ghc(9,0,0)
-import           GHC.Parser.CharClass                              (is_ident)
-#endif
 import           Ide.PluginUtils                                   (subRange)
 import           Ide.Types
 import qualified Language.LSP.Server                               as LSP

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1276,19 +1276,20 @@ removeImportTests = testGroup "remove import actions"
             , "stuffB :: Integer"
             , "stuffB = 123"
             , "stuffC = ()"
+            , "_stuffD = '_'"
             ]
       _docA <- createDoc "ModuleA.hs" "haskell" contentA
       let contentB = T.unlines
             [ "{-# OPTIONS_GHC -Wunused-imports #-}"
             , "module ModuleB where"
-            , "import ModuleA (stuffA, stuffB, stuffC, stuffA)"
+            , "import ModuleA (stuffA, stuffB, _stuffD, stuffC, stuffA)"
             , "main = print stuffB"
             ]
       docB <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- waitForDiagnostics
       [InR action@CodeAction { _title = actionTitle }, _]
           <- getCodeActions docB (Range (Position 2 0) (Position 2 5))
-      liftIO $ "Remove stuffA, stuffC from import" @=? actionTitle
+      liftIO $ "Remove _stuffD, stuffA, stuffC from import" @=? actionTitle
       executeCodeAction action
       contentAfterAction <- documentContents docB
       let expectedContentAfterAction = T.unlines


### PR DESCRIPTION
Names starting with `_` is often used, for example, with `lens` among many others. However, the current redundant import action does not remove those even when they are redundant.

For instance,
```haskell
import Control.Lens ((^.), _1, _2)

myVal = (1, 2) ^. _1
```
Here, `_2` is redundant, but GHCIDE does not give any actions. Adding one more redundant import like
```haskell
import Control.Lens ((^.), _1, _2, use)
```
gives the action, but the action removes only `use`, not `_2`.

This PR resolves this issue.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2483"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

