### PR TITLE
Apply missing update for stack-9.0.1.yaml

### DIFF
--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -76,7 +76,6 @@ flags:
     pedantic: true
 
     ignore-plugins-ghc-bounds: true
-    class: false
     tactic: false # Dependencies fail
     stylishHaskell: false
     brittany: false


### PR DESCRIPTION
I somehow forgot to commit this change when I updated the settings related to the class plugin for GHC 9.0.1

(That's why I need Magit, haha)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2556"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

