### PR TITLE
CI: add hlint workflow

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -20,4 +20,5 @@ jobs:
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v1
       with:
-        path: '[ "--with-group=extra", "--hint=ghcide/.hlint.yaml", "ghcide/src", "ghcide/exe", "ghcide/bench/lib", "ghcide/bench/exe", "ghcide/bench/hist", "shake-bench/src", "ghcide/test/exe" ]'
+        hlint-bin: "hlint --with-group=extra --hint=ghcide/.hlint.yaml"
+        path: '[ "ghcide/src", "ghcide/exe", "ghcide/bench/lib", "ghcide/bench/exe", "ghcide/bench/hist", "shake-bench/src", "ghcide/test/exe" ]'

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: 'Installing'
       uses: rwe/actions-hlint-setup@v1
       with:
-        version: '3.3.5'
+        version: '3.3.1'
 
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v1

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: 'Installing'
       uses: rwe/actions-hlint-setup@v1
       with:
-        version: '3.3.1'
+        version: '3.3.4'
 
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v1

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,0 +1,17 @@
+name: "Checking with HLint"
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build10:
+    name: "HLint check"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: "HLint via ./fmt.sh"
+      run: |
+        ./fmt.sh

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,4 +1,4 @@
-name: "Checking with HLint"
+name: "HLint check"
 
 on:
   pull_request:
@@ -7,11 +7,17 @@ on:
 
 jobs:
   build10:
-    name: "HLint check"
+    name: "Run"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
-    - name: "HLint via ./fmt.sh"
-      run: |
-        ./fmt.sh
+    - name: 'Installing'
+      uses: rwe/actions-hlint-setup@v1
+      with:
+        version: '3.3.5'
+
+    - name: 'Checking code'
+      uses: rwe/actions-hlint-run@v1
+      with:
+        path: '[ "--with-group=extra", "--hint=ghcide/.hlint.yaml", "ghcide/src", "ghcide/exe", "ghcide/bench/lib", "ghcide/bench/exe", "ghcide/bench/hist", "shake-bench/src", "ghcide/test/exe" ]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,11 +154,7 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
 
-      - run: cabal update
-
-      - name: "HLint via ./fmt.sh"
-        run: |
-          ./fmt.sh
+      - run: cabal v2-update
 
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
       - name: Build


### PR DESCRIPTION
As I understand, CI installs executable & runs it.

HLint gives the same output regardless of the GHC versions, so there is no reason to run it inside GHC matrix. In fact HLint executable installed does not need GHC at all.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2537"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

