### PR TITLE
test: Add regression tests for #2403

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4528,6 +4528,15 @@ localCompletionTests = [
         ,("abcdefghi", CiFunction, "abcdefghi", True, False, Nothing)
         ],
     completionTest
+        "type family"
+        ["{-# LANGUAGE DataKinds, TypeFamilies #-}"
+        ,"type family Bar a"
+        ,"a :: Ba"
+        ]
+        (Position 2 7)
+        [("Bar", CiStruct, "Bar", True, False, Nothing)
+        ],
+    completionTest
         "class method"
         [
           "class Test a where"


### PR DESCRIPTION
Continuing the work on #2569, this is regression test for type family completion.

I've implemented the tests in `ghcide` and `haskell-language-server`, not sure if that's the way or if I should drop one.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2576"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

