### PR TITLE
Disable alternate numbers format plugin temporary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,7 +244,7 @@ jobs:
         name: Test hls-hlint-plugin test suite
         run: cabal test hls-hlint-plugin --test-options="$TEST_OPTS" || cabal test hls-hlint-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-hlint-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test
+      - if: matrix.test && false
         name: Test hls-alternate-number-format-plugin test suite
         run: cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS" || cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS"
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,7 @@ You can watch demos for some of these features [below](#demos).
 - [Module name suggestions](#module-names) for insertion or correction
 - [Call hierarchy support](#call-hierarchy)
 - [Qualify names from an import declaration](#qualify-imported-names) in your code
-- [Suggest alternate numeric formats](#alternate-number-formatting)
+- [Suggest alternate numeric formats](#alternate-number-formatting). This plugin is not included by default yet.
 
 ## Demos
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,7 @@ You can watch demos for some of these features [below](#demos).
 - [Module name suggestions](#module-names) for insertion or correction
 - [Call hierarchy support](#call-hierarchy)
 - [Qualify names from an import declaration](#qualify-imported-names) in your code
-- [Suggest alternate numeric formats](#alternate-number-formatting). This plugin is not included by default yet.
+- [Suggest alternate numeric formats](#alternate-number-formatting). This plugin is not included by default yet due to a performance issue, see <https://github.com/haskell/haskell-language-server/issues/2490>
 
 ## Demos
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -165,7 +165,7 @@ flag splice
 
 flag alternateNumberFormat
   description: Enable Alternate Number Format plugin
-  default:     True
+  default:     False
   manual:      True
 
 flag qualifyImportedNames


### PR DESCRIPTION
* Due to the performance issue reported here: https://github.com/haskell/haskell-language-server/issues/2490
* The plugin could be included in the build forcing the manual flag: `cabal install -falternateNumberFormat`

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2498"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

