### PR TITLE
Fix crash on completion with type family

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -445,7 +445,7 @@ localCompletionsForParsedModule uri pm@ParsedModule{pm_parsed_source = L _ HsMod
                 | L _ (ClassOpSig _ _ ids typ) <- tcdSigs
                 , id <- ids]
             TyClD _ x ->
-                let generalCompls = [mkComp id cl (Just $ ppr $ tcdLName x)
+                let generalCompls = [mkComp id cl (Just $ ppr $ tyClDeclLName x)
                         | id <- listify (\(_ :: Located(IdP GhcPs)) -> True) x
                         , let cl = occNameToComKind Nothing (rdrNameOcc $ unLoc id)]
                     -- here we only have to look at the outermost type


### PR DESCRIPTION
Close #2404.

`tcdLName` is partial for type/data families, its a record field
accessor which is not defined for all cases of the `TyClDecl` type.

Instead we use `tyClDeclLName` which will look for the name through an
indirection.

Note: I've checked that it works with GHC 8.10.7. The symbol is available starting from GHC 8.2: https://hackage.haskell.org/package/ghc-8.2.1/docs/HsDecls.html#v:tyClDeclLName so it should be compatible (minor the change in the module hierarchy, we'll see how the CI behaves).

Side question: I was able to remove the failure observed in #2404. However this bug was a pain to diagnostic. I'm experimenting random failures with HLS and I was used to restart my HLS session because HLS does not crash, it just stops responding.

I suspect (but that's pure guess) that a thread is launched, crashs (because of the exception, which is actually correctly sent to lsp log of my editor), but HLS is never restored in a working state. There is on `forkIO` in the codebase which may be responsible for it, and on `forkFinally`, which is supposed to crash the server with `Fatal error in server thread` which is not sent to my client. Maybe an issue should be opened to discuss that matter, I rather prefer to see a fully crashed HLS than a zombie processus ;)