### PR TITLE
Sort out some compatibility issues

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -37,6 +37,7 @@ import           GHC.Parser.Errors
 import qualified GHC.Parser.Errors.Ppr           as Ppr
 import qualified GHC.Types.Error                 as Error
 import           GHC.Types.Name.Ppr
+import           GHC.Types.Name.Reader
 import           GHC.Types.SourceError
 import           GHC.Types.SrcLoc
 import           GHC.Unit.State
@@ -154,7 +155,13 @@ type PsError = ErrMsg
 
 mkPrintUnqualifiedDefault :: GlobalRdrEnv -> PrintUnqualified
 mkPrintUnqualifiedDefault =
+#if MIN_VERSION_ghc(9,2,0)
+  -- GHC 9.2.1 version
+  -- mkPrintUnqualified :: UnitEnv -> GlobalRdrEnv -> PrintUnqualified
+  mkPrintUnqualified unsafeGlobalDynFlags
+#else
   HscTypes.mkPrintUnqualified unsafeGlobalDynFlags
+#endif
 
 mkWarnMsg :: DynFlags -> SrcSpan -> PrintUnqualified -> SDoc -> MsgEnvelope DecoratedSDoc
 mkWarnMsg =


### PR DESCRIPTION
`mkPrintUnqualified` needs a `UnitEnv`, I have no idea where to get one.
I suspect we could use a different print function, for the only place this is called.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2511"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

