### PR TITLE
Fix ci update hackage index

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -85,7 +85,19 @@ jobs:
         INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
         echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      # We have to restore package sources before `cabal update`
+      # cause it overwrites the hackage index with the cached one
+    - name: Hackage sources cache
+      uses: actions/cache@v2
+      env:
+        cache-name: hackage-sources
+      with:
+        path:  ${{ env.CABAL_PKGS_DIR }}
+        key:   ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+        restore-keys: ${{ env.cache-name }}-
+
     # To ensure we get the lastest hackage index and not relying on haskell action logic
+    # It has to be done before `cabal freeze` to make it aware of the new index
     - run: cabal update
 
     - name: Form the package list ('cabal.project.freeze')
@@ -99,15 +111,6 @@ jobs:
         echo '' || \
         echo 'WARNING: Could not produce the `freeze`.'
         echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
-
-    - name: Hackage sources cache
-      uses: actions/cache@v2
-      env:
-        cache-name: hackage-sources
-      with:
-        path:  ${{ env.CABAL_PKGS_DIR }}
-        key:   ${{ env.cache-name }}-${{ env.INDEX_STATE }}
-        restore-keys: ${{ env.cache-name }}-
 
     - name: Compiled deps cache
       id: compiled-deps

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -101,7 +101,6 @@ jobs:
     - run: cabal update
 
     - name: Form the package list ('cabal.project.freeze')
-      id: compute-cache-key
       run: |
         cabal v2-freeze && \
         echo "" && \
@@ -110,7 +109,6 @@ jobs:
         cat 'cabal.project.freeze' && \
         echo '' || \
         echo 'WARNING: Could not produce the `freeze`.'
-        echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
 
     - name: Compiled deps cache
       id: compiled-deps
@@ -119,7 +117,7 @@ jobs:
         cache-name: compiled-deps
       with:
         path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
-        key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ steps.compute-cache-key.outputs.value }}
+        key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project.freeze') }}
         restore-keys: |
               ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
               ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -142,7 +142,24 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      # 2021-12-02: NOTE: Cabal Hackage source tree storage does not depend on OS or GHC really,
+      # but can depend on `base`.
+      # But this caching is happens only inside `master` for `master` purposes of compiling the deps
+      # so having a shared pool here that depends only on Hackage pin & does not depend on `base` is "good enough"
+      # & used such because it preserves 10% of a global cache storage pool.
+      # We have to restore package sources before `cabal update`
+      # cause it overwrites the hackage index with the cached one
+      - name: Hackage sources cache
+        uses: actions/cache@v2
+        env:
+          cache-name: hackage-sources
+        with:
+          path:  ${{ env.CABAL_PKGS_DIR }}
+          key:   ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+          restore-keys: ${{ env.cache-name }}-
+
       # To ensure we get the lastest hackage index and not relying on haskell action logic
+      # It has to be done before `cabal freeze` to make it aware of the new index
       - run: cabal update
 
       - name: Form the package list ('cabal.project.freeze')
@@ -156,20 +173,6 @@ jobs:
           echo '' || \
           echo 'WARNING: Could not produce the `freeze`.'
           echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
-
-      # 2021-12-02: NOTE: Cabal Hackage source tree storage does not depend on OS or GHC really,
-      # but can depend on `base`.
-      # But this caching is happens only inside `master` for `master` purposes of compiling the deps
-      # so having a shared pool here that depends only on Hackage pin & does not depend on `base` is "good enough"
-      # & used such because it preserves 10% of a global cache storage pool.
-      - name: Hackage sources cache
-        uses: actions/cache@v2
-        env:
-          cache-name: hackage-sources
-        with:
-          path:  ${{ env.CABAL_PKGS_DIR }}
-          key:   ${{ env.cache-name }}-${{ env.INDEX_STATE }}
-          restore-keys: ${{ env.cache-name }}-
 
       - name: Compiled deps cache
         id: compiled-deps

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -163,7 +163,6 @@ jobs:
       - run: cabal update
 
       - name: Form the package list ('cabal.project.freeze')
