### PR TITLE
CI: caching: fix early termination expression check & cabal.project replacement

### DIFF
--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -100,7 +100,9 @@ jobs:
       - if: matrix.ghc == '9.0.1'
         name: (GHC 9.0.1) Use modified `cabal.project`
         run: |
-          # This seems insane, but it is needed.
+          # File has some protections preventing regular `rm`.
+          # `&&` insures `rm -f` returns positive.
+          # Some platforms have `alias cp='cp -i'`.
           rm -f -v cabal.project && cp -v cabal-ghc901.project cabal.project
       - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
         name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -103,7 +103,7 @@ jobs:
           # File has some protections preventing regular `rm`.
           # (most probably sticky bit is set on $HOME)
           # `&&` insures `rm -f` return is positive.
-          # Many platforms aslo have `alias cp='cp -i'`.
+          # Many platforms also have `alias cp='cp -i'`.
           rm -f -v cabal.project && cp -v cabal-ghc901.project cabal.project
       - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
         name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -154,11 +154,11 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
 
-      - if: (! steps.compiled-deps.outputs.cache-hit)
+      - if: steps.compiled-deps.outputs.cache-hit != 'true'
         run: |
           cabal update
 
-      - if: (! steps.compiled-deps.outputs.cache-hit)
+      - if: steps.compiled-deps.outputs.cache-hit != 'true'
         name: Download all sources
         run: |
           cabal $cabalBuild --only-download
@@ -168,7 +168,7 @@ jobs:
       # but to cache what can be cached, so step is fault tolerant & would always succseed.
       # 2021-12-11: NOTE: Building all targets, since
       # current Cabal does not allow `all --enable-tests --enable-benchmarks --only-dependencies`
-      - if: (! steps.compiled-deps.outputs.cache-hit)
+      - if: steps.compiled-deps.outputs.cache-hit != 'true'
         name: Build all targets; try 3 times
         continue-on-error: true
         run: |

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -100,7 +100,8 @@ jobs:
       - if: matrix.ghc == '9.0.1'
         name: (GHC 9.0.1) Use modified `cabal.project`
         run: |
-          cp cabal-ghc901.project cabal.project
+          # This seems insane, but it is needed.
+          rm -f -v cabal.project && cp -v cabal-ghc901.project cabal.project
       - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
         name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults
         run: |

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -101,8 +101,9 @@ jobs:
         name: (GHC 9.0.1) Use modified `cabal.project`
         run: |
           # File has some protections preventing regular `rm`.
-          # `&&` insures `rm -f` returns positive.
-          # Some platforms have `alias cp='cp -i'`.
+          # (most probably sticky bit is set on $HOME)
+          # `&&` insures `rm -f` return is positive.
+          # Many platforms aslo have `alias cp='cp -i'`.
           rm -f -v cabal.project && cp -v cabal-ghc901.project cabal.project
       - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
         name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,9 @@ jobs:
       - if: matrix.ghc == '9.0.1'
         name: (GHC 9.0.1) Use modified `cabal.project`
         run: |
-          # This seems insane, but it is needed.
+          # File has some protections preventing regular `rm`.
+          # `&&` insures `rm -f` returns positive.
+          # Some platforms have `alias cp='cp -i'`.
           rm -f -v cabal.project && cp -v cabal-ghc901.project cabal.project
       - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
         name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,8 @@ jobs:
       - if: matrix.ghc == '9.0.1'
         name: (GHC 9.0.1) Use modified `cabal.project`
         run: |
-          cp cabal-ghc901.project cabal.project
+          # This seems insane, but it is needed.
+          rm -f -v cabal.project && cp -v cabal-ghc901.project cabal.project
       - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
         name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,8 +96,9 @@ jobs:
         name: (GHC 9.0.1) Use modified `cabal.project`
         run: |
           # File has some protections preventing regular `rm`.
-          # `&&` insures `rm -f` returns positive.
-          # Some platforms have `alias cp='cp -i'`.
+          # (most probably sticky bit is set on $HOME)
+          # `&&` insures `rm -f` return is positive.
+          # Many platforms aslo have `alias cp='cp -i'`.
           rm -f -v cabal.project && cp -v cabal-ghc901.project cabal.project
       - if: runner.os == 'Windows' && matrix.ghc == '8.8.4'
         name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -37,7 +37,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2021-11-29T12:30:09Z
+index-state: 2021-11-29T12:30:10Z
 
 constraints:
   -- These plugins don't work on GHC9 yet

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -37,7 +37,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2021-11-29T12:30:08Z
+index-state: 2021-11-29T12:30:09Z
 
 constraints:
   -- These plugins don't work on GHC9 yet

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -36,7 +36,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2021-11-29T12:30:09Z
+index-state: 2021-11-29T12:30:10Z
 
 constraints:
   -- These plugins doesn't work on GHC92 yet

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -36,7 +36,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2021-11-29T12:30:08Z
+index-state: 2021-11-29T12:30:09Z
 
 constraints:
   -- These plugins doesn't work on GHC92 yet

--- a/cabal.project
+++ b/cabal.project
@@ -40,7 +40,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2021-11-29T12:30:08Z
+index-state: 2021-11-29T12:30:09Z
 
 constraints:
     hyphenation +embed

--- a/cabal.project
+++ b/cabal.project
@@ -40,7 +40,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2021-11-29T12:30:09Z
+index-state: 2021-11-29T12:30:10Z
 
 constraints:
     hyphenation +embed


### PR DESCRIPTION
Details are in the commit messages.

1. We not noticed the first specific of the CI, because the early cutoff behaved as it should. It was respected to return `'false'` to terminate early, but that check always returned `'false'`. When working in GHC 9.2 PR could not force the caching build to start, because check that I fix - always skipped the steps (always returned `False`). New check is done in the way how it is done in other `if: ... != 'true'` statements in the workflow.

2. The second specific is both Ubuntu-specific & maybe  GitHub specific. Some OSes run `alias cp='cp -i'` & when I tried to `rm` manually - `cabal.project` appeared to be protected from simple `rm` by setinning (most probably) of a "sticky bit" on `$HOME` directory. I found that-out by working in GHC 9.2 PR (where `index-state` is actually different between `.project` files & noticed that CI cache key was with the same inferred `index-state` in all jobs). Now `rm -f` forced & that allows removing file with a sticky bit. log reports the situation of files changes there: https://github.com/haskell/haskell-language-server/runs/4597911492?check_suite_focus=true#step:14:460

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2520"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

