### PR TITLE
CI: caching: add early termination & run check on schedule

### DIFF
--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -30,6 +30,18 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # Refresh snapshot every (02+8*x):25 UTC
+    # When cache is present it is a light check workflow with early termination.
+    # When primary cache is not hit - runs the cache generation.
+    # Why: GitHub repo has 10G pool & on overflow GitHub removes caches in FIFO manner.
+    # When internal branche PRs save into the same pool -
+    #   their cache is accessible only inside of the scope of the PR.
+    # If main cache is forced out - there are no cache shared between PRs,
+    #   which implies all PRs would start to create & save their cache.
+    # Reinstitution of the main chache puts it back into FIFO
+    #   & so it gets shared across all PRs.
+    - cron: "25 2/8 * * *"
 
 env:
   cabalBuild: "v2-build all --enable-tests --enable-benchmarks"

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -130,6 +130,7 @@ jobs:
           restore-keys: ${{ env.cache-name }}-
 
       - name: Compiled deps cache
+        id: compiled-deps
         uses: actions/cache@v2
         env:
           cache-name: compiled-deps
@@ -141,9 +142,12 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
 
-      - run: cabal update
+      - if: (! steps.compiled-deps.outputs.cache-hit)
+        run: |
+          cabal update
 
-      - name: Download all sources
+      - if: (! steps.compiled-deps.outputs.cache-hit)
+        name: Download all sources
         run: |
           cabal $cabalBuild --only-download
 
@@ -152,7 +156,8 @@ jobs:
       # but to cache what can be cached, so step is fault tolerant & would always succseed.
       # 2021-12-11: NOTE: Building all targets, since
       # current Cabal does not allow `all --enable-tests --enable-benchmarks --only-dependencies`
-      - name: Build all targets; try 3 times
+      - if: (! steps.compiled-deps.outputs.cache-hit)
+        name: Build all targets; try 3 times
         continue-on-error: true
         run: |
           cabal $cabalBuild || cabal $cabalBuild || cabal $cabalBuild


### PR DESCRIPTION
This PR allows to forget about cache pool exhaustion through internal branches.

Despite `caching` workflow runs on `master` only, GitHub caching is designed such that every workflow run that uses the cache `(test, bench)` can also save cache into the pool of own git repo. Which means the changes to the project configuration files inside PRs would produce caches for PR, which when there is enough internal branches PRs activity would push `master` cache out of the 10G FIFO pool because GitHub removes from the pool by the creation time. While PR caches that would stay - have a sharing & access scope limited to the PRs they are built for.

![Screenshot-2021-12-18-22:36:49](https://user-images.githubusercontent.com/20933385/146654929-0cd32a17-8e34-4ca4-a704-e661878c320a.png)

Removal of the `master` cache out of the pool means that cache that was shared for all PRs - no longer there, which `⇒ ∀` PRs to build & save their own cache - which creates the pool exhaustion & congestion problem.

For example: in #2502 https://github.com/haskell/haskell-language-server/runs/4571293708?check_suite_focus=true we see that master cache got pushed-out & see this situation.

*afaik* there is no way (documented one or more KISS/elegant one) to prioritize main branch cache better.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2506"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

