### PR TITLE
CI: Nix: make Nix dev env passing optional

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -35,6 +35,7 @@ jobs:
   develop:
     if: needs.pre_job.outputs.should_skip_develop != 'true'
     needs: pre_job
+    continue-on-error: true
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -68,6 +69,7 @@ jobs:
   build:
     needs: pre_job
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     env:
       HAS_TOKEN: ${{ secrets.HLS_CACHIX_AUTH_TOKEN != '' }}
     if: (needs.pre_job.outputs.should_skip_build != 'true' && needs.pre_job.outputs.should_skip_pr != 'true') || (github.repository_owner == 'haskell' && github.ref == 'refs/heads/master')


### PR DESCRIPTION
This makes Nix dev env configuration in HLS development a non-blocking process.

Now CI would simply report the status of the build, but wouldn't block the workflow/merges.

This allows both HLS to be developed & for Nix dev env to be maintained at its own pase.

---

*derived from #2480*

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2488"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

