### PR TITLE
Improve action for fixing import typo

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -700,17 +700,33 @@ suggestFillTypeWildcard Diagnostic{_range=_range,..}
         =  [("Use type signature: ‘" <> typeSignature <> "’", TextEdit _range typeSignature)]
     | otherwise = []
 
+{- Handles two variants with different formatting
+
+1. Could not find module ‘Data.Cha’
+   Perhaps you meant Data.Char (from base-4.12.0.0)
+
+2. Could not find module ‘Data.I’
+   Perhaps you meant
+      Data.Ix (from base-4.14.3.0)
+      Data.Eq (from base-4.14.3.0)
+      Data.Int (from base-4.14.3.0)
+-}
 suggestModuleTypo :: Diagnostic -> [(T.Text, TextEdit)]
 suggestModuleTypo Diagnostic{_range=_range,..}
--- src/Development/IDE/Core/Compile.hs:58:1: error:
---     Could not find module ‘Data.Cha’
---     Perhaps you meant Data.Char (from base-4.12.0.0)
     | "Could not find module" `T.isInfixOf` _message
-    , "Perhaps you meant"     `T.isInfixOf` _message = let
-      findSuggestedModules = map (head . T.words) . drop 2 . T.lines
-      proposeModule mod = ("replace with " <> mod, TextEdit _range mod)
-      in map proposeModule $ nubOrd $ findSuggestedModules _message
+    , "Perhaps you meant" `T.isInfixOf` _message =
+      case T.splitOn "Perhaps you meant" _message of
+          [_, stuff] ->
+              [ ("replace with " <> modul, TextEdit _range modul)
+              | modul <- mapMaybe extractModule (T.lines stuff)
+              ]
+          _ -> []
     | otherwise = []
+  where
+    extractModule line = case T.words line of
+        [modul, "(from", _] -> Just modul
+        _ -> Nothing
+    
 
 suggestFillHole :: Diagnostic -> [(T.Text, TextEdit)]
 suggestFillHole Diagnostic{_range=_range,..}

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -713,8 +713,7 @@ suggestFillTypeWildcard Diagnostic{_range=_range,..}
 -}
 suggestModuleTypo :: Diagnostic -> [(T.Text, TextEdit)]
 suggestModuleTypo Diagnostic{_range=_range,..}
-    | "Could not find module" `T.isInfixOf` _message
-    , "Perhaps you meant" `T.isInfixOf` _message =
+    | "Could not find module" `T.isInfixOf` _message =
       case T.splitOn "Perhaps you meant" _message of
           [_, stuff] ->
               [ ("replace with " <> modul, TextEdit _range modul)


### PR DESCRIPTION
Adding missing tests mentioned here: https://github.com/haskell/haskell-language-server/pull/2519#discussion_r773149782

Fixing this code action to work in more cases

After this fix:

https://user-images.githubusercontent.com/2716069/147052667-2946d450-7d2b-46d9-a3a9-6e1aedf8570a.mp4




<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2522"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

