### PR TITLE
CI: caching: closer match work/CI guarantees

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -118,9 +118,6 @@ jobs:
               ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
               ${{ env.cache-name }}-${{ runner.os }}-
 
-    - run: |
-        cabal v2-update
-
     # max-backjumps is increased as a temporary solution
     # for dependency resolution failure
     - run: cabal configure --enable-benchmarks --max-backjumps 12000

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -118,7 +118,8 @@ jobs:
               ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
               ${{ env.cache-name }}-${{ runner.os }}-
 
-    - run: cabal update
+    - run: |
+        cabal v2-update
 
     # max-backjumps is increased as a temporary solution
     # for dependency resolution failure

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -88,11 +88,13 @@ jobs:
     - name: Form the package list ('cabal.project.freeze')
       continue-on-error: true
       run: |
-        cabal v2-freeze
-        echo ''
-        echo 'Output:'
-        echo ''
-        cat 'cabal.project.freeze'
+        cabal v2-freeze && \
+        echo '' && \
+        echo 'Output:' && \
+        echo '' && \
+        cat 'cabal.project.freeze' && \
+        echo '' || \
+        echo 'WARNING: Could not produce the `freeze`.
 
     - name: Hackage sources cache
       uses: actions/cache@v2

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -201,10 +201,5 @@ jobs:
         continue-on-error: true
         # Done separately, matching the tested work/PR workflow guarantees
         run: |
-
-      # Despite the `continue-on-error: true` directive - CI does not ignore the return code of the last step
-      - name: Workaround to CI platform
-        run: |
-          true
           cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks
           cabal $cabalBuild --enable-test || cabal $cabalBuild --enable-test || cabal $cabalBuild --enable-test

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -206,6 +206,7 @@ jobs:
 
       - if: steps.compiled-deps.outputs.cache-hit != 'true' && runner.os == 'Linux' && matrix.ghc == '8.10.7'
         name: (For Bench workflow) Build benchmark targets
+        continue-on-error: true
         #  Downloaded separately, to match the tested work/PR workflow guarantees
         run: |
           cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -45,7 +45,7 @@ on:
     - cron: "25 2/8 * * *"
 
 env:
-  cabalBuild: "v2-build all --enable-tests --enable-benchmarks --keep-going"
+  cabalBuild: "v2-build all --keep-going"
 
 jobs:
 
@@ -186,8 +186,10 @@ jobs:
 
       - if: steps.compiled-deps.outputs.cache-hit != 'true'
         name: Download all sources
+        #  Downloaded separately, to match the tested work/PR workflow guarantees
         run: |
-          cabal $cabalBuild --only-download
+          cabal $cabalBuild --enable-benchmarks --only-download
+          cabal $cabalBuild --enable-tests      --only-download
 
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
       # This build agenda in not to have successful code,
@@ -197,10 +199,12 @@ jobs:
       - if: steps.compiled-deps.outputs.cache-hit != 'true'
         name: Build all targets; try 3 times
         continue-on-error: true
+        # Done separately, matching the tested work/PR workflow guarantees
         run: |
-          cabal $cabalBuild || cabal $cabalBuild || cabal $cabalBuild
 
       # Despite the `continue-on-error: true` directive - CI does not ignore the return code of the last step
       - name: Workaround to CI platform
         run: |
           true
+          cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks
+          cabal $cabalBuild --enable-test || cabal $cabalBuild --enable-test || cabal $cabalBuild --enable-test

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -145,11 +145,13 @@ jobs:
       - name: Form the package list ('cabal.project.freeze')
         continue-on-error: true
         run: |
-          cabal v2-freeze
-          echo ''
-          echo 'Output:'
-          echo ''
-          cat 'cabal.project.freeze'
+          cabal v2-freeze && \
+          echo '' && \
+          echo 'Output:' && \
+          echo '' && \
+          cat 'cabal.project.freeze' && \
+          echo '' || \
+          echo 'WARNING: Could not produce the `freeze`.
 
       # 2021-12-02: NOTE: Cabal Hackage source tree storage does not depend on OS or GHC really,
       # but can depend on `base`.

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -182,10 +182,6 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
 
-      - if: steps.compiled-deps.outputs.cache-hit != 'true'
-        run: |
-          cabal v2-update
-
       - if: steps.compiled-deps.outputs.cache-hit != 'true' && runner.os == 'Linux' && matrix.ghc == '8.10.7'
         name: Download sources for bench
         #  Downloaded separately, to match the tested work/PR workflow guarantees

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -184,7 +184,7 @@ jobs:
 
       - if: steps.compiled-deps.outputs.cache-hit != 'true'
         run: |
