### PR TITLE
Fix hls-graph ide build with embed-files

### DIFF
--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -10,7 +10,7 @@ bug-reports:   https://github.com/haskell/haskell-language-server/issues
 license:       Apache-2.0
 license-file:  LICENSE
 author:        The Haskell IDE Team
-maintainer:    alan.zimm@gmail.com
+maintainer:    The Haskell IDE Team
 copyright:     The Haskell IDE Team
 category:      Development
 build-type:    Simple

--- a/hls-graph/src/Development/IDE/Graph/Internal/Paths.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Paths.hs
@@ -20,8 +20,14 @@ import           Data.FileEmbed
 
 htmlDataFiles :: [(FilePath, BS.ByteString)]
 htmlDataFiles =
-  [ ("profile.html",  $(embedFile "html/profile.html"))
+  [
+#ifdef __GHCIDE__
+    ("profile.html",  $(embedFile "hls-graph/html/profile.html"))
+  , ("shake.js",      $(embedFile "hls-graph/html/shake.js"))
+#else
+    ("profile.html",  $(embedFile "html/profile.html"))
   , ("shake.js",      $(embedFile "html/shake.js"))
+#endif
   ]
 
 readDataFileHTML :: FilePath -> IO LBS.ByteString


### PR DESCRIPTION
Fix the hls-graph ide build when the `embed-files` flag is given. 

I also noticed that Alan's email is used as the maintainer for hls-graph, which seems a bit unfair since Alan knows little about this package, so change it to Haskell IDE Team

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2485"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

