### PR TITLE
Add space after comma when exporting a name

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -541,7 +541,7 @@ suggestExportUnusedTopBinding srcOpt ParsedModule{pm_parsed_source = L _ HsModul
                             $ hsmodDecls
   , Just pos <- fmap _end . getLocatedRange =<< hsmodExports
   , Just needComma <- needsComma source <$> hsmodExports
-  , let exportName = (if needComma then "," else "") <> printExport exportType name
+  , let exportName = (if needComma then ", " else "") <> printExport exportType name
         insertPos = pos {_character = pred $ _character pos}
   = [("Export ‘" <> name <> "’", TextEdit (Range insertPos insertPos) exportName)]
   | otherwise = []

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -3367,7 +3367,7 @@ exportUnusedTests = testGroup "export unused actions"
         "Export ‘bar’"
         (Just $ T.unlines
               [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
-              , "module A (foo,bar) where"
+              , "module A (foo, bar) where"
               , "foo = id"
               , "bar = foo"])
     , testSession "multi line explicit exports" $ template
@@ -3384,7 +3384,7 @@ exportUnusedTests = testGroup "export unused actions"
               [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
               , "module A"
               , "  ("
-              , "    foo,bar) where"
+              , "    foo, bar) where"
               , "foo = id"
               , "bar = foo"])
     , testSession "export list ends in comma" $ template


### PR DESCRIPTION
I felt that since `hls-explicit-imports-plugin` puts spaces after commas then this code action should also do so for consistency.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2547"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

