### PR TITLE
Wingman: Stringify command

### DIFF
--- a/plugins/hls-tactics-plugin/COMMANDS.md
+++ b/plugins/hls-tactics-plugin/COMMANDS.md
@@ -544,6 +544,30 @@ running  `split` will produce:
 Right (_ :: b)
 ```
 
+## stringify
+
+arguments: tactic.  
+deterministic.
+
+> Pretty print the result of a tactic as a string literal.
+
+
+### Example
+
+> The tactic parameter is run in the same environment as `stringify`, except its goal is a fresh type variable. 
+
+Given:
+
+```haskell
+_ :: String
+```
+
+running  `stringify (ctor False)` will produce:
+
+```haskell
+"False"
+```
+
 ## try
 
 arguments: tactic.  

--- a/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/CodeGen.hs
@@ -23,7 +23,7 @@ import qualified Data.Set as S
 import           Data.Traversable
 import           Development.IDE.GHC.Compat
 import           GHC.Exts
-import           GHC.SourceGen (occNameToStr)
+import           GHC.SourceGen (occNameToStr, string)
 import           GHC.SourceGen.Binds
 import           GHC.SourceGen.Expr
 import           GHC.SourceGen.Overloaded
@@ -330,4 +330,8 @@ nonrecLet occjdgs jdg = do
             (\(occ, ext) -> valBind (occNameToStr occ) <$> fmap unLoc ext)
             (zip (fmap fst occjdgs) occexts)
       <*> fmap unLoc ext
+
+
+mkString :: String -> LHsExpr GhcPs
+mkString str = noLoc $ string @HsExpr' str
 

--- a/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Metaprogramming/Parser.hs
@@ -208,6 +208,17 @@ commands =
           "Right (_ :: b)"
       ]
 
+  , command "stringify" Deterministic Tactic
+      "Pretty print the result of a tactic as a string literal."
+      (pure . stringify)
+      [ Example
+          (Just "The tactic parameter is run in the same environment as `stringify`, except its goal is a fresh type variable. ")
+          ["(ctor False)"]
+          []
+          (Just "String")
+          (T.pack $ show @String "False")
+      ]
+
   , command "ctor" Deterministic (Ref One)
       "Use the given data cosntructor."
       (pure . userSplit)
@@ -415,7 +426,7 @@ oneTactic =
 
 
 tactic :: Parser (TacticsM ())
-tactic = P.makeExprParser oneTactic operators 
+tactic = P.makeExprParser oneTactic operators
 
 operators :: [[P.Operator Parser (TacticsM ())]]
 operators =

--- a/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
+++ b/plugins/hls-tactics-plugin/test/CodeAction/RunMetaprogramSpec.hs
@@ -24,6 +24,7 @@ spec = do
 #endif
 
   describe "golden" $ do
+    metaTest  2  9 "MetaStringify"
     metaTest  6 11 "MetaMaybeAp"
     metaTest  2 32 "MetaBindOne"
     metaTest  2 32 "MetaBindAll"

--- a/plugins/hls-tactics-plugin/test/golden/MetaStringify.expected.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaStringify.expected.hs
@@ -1,0 +1,2 @@
+test :: String
+test = "const test _w0"

--- a/plugins/hls-tactics-plugin/test/golden/MetaStringify.hs
+++ b/plugins/hls-tactics-plugin/test/golden/MetaStringify.hs
@@ -1,0 +1,2 @@
+test :: String
+test = [wingman| stringify (use const, use test) |]


### PR DESCRIPTION
## stringify

arguments: tactic.  
deterministic.

> Pretty print the result of a tactic as a string literal.

### Example

> The tactic parameter is run in the same environment as `stringify`, except its goal is a fresh type variable. 
Given:

```haskell
_ :: String
```

running  `stringify (ctor False)` will produce:

```haskell
"False"
```