### PR TITLE
Fail if main or pre jobs are cancelled

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -206,3 +206,5 @@ jobs:
       - if: contains(needs.*.result, 'cancelled')
         name: cancelling
         uses: andymckay/cancel-action@0.2
+      - name: Waiting for cancellation
+        run: sleep 60

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -203,8 +203,5 @@ jobs:
           echo "jobs info: ${{ toJSON(needs) }}"
       - if: contains(needs.*.result, 'failure')
         run: exit 1
-      - if: contains(needs.*.result, 'cancelled')
-        name: cancelling
-        uses: andymckay/cancel-action@0.2
-      - name: Waiting for cancellation
-        run: sleep 60
+      - if: contains(needs.*.result, 'cancelled') && needs.pre_job.outputs.should_skip != 'true'
+        run: exit 1

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -117,3 +117,5 @@ jobs:
       - if: contains(needs.*.result, 'cancelled')
         name: cancelling
         uses: andymckay/cancel-action@0.2
+      - name: Waiting for cancellation
+        run: sleep 60

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -114,8 +114,5 @@ jobs:
           echo "jobs info: ${{ toJSON(needs) }}"
       - if: contains(needs.*.result, 'failure')
         run: exit 1
-      - if: contains(needs.*.result, 'cancelled')
-        name: cancelling
-        uses: andymckay/cancel-action@0.2
-      - name: Waiting for cancellation
-        run: sleep 60
+      - if: contains(needs.*.result, 'cancelled') && needs.pre_job.outputs.should_skip != 'true'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,8 +261,5 @@ jobs:
           echo "jobs info: ${{ toJSON(needs) }}"
       - if: contains(needs.*.result, 'failure')
         run: exit 1
-      - if: contains(needs.*.result, 'cancelled')
-        name: cancelling
-        uses: andymckay/cancel-action@0.2
-      - name: Waiting for cancellation
-        run: sleep 60
+      - if: contains(needs.*.result, 'cancelled') && needs.pre_job.outputs.should_skip != 'true'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,3 +264,5 @@ jobs:
       - if: contains(needs.*.result, 'cancelled')
         name: cancelling
         uses: andymckay/cancel-action@0.2
+      - name: Waiting for cancellation
+        run: sleep 60


### PR DESCRIPTION
* To hopefully ensure the job does no terminate succesfully before the cancellation is effective
* This workflow was marked as succesful although the cancel action was succesful: https://github.com/haskell/haskell-language-server/runs/4549724494?check_suite_focus=true
* It seems the cancel request is asynchronous and here https://github.community/t/is-there-a-way-to-cancel-a-running-workflow-within-one-of-its-jobs/17493/4 uses this trick to ensure the cancel action is effective

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2493"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

