### PR TITLE
Fix some import module completions being dropped (and fix flaky test too)

### DIFF
--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -132,7 +132,7 @@ parVectorChunk chunkSize st v =
 chunkVector :: Int -> Vector a -> [Vector a]
 chunkVector chunkSize v = do
     let indices = chunkIndices chunkSize (0,V.length v)
-    [V.slice l (h-l) v | (l,h) <- indices]
+    [V.slice l (h-l+1) v | (l,h) <- indices]
 
 -- >>> chunkIndices 3 (0,9)
 -- >>> chunkIndices 3 (0,10)


### PR DESCRIPTION
Fixes #2577 and maybe other issues involving import module completions.

The superficial reason why the module completions test was failing is that `HashMap`'s `toList` ordering is not deterministic between runs. This meant that the list ordering of the target files/modules would occur in different orders.

Of course why should the order of module names affect anything with regards to completions? 

The test generates 3 targets, 2 `TargetModule`s and 1 `TargetFile`. Since we seem to only care about actual modules we convert `TargetFile`s to empty strings. This list of module names (including the empty string) eventually get passed to the fuzzy matcher which attempts to run the matcher on the names in parallel.

Interestingly different orders can cause the parallel strategy to give different results which should be impossible unless the `Strategy` changes its input. Therefore the strategy does change its input.

Turns out the function used to chunk vectors had an off-by-one error when doing the `Vector` chunking, and if the empty string wasn't in the last position some module completions would be dropped.
e.g.
```
> chunk 3 [1,2,3]
[[1,2], []]
```

Also interesting is the comment on the `chunkVector` function seems to have come from eval plugin usage and has the correct output underneath it, yet when I eventually ran the eval plugin for kicks it produced the wrong output :sweat_smile:

The fix is just adding `+1` to the slice length.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2595"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

