### PR TITLE
doc: Enable relative links with anchors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,3 +83,7 @@ html_favicon = "logos/logo.svg"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# Enable linking to an anchor of a relative page
+# See https://github.com/executablebooks/MyST-Parser/issues/443
+myst_heading_anchors = 2


### PR DESCRIPTION
Fix links like `[foo](../bar.md#baz)` incorrectly linking to `../bar.md#baz` instead of `../bar.html#baz`.

E.g. in https://haskell-language-server.readthedocs.io/en/latest/contributing/contributing.html#using-hls-on-hls-code the link `Configuring project build` incorrectly links to https://haskell-language-server.readthedocs.io/en/latest/configuration.md#configuring-your-project-build instead of https://haskell-language-server.readthedocs.io/en/latest/configuration.html#configuring-your-project-build

[I checked with MyST parser people](https://github.com/executablebooks/MyST-Parser/issues/443) and this is the right fix.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2555"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

