### PR TITLE
[ghc-9.2] Fix rename plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,7 +202,7 @@ jobs:
         name: Test hls-call-hierarchy-plugin test suite
         run: cabal test hls-call-hierarchy-plugin --test-options="$TEST_OPTS" || cabal test hls-call-hierarchy-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-call-hierarchy-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.1'
+      - if: matrix.test
         name: Test hls-rename-plugin test suite
         run: cabal test hls-rename-plugin --test-options="$TEST_OPTS" || cabal test hls-rename-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-rename-plugin --test-options="$TEST_OPTS"
 

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -65,9 +65,7 @@ constraints:
     -retrie
     -splice
     -stylishhaskell
-    -tactic
-  -- the rename plugin builds, but doesn't work
-    -rename,
+    -tactic,
   ghc-lib-parser ^>= 9.2,
   attoparsec ^>= 0.14.3,
   ghc-exactprint >= 1.3,

--- a/ghcide/.hlint.yaml
+++ b/ghcide/.hlint.yaml
@@ -95,6 +95,7 @@
     - Development.IDE.GHC.Compat
     - Development.IDE.GHC.Compat.Core
     - Development.IDE.GHC.Compat.Env
+    - Development.IDE.GHC.Compat.ExactPrint
     - Development.IDE.GHC.Compat.Iface
     - Development.IDE.GHC.Compat.Logger
     - Development.IDE.GHC.Compat.Outputable

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -239,11 +239,7 @@ extendImportHandler' ideState ExtendImport {..}
                   Just p  -> p <> "(" <> newThing <> ")"
             t <- liftMaybe $ snd <$> newImportToEdit
                 n
-#if !MIN_VERSION_ghc(9,2,0)
                 (astA ps)
-#else
-                ps
-#endif
                 (fromMaybe "" contents)
             return (nfp, WorkspaceEdit {_changes=Just (fromList [(doc,List [t])]), _documentChanges=Nothing, _changeAnnotations=Nothing})
   | otherwise =

--- a/plugins/hls-haddock-comments-plugin/src/Ide/Plugin/HaddockComments.hs
+++ b/plugins/hls-haddock-comments-plugin/src/Ide/Plugin/HaddockComments.hs
@@ -15,8 +15,7 @@ import qualified Data.Map                              as Map
 import qualified Data.Text                             as T
 import           Development.IDE                       hiding (pluginHandlers)
 import           Development.IDE.GHC.Compat
-import           Development.IDE.GHC.ExactPrint        (GetAnnotatedParsedSource (..),
-                                                        annsA, astA)
+import           Development.IDE.GHC.ExactPrint        (GetAnnotatedParsedSource (..))
 import           Ide.Types
 import           Language.Haskell.GHC.ExactPrint
 import           Language.Haskell.GHC.ExactPrint.Types hiding (GhcPs)

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -32,7 +32,6 @@ import           GHC.Types.Name
 #else
 import           Name
 #endif
-import           Debug.Trace
 import           Development.IDE.GHC.ExactPrint       (GetAnnotatedParsedSource (GetAnnotatedParsedSource))
 import           HieDb.Query
 import           Ide.Plugin.Config
