### PR TITLE
Enable manual run for caching, hackage and build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Builds
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
   push:

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -53,19 +53,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
-      should_skip_ghcide: ${{ steps.skip_ghcide_check.outputs.should_skip }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.1
         with:
           cancel_others: false
           paths_ignore: '["**/docs/**", "**.md", "**/LICENSE", "install/**", "**.nix", "flake.lock", "**/README.md", "FUNDING.yml", ".circleci/**"]'
-      # If we only change ghcide downstream packages we have not test ghcide itself
-      - id: skip_ghcide_check
-        uses: fkirc/skip-duplicate-actions@v3.4.1
-        with:
-          cancel_others: false
-          paths_ignore: '["hls-test-utils/**", "plugins/**", "src/**", "exe/**", "test/**", "shake-bench/**"]'
 
   caching:
     if: needs.pre_job.outputs.should_skip != 'true'

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -27,6 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -6,6 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - '*-hackage'
@@ -28,7 +29,6 @@ jobs:
                   "hls-call-hierarchy-plugin", "hls-alternate-number-format-plugin",
                   "hls-qualify-imported-names-plugin",
                   "haskell-language-server"]
-        # Uncomment 9.0.1 when ghcide is buildable
         ghc: [ "9.0.1",
               "8.10.7",
               "8.8.4",

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -7,6 +7,11 @@ concurrency:
 
 on:
   workflow_dispatch:
+    inputs:
+      upload-candidates:
+        description: 'Whether packages should be uploaded'
+        required: true
+        default: 'true'
   push:
     branches:
       - '*-hackage'
@@ -15,7 +20,7 @@ jobs:
   check-and-upload-tarballs:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: ${{ !contains(github.ref_name, 'check') }}
+      fail-fast: ${{ !contains(github.ref_name, 'check') && github.event.inputs.upload-candidates != 'true' }}
       matrix:
         package: ["hie-compat", "hls-graph", "shake-bench",
                   "hls-plugin-api", "ghcide", "hls-test-utils",
@@ -181,7 +186,7 @@ jobs:
           path: ${{ steps.generate-dist-tarball.outputs.path }}
 
   upload-candidate:
-    if: ${{ !contains(github.ref_name, 'check') }}
+    if: ${{ !contains(github.ref_name, 'check') || github.event.inputs.name == 'true' }}
     needs: check-and-upload-tarballs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
* Those workflows are not being triggered on pull request and use branch names to trigger them is a little bit clumsy
* This way we could, for example, manually trigger caching on any branch, to control the cache behaviour: this can lead to slow ci builds so you have to know what are you doing (experimenting in your own fork if possible before)
* Here there is docs on how to do the manual trigger: https://docs.github.com/es/actions/managing-workflow-runs/manually-running-a-workflow


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2528"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

