### PR TITLE
CI: caching: keep-going

### DIFF
--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -45,7 +45,7 @@ on:
     - cron: "25 2/8 * * *"
 
 env:
-  cabalBuild: "v2-build all --enable-tests --enable-benchmarks"
+  cabalBuild: "v2-build all --enable-tests --enable-benchmarks --keep-going"
 
 jobs:
 


### PR DESCRIPTION
This solves the `build all` problem when all projects can't infer the consitent
package version.

Also would allow caching workflow on manual start - to work & cache in a broken
or complex PRs.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2535"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

