### PR TITLE
Set an unique name for Hlint job

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build10:
-    name: "Run"
+    name: "Hlint check run"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -21,4 +21,5 @@ jobs:
       uses: rwe/actions-hlint-run@v1
       with:
         hlint-bin: "hlint --with-group=extra --hint=ghcide/.hlint.yaml"
-        path: '[ "ghcide/src", "ghcide/exe", "ghcide/bench/lib", "ghcide/bench/exe", "ghcide/bench/hist", "shake-bench/src", "ghcide/test/exe" ]'
+        path: '[ "ghcide/src", "ghcide/exe", "ghcide/bench/lib", "ghcide/bench/exe", "ghcide/bench/hist", "shake-bench/src", "ghcide/test/exe" pop]'
+

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -21,5 +21,5 @@ jobs:
       uses: rwe/actions-hlint-run@v1
       with:
         hlint-bin: "hlint --with-group=extra --hint=ghcide/.hlint.yaml"
-        path: '[ "ghcide/src", "ghcide/exe", "ghcide/bench/lib", "ghcide/bench/exe", "ghcide/bench/hist", "shake-bench/src", "ghcide/test/exe" pop]'
+        path: '[ "ghcide/src", "ghcide/exe", "ghcide/bench/lib", "ghcide/bench/exe", "ghcide/bench/hist", "shake-bench/src", "ghcide/test/exe"]'
 


### PR DESCRIPTION
As we have to add the *job* to branch pr merge checks and `Run` is too generic

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2544"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

