### PR TITLE
[ghc-9.2] Fix qualify-imported-names plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,7 +226,7 @@ jobs:
         name: Test hls-alternate-number-format-plugin test suite
         run: cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS" || cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.1'
+      - if: matrix.test
         name: Test hls-qualify-imported-names-plugin test suite
         run: cabal test hls-qualify-imported-names-plugin --test-options="$TEST_OPTS" || cabal test hls-qualify-imported-names-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-qualify-imported-names-plugin --test-options="$TEST_OPTS"
 

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -59,7 +59,6 @@ constraints:
     -eval
     -haddockComments
     -hlint
-    -qualifyImportedNames
     -refineImports
     -retrie
     -splice

--- a/plugins/hls-qualify-imported-names-plugin/README.md
+++ b/plugins/hls-qualify-imported-names-plugin/README.md
@@ -13,7 +13,9 @@
 - Names are qualified by the imported module's alias if it has one, otherwise by the imported module's name.
 - If the import declaration has an explicit import list then the plugin will qualify only names on the list.
 - If the import declaration has an explicit hiding list then the plugin will qualify names from the imported module that are not on the list.
- 
+
 ## Change log
+### 1.0.0.1
+- GHC 9.2.1 compatibility
 ### 1.0.0.0
 - Released...

--- a/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
+++ b/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-qualify-imported-names-plugin
-version:            1.0.0.0
+version:            1.0.0.1
 synopsis:           A Haskell Language Server plugin that qualifies imported names
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-qualify-imported-names-plugin/src/Ide/Plugin/QualifyImportedNames.hs
+++ b/plugins/hls-qualify-imported-names-plugin/src/Ide/Plugin/QualifyImportedNames.hs
@@ -42,7 +42,7 @@ import           Development.IDE.GHC.Compat        (ContextInfo (Use),
                                                     SrcSpan,
                                                     TcGblEnv (tcg_rdr_env),
                                                     emptyUFM, globalRdrEnvElts,
-                                                    gre_imp, gre_name,
+                                                    gre_imp, gre_name, locA,
                                                     lookupNameEnv,
                                                     moduleNameString,
                                                     nameOccName, occNameString,
@@ -96,8 +96,7 @@ findLImportDeclAt range parsedModule
   | ParsedModule {..} <- parsedModule
   , L _ hsModule <- pm_parsed_source
   , locatedImportDecls <- hsmodImports hsModule =
-      find (\ (L srcSpan _) -> isRangeWithinSrcSpan range srcSpan) locatedImportDecls
-  | otherwise = Nothing
+      find (\ (L (locA -> srcSpan) _) -> isRangeWithinSrcSpan range srcSpan) locatedImportDecls
 
 makeCodeActions :: Uri -> [TextEdit] -> [a |? CodeAction]
 makeCodeActions uri textEdits = [InR CodeAction {..} | not (null textEdits)]

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -100,9 +100,7 @@ flags:
     haddockComments: false
     hlint: false
     importLens: false
-    moduleName: true
     ormolu: false
-    qualifyImportedNames: true
     refineImports: false
     retrie: false
     splice: false

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -102,7 +102,7 @@ flags:
     importLens: false
     moduleName: true
     ormolu: false
-    qualifyImportedNames: false
+    qualifyImportedNames: true
     refineImports: false
     retrie: false
     splice: false


### PR DESCRIPTION
ghc-9.2.1 assures me that `| otherwise` in `QualifyImportedNames.hs @ 100` is redundant; hope other ghcs agree.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2600"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

