### PR TITLE
More work around next ghc-9.2.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,6 +210,10 @@ jobs:
         name: Test hls-hlint-plugin test suite
         run: cabal test hls-hlint-plugin --test-options="$TEST_OPTS" || cabal test hls-hlint-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-hlint-plugin --test-options="$TEST_OPTS"
 
+      - if: matrix.test
+        name: Test hls-module-name-plugin test suite
+        run: cabal test hls-module-name-plugin --test-options="$TEST_OPTS" || cabal test hls-module-name-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-module-name-plugin --test-options="$TEST_OPTS"
+
       - if: matrix.test && matrix.ghc != '9.2.1'
         name: Test hls-alternate-number-format-plugin test suite
         run: cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS" || cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS"

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -55,7 +55,6 @@ constraints:
     +ignore-plugins-ghc-bounds
     -alternateNumberFormat
     -brittany
-    -callhierarchy
     -class
     -eval
     -haddockComments

--- a/docs/supported-versions.md
+++ b/docs/supported-versions.md
@@ -6,7 +6,7 @@ The current support for different GHC versions is given in the following table.
 
 | GHC version | Last supporting HLS version                                                                                                                              | Deprecation status                       |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| 9.2.0       | [not supported](https://github.com/haskell/haskell-language-server/issues/2179) yet                                                                                                                                        |                                          |
+| 9.2.0       | incoming [partial](https://github.com/haskell/haskell-language-server/issues/2179)                                                                                                                                       |                                          |
 | 9.0.1       | [current](https://github.com/haskell/haskell-language-server/releases/latest) ([partial](https://github.com/haskell/haskell-language-server/issues/297)) |                                          |
 | 8.10.7      | [current](https://github.com/haskell/haskell-language-server/releases/latest)                                                                            |                                          |
 | 8.10.6      | [current](https://github.com/haskell/haskell-language-server/releases/latest)                                                                            | will be deprecated after LTS and HLS full support for ghc-9.0 |

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -211,7 +211,7 @@ common class
     cpp-options: -Dclass
 
 common callHierarchy
-  if flag(callHierarchy) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
+  if flag(callHierarchy)
     build-depends: hls-call-hierarchy-plugin ^>=1.0.0.0
     cpp-options: -DcallHierarchy
 


### PR DESCRIPTION
* Updating the issue about i 've noted:
  * hls-class-hierarchy-plugin is being tested for ghc-9.2.1 but it is not included in the executable via flags, this includes it

https://github.com/haskell/haskell-language-server/blob/8804cbdf650e85ebb44adf39848d61454c26e8f5/.github/workflows/test.yml#L201-L203

https://github.com/haskell/haskell-language-server/blob/8804cbdf650e85ebb44adf39848d61454c26e8f5/cabal-ghc921.project#L54-L69

  * hls-module-name-plugin has a test suite but it not was being tested in ci :facepalm:, this includes even for ghc-9.2.1, if it does not work, will exclude from that version
