### PR TITLE
Fix tracing of recordDirtyKeys

### DIFF
--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -455,7 +455,7 @@ recordDirtyKeys
 recordDirtyKeys ShakeExtras{dirtyKeys} key file = do
     modifyTVar' dirtyKeys $ \x -> foldl' (flip HSet.insert) x (toKey key <$> file)
     return $ withEventTrace "recordDirtyKeys" $ \addEvent -> do
-        addEvent (fromString $ "dirty " <> show key) (fromString $ unlines $ map fromNormalizedFilePath file)
+        addEvent (fromString $ unlines $ "dirty " <> show key : map fromNormalizedFilePath file)
 
 -- | We return Nothing if the rule has not run and Just Failed if it has failed to produce a value.
 getValues ::

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -71,11 +71,11 @@ import qualified StmContainers.Map                 as STM
 #if MIN_VERSION_ghc(8,8,0)
 otTracedProvider :: MonadUnliftIO m => PluginId -> ByteString -> m a -> m a
 otTracedGarbageCollection :: (MonadMask f, MonadIO f, Show a) => ByteString -> f [a] -> f [a]
-withEventTrace :: (MonadMask m, MonadIO m) => String -> ((ByteString -> ByteString -> m ()) -> m a) -> m a
+withEventTrace :: (MonadMask m, MonadIO m) => String -> ((ByteString -> m ()) -> m a) -> m a
 #else
 otTracedProvider :: MonadUnliftIO m => PluginId -> String -> m a -> m a
 otTracedGarbageCollection :: (MonadMask f, MonadIO f, Show a) => String -> f [a] -> f [a]
-withEventTrace :: (MonadMask m, MonadIO m) => String -> ((String -> ByteString -> m ()) -> m a) -> m a
+withEventTrace :: (MonadMask m, MonadIO m) => String -> ((ByteString -> m ()) -> m a) -> m a
 #endif
 
 withTrace :: (MonadMask m, MonadIO m) =>
@@ -90,8 +90,8 @@ withTrace name act
 withEventTrace name act
   | userTracingEnabled
   = withSpan (fromString name) $ \sp -> do
-      act (addEvent sp)
-  | otherwise = act (\_ _ -> pure ())
+      act (addEvent sp "")
+  | otherwise = act (\_ -> pure ())
 
 -- | Returns a logger that produces telemetry events in a single span
 withTelemetryLogger :: (MonadIO m, MonadMask m) => (Logger -> m a) -> m a


### PR DESCRIPTION
I misunderstood how [`OpenTelemetry.Eventlog.addEvent`](https://hackage.haskell.org/package/opentelemetry-0.7.0/docs/OpenTelemetry-Eventlog.html#v:addEvent) works, which is not totally surprising since there are no docs.

But it looks like, judging by other call sites, that the event goes in the second argument and the first argument is always "":

https://github.com/haskell/haskell-language-server/blob/779439876855872c523088e400526c6f1807bca2/ghcide/src/Development/IDE/Core/Tracing.hs#L123


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2505"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

