### PR TITLE
Fix module-name plugin on ghc-9.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
         name: Test hls-hlint-plugin test suite
         run: cabal test hls-hlint-plugin --test-options="$TEST_OPTS" || cabal test hls-hlint-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-hlint-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.1'
+      - if: matrix.test
         name: Test hls-module-name-plugin test suite
         run: cabal test hls-module-name-plugin --test-options="$TEST_OPTS" || cabal test hls-module-name-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-module-name-plugin --test-options="$TEST_OPTS"
 

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -59,7 +59,7 @@ constraints:
     -eval
     -haddockComments
     -hlint
-    -moduleName
+    +moduleName
     -qualifyImportedNames
     -refineImports
     -retrie

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -59,7 +59,6 @@ constraints:
     -eval
     -haddockComments
     -hlint
-    +moduleName
     -qualifyImportedNames
     -refineImports
     -retrie

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -256,7 +256,7 @@ common hlint
     cpp-options: -Dhlint
 
 common moduleName
-  if flag(moduleName) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
+  if flag(moduleName)
     build-depends: hls-module-name-plugin ^>=1.0.0.0
     cpp-options: -DmoduleName
 

--- a/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
+++ b/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-module-name-plugin
-version:            1.0.0.3
+version:            1.0.0.4
 synopsis:           Module name plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
+++ b/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE ViewPatterns      #-}
 {-# OPTIONS_GHC -Wall -Wwarn -fno-warn-type-defaults #-}
 
 {- | Keep the module name in sync with its file path.
@@ -33,7 +34,7 @@ import           Development.IDE            (GetParsedModule (GetParsedModule),
                                              realSrcSpanToRange, runAction,
                                              uriToFilePath', use, use_)
 import           Development.IDE.GHC.Compat (GenLocated (L), getSessionDynFlags,
-                                             hsmodName, importPaths,
+                                             hsmodName, importPaths, locA,
                                              pattern RealSrcSpan,
                                              pm_parsed_source, unLoc)
 import           Ide.Types
@@ -138,7 +139,7 @@ pathModuleNames state normFilePath filePath
 codeModuleName :: IdeState -> NormalizedFilePath -> IO (Maybe (Range, T.Text))
 codeModuleName state nfp = runMaybeT $ do
   pm <- MaybeT . runAction "ModuleName.GetParsedModule" state $ use GetParsedModule nfp
-  L (RealSrcSpan l _) m <- MaybeT . pure . hsmodName . unLoc $ pm_parsed_source pm
+  L (locA -> (RealSrcSpan l _)) m <- MaybeT . pure . hsmodName . unLoc $ pm_parsed_source pm
   pure (realSrcSpanToRange l, T.pack $ show m)
 
 -- traceAs :: Show a => String -> a -> a

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -97,7 +97,7 @@ flags:
     haddockComments: false
     hlint: false
     importLens: false
-    moduleName: false
+    moduleName: true
     ormolu: false
     qualifyImportedNames: false
     refineImports: false


### PR DESCRIPTION
Actual fix mimics changes from #2503 ; config changes indiscriminately turn building with module-name on ghc-9.2.1 on.
I assume that bumping minor version of the plugin is useful for constraint configuration.
(AFAIU building 9.2.1 with stack is not ready yet, but why not turn module-name on in there too, in preparation.)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2594"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

