### PR TITLE
Automatically read in the doc version from the cabal file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,16 +14,41 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import re
+import sys
 
 # -- Project information -----------------------------------------------------
 
 project = 'haskell-language-server'
-copyright = '2021, The Haskell IDE Team'
-author = 'The Haskell IDE Team'
 
-# The full version, including alpha/beta/rc tags
-release = '1.3.0'
+# We want to take some of the metadata from the Cabal file, especially the version.
+# (otherwise it's very easy to forget to update it!)
+release = None
+copyright = None
+author = None
+versionPattern = re.compile("^version:\s*([\d.]+)")
+copyrightPattern = re.compile("^copyright:\s*(.+)")
+authorPattern = re.compile("^author:\s*(.+)")
+for i, line in enumerate(open('../haskell-language-server.cabal')):
+    versionMatch = re.search(versionPattern, line)
+    if versionMatch:
+        release = versionMatch.group(1)
+    copyrightMatch = re.search(copyrightPattern, line)
+    if copyrightMatch:
+        copyright = copyrightMatch.group(1)
+    authorMatch = re.search(authorPattern, line)
+    if authorMatch:
+        author = authorMatch.group(1)
 
+if not release:
+    print("Couldn't find version")
+    sys.exit()
+if not copyright:
+    print("Couldn't find copyright")
+    sys.exit()
+if not author:
+    print("Couldn't find author")
+    sys.exit()
 
 # -- General configuration ---------------------------------------------------
 

--- a/flake.nix
+++ b/flake.nix
@@ -179,10 +179,10 @@
 
         docs = pkgs.stdenv.mkDerivation {
           name = "hls-docs";
-          src = pkgs.lib.sourceFilesBySuffices ./docs [ ".py" ".rst" ".md" ".png" ".gif" ".svg" ];
+          src = pkgs.lib.sourceFilesBySuffices ./. [ ".py" ".rst" ".md" ".png" ".gif" ".svg" ".cabal" ];
           buildInputs = [ pythonWithPackages ];
           # -n gives warnings on missing link targets, -W makes warnings into errors
-          buildPhase = ''sphinx-build -n -W . $out'';
+          buildPhase = ''cd docs; sphinx-build -n -W . $out'';
           dontInstall = true;
         };
 


### PR DESCRIPTION
It was out of date. This way it will always be read in from the file, so
we can forget about it.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2500"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

