### PR TITLE
Enable rename plugin

### DIFF
--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -32,7 +32,7 @@ jobs:
                   "hls-refine-imports-plugin", "hls-retrie-plugin",
                   "hls-splice-plugin", "hls-tactics-plugin",
                   "hls-call-hierarchy-plugin", "hls-alternate-number-format-plugin",
-                  "hls-qualify-imported-names-plugin",
+                  "hls-qualify-imported-names-plugin", "hls-rename-plugin",
                   "haskell-language-server"]
         ghc: [ "9.0.2"
              , "8.10.7"

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,6 +18,8 @@ You can watch demos for some of these features [below](#demos).
 - [Call hierarchy support](#call-hierarchy)
 - [Qualify names from an import declaration](#qualify-imported-names) in your code
 - [Suggest alternate numeric formats](#alternate-number-formatting)
+- [Renaming](#renaming) definitions automatically across modules of *the same component* (library, executable, test suite, benchmark).
+  - Full renaming support for the entire project is being tracked in [this issue](https://github.com/haskell/haskell-language-server/issues/2193)
 
 ## Demos
 
@@ -56,3 +58,7 @@ You can watch demos for some of these features [below](#demos).
 ### Alternate Number Formatting
 
 ![Alternate Number Format Demo](../plugins/hls-alternate-number-format-plugin/HLSAll.gif)
+
+### Renaming
+
+![Rename Demo](https://user-images.githubusercontent.com/30090176/133072143-d7d03ec7-3db1-474e-ad5e-6f40d75ff7ab.gif)

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -133,7 +133,7 @@ flag refineImports
 
 flag rename
   description: Enable rename plugin
-  default:     False
+  default:     True
   manual:      True
 
 flag retrie


### PR DESCRIPTION
* Make progress on #2193
* Only noting in docs it works inside component boundaries (it also will be noted in the release itself)
  * So it will *not* be disabled by default in config as suggested here: https://github.com/haskell/haskell-language-server/issues/2193#issuecomment-945697950
* Not sure if a warning in logs would be needed
//cc @OliverMadine 