### PR TITLE
[ghc-9.2] Fix refine-imports plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
         name: Test hls-tactics-plugin test suite
         run: cabal test hls-tactics-plugin --test-options="$TEST_OPTS" || cabal test hls-tactics-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-tactics-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.1'
+      - if: matrix.test
         name: Test hls-refine-imports-plugin test suite
         run: cabal test hls-refine-imports-plugin --test-options="$TEST_OPTS" || cabal test hls-refine-imports-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-refine-imports-plugin --test-options="$TEST_OPTS"
 

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -59,7 +59,6 @@ constraints:
     -eval
     -haddockComments
     -hlint
-    -refineImports
     -retrie
     -splice
     -stylishhaskell

--- a/ghcide/src/Development/IDE/GHC/Compat/Core.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Core.hs
@@ -193,6 +193,7 @@ module Development.IDE.GHC.Compat.Core (
     getLoc,
     getLocA,
     locA,
+    noLocA,
     LocatedAn,
 #if MIN_VERSION_ghc(9,2,0)
     GHC.AnnListItem(..),
@@ -1019,6 +1020,13 @@ getLocA = GHC.getLocA
 #else
 -- getLocA :: HasSrcSpan a => a -> SrcSpan
 getLocA x = GHC.getLoc x
+#endif
+
+noLocA :: a -> LocatedAn an a
+#if MIN_VERSION_ghc(9,2,0)
+noLocA = GHC.noLocA
+#else
+noLocA = GHC.noLoc
 #endif
 
 #if !MIN_VERSION_ghc(9,2,0)

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -234,7 +234,7 @@ common importLens
     cpp-options: -DimportLens
 
 common refineImports
-  if flag(refineImports) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
+  if flag(refineImports)
     build-depends: hls-refine-imports-plugin ^>=1.0.0.0
     cpp-options: -DrefineImports
 

--- a/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
+++ b/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-refine-imports-plugin
-version:            1.0.0.2
+version:            1.0.0.3
 synopsis:           Refine imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
+++ b/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
@@ -215,8 +215,8 @@ refineImportsRule = define $ \RefineImports nfp -> do
         i@(L lim id@ImportDecl
                   {ideclName = L _ mn, ideclHiding = Just (hiding, L _ names)})
         (newModuleName, avails) = L lim id
-          { ideclName = noLoc newModuleName
-          , ideclHiding = Just (hiding, noLoc newNames)
+          { ideclName = noLocA newModuleName
+          , ideclHiding = Just (hiding, noLocA newNames)
           }
           where newNames = filter (\n -> any (n `containsAvail`) avails) names
       constructImport lim _ = lim
@@ -247,9 +247,9 @@ refineImportsRule = define $ \RefineImports nfp -> do
 
 --------------------------------------------------------------------------------
 
-mkExplicitEdit :: PositionMapping -> LImportDecl pass -> T.Text -> Maybe TextEdit
+mkExplicitEdit :: PositionMapping -> LImportDecl GhcRn -> T.Text -> Maybe TextEdit
 mkExplicitEdit posMapping (L src imp) explicit
-  | RealSrcSpan l _ <- src,
+  | RealSrcSpan l _ <- locA src,
     L _ mn <- ideclName imp,
     -- (almost) no one wants to see an refine import list for Prelude
     mn /= moduleName pRELUDE,

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -134,9 +134,6 @@ renameModRefs newNameText refs = everywhere $ mkT replace
             _              -> Unqual newOccName
 
         newOccName = mkTcOcc $ T.unpack newNameText
-
-newRdrName :: RdrName -> RdrName
-newRdrName = error "not implemented"
 -------------------------------------------------------------------------------
 -- Reference finding
 

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -101,7 +101,6 @@ flags:
     hlint: false
     importLens: false
     ormolu: false
-    refineImports: false
     retrie: false
     splice: false
     stylishhaskell: false


### PR DESCRIPTION
`newRdrName` in Rename.hs seems to be a debugging leftover.