### PR TITLE
Reduce usages of Prelude/Data.Text.head

### DIFF
--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -49,6 +49,7 @@ import           Language.LSP.Types              hiding
 import           Language.LSP.Types.Capabilities
 import           Numeric.Natural
 import           Options.Applicative
+import           Safe                            (headNote)
 import           System.Directory
 import           System.Environment.Blank        (getEnv)
 import           System.FilePath                 ((<.>), (</>))
@@ -474,7 +475,7 @@ runBench runSess b = handleAny (\e -> print e >> return badRun)
         output $ "Setting up document contents took " <> showDuration d
         -- wait again, as the progress is restarted once while loading the cradle
         -- make an edit, to ensure this doesn't block
-        let DocumentPositions{..} = head docs
+        let DocumentPositions{..} = headNote "Experiments.runBench" docs
         changeDoc doc [charEdit stringLiteralP]
         waitForProgressDone
         return docs

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -461,6 +461,7 @@ executable ghcide-bench
         lsp-types,
         optparse-applicative,
         process,
+        safe,
         safe-exceptions,
         hls-graph,
         shake,

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -168,6 +168,7 @@ import qualified Ide.PluginUtils                        as HLS
 import           Ide.Types                              (PluginId)
 import qualified "list-t" ListT
 import qualified StmContainers.Map                      as STM
+import           Safe                                   (headNote)
 
 -- | We need to serialize writes to the database, so we send any function that
 -- needs to write to the database over the channel, where it will be picked up by