-          cabal update
+          cabal v2-update
 
       - if: steps.compiled-deps.outputs.cache-hit != 'true'
         name: Download all sources

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -186,19 +186,19 @@ jobs:
         name: Download sources for bench
         #  Downloaded separately, to match the tested work/PR workflow guarantees
         run: |
-          cabal $cabalBuild --enable-benchmarks --only-download
+          cabal $cabalBuild --only-download --enable-benchmarks
 
       - if: steps.compiled-deps.outputs.cache-hit != 'true'
         name: Download the rest of the sources
         #  Downloaded separately, to match the tested work/PR workflow guarantees
         run: |
-          cabal $cabalBuild --enable-tests      --only-download
+          cabal $cabalBuild --only-download --enable-tests
 
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
       # This build agenda in not to have successful code,
-      # but to cache what can be cached, so step is fault tolerant & would always succseed.
-      # 2021-12-11: NOTE: Building all targets, since
-      # current Cabal does not allow `all --enable-tests --enable-benchmarks --only-dependencies`
+      # but to cache what can be cached, so step is fault tolerant & would always succeed.
+      # 2021-12-11: NOTE: Need to building all targets (build the project also), since
+      # current Cabal does not allow `all --enable-tests --enable-benchmarks --only-dependencies` combination
 
       - if: steps.compiled-deps.outputs.cache-hit != 'true' && runner.os == 'Linux' && matrix.ghc == '8.10.7'
         name: (For Bench workflow) Build benchmark targets

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -186,11 +186,16 @@ jobs:
         run: |
           cabal v2-update
 
-      - if: steps.compiled-deps.outputs.cache-hit != 'true'
-        name: Download all sources
+      - if: steps.compiled-deps.outputs.cache-hit != 'true' && runner.os == 'Linux' && matrix.ghc == '8.10.7'
+        name: Download sources for bench
         #  Downloaded separately, to match the tested work/PR workflow guarantees
         run: |
           cabal $cabalBuild --enable-benchmarks --only-download
+
+      - if: steps.compiled-deps.outputs.cache-hit != 'true'
+        name: Download the rest of the sources
+        #  Downloaded separately, to match the tested work/PR workflow guarantees
+        run: |
           cabal $cabalBuild --enable-tests      --only-download
 
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
@@ -198,10 +203,16 @@ jobs:
       # but to cache what can be cached, so step is fault tolerant & would always succseed.
       # 2021-12-11: NOTE: Building all targets, since
       # current Cabal does not allow `all --enable-tests --enable-benchmarks --only-dependencies`
+
+      - if: steps.compiled-deps.outputs.cache-hit != 'true' && runner.os == 'Linux' && matrix.ghc == '8.10.7'
+        name: (For Bench workflow) Build benchmark targets
+        #  Downloaded separately, to match the tested work/PR workflow guarantees
+        run: |
+          cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks
+
       - if: steps.compiled-deps.outputs.cache-hit != 'true'
-        name: Build all targets; try 3 times
+        name: Build targets; try 3 times
         continue-on-error: true
         # Done separately, matching the tested work/PR workflow guarantees
         run: |
-          cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks || cabal $cabalBuild --enable-benchmarks
           cabal $cabalBuild --enable-test || cabal $cabalBuild --enable-test || cabal $cabalBuild --enable-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,9 +179,6 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
 
-      - run: |
-          cabal v2-update
-
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
       - name: Build
         run: cabal build || cabal build || cabal build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,11 +149,13 @@ jobs:
       - name: Form the package list ('cabal.project.freeze')
         continue-on-error: true
         run: |
-          cabal v2-freeze
-          echo ''
-          echo 'Output:'
-          echo ''
-          cat 'cabal.project.freeze'
+          cabal v2-freeze && \
+          echo '' && \
+          echo 'Output:' && \
+          echo '' && \
+          cat 'cabal.project.freeze' && \
+          echo '' || \
+          echo 'WARNING: Could not produce the `freeze`.
 
       - name: Hackage sources cache
         uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,8 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
 
-      - run: cabal v2-update
+      - run: |
+          cabal v2-update
 
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
       - name: Build


### PR DESCRIPTION
* Would note we have a `cabal v2-build all --enable-tests --enable-benchmark` problem - that command requires the level of dependency consistency guarantees that PR CI does not checks.

`test` workflow does essentially `cabal v2-build --enable-tests` on matrix by target.
`bench` workflow does `cabal v2-build --enable-benchmarks` by target.

`caching` used `all --enable-tests --enable-benchmarks` - requiring total consistency.

These changes are to make `caching` able to work when `test` & `bench` deps
versions are inconsistent (which is how CI & people use them - separately).

* "`Workaround to CI platform`" needs to be removed either way, since I found out post hooks does not run if any of (even marked `continue-on-error: true`) steps fail.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2536"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