-        id: compute-cache-key
         run: |
           cabal v2-freeze && \
           echo "" && \
@@ -172,7 +171,6 @@ jobs:
           cat 'cabal.project.freeze' && \
           echo '' || \
           echo 'WARNING: Could not produce the `freeze`.'
-          echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
 
       - name: Compiled deps cache
         id: compiled-deps
@@ -181,7 +179,7 @@ jobs:
           cache-name: compiled-deps
         with:
           path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
-          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ steps.compute-cache-key.outputs.value }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project.freeze') }}
           restore-keys: |
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-

--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -85,7 +85,19 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      # We have to restore package sources before `cabal update`
+      # cause it overwrites the hackage index with the cached one
+      - name: Hackage sources cache
+        uses: actions/cache@v2
+        env:
+          cache-name: hackage-sources
+        with:
+          path: ${{ env.CABAL_PKGS_DIR }}
+          key:          ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+          restore-keys: ${{ env.cache-name }}-
+
       # To ensure we get the lastest hackage index and not relying on haskell action logic
+      # It has to be done before `cabal freeze` to make it aware of the new index
       - run: cabal update
 
       - name: Form the package list ('cabal.project.freeze')
@@ -101,15 +113,6 @@ jobs:
           echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
           # Removing freeze file as it breaks builds with alternative flags
           rm -rf cabal.project.freeze
-
-      - name: Hackage sources cache
-        uses: actions/cache@v2
-        env:
-          cache-name: hackage-sources
-        with:
-          path: ${{ env.CABAL_PKGS_DIR }}
-          key:          ${{ env.cache-name }}-${{ env.INDEX_STATE }}
-          restore-keys: ${{ env.cache-name }}-
 
       - name: Compiled deps cache
         id: compiled-deps

--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -101,18 +101,14 @@ jobs:
       - run: cabal update
 
       - name: Form the package list ('cabal.project.freeze')
-        id: compute-cache-key
         run: |
           cabal v2-freeze && \
           echo "" && \
           echo 'Output:' && \
           echo "" && \
           cat 'cabal.project.freeze' && \
-          echo "" || \
+          echo '' || \
           echo 'WARNING: Could not produce the `freeze`.'
-          echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
-          # Removing freeze file as it breaks builds with alternative flags
-          rm -rf cabal.project.freeze
 
       - name: Compiled deps cache
         id: compiled-deps
@@ -121,11 +117,15 @@ jobs:
           cache-name: compiled-deps
         with:
           path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
-          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ steps.compute-cache-key.outputs.value  }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project.freeze') }}
           restore-keys: |
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
                 ${{ env.cache-name }}-${{ runner.os }}-
+
+      # Removing freeze file cause it breaks builds with alternative flags
+      - name: Remove freeze file
+        run: rm -f cabal.project.freeze
 
       - name: Build `hls-graph` with flags
         run: cabal v2-build hls-graph --flags="pedantic embed-files stm-stats"

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -86,8 +86,7 @@ jobs:
       - name: "Ensure we will use hackage head"
         run: cabal update
 
-      - name: Compute the cache key
-        id: compute-cache-key
+      - name: Form the package list ('cabal.project.freeze')
         run: |
           cabal v2-freeze && \
           echo "" && \
@@ -96,15 +95,15 @@ jobs:
           cat 'cabal.project.freeze' && \
           echo '' || \
           echo 'WARNING: Could not produce the `freeze`.'
-          echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
 
       - name: Compiled deps cache
+        id: compiled-deps
         uses: actions/cache@v2
         env:
           cache-name: compiled-deps
         with:
           path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
-          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ steps.compute-cache-key.outputs.value }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project.freeze') }}
           restore-keys: |
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-

--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -78,8 +78,25 @@ jobs:
           cache-name: hackage-sources
         with:
           path: ${{ env.CABAL_PKGS_DIR }}
-          key:          ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+          key:  ${{ env.cache-name }}-${{ env.INDEX_STATE }}
           restore-keys: ${{ env.cache-name }}-