@@ -853,18 +854,18 @@ defineNoDiagnostics op = defineEarlyCutoff $ RuleNoDiagnostics $ \k v -> (Nothin
 -- | Request a Rule result if available
 use :: IdeRule k v
     => k -> NormalizedFilePath -> Action (Maybe v)
-use key file = head <$> uses key [file]
+use key file = headNote "Development.IDE.Core.Shake.use" <$> uses key [file]
 
 -- | Request a Rule result, it not available return the last computed result, if any, which may be stale
 useWithStale :: IdeRule k v
     => k -> NormalizedFilePath -> Action (Maybe (v, PositionMapping))
-useWithStale key file = head <$> usesWithStale key [file]
+useWithStale key file = headNote "Development.IDE.Core.Shake.useWithStale" <$> usesWithStale key [file]
 
 -- | Request a Rule result, it not available return the last computed result which may be stale.
 --   Errors out if none available.
 useWithStale_ :: IdeRule k v
     => k -> NormalizedFilePath -> Action (v, PositionMapping)
-useWithStale_ key file = head <$> usesWithStale_ key [file]
+useWithStale_ key file = headNote "Development.IDE.Core.Shake.useWithStale_" <$> usesWithStale_ key [file]
 
 -- | Plural version of 'useWithStale_'
 usesWithStale_ :: IdeRule k v => k -> [NormalizedFilePath] -> Action [(v, PositionMapping)]
@@ -932,7 +933,7 @@ useNoFile :: IdeRule k v => k -> Action (Maybe v)
 useNoFile key = use key emptyFilePath
 
 use_ :: IdeRule k v => k -> NormalizedFilePath -> Action v
-use_ key file = head <$> uses_ key [file]
+use_ key file = headNote "Development.IDE.Core.Shake.use_" <$> uses_ key [file]
 
 useNoFile_ :: IdeRule k v => k -> Action v
 useNoFile_ key = use_ key emptyFilePath

--- a/ghcide/src/Development/IDE/GHC/Compat/Units.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Units.hs
@@ -89,6 +89,7 @@ import           Data.Map                        (Map)
 #endif
 import           Data.Either
 import           Data.Version
+import qualified Data.List.NonEmpty              as NE
 
 #if MIN_VERSION_ghc(9,0,0)
 type PreloadUnitClosure = UniqSet UnitId
@@ -324,7 +325,7 @@ moduleUnit =
     Module.moduleUnitId
 #endif
 
-filterInplaceUnits :: [UnitId] -> [PackageFlag] -> ([UnitId], [PackageFlag])
+filterInplaceUnits :: NE.NonEmpty UnitId -> [PackageFlag] -> ([UnitId], [PackageFlag])
 filterInplaceUnits us packageFlags =
   partitionEithers (map isInplace packageFlags)
   where
@@ -335,7 +336,7 @@ filterInplaceUnits us packageFlags =
         then Left $ toUnitId  u
         else Right p
 #else
-      if u `elem` us
+      if u `elem` NE.toList us
         then Left u
         else Right p
 #endif

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -77,8 +77,7 @@ import           Development.IDE.Types.Options         (IdeGhcSession,
                                                         defaultIdeOptions,
                                                         optModifyDynFlags,
                                                         optTesting)
-import           Development.IDE.Types.Shake           (Key(Key),
-                                                        fromKeyType)
+import           Development.IDE.Types.Shake           (fromKeyType)
 import           GHC.Conc                              (getNumProcessors)
 import           GHC.IO.Encoding                       (setLocaleEncoding)
 import           GHC.IO.Handle                         (hDuplicate)
@@ -283,7 +282,7 @@ defaultMain Arguments{..} = flip withHeapStats fun =<< argsLogger
                 -- `unsafeGlobalDynFlags` even before the project is configured
                 _mlibdir <-
                     setInitialDynFlags logger dir argsSessionLoadingOptions
-                        `catchAny` (\e -> (logDebug logger $ T.pack $ "setInitialDynFlags: " ++ displayException e) >> pure Nothing)
+                        `catchAny` (\e -> logDebug logger (T.pack $ "setInitialDynFlags: " ++ displayException e) >> pure Nothing)
 
 
                 sessionLoader <- loadSessionWithOptions argsSessionLoadingOptions dir

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -40,6 +40,7 @@ import           Language.Haskell.GHC.ExactPrint
 import           Language.Haskell.GHC.ExactPrint.Types (DeltaPos (DP),
                                                         KeywordId (G), mkAnnKey)
 import           Language.LSP.Types
+import           Safe                                  (headNote)
 
 ------------------------------------------------------------------------------
 
@@ -321,7 +322,7 @@ extendImportViaParent df parent child (L l it@ImportDecl{..})
       let childRdr = L srcChild $ mkRdrUnqual $ mkVarOcc child
           isParentOperator = hasParen parent
       when hasSibling $
-        addTrailingCommaT (head pre)
+        addTrailingCommaT (headNote "Development.IDE.Plugin.CodeAction.ExactPrint.extendImportViaParent" pre)
       let parentLIE = L srcParent $ (if isParentOperator then IEType else IEName) parentRdr
           childLIE = L srcChild $ IEName childRdr
           x :: LIE GhcPs = L l'' $ IEThingWith noExtField parentLIE NoIEWildcard [childLIE] []
@@ -396,9 +397,9 @@ extendHiding symbol (L l idecls) mlies df = do
   if hasSibling
     then when hasSibling $ do
       addTrailingCommaT x
-      addSimpleAnnT (head lies) (DP (0, 1)) []
+      addSimpleAnnT (headNote "Development.IDE.Plugin.CodeAction.ExactPrint.extendHiding1" lies) (DP (0, 1)) []
       unless (null $ tail lies) $
-        addTrailingCommaT (head lies) -- Why we need this?
+        addTrailingCommaT (headNote "Development.IDE.Plugin.CodeAction.ExactPrint.extendHiding2" lies) -- Why we need this?
     else forM_ mlies $ \lies0 -> do
       transferAnn lies0 singleHide id
   return $ L l idecls{ideclHiding = Just (True, L l' $ x : lies)}

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -48,6 +48,7 @@ import qualified Language.LSP.Server                          as LSP
 import           Language.LSP.Types
 import qualified Language.LSP.VFS                             as VFS
 import           Text.Fuzzy.Parallel                          (Scored (..))
+import           Safe                                         (headNote)
 
 descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId = (defaultPluginDescriptor plId)
@@ -210,7 +211,7 @@ extendImportHandler :: CommandFunction IdeState ExtendImport
 extendImportHandler ideState edit@ExtendImport {..} = do
   res <- liftIO $ runMaybeT $ extendImportHandler' ideState edit
   whenJust res $ \(nfp, wedit@WorkspaceEdit {_changes}) -> do
-    let (_, List (head -> TextEdit {_range})) = fromJust $ _changes >>= listToMaybe . toList
+    let (_, List (headNote "Development.IDE.Plugin.Completions.extendImportHandler" -> TextEdit {_range})) = fromJust $ _changes >>= listToMaybe . toList
         srcSpan = rangeToSrcSpan nfp _range
     LSP.sendNotification SWindowShowMessage $
       ShowMessageParams MtInfo $

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -626,10 +626,10 @@ getCompletions plId ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls, qu
   if
     -- TODO: handle multiline imports
     | "import " `T.isPrefixOf` fullLine
-      && (List.length (words (T.unpack fullLine)) >= 2)
-      && "(" `isInfixOf` T.unpack fullLine
+      && List.length (T.words fullLine) >= 2
+      && T.any (=='(') fullLine
     -> do
-      let moduleName = T.pack $ words (T.unpack fullLine) !! 1
+      let moduleName = T.words fullLine !! 1
           funcs = HM.lookupDefault HashSet.empty moduleName moduleExportsMap
           funs = map (show . name) $ HashSet.toList funcs
       return $ filterModuleExports moduleName $ map T.pack funs

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -28,6 +28,7 @@ import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
 import           Development.IDE.GHC.Error
 import           Development.IDE.Spans.Common
+import           Safe                           (headNote)
 import           System.Directory
 import           System.FilePath
 
@@ -63,7 +64,9 @@ lookupKind env mod =
     fmap (fromRight Nothing) . catchSrcErrors (hsc_dflags env) "span" . lookupName env mod
 
 getDocumentationTryGhc :: HscEnv -> Module -> Name -> IO SpanDoc
-getDocumentationTryGhc env mod n = head <$> getDocumentationsTryGhc env mod [n]
+getDocumentationTryGhc env mod n =
+    headNote "Development.IDE.Spans.Documentation.getDocumentationTryGhc"
+    <$> getDocumentationsTryGhc env mod [n]
 
 getDocumentationsTryGhc :: HscEnv -> Module -> [Name] -> IO [SpanDoc]
 getDocumentationsTryGhc env mod names = do

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4887,7 +4887,7 @@ projectCompletionTests =
             ]
         compls <- getCompletions doc (Position 1 13)
         item <- case find (\c -> c ^. Lens.label == "ALocalModule") compls of
-            Nothing -> liftIO . assertFail $ "No completion with label ALocalModule found in : " <> show compls
+            Nothing -> liftIO . assertFailure $ "No completion with label ALocalModule found in : " <> show compls
             Just c -> pure c
         liftIO $ do
           item ^. Lens.label @?= "ALocalModule",

--- a/hls-graph/src/Development/IDE/Graph/Internal/Action.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Action.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
 

--- a/hls-graph/src/Development/IDE/Graph/Internal/Profile.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Profile.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP             #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns    #-}
 
 {- HLINT ignore "Redundant bracket" -} -- a result of CPP expansion

--- a/plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs
+++ b/plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs
@@ -14,6 +14,7 @@ import           Floskell
 import           Ide.PluginUtils
 import           Ide.Types
 import           Language.LSP.Types
+import Data.Foldable (find)
 
 -- ---------------------------------------------------------------------
 
@@ -49,7 +50,9 @@ findConfigOrDefault file = do
   case mbConf of
     Just confFile -> readAppConfig confFile
     Nothing ->
-      let gibiansky = head (filter (\s -> styleName s == "gibiansky") styles)
+      let gibiansky = case find (\s -> styleName s == "gibiansky") styles of
+            Just gibStyle -> gibStyle
+            Nothing -> error "Ide.Plugin.Floskell.findConfigOrDefault: Style with name 'gibiansky' not found"
       in pure $ defaultAppConfig { appStyle = gibiansky }
 
 -- ---------------------------------------------------------------------

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -94,6 +94,7 @@ library
     , prettyprinter
     , refinery              ^>=0.4
     , retrie                >=0.1.1.0
+    , safe
     , syb
     , unagi-chan
     , text

--- a/plugins/hls-tactics-plugin/src/Wingman/CaseSplit.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CaseSplit.hs
@@ -12,6 +12,7 @@ import qualified Data.Set as S
 import           Development.IDE.GHC.Compat
 import           GHC.Exts (IsString (fromString))
 import           GHC.SourceGen (funBindsWithFixity, match, wildP)
+import           Safe (atNote)
 import           Wingman.GHC
 import           Wingman.Types
 
@@ -105,5 +106,5 @@ splitToDecl fixity name ams = do
 iterateSplit :: AgdaMatch -> [AgdaMatch]
 iterateSplit am =
   let iterated = iterate (agdaSplit =<<) $ pure am
-   in fmap wildify . head . drop 5 $ iterated
+   in fmap wildify . (\xs -> atNote "Wingman.CaseSplit.iterateSplit" xs 5) $ iterated
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Context.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Context.hs
@@ -28,8 +28,7 @@ mkContext cfg locals tcg hscenv eps ev = fix $ \ctx ->
     , ctxModuleFuncs
         = fmap (second (coerce $ normalizeType ctx) . splitId)
         . mappend (locallyDefinedMethods tcg)
-        . (getFunBindId =<<)
-        . fmap unLoc
+        . (getFunBindId . unLoc =<<)
         . bagToList
         $ tcg_binds tcg
     , ctxConfig = cfg
@@ -102,5 +101,5 @@ hasClassInstance predty = do
       let (con, apps) = tcSplitTyConApp predty
       case tyConClass_maybe con of
         Nothing -> pure False
-        Just cls -> fmap isJust $ getInstance cls apps
+        Just cls -> isJust <$> getInstance cls apps
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Judgements.hs
@@ -34,6 +34,9 @@ buildHypothesis
   where
     go (occName -> occ, t)
       | Just ty <- t
+      -- TODO what's the intention behind this check?
+      -- can it be replace with something like `not . isSymOcc`?
+      -- https://hackage.haskell.org/package/ghc-9.2.1/docs/GHC-Plugins.html#v:isSymOcc
       , isAlpha . head . occNameString $ occ = Just $ HyInfo occ UserPrv $ CType ty
       | otherwise = Nothing
 
@@ -140,7 +143,7 @@ hasPositionalAncestry
                    -- otherwise nothing
 hasPositionalAncestry ancestors jdg name
   | not $ null ancestors
-  = case any (== name) ancestors of
+  = case name `elem` ancestors of
       True  -> Just True
       False ->
         case M.lookup name $ jAncestryMap jdg of
@@ -162,8 +165,7 @@ filterAncestry ancestry reason jdg =
     disallowing reason (M.keysSet $ M.filterWithKey go $ hyByName $ jHypothesis jdg) jdg
   where
     go name _
-      = not
-      . isJust
+      = isNothing
       $ hasPositionalAncestry ancestry jdg name
 
 
@@ -233,14 +235,12 @@ filterSameTypeFromOtherPositions dcon pos jdg =
 -- | Return the ancestry of a 'PatVal', or 'mempty' otherwise.
 getAncestry :: Judgement' a -> OccName -> Set OccName
 getAncestry jdg name =
-  case M.lookup name $ jPatHypothesis jdg of
-    Just pv -> pv_ancestry pv
-    Nothing -> mempty
+  maybe mempty pv_ancestry . M.lookup name $ jPatHypothesis jdg
 
 
 jAncestryMap :: Judgement' a -> Map OccName (Set OccName)
 jAncestryMap jdg =
-  flip M.map (jPatHypothesis jdg) pv_ancestry
+  M.map pv_ancestry (jPatHypothesis jdg)
 
 
 provAncestryOf :: Provenance -> Set OccName
@@ -365,9 +365,7 @@ hyNamesInScope = M.keysSet . hyByName
 -- | Are there any top-level function argument bindings in this judgement?
 jHasBoundArgs :: Judgement' a -> Bool
 jHasBoundArgs
-  = not
-  . null
-  . filter (isTopLevel . hi_provenance)
+  = any (isTopLevel . hi_provenance)
   . unHypothesis
   . jLocalHypothesis
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
 module Wingman.Metaprogramming.Parser where
 
 import qualified Control.Monad.Combinators.Expr as P
+import           Data.Either (fromRight)
 import           Data.Functor
 import           Data.Maybe (listToMaybe)
 import qualified Data.Text as T
@@ -415,7 +415,7 @@ oneTactic =
 
 
 tactic :: Parser (TacticsM ())
-tactic = flip P.makeExprParser operators oneTactic
+tactic = P.makeExprParser oneTactic operators
 
 operators :: [[P.Operator Parser (TacticsM ())]]
 operators =
@@ -473,7 +473,7 @@ attempt_it rsl ctx jdg program =
 
 parseMetaprogram :: T.Text -> TacticsM ()
 parseMetaprogram
-    = either (const $ pure ()) id
+    = fromRight (pure ())
     . P.runParser tacticProgram "<splice>"
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Plugin.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Plugin.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-
 -- | A plugin that uses tactics to synthesize code
 module Wingman.Plugin where
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Tactics.hs
@@ -8,8 +8,7 @@ module Wingman.Tactics
 
 import           Control.Applicative (Alternative(empty), (<|>))
 import           Control.Lens ((&), (%~), (<>~))
-import           Control.Monad (filterM)
-import           Control.Monad (unless)
+import           Control.Monad (filterM, unless)
 import           Control.Monad.Extra (anyM)
 import           Control.Monad.Reader.Class (MonadReader (ask))
 import           Control.Monad.State.Strict (StateT(..), runStateT)
@@ -95,7 +94,7 @@ recursion = requireConcreteHole $ tracing "recursion" $ do
         -- Make sure that the recursive call contains at least one already-bound
         -- pattern value. This ensures it is structurally smaller, and thus
         -- suggests termination.
-        case (any (flip M.member pat_vals) $ syn_used_vals ext) of
+        case any (flip M.member pat_vals) $ syn_used_vals ext of
           True -> Nothing
           False -> Just UnhelpfulRecursion
 
@@ -233,7 +232,7 @@ homo hi = requireConcreteHole . tracing "homo" $ do
 
   -- Ensure that every data constructor in the domain type is covered in the
   -- codomain; otherwise 'homo' will produce an ill-typed program.
-  case (uncoveredDataCons (coerce $ hi_type hi) (coerce g)) of
+  case uncoveredDataCons (coerce $ hi_type hi) (coerce g) of
     Just uncovered_dcs ->
       unless (S.null uncovered_dcs) $
         failure  $ TacticPanic "Can't cover every datacon in domain"
@@ -243,7 +242,7 @@ homo hi = requireConcreteHole . tracing "homo" $ do
     $ destruct'
         False
         (\dc jdg -> buildDataCon False jdg dc $ snd $ splitAppTys $ unCType $ jGoal jdg)
-    $ hi
+      hi
 
 
 ------------------------------------------------------------------------------
@@ -266,7 +265,7 @@ homoLambdaCase =
         $ jGoal jdg
 
 
-data Saturation = Unsaturated Int
+newtype Saturation = Unsaturated Int
   deriving (Eq, Ord, Show)
 
 pattern Saturated :: Saturation
@@ -519,8 +518,8 @@ applyByType ty = tracing ("applyByType " <> show ty) $ do
   rule $ \jdg -> do
     unify g (CType ret)
     ext
-        <- fmap unzipTrace
-        $ traverse ( newSubgoal
+        <- unzipTrace
+        <$> traverse ( newSubgoal
                     . blacklistingDestruct
                     . flip withNewGoal jdg
                     . CType
@@ -582,8 +581,7 @@ letBind occs = do
            $ \occ
           -> fmap (occ, )
            $ fmap (<$ jdg)
-           $ fmap CType
-           $ newUnivar
+           $ fmap CType newUnivar
   rule $ nonrecLet occ_tys
 
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Types.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Types.hs
@@ -333,12 +333,12 @@ instance MonadExtract Int (Synthesized (LHsExpr GhcPs)) TacticError TacticState 
 
 
 instance MonadReader r m => MonadReader r (TacticT jdg ext err s m) where
-  ask = TacticT $ lift $ Effect $ fmap pure ask
+  ask = TacticT $ lift $ Effect $ asks pure
   local f (TacticT m) = TacticT $ Strict.StateT $ \jdg ->
     Effect $ local f $ pure $ Strict.runStateT m jdg
 
 instance MonadReader r m => MonadReader r (RuleT jdg ext err s m) where
-  ask = RuleT $ Effect $ fmap Axiom ask
+  ask = RuleT $ Effect $ asks Axiom
   local f (RuleT m) = RuleT $ Effect $ local f $ pure m
 
 mkMetaHoleName :: Int -> RdrName
@@ -463,7 +463,7 @@ data Context = Context
   }
 
 instance Show Context where
-  show (Context {..}) = mconcat
+  show Context{..} = mconcat
     [ "Context "
     , showsPrec 10 ctxDefiningFuncs ""
     , showsPrec 10 ctxModuleFuncs ""

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -4,6 +4,7 @@ module Completion(tests) where
 
 import           Control.Lens            hiding ((.=))
 import           Data.Aeson              (object, (.=))
+import           Data.Foldable           (find)
 import qualified Data.Text               as T
 import           Ide.Plugin.Config       (maxCompletions)
 import           Language.LSP.Types.Lens hiding (applyEdit)
@@ -19,7 +20,7 @@ tests = testGroup "completions" [
          _ <- applyEdit doc te
 
          compls <- getCompletions doc (Position 5 9)
-         let item = head $ filter ((== "putStrLn") . (^. label)) compls
+         item <- findCompletionWithLabel "putStrLn" compls
          liftIO $ do
              item ^. label @?= "putStrLn"
              item ^. kind @?= Just CiFunction
@@ -35,7 +36,7 @@ tests = testGroup "completions" [
          _ <- applyEdit doc te
 
          compls <- getCompletions doc (Position 5 9)
-         let item = head $ filter ((== "putStrLn") . (^. label)) compls
+         item <- findCompletionWithLabel "putStrLn" compls
          resolvedRes <- request SCompletionItemResolve item
          let Right resolved = resolvedRes ^. result
          liftIO $ print resolved
@@ -55,7 +56,7 @@ tests = testGroup "completions" [
          _ <- applyEdit doc te
 
          compls <- getCompletions doc (Position 1 23)
-         let item = head $ filter ((== "Maybe") . (^. label)) compls
+         item <- findCompletionWithLabel "Maybe" compls
          liftIO $ do
              item ^. label @?= "Maybe"
              item ^. detail @?= Just "Data.Maybe"
@@ -70,7 +71,7 @@ tests = testGroup "completions" [
          _ <- applyEdit doc te
 
          compls <- getCompletions doc (Position 2 24)
-         let item = head $ filter ((== "List") . (^. label)) compls
+         item <- findCompletionWithLabel "List" compls
          liftIO $ do
              item ^. label @?= "List"
              item ^. detail @?= Just "Data.List"
@@ -90,7 +91,7 @@ tests = testGroup "completions" [
          _ <- applyEdit doc te
 
          compls <- getCompletions doc (Position 5 4)
-         let item = head $ filter (\c -> c^.label == "accessor") compls
+         item <- findCompletionWithLabel "accessor" compls
          liftIO $ do
              item ^. label @?= "accessor"
              item ^. kind @?= Just CiFunction
@@ -100,7 +101,7 @@ tests = testGroup "completions" [
          let te = TextEdit (Range (Position 5 7) (Position 5 9)) "id"
          _ <- applyEdit doc te
          compls <- getCompletions doc (Position 5 9)
-         let item = head $ filter ((== "id") . (^. label)) compls
+         item <- findCompletionWithLabel "id" compls
          liftIO $ do
              item ^. detail @?= Just ":: a -> a"
 
@@ -110,7 +111,7 @@ tests = testGroup "completions" [
          let te = TextEdit (Range (Position 5 7) (Position 5 24)) "flip"
          _ <- applyEdit doc te
          compls <- getCompletions doc (Position 5 11)
-         let item = head $ filter ((== "flip") . (^. label)) compls
+         item <- findCompletionWithLabel "flip" compls
          liftIO $
              item ^. detail @?= Just ":: (a -> b -> c) -> b -> a -> c"
 
@@ -127,7 +128,7 @@ tests = testGroup "completions" [
          _ <- applyEdit doc te
 
          compls <- getCompletions doc (Position 0 31)
-         let item = head $ filter ((== "Alternative") . (^. label)) compls
+         item <- findCompletionWithLabel "Alternative" compls
          liftIO $ do
              item ^. label @?= "Alternative"
              item ^. kind @?= Just CiFunction
@@ -140,7 +141,7 @@ tests = testGroup "completions" [
          _ <- applyEdit doc te
 
          compls <- getCompletions doc (Position 0 41)
-         let item = head $ filter ((== "liftA") . (^. label)) compls
+         item <- findCompletionWithLabel "liftA" compls
          liftIO $ do
              item ^. label @?= "liftA"
              item ^. kind @?= Just CiFunction
@@ -158,7 +159,7 @@ snippetTests = testGroup "snippets" [
       _ <- applyEdit doc te
 
       compls <- getCompletions doc (Position 5 14)
-      let item = head $ filter ((== "Nothing") . (^. label)) compls
+      item <- findCompletionWithLabel "Nothing" compls
       liftIO $ do
           item ^. insertTextFormat @?= Just Snippet
           item ^. insertText @?= Just "Nothing "
@@ -170,7 +171,7 @@ snippetTests = testGroup "snippets" [
         _ <- applyEdit doc te
 
         compls <- getCompletions doc (Position 5 11)
-        let item = head $ filter ((== "foldl") . (^. label)) compls
+        item <- findCompletionWithLabel "foldl" compls
         liftIO $ do
             item ^. label @?= "foldl"
             item ^. kind @?= Just CiFunction
@@ -184,7 +185,7 @@ snippetTests = testGroup "snippets" [
         _ <- applyEdit doc te
 
         compls <- getCompletions doc (Position 5 11)
-        let item = head $ filter ((== "mapM") . (^. label)) compls
+        item <- findCompletionWithLabel "mapM" compls
         liftIO $ do
             item ^. label @?= "mapM"
             item ^. kind @?= Just CiFunction
@@ -198,7 +199,7 @@ snippetTests = testGroup "snippets" [
         _ <- applyEdit doc te
 
         compls <- getCompletions doc (Position 5 18)
-        let item = head $ filter ((== "filter") . (^. label)) compls
+        item <- findCompletionWithLabel "filter" compls
         liftIO $ do
             item ^. label @?= "filter"
             item ^. kind @?= Just CiFunction
@@ -212,7 +213,7 @@ snippetTests = testGroup "snippets" [
         _ <- applyEdit doc te
 
         compls <- getCompletions doc (Position 5 18)
-        let item = head $ filter ((== "filter") . (^. label)) compls
+        item <- findCompletionWithLabel "filter" compls
         liftIO $ do
             item ^. label @?= "filter"
             item ^. kind @?= Just CiFunction
@@ -226,7 +227,7 @@ snippetTests = testGroup "snippets" [
         _ <- applyEdit doc te
 
         compls <- getCompletions doc (Position 5 29)
-        let item = head $ filter ((== "intersperse") . (^. label)) compls
+        item <- findCompletionWithLabel "intersperse" compls
         liftIO $ do
             item ^. label @?= "intersperse"
             item ^. kind @?= Just CiFunction
@@ -240,7 +241,7 @@ snippetTests = testGroup "snippets" [
         _ <- applyEdit doc te
 
         compls <- getCompletions doc (Position 5 29)
-        let item = head $ filter ((== "intersperse") . (^. label)) compls
+        item <- findCompletionWithLabel "intersperse" compls
         liftIO $ do
             item ^. label @?= "intersperse"
             item ^. kind @?= Just CiFunction
@@ -267,7 +268,9 @@ snippetTests = testGroup "snippets" [
          _ <- applyEdit doc te
 
          compls <- getCompletions doc (Position 1 6)
-         let item = head $ filter (\c -> (c ^. label == "MkFoo") && maybe False ("MkFoo {" `T.isPrefixOf`) (c ^. insertText)) compls
+         item <- case find (\c -> (c ^. label == "MkFoo") && maybe False ("MkFoo {" `T.isPrefixOf`) (c ^. insertText)) compls of
+            Just c -> pure c
+            Nothing -> liftIO . assertFailure $ "No completion with label/insertText MkFoo found in " ++ show compls
          liftIO $ do
             item ^. insertTextFormat @?= Just Snippet
             item ^. insertText @?= Just "MkFoo {arg1=${1:_arg1}, arg2=${2:_arg2}, arg3=${3:_arg3}, arg4=${4:_arg4}, arg5=${5:_arg5}}"
@@ -278,7 +281,7 @@ snippetTests = testGroup "snippets" [
             _      <- applyEdit doc te
 
             compls <- getCompletions doc (Position 5 11)
-            let item = head $ filter ((== "foldl") . (^. label)) compls
+            item <- findCompletionWithLabel "foldl" compls
             liftIO $ do
                 item ^. label @?= "foldl"
                 item ^. kind @?= Just CiFunction
@@ -296,6 +299,15 @@ snippetTests = testGroup "snippets" [
             ?~ False
             )
             fullCaps
+
+
+findCompletionWithLabel :: T.Text -> [CompletionItem] -> Session CompletionItem
+findCompletionWithLabel desiredLabel compls =
+    case find (\ ci -> ci ^. label == desiredLabel) compls of
+        Nothing -> liftIO . assertFailure $
+            "Completion with label " ++ show desiredLabel ++ " not found in " ++ show compls
+        Just ci -> pure ci
+
 
 contextTests :: TestTree
 contextTests = testGroup "contexts" [

--- a/test/functional/FunctionalCodeAction.hs
+++ b/test/functional/FunctionalCodeAction.hs
@@ -135,7 +135,8 @@ packageTests = testGroup "add package suggestions" [
             -- ignore the first empty hlint diagnostic publish
             [_,_:diag:_] <- count 2 $ waitForDiagnosticsFrom doc
 
-            let prefixes = [ "Could not load module `Codec.Compression.GZip'" -- Windows && GHC >= 8.6
+            let prefixes =
+                        [ "Could not load module `Codec.Compression.GZip'" -- Windows && GHC >= 8.6
                         , "Could not find module `Codec.Compression.GZip'" -- Windows
                         , "Could not load module ‘Codec.Compression.GZip’" -- GHC >= 8.6
                         , "Could not find module ‘Codec.Compression.GZip’"


### PR DESCRIPTION
First batch of fixes to https://github.com/haskell/haskell-language-server/issues/2514

This is going to be harder than I thought :P
There are more `head`s to come, but opening this just to get initial feedback on the general approach.

Also (due to my ocd) I had to fix bunch of hlint warnings which lead to meaningful simplifications.

Vague questions: how are you guys dealing with running tests locally?
I'm getting bunch of `fd:28: hPutBuf: resource vanished (Broken pipe)` when running `cabal test` locally..

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2519"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

