### PR TITLE
Correctly handle LSP shutdown/exit

### DIFF
--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -93,6 +93,7 @@ runLanguageServer options inH outH getHieDbLoc defaultConfig onConfigurationChan
           [ ideHandlers
           , cancelHandler cancelRequest
           , exitHandler exit
+          , shutdownHandler
           ]
           -- Cancel requests are special since they need to be handled
           -- out of order to be useful. Existing handlers are run afterwards.
@@ -185,13 +186,16 @@ cancelHandler :: (SomeLspId -> IO ()) -> LSP.Handlers (ServerM c)
 cancelHandler cancelRequest = LSP.notificationHandler SCancelRequest $ \NotificationMessage{_params=CancelParams{_id}} ->
   liftIO $ cancelRequest (SomeLspId _id)
 
-exitHandler :: IO () -> LSP.Handlers (ServerM c)
-exitHandler exit = LSP.notificationHandler SExit $ const $ do
+shutdownHandler :: LSP.Handlers (ServerM c)
+shutdownHandler = LSP.requestHandler SShutdown $ \_ resp -> do
     (_, ide) <- ask
     liftIO $ logDebug (ideLogger ide) "Received exit message"
     -- flush out the Shake session to record a Shake profile if applicable
     liftIO $ shakeShut ide
-    liftIO exit
+    resp $ Right Empty
+
+exitHandler :: IO () -> LSP.Handlers (ServerM c)
+exitHandler exit = LSP.notificationHandler SExit $ const $ liftIO exit
 
 modifyOptions :: LSP.Options -> LSP.Options
 modifyOptions x = x{ LSP.textDocumentSync   = Just $ tweakTDS origTDS


### PR DESCRIPTION
The LSP spec says:

> The shutdown request is sent from the client to the server. It asks the server to shut down, but to not exit (otherwise the response might not be delivered correctly to the client). There is a separate exit notification that asks the server to exit. Clients must not send any notifications other than exit or requests to a server to which they have sent a shutdown request. Clients should also wait with sending the exit notification until they have received a response from the shutdown request.

We are doing the shut down in the `Exit` notification handler, which is too late. 

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2486"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

