### PR TITLE
Post ghc-9.2.1 config cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         name: Test hls-brittany-plugin
         run: cabal test hls-brittany-plugin --test-options="$TEST_OPTS" || cabal test hls-brittany-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-brittany-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.1'
+      - if: matrix.test
         name: Test hls-floskell-plugin
         run: cabal test hls-floskell-plugin --test-options="$TEST_OPTS" || cabal test hls-floskell-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-floskell-plugin --test-options="$TEST_OPTS"
 

--- a/cabal-ghc901.project
+++ b/cabal-ghc901.project
@@ -63,7 +63,3 @@ allow-newer:
 
     floskell:base,
     floskell:ghc-prim,
-
-    -- for shake-bench
-    Chart-diagrams:diagrams-core,
-    SVGFonts:diagrams-core

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -81,44 +81,56 @@ constraints:
   primitive-unlifted ==0.1.3.1
 
 allow-newer:
-  Cabal,
-  base,
-  binary,
-  bytestring,
-  ghc,
-  ghc-bignum,
-  ghc-prim,
-  integer-gmp,
-  template-haskell,
-  text,
-  time,
+  -- base,
 
-  diagrams-postscript:lens,
-  diagrams-postscript:diagrams-core,
-  diagrams-postscript:monoid-extras,
-  dependent-sum:some,
-  dependent-sum:constraints,
-  diagrams:diagrams-core,
-  Chart-diagrams:diagrams-core,
-  SVGFonts:diagrams-core,
+  -- for shake-bench
+  Chart:lens,
+  Chart-diagrams:lens,
 
   -- for head.hackage
   primitive-unlifted:base,
 
+  brittany:ghc-boot,
   brittany:ghc-boot-th,
+  brittany:ghc,
   brittany:ghc-exactprint,
+  brittany:bytestring,
+  brittany:base,
+  -- https://github.com/lspitzner/multistate/pull/8
+  multistate:base,
+  -- https://github.com/lspitzner/data-tree-print/pull/3
+  data-tree-print:base,
+  -- https://github.com/lspitzner/butcher/pull/8
+  butcher:base,
 
   stylish-haskell:ghc-lib-parser,
+  stylish-haskell:Cabal,
+  stylish-haskell:bytestring,
+  stylish-haskell:aeson,
 
   ormolu:ghc-lib-parser,
 
   fourmolu:ghc-lib-parser,
+  fourmolu:Cabal,
 
   hls-hlint-plugin:ghc-lib,
   hls-hlint-plugin:ghc-lib-parser,
   hls-hlint-plugin:ghc-lib-parser-ex,
   hlint:ghc-lib-parser,
-  hlint:ghc-lib-parser-ex
+  hlint:ghc-lib-parser-ex,
+  -- See https://github.com/mpickering/apply-refact/pull/116
+  apply-refact:base,
+
+  implicit-hie-cradle:bytestring,
+  implicit-hie-cradle:time,
+
+  -- For tactics
+  ghc-source-gen:ghc,
+
+  -- for ghcide:test via ghc-typelits-knownnat
+  ghc-typelits-natnormalise:ghc-bignum,
+
+  hiedb:base
 
 allow-older:
   primitive-extras:primitive-unlifted

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -6,33 +6,26 @@ packages:
          ./ghcide
          ./hls-plugin-api
          ./hls-test-utils
-        --  ./plugins/hls-tactics-plugin
-        --  ./plugins/hls-brittany-plugin
-        --  ./plugins/hls-stylish-haskell-plugin
-        --  ./plugins/hls-fourmolu-plugin
+         ./plugins/hls-tactics-plugin
+         ./plugins/hls-brittany-plugin
+         ./plugins/hls-stylish-haskell-plugin
+         ./plugins/hls-fourmolu-plugin
          ./plugins/hls-class-plugin
-        -- ./plugins/hls-eval-plugin
+         ./plugins/hls-eval-plugin
          ./plugins/hls-explicit-imports-plugin
-        -- ./plugins/hls-refine-imports-plugin
-        -- ./plugins/hls-hlint-plugin
-        ./plugins/hls-rename-plugin
-        -- ./plugins/hls-retrie-plugin
-        -- ./plugins/hls-haddock-comments-plugin
-        -- ./plugins/hls-splice-plugin
+         ./plugins/hls-refine-imports-plugin
+         ./plugins/hls-hlint-plugin
+         ./plugins/hls-rename-plugin
+         ./plugins/hls-retrie-plugin
+         ./plugins/hls-haddock-comments-plugin
+         ./plugins/hls-splice-plugin
          ./plugins/hls-qualify-imported-names-plugin
-        -- ./plugins/hls-floskell-plugin
+         ./plugins/hls-floskell-plugin
          ./plugins/hls-pragmas-plugin
          ./plugins/hls-module-name-plugin
-        -- ./plugins/hls-ormolu-plugin
+         ./plugins/hls-ormolu-plugin
          ./plugins/hls-call-hierarchy-plugin