+
+      # To ensure we get the lastest hackage index and not relying on haskell action logic
+      # It has to be done before `cabal freeze` to make it aware of the new index
+      - name: "Ensure we will use hackage head"
+        run: cabal update
+
+      - name: Compute the cache key
+        id: compute-cache-key
+        run: |
+          cabal v2-freeze && \
+          echo "" && \
+          echo 'Output:' && \
+          echo "" && \
+          cat 'cabal.project.freeze' && \
+          echo '' || \
+          echo 'WARNING: Could not produce the `freeze`.'
+          echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
 
       - name: Compiled deps cache
         uses: actions/cache@v2
@@ -87,7 +104,7 @@ jobs:
           cache-name: compiled-deps
         with:
           path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
-          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project') }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ steps.compute-cache-key.outputs.value }}
           restore-keys: |
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-
@@ -115,9 +132,6 @@ jobs:
 
       - name: "Unpack package source in an isolated location"
         run: cabal unpack ${{ steps.generate-dist-tarball.outputs.path }} --destdir=./incoming
-
-      - name: "Ensure we will use hackage head"
-        run: cabal update
 
       - name: "Try to get the current hackage version"
         id: get-hackage-version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,8 +161,7 @@ jobs:
       # It has to be done before `cabal freeze` to make it aware of the new index
       - run: cabal update
 
-      - name: Compute the cache key
-        id: compute-cache-key
+      - name: Form the package list ('cabal.project.freeze')
         run: |
           cabal v2-freeze && \
           echo "" && \
@@ -171,7 +170,6 @@ jobs:
           cat 'cabal.project.freeze' && \
           echo '' || \
           echo 'WARNING: Could not produce the `freeze`.'
-          echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
 
       - name: Compiled deps cache
         id: compiled-deps
@@ -180,7 +178,7 @@ jobs:
           cache-name: compiled-deps
         with:
           path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
-          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ steps.compute-cache-key.outputs.value }}
+          key:  ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project.freeze') }}
           restore-keys: |
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.INDEX_STATE }}-
                 ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,19 @@ jobs:
           INDEX_STATE1=$(echo "$INDEX_STATE_ENTRY" | cut -d' ' -f2 | tr ':' '-')
           echo "INDEX_STATE=$INDEX_STATE1" >> $GITHUB_ENV
 
+      # We have to restore package sources before `cabal update`
+      # cause it overwrites the hackage index with the cached one
+      - name: Hackage sources cache
+        uses: actions/cache@v2
+        env:
+          cache-name: hackage-sources
+        with:
+          path:  ${{ env.CABAL_PKGS_DIR }}
+          key:   ${{ env.cache-name }}-${{ env.INDEX_STATE }}
+          restore-keys: ${{ env.cache-name }}-
+
       # To ensure we get the lastest hackage index and not relying on haskell action logic
+      # It has to be done before `cabal freeze` to make it aware of the new index
       - run: cabal update
 
       - name: Compute the cache key
@@ -160,15 +172,6 @@ jobs:
           echo '' || \
           echo 'WARNING: Could not produce the `freeze`.'
           echo ::set-output name=value::${{ hashFiles('cabal.project.freeze') }}
-
-      - name: Hackage sources cache
-        uses: actions/cache@v2
-        env:
-          cache-name: hackage-sources
-        with:
-          path:  ${{ env.CABAL_PKGS_DIR }}
-          key:   ${{ env.cache-name }}-${{ env.INDEX_STATE }}
-          restore-keys: ${{ env.cache-name }}-
 
       - name: Compiled deps cache
         id: compiled-deps


### PR DESCRIPTION
* #2560 fixed the `cabal freeze` step putting `cabal update` before it
* But it had a unintended effect detected in the ghc-9.2 branch: the hackage index bump done by cabal update was being overwritten by the package sources cache restoring done immediately after
* Also reviewing ci logs i also checked the freeze file hash was not being computed. It seems the `${{ hasFiles('...') }}` is resolved before the script is run 🤦 

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2562"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

