### PR TITLE
Fix freeze cache key correctly

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -85,6 +85,9 @@ jobs:
         INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
         echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+    # To ensure we get the lastest hackage index and not relying on haskell action logic
+    - run: cabal update
+
     - name: Form the package list ('cabal.project.freeze')
       id: compute-cache-key
       run: |
@@ -120,9 +123,6 @@ jobs:
               ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
               ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
               ${{ env.cache-name }}-${{ runner.os }}-
-
-    # To ensure we get the lastest hackage index and not relying on haskell action logic
-    - run: cabal update
 
     # max-backjumps is increased as a temporary solution
     # for dependency resolution failure

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -99,8 +99,6 @@ jobs:
         echo '' || \
         echo 'WARNING: Could not produce the `freeze`.'
         echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
-        # Removing freeze file as it can break builds using allow-newer
-        rm -f cabal.project.freeze
 
     - name: Hackage sources cache
       uses: actions/cache@v2

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -156,8 +156,6 @@ jobs:
           echo '' || \
           echo 'WARNING: Could not produce the `freeze`.'
           echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
-          # Removing freeze file as it can break builds using allow-newer
-          rm -f cabal.project.freeze
 
       # 2021-12-02: NOTE: Cabal Hackage source tree storage does not depend on OS or GHC really,
       # but can depend on `base`.

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -142,6 +142,9 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      # To ensure we get the lastest hackage index and not relying on haskell action logic
+      - run: cabal update
+
       - name: Form the package list ('cabal.project.freeze')
         id: compute-cache-key
         run: |
@@ -182,10 +185,6 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
-
-      # To ensure we get the lastest hackage index and not relying on haskell action logic
-      - if: steps.compiled-deps.outputs.cache-hit != 'true'
-        run: cabal update
 
       - if: steps.compiled-deps.outputs.cache-hit != 'true' && runner.os == 'Linux' && matrix.ghc == '8.10.7'
         name: Download sources for bench

--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -99,6 +99,8 @@ jobs:
           echo "" || \
           echo 'WARNING: Could not produce the `freeze`.'
           echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
+          # Removing freeze file as it breaks builds with alternative flags
+          rm -rf cabal.project.freeze
 
       - name: Hackage sources cache
         uses: actions/cache@v2

--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -85,6 +85,9 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      # To ensure we get the lastest hackage index and not relying on haskell action logic
+      - run: cabal update
+
       - name: Form the package list ('cabal.project.freeze')
         id: compute-cache-key
         run: |
@@ -118,10 +121,6 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
-
-      # To ensure we get the lastest hackage index and not relying on haskell action logic
-      - if: steps.compiled-deps.outputs.cache-hit != 'true'
-        run: cabal update
 
       - name: Build `hls-graph` with flags
         run: cabal v2-build hls-graph --flags="pedantic embed-files stm-stats"

--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -86,7 +86,7 @@ jobs:
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
       - name: Form the package list ('cabal.project.freeze')
-        continue-on-error: true
+        id: compute-cache-key
         run: |
           cabal v2-freeze && \
           echo "" && \
@@ -95,6 +95,7 @@ jobs:
           cat 'cabal.project.freeze' && \
           echo "" || \
           echo 'WARNING: Could not produce the `freeze`.'
+          echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
 
       - name: Hackage sources cache
         uses: actions/cache@v2
@@ -112,7 +113,7 @@ jobs:
           cache-name: compiled-deps
         with:
           path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
-          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project.freeze') }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ steps.compute-cache-key.outputs.value  }}
           restore-keys: |
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,6 +146,9 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      # To ensure we get the lastest hackage index and not relying on haskell action logic
+      - run: cabal update
+
       - name: Compute the cache key
         id: compute-cache-key
         run: |
@@ -181,10 +184,6 @@ jobs:
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
-
-      # To ensure we get the lastest hackage index and not relying on haskell action logic
-      - if: steps.compiled-deps.outputs.cache-hit != 'true'
-        run: cabal update
 
       # repeating builds to workaround segfaults in windows and ghc-8.8.4
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,8 +160,6 @@ jobs:
           echo '' || \
           echo 'WARNING: Could not produce the `freeze`.'
           echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
-          # Removing freeze file as it can break builds using allow-newer
-          rm -rf cabal.project.freeze
 
       - name: Hackage sources cache
         uses: actions/cache@v2


### PR DESCRIPTION
* The problem with the freeze file in 9.2.1 was not the use of allow-newer: `cabal freeze` use the same solver as `cabal build` and it takes in account the same config. The problem was `cabal freeze` was being done before `cabal update` so it cant take in account the head.hackage updates
* So remove the freeze file as i did in #2552 is not needed but move the `cabal update` step

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2560"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