-        -- ./plugins/hls-alternate-number-format-plugin
-
-source-repository-package
-  type: git
-  location: https://github.com/tfausak/unix-compat
-  tag: 154c3a63f154cb49c51d5f9d13488e8119631d8a
-  -- To fix windows build
-  -- https://github.com/jacobstanley/unix-compat/pull/47
+         ./plugins/hls-alternate-number-format-plugin
 
 repository head.hackage.ghc.haskell.org
    url: https://ghc.gitlab.haskell.org/head.hackage/
@@ -54,7 +47,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-01-03T18:45:00Z
+index-state: 2022-01-11T22:05:45Z
 
 constraints:
   -- These plugins don't build/work on GHC92 yet
@@ -85,9 +78,7 @@ constraints:
   retrie >= 1.2,
   direct-sqlite == 2.3.26,
   lens >= 5.0.1,
-  primitive-unlifted ==0.1.3.1,
-  -- these constraints are for head.hackage
-  aeson ==1.5.6.0,
+  primitive-unlifted ==0.1.3.1
 
 allow-newer:
   Cabal,
@@ -112,7 +103,22 @@ allow-newer:
   SVGFonts:diagrams-core,
 
   -- for head.hackage
-  primitive-unlifted:base
+  primitive-unlifted:base,
+
+  brittany:ghc-boot-th,
+  brittany:ghc-exactprint,
+
+  stylish-haskell:ghc-lib-parser,
+
+  ormolu:ghc-lib-parser,
+
+  fourmolu:ghc-lib-parser,
+
+  hls-hlint-plugin:ghc-lib,
+  hls-hlint-plugin:ghc-lib-parser,
+  hls-hlint-plugin:ghc-lib-parser-ex,
+  hlint:ghc-lib-parser,
+  hlint:ghc-lib-parser-ex
 
 allow-older:
   primitive-extras:primitive-unlifted

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -58,7 +58,6 @@ constraints:
     -callhierarchy
     -class
     -eval
-    -floskell
     -fourmolu
     -haddockComments
     -hlint

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -6,15 +6,9 @@ packages:
          ./ghcide
          ./hls-plugin-api
          ./hls-test-utils
-<<<<<<< HEAD
          ./plugins/hls-tactics-plugin
          ./plugins/hls-brittany-plugin
          ./plugins/hls-stylish-haskell-plugin
-=======
-        --  ./plugins/hls-tactics-plugin
-        --  ./plugins/hls-brittany-plugin
-        --  ./plugins/hls-stylish-haskell-plugin
->>>>>>> master
          ./plugins/hls-fourmolu-plugin
          ./plugins/hls-class-plugin
          ./plugins/hls-eval-plugin

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -107,7 +107,7 @@ library
         ghc-paths,
         cryptohash-sha1 >=0.11.100 && <0.12,
         hie-bios >= 0.8 && < 0.9.0,
-        implicit-hie-cradle >= 0.3.0.5 && < 0.4,
+        implicit-hie-cradle ^>= 0.3.0.5 || ^>= 0.5,
         base16-bytestring >=0.1.1 && <1.1
     if os(windows)
       build-depends:

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -283,7 +283,7 @@ common qualifyImportedNames
 -- formatters
 
 common floskell
-  if flag(floskell) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
+  if flag(floskell) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-floskell-plugin ^>=1.0.0.0
     cpp-options: -Dfloskell
 
@@ -293,7 +293,7 @@ common fourmolu
     cpp-options: -Dfourmolu
 
 common ormolu
-  if flag(ormolu)
+  if flag(ormolu) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-ormolu-plugin ^>=1.0.0.0
     cpp-options: -Dormolu
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -283,17 +283,17 @@ common qualifyImportedNames
 -- formatters
 
 common floskell
-  if flag(floskell) || flag(ignore-plugins-ghc-bounds))
+  if flag(floskell)
     build-depends: hls-floskell-plugin ^>=1.0.0.0
     cpp-options: -Dfloskell
 
 common fourmolu
-  if flag(fourmolu) && flag(ignore-plugins-ghc-bounds)
+  if flag(fourmolu)
     build-depends: hls-fourmolu-plugin ^>=1.0.0.0
     cpp-options: -Dfourmolu
 
 common ormolu
-  if flag(ormolu) || flag(ignore-plugins-ghc-bounds))
+  if flag(ormolu)
     build-depends: hls-ormolu-plugin ^>=1.0.0.0
     cpp-options: -Dormolu
 

--- a/hie-compat/hie-compat.cabal
+++ b/hie-compat/hie-compat.cabal
@@ -23,7 +23,7 @@ flag ghc-lib
 library
   default-language:    Haskell2010
   build-depends:
-     base < 4.16, array, bytestring, containers, directory, filepath, transformers
+     base < 4.17, array, bytestring, containers, directory, filepath, transformers
   if flag(ghc-lib)
     build-depends: ghc-lib
   else
@@ -50,5 +50,3 @@ library
     hs-source-dirs: src-reexport-ghc9
   if (impl(ghc >= 9.2) && impl(ghc < 9.3))
     hs-source-dirs: src-reexport-ghc9
-
-


### PR DESCRIPTION
* I've removed grain coarsed allow-newer's and uncomment all subpackages to track what precise dependencies we need to get full ghc-9.2.1 support
* Some changes in .cabal has being unveiled

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2582"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