@@ -52,16 +51,10 @@ renameProvider state pluginId (RenameParams (TextDocumentIdentifier uri) pos _pr
     response $ do
         nfp <- safeUriToNfp uri
         oldName <- getNameAtPos state nfp pos
-        traceM $ "oldName: " <> prettyPrint oldName
         workspaceRefs <- refsAtName state nfp oldName
-        traceM $ "workspaceRefs: " <> show workspaceRefs
         let filesRefs = groupOn locToUri workspaceRefs
             getFileEdits = ap (getSrcEdits state . renameModRefs newNameText) (locToUri . head)
-
-        traceM $ "\nfilesRefs: " <> show filesRefs
-
         fileEdits <- mapM getFileEdits filesRefs
-        traceM $ "\nfileEdits: " <> show fileEdits
         pure $ foldl' (<>) mempty fileEdits
 
 -------------------------------------------------------------------------------

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE CPP            #-}
-{-# LANGUAGE DataKinds      #-}
-{-# LANGUAGE GADTs          #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Ide.Plugin.Rename (descriptor) where
 
@@ -11,7 +14,7 @@ import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Except
 import           Data.Containers.ListUtils
 import           Data.Generics
-import           Data.List.Extra                      hiding (nubOrd)
+import           Data.List.Extra                      hiding (nubOrd, replace)
 import qualified Data.Map                             as M
 import           Data.Maybe
 import qualified Data.Text                            as T
@@ -20,11 +23,16 @@ import           Development.IDE.Core.PositionMapping
 import           Development.IDE.Core.Shake
 import           Development.IDE.GHC.Compat
 import           Development.IDE.Spans.AtPoint
+#if MIN_VERSION_ghc(9,2,1)
+import           GHC.Parser.Annotation                (AnnContext, AnnList,
+                                                       AnnParen, AnnPragma)
+#endif
 #if MIN_VERSION_ghc(9,0,1)
 import           GHC.Types.Name
 #else
 import           Name
 #endif
+import           Debug.Trace
 import           Development.IDE.GHC.ExactPrint       (GetAnnotatedParsedSource (GetAnnotatedParsedSource))
 import           HieDb.Query
 import           Ide.Plugin.Config
@@ -44,11 +52,16 @@ renameProvider state pluginId (RenameParams (TextDocumentIdentifier uri) pos _pr
     response $ do
         nfp <- safeUriToNfp uri
         oldName <- getNameAtPos state nfp pos
+        traceM $ "oldName: " <> prettyPrint oldName
         workspaceRefs <- refsAtName state nfp oldName
+        traceM $ "workspaceRefs: " <> show workspaceRefs
         let filesRefs = groupOn locToUri workspaceRefs
             getFileEdits = ap (getSrcEdits state . renameModRefs newNameText) (locToUri . head)
 
+        traceM $ "\nfilesRefs: " <> show filesRefs
+
         fileEdits <- mapM getFileEdits filesRefs
+        traceM $ "\nfileEdits: " <> show fileEdits
         pure $ foldl' (<>) mempty fileEdits
 
 -------------------------------------------------------------------------------
@@ -73,7 +86,7 @@ getSrcEdits state updateMod uri = do
             "Rename.GetParsedModuleWithComments"
             state
             (use GetAnnotatedParsedSource nfp)
-    let (ps, apiAnns) = (astA annotatedAst, annsA annotatedAst)
+    let (ps, anns) = (astA annotatedAst, annsA annotatedAst)
 #if !MIN_VERSION_ghc(9,2,1)
     let src = T.pack $ exactPrint ps anns
         res = T.pack $ exactPrint (updateMod <$> ps) anns
@@ -95,12 +108,32 @@ renameModRefs ::
     HsModule GhcPs
     -> HsModule GhcPs
 #endif
+#if MIN_VERSION_ghc(9,2,1)
+renameModRefs newNameText refs = everywhere $
+    -- there has to be a better way...
+    mkT (replace @AnnListItem) `extT`
+    -- replace @AnnList `extT` -- not needed
+    -- replace @AnnParen `extT`   -- not needed
+    -- replace @AnnPragma `extT` -- not needed
+    -- replace @AnnContext `extT` -- not needed
+    -- replace @NoEpAnns `extT` -- not needed
+    replace @NameAnn
+    where
+        replace :: forall an. Typeable an => LocatedAn an RdrName -> LocatedAn an RdrName
+        replace (L srcSpan oldRdrName)
+            | isRef (locA srcSpan) = L srcSpan $ newRdrName oldRdrName
+        replace lOldRdrName = lOldRdrName
+#else
 renameModRefs newNameText refs = everywhere $ mkT replace
     where
         replace :: Located RdrName -> Located RdrName
         replace (L srcSpan oldRdrName)
             | isRef srcSpan = L srcSpan $ newRdrName oldRdrName
         replace lOldRdrName = lOldRdrName
+#endif
+
+        isRef :: SrcSpan -> Bool
+        isRef = (`elem` refs) . fromJust . srcSpanToLocation
 
         newRdrName :: RdrName -> RdrName
         newRdrName oldRdrName = case oldRdrName of
@@ -109,9 +142,8 @@ renameModRefs newNameText refs = everywhere $ mkT replace
 
         newOccName = mkTcOcc $ T.unpack newNameText
 
-        isRef :: SrcSpan -> Bool
-        isRef = (`elem` refs) . fromJust . srcSpanToLocation
-
+newRdrName :: RdrName -> RdrName
+newRdrName = error "not implemented"
 -------------------------------------------------------------------------------
 -- Reference finding
 


### PR DESCRIPTION
The rename plugin relies on SYB to find located AST trees that need renaming. This breaks in GHC 9.2 because the representation of located AST trees has changed: it now includes exactprint annotations.

To make the rename plugin work in 9.2, we need to adjust the SYB queries to look for the new located AST types.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2593"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

