### PR TITLE
Use ghc+integer-gmp for alpine linux build release

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -54,15 +54,6 @@ runs:
         fi
       shell: bash
 
-    # some alpines come with integer-simple instead of integer-gmp
-    - if: inputs.os == 'Linux'
-      name: Force integer-simple
-      run: |
-        if ghc --info | grep -q integer-simple ; then
-          echo -e 'package blaze-textual\n    flags: +integer-simple' >> cabal.project.local
-        fi
-      shell: bash
-
     - if: inputs.os == 'Windows' && inputs.ghc == '8.8.4'
       name: (Windows,GHC 8.8) Modify `cabal.project` to workaround segfaults
       run: |

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -11,6 +11,10 @@ inputs:
   os:
     description: "Operating system: Linux, Windows or macOS"
     required: true
+  cache-prefix:
+    description: "To allow make unique the cache key"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -114,11 +118,11 @@ runs:
         cache-name: compiled-deps
       with:
         path: ${{ steps.HaskEnvSetup.outputs.cabal-store }}
-        key:  ${{ env.cache-name }}-${{ inputs.os }}-${{ inputs.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project.freeze') }}
+        key:  ${{ inputs.cache-prefix }}${{ env.cache-name }}-${{ inputs.os }}-${{ inputs.ghc }}-${{ env.INDEX_STATE }}-${{ hashFiles('cabal.project.freeze') }}
         restore-keys: |
-              ${{ env.cache-name }}-${{ inputs.os }}-${{ inputs.ghc }}-${{ env.INDEX_STATE }}-
-              ${{ env.cache-name }}-${{ inputs.os }}-${{ inputs.ghc }}-
-              ${{ env.cache-name }}-${{ inputs.os }}-
+              ${{ inputs.cache-prefix }}${{ env.cache-name }}-${{ inputs.os }}-${{ inputs.ghc }}-${{ env.INDEX_STATE }}-
+              ${{ inputs.cache-prefix }}${{ env.cache-name }}-${{ inputs.os }}-${{ inputs.ghc }}-
+              ${{ inputs.cache-prefix }}${{ env.cache-name }}-${{ inputs.os }}-
 
     # We remove the freeze file because it could interfere with the build
     - name: "Remove freeze file"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,8 @@ jobs:
 
     - name: Disable tests and bechmarks
       run: |
-        echo -e 'tests: false' >> cabal.project.local
-        echo -e 'benchmarks: false' >> cabal.project.local
+        echo "tests: false" >> cabal.project.local
+        echo "benchmarks: false" >> cabal.project.local
 
     - uses: ./.github/actions/setup-build
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: ${{ (startsWith(matrix.os,'ubuntu') && 'alpine:3.12') || '' }}
+    container: ${{ (startsWith(matrix.os,'ubuntu') && matrix.ghc != '9.2.1' && 'alpine:3.12') || '' }}
     defaults:
       run:
         shell: ${{ (startsWith(matrix.os,'windows') && 'bash') || 'sh' }}
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Install system dependencies
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.ghc != '9.2.1'
       run: |
         apk add --no-cache curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz gzip tar perl git bash sudo binutils-gold
         apk add --no-cache zlib zlib-dev zlib-static gmp gmp-dev ncurses-static

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         fi
 
     - name: (not check) Upload server to release
-      if: ${{ !contains(github.ref_name, 'check') }}
+      if: ${{ !contains(github.ref_name, 'check') && github.event.release.upload_url != ''}}
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
         fi
 
     - name: (GHC 8.10, not check) Upload wrapper to the release
-      if: ${{ matrix.ghc == '8.10.7' && !contains(github.ref_name, 'check') }}
+      if: ${{ matrix.ghc == '8.10.7' && !contains(github.ref_name, 'check') && github.event.release.upload_url != '' }}
       uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +172,7 @@ jobs:
                       HEAD
 
       - name: (not check) Upload source tarball to the release
-        if: ${{ !contains(github.ref_name, 'check') }}
+        if: ${{ !contains(github.ref_name, 'check')  && github.event.release.upload_url != '' }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -219,7 +219,7 @@ jobs:
           tar -czpf haskell-language-server.tar.gz *
 
       - name: (not check) Upload binaries tarball to the release
-        if: ${{ !contains(github.ref_name, 'check') }}
+        if: ${{ !contains(github.ref_name, 'check')  && github.event.release.upload_url != '' }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -248,7 +248,7 @@ jobs:
           sed -i 's/\/.*)/)/g' SHA256SUMS
 
       - name: (not check) Upload sha256sums to the release
-        if: ${{ !contains(github.ref_name, 'check') }}
+        if: ${{ !contains(github.ref_name, 'check')  && github.event.release.upload_url != '' }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
     - name: Build the server
       # Try building it twice in case of flakey builds on Windows
       run: |
+        echo "Path: $PATH"
         cabal build exe:hls -O2 $LINUX_CABAL_ARGS || cabal build exe:hls -O2 $LINUX_CABAL_ARGS -j1
 
     - name: Compress server binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: ${{ (runner.os == 'Linux' && 'alpine:3.12') || '' }}
+    container: ${{ (startsWith(matrix.os,'ubuntu') && 'alpine:3.12') || '' }}
     defaults:
       run:
-        shell: ${{ (runner.os == 'Windows' && 'bash') || 'sh' }}
+        shell: ${{ (startsWith(matrix.os,'windows') && 'bash') || 'sh' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: ${{ (matrix.os == 'ubuntu-18.04' && 'alpine:3.12') || '' }}
+    container: ${{ (runner.os == 'Linux' && 'alpine:3.12') || '' }}
     defaults:
       run:
-        shell: ${{ (matrix.os == 'windows-latest' && 'bash') || 'sh' }}
+        shell: ${{ (runner.os == 'Windows' && 'bash') || 'sh' }}
     strategy:
       fail-fast: false
       matrix:
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Install system dependencies
-      if: matrix.os == 'ubuntu-18.04'
+      if: runner.os == 'Linux'
       run: |
         apk add --no-cache curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz gzip tar perl git bash sudo binutils-gold
         apk add --no-cache zlib zlib-dev zlib-static gmp gmp-dev ncurses-static
@@ -50,9 +50,10 @@ jobs:
       with:
         ghc: ${{ matrix.ghc }}
         os:  ${{ runner.os }}
+        cache-prefix: ${{ github.workflow }}
 
     - name: (Windows) Platform specifics
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
       env:
         GHC_VER: ${{ matrix.ghc }}
       run: |
@@ -60,7 +61,7 @@ jobs:
         echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
 
     - name: (Linux) Platform specifics
-      if: matrix.os == 'ubuntu-18.04'
+      if: runner.os == 'Linux'
       env:
         GHC_VER: ${{ matrix.ghc }}
       run: |
@@ -68,7 +69,7 @@ jobs:
         echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
 
     - name: (macOS) Platform specifics
-      if: matrix.os == 'macOS-latest'
+      if: runner.os == 'macOS'
       env:
         GHC_VER: ${{ matrix.ghc }}
       run: |
@@ -77,7 +78,6 @@ jobs:
     - name: Build the server
       # Try building it twice in case of flakey builds on Windows
       run: |
-        echo "Path: $PATH"
         cabal build exe:hls -O2 $LINUX_CABAL_ARGS || cabal build exe:hls -O2 $LINUX_CABAL_ARGS -j1
 
     - name: Compress server binary
@@ -106,13 +106,13 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ${{ steps.compress_server_binary.outputs.path }}
-        asset_name: haskell-language-server-${{ runner.OS }}-${{ env.GHC_VERSION }}${{env.EXE_EXT}}.${{ steps.compress_server_binary.outputs.extension }}
+        asset_name: haskell-language-server-${{ runner.os }}-${{ env.GHC_VERSION }}${{env.EXE_EXT}}.${{ steps.compress_server_binary.outputs.extension }}
         asset_content_type: ${{ steps.compress_server_binary.outputs.content_type }}
 
     - name: Upload server to workflow artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: haskell-language-server-${{ runner.OS }}-${{ matrix.ghc }}${{env.EXE_EXT}}.${{ steps.compress_server_binary.outputs.extension }}
+        name: haskell-language-server-${{ runner.os }}-${{ matrix.ghc }}${{env.EXE_EXT}}.${{ steps.compress_server_binary.outputs.extension }}
         path: ${{ steps.compress_server_binary.outputs.path }}
 
     - name: (GHC 8.10) Build the wrapper
@@ -146,14 +146,14 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ${{ steps.compress_wrapper_binary.outputs.path }}
-        asset_name: haskell-language-server-wrapper-${{ runner.OS }}${{env.EXE_EXT}}.${{ steps.compress_wrapper_binary.outputs.extension }}
+        asset_name: haskell-language-server-wrapper-${{ runner.os }}${{env.EXE_EXT}}.${{ steps.compress_wrapper_binary.outputs.extension }}
         asset_content_type: ${{ steps.compress_wrapper_binary.outputs.content_type}}
 
     - name: (GHC 8.10) Upload wrapper to workflow artifacts
       uses: actions/upload-artifact@v2
       if: matrix.ghc == '8.10.7'
       with:
-        name: haskell-language-server-wrapper-${{ runner.OS }}${{env.EXE_EXT}}.${{ steps.compress_wrapper_binary.outputs.extension }}
+        name: haskell-language-server-wrapper-${{ runner.os }}${{env.EXE_EXT}}.${{ steps.compress_wrapper_binary.outputs.extension }}
         path: ${{ steps.compress_wrapper_binary.outputs.path }}
 
   # generates a custom tarball with sources, used by `ghcup compile hls`
@@ -196,10 +196,10 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        os: [ "Linux"
-            , "macOS"
-            , "Windows"
-            ]
+        target-os: [ "Linux"
+                   , "macOS"
+                   , "Windows"
+                   ]
     steps:
       - uses: actions/download-artifact@v2
 
@@ -207,11 +207,11 @@ jobs:
         run: |
           # move the binaries for the specific platform into bin/
           mkdir bin
-          mv haskell-language-server-${{ matrix.os }}-*/* bin
-          mv haskell-language-server-wrapper-${{ matrix.os }}.*/* bin
+          mv haskell-language-server-${{ matrix.target-os }}-*/* bin
+          mv haskell-language-server-wrapper-${{ matrix.target-os }}.*/* bin
           # decompress them
           cd bin
-          if [[ "${{ matrix.os }}" == "Windows" ]]; then
+          if [[ "${{ matrix.target-os }}" == "Windows" ]]; then
             7z x "*.zip"
             rm *.zip
           else
@@ -227,13 +227,13 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: bin/haskell-language-server.tar.gz
-          asset_name: haskell-language-server-${{ matrix.os }}-${{ github.event.release.tag_name }}.tar.gz
+          asset_name: haskell-language-server-${{ matrix.target-os }}-${{ github.event.release.tag_name }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload binaries tarball to workflow artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: haskell-language-server-${{ matrix.os }}-${{ github.event.release.tag_name }}.tar.gz
+          name: haskell-language-server-${{ matrix.target-os }}-${{ github.event.release.tag_name }}.tar.gz
           path: bin/haskell-language-server.tar.gz
 
   sha256sum:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: ${{ (startsWith(matrix.os,'ubuntu') && matrix.ghc != '9.2.1' && 'alpine:3.12') || '' }}
+    container: ${{ (startsWith(matrix.os,'ubuntu') && 'alpine:3.12') || '' }}
     defaults:
       run:
         shell: ${{ (startsWith(matrix.os,'windows') && 'bash') || 'sh' }}
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Install system dependencies
-      if: runner.os == 'Linux' && matrix.ghc != '9.2.1'
+      if: runner.os == 'Linux'
       run: |
         apk add --no-cache curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz gzip tar perl git bash sudo binutils-gold
         apk add --no-cache zlib zlib-dev zlib-static gmp gmp-dev ncurses-static

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,40 +53,27 @@ jobs:
 
     - name: (Windows) Platform specifics
       if: runner.os == 'Windows'
-      env:
-        GHC_VER: ${{ matrix.ghc }}
       run: |
         echo "EXE_EXT=.exe" >> $GITHUB_ENV
-        echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
 
     - name: (Linux) Platform specifics
       if: runner.os == 'Linux'
-      env:
-        GHC_VER: ${{ matrix.ghc }}
       run: |
-        echo "LINUX_CABAL_ARGS=--enable-executable-static --ghc-options=-split-sections" >> $GITHUB_ENV
-        echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
-
-    - name: (macOS) Platform specifics
-      if: runner.os == 'macOS'
-      env:
-        GHC_VER: ${{ matrix.ghc }}
-      run: |
-        echo "GHC_VERSION=$GHC_VER" >> $GITHUB_ENV
+        echo "CABAL_ARGS=--enable-executable-static --ghc-options=-split-sections" >> $GITHUB_ENV
 
     - name: Build the server
       # Try building it twice in case of flakey builds on Windows
       run: |
-        cabal build exe:hls -O2 $LINUX_CABAL_ARGS || cabal build exe:hls -O2 $LINUX_CABAL_ARGS -j1
+        cabal build exe:hls -O2 $CABAL_ARGS || cabal build exe:hls -O2 $CABAL_ARGS -j1
 
     - name: Compress server binary
       id: compress_server_binary
       run: |
         HLS_BUILD=$(find dist-newstyle \( -name 'hls' -o -name 'hls.exe' \) -type f)
-        HLS=haskell-language-server-${{env.GHC_VERSION}}
-        mv $HLS_BUILD $HLS${{env.EXE_EXT}}
-        if [[ "$OSTYPE" == "msys" ]]; then
-          7z a $HLS.zip $HLS${{env.EXE_EXT}}
+        HLS=haskell-language-server-${{ matrix.ghc }}
+        mv $HLS_BUILD $HLS${{ env.EXE_EXT }}
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          7z a $HLS.zip $HLS${{ env.EXE_EXT }}
           echo ::set-output name=path::$HLS.zip
           echo ::set-output name=content_type::application/zip
           echo ::set-output name=extension::zip
@@ -97,7 +84,7 @@ jobs:
           echo ::set-output name=extension::gz
         fi
 
-    - name: (not check) Upload server to release
+    - name: Upload server to release
       if: ${{ !contains(github.ref_name, 'check') && github.event.release.upload_url != ''}}
       uses: actions/upload-release-asset@v1.0.2
       env:
@@ -105,28 +92,28 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ${{ steps.compress_server_binary.outputs.path }}
-        asset_name: haskell-language-server-${{ runner.os }}-${{ env.GHC_VERSION }}${{env.EXE_EXT}}.${{ steps.compress_server_binary.outputs.extension }}
+        asset_name: haskell-language-server-${{ runner.os }}-${{ matrix.ghc  }}${{env.EXE_EXT}}.${{ steps.compress_server_binary.outputs.extension }}
         asset_content_type: ${{ steps.compress_server_binary.outputs.content_type }}
 
     - name: Upload server to workflow artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: haskell-language-server-${{ runner.os }}-${{ matrix.ghc }}${{env.EXE_EXT}}.${{ steps.compress_server_binary.outputs.extension }}
+        name: haskell-language-server-${{ runner.os }}-${{ matrix.ghc }}${{ env.EXE_EXT }}.${{ steps.compress_server_binary.outputs.extension }}
         path: ${{ steps.compress_server_binary.outputs.path }}
 
-    - name: (GHC 8.10) Build the wrapper
+    - name: Build the wrapper
       if: matrix.ghc == '8.10.7'
       run: cabal build exe:hls-wrapper -O2 $LINUX_CABAL_ARGS
 
-    - name: (GHC 8.10) Compress wrapper binary
+    - name: Compress wrapper binary
       if: matrix.ghc == '8.10.7'
       id: compress_wrapper_binary
       run: |
         HLS_WRAPPER_BUILD=$(find dist-newstyle \( -name 'hls-wrapper' -o -name 'hls-wrapper.exe' \) -type f)
         HLS_WRAPPER=haskell-language-server-wrapper
-        mv $HLS_WRAPPER_BUILD $HLS_WRAPPER${{env.EXE_EXT}}
-        if [[ "$OSTYPE" == "msys" ]]; then
-          7z a $HLS_WRAPPER.zip $HLS_WRAPPER${{env.EXE_EXT}}
+        mv $HLS_WRAPPER_BUILD $HLS_WRAPPER${{ env.EXE_EXT }}
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          7z a $HLS_WRAPPER.zip $HLS_WRAPPER${{ env.EXE_EXT }}
           echo ::set-output name=path::$HLS_WRAPPER.zip
           echo ::set-output name=content_type::application/zip
           echo ::set-output name=extension::zip
@@ -137,7 +124,7 @@ jobs:
           echo ::set-output name=extension::gz
         fi
 
-    - name: (GHC 8.10, not check) Upload wrapper to the release
+    - name: Upload wrapper to the release
       if: ${{ matrix.ghc == '8.10.7' && !contains(github.ref_name, 'check') && github.event.release.upload_url != '' }}
       uses: actions/upload-release-asset@v1.0.2
       env:
@@ -145,14 +132,14 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ${{ steps.compress_wrapper_binary.outputs.path }}
-        asset_name: haskell-language-server-wrapper-${{ runner.os }}${{env.EXE_EXT}}.${{ steps.compress_wrapper_binary.outputs.extension }}
+        asset_name: haskell-language-server-wrapper-${{ runner.os }}${{ env.EXE_EXT }}.${{ steps.compress_wrapper_binary.outputs.extension }}
         asset_content_type: ${{ steps.compress_wrapper_binary.outputs.content_type}}
 
-    - name: (GHC 8.10) Upload wrapper to workflow artifacts
+    - name: Upload wrapper to workflow artifacts
       uses: actions/upload-artifact@v2
       if: matrix.ghc == '8.10.7'
       with:
-        name: haskell-language-server-wrapper-${{ runner.os }}${{env.EXE_EXT}}.${{ steps.compress_wrapper_binary.outputs.extension }}
+        name: haskell-language-server-wrapper-${{ runner.os }}${{ env.EXE_EXT }}.${{ steps.compress_wrapper_binary.outputs.extension }}
         path: ${{ steps.compress_wrapper_binary.outputs.path }}
 
   # generates a custom tarball with sources, used by `ghcup compile hls`
@@ -163,29 +150,38 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set hls release version
+        run: |
+          HLS_VER="${{ github.event.release.tag_name }}"
+          if [[ -z $HLS_VER ]]; then
+            HLS_VER=${{ github.sha }}
+            HLS_VER=${HLS_VER:0:5}
+          fi
+          echo "HLS_VER=$HLS_VER" >> $GITHUB_ENV
+
       - name: Create source tarball
         run: |
           mkdir src-dist
-          git archive --prefix=haskell-language-server-${{ github.event.release.tag_name }}/ \
+          git archive --prefix=haskell-language-server-${{ env.HLS_VER }}/ \
                       --format=tar.gz \
                       -o src-dist/haskell-language-server.tar.gz \
                       HEAD
 
-      - name: (not check) Upload source tarball to the release
-        if: ${{ !contains(github.ref_name, 'check')  && github.event.release.upload_url != '' }}
+      - name: Upload source tarball to the release
+        if: ${{ !contains(github.ref_name, 'check') && github.event.release.upload_url != '' }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: src-dist/haskell-language-server.tar.gz
-          asset_name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
+          asset_name: haskell-language-server-${{ env.HLS_VER }}-src.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload source tarball to workflow artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: haskell-language-server-${{ github.event.release.tag_name }}-src.tar.gz
+          name: haskell-language-server-${{ env.HLS_VER }}-src.tar.gz
           path: src-dist/haskell-language-server.tar.gz
 
   # this generates .gz tarfiles containing binaries for all GHC versions and OS's
@@ -218,7 +214,7 @@ jobs:
           fi
           tar -czpf haskell-language-server.tar.gz *
 
-      - name: (not check) Upload binaries tarball to the release
+      - name: Upload binaries tarball to the release
         if: ${{ !contains(github.ref_name, 'check')  && github.event.release.upload_url != '' }}
         uses: actions/upload-release-asset@v1.0.2
         env:
@@ -229,10 +225,19 @@ jobs:
           asset_name: haskell-language-server-${{ matrix.target-os }}-${{ github.event.release.tag_name }}.tar.gz
           asset_content_type: application/gzip
 
+      - name: Set hls release version
+        run: |
+          HLS_VER="${{ github.event.release.tag_name }}"
+          if [[ -z $HLS_VER ]]; then
+            HLS_VER=${{ github.sha }}
+            HLS_VER=${HLS_VER:0:5}
+          fi
+          echo "HLS_VER=$HLS_VER" >> $GITHUB_ENV
+
       - name: Upload binaries tarball to workflow artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: haskell-language-server-${{ matrix.target-os }}-${{ github.event.release.tag_name }}.tar.gz
+          name: haskell-language-server-${{ matrix.target-os }}-${{ env.HLS_VER }}.tar.gz
           path: bin/haskell-language-server.tar.gz
 
   sha256sum:
@@ -247,7 +252,7 @@ jobs:
           # we clean up tags to match the release file names
           sed -i 's/\/.*)/)/g' SHA256SUMS
 
-      - name: (not check) Upload sha256sums to the release
+      - name: Upload sha256sums to the release
         if: ${{ !contains(github.ref_name, 'check')  && github.event.release.upload_url != '' }}
         uses: actions/upload-release-asset@v1.0.2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,6 @@ jobs:
       with:
         ghc: ${{ matrix.ghc }}
         os:  ${{ runner.os }}
-        cache-prefix: ${{ github.workflow }}
 
     - name: (Windows) Platform specifics
       if: runner.os == 'Windows'

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -71,7 +71,7 @@ library
     , data-default
     , ghc
     , ghcide                ^>=1.4 || ^>=1.5
-    , gitrev
+    , githash
     , lsp
     , hie-bios
     , hiedb

--- a/src/Ide/Arguments.hs
+++ b/src/Ide/Arguments.hs
@@ -17,7 +17,7 @@ module Ide.Arguments
   ) where
 
 import           Data.Version
-import           Development.GitRev
+import           GitHash                       (tGitInfoCwd, giHash)
 import           Development.IDE               (IdeState)
 import           Development.IDE.Main          (Command (..), commandP)
 import           Ide.Types                     (IdePlugins)
@@ -141,11 +141,9 @@ haskellLanguageServerNumericVersion = showVersion version
 haskellLanguageServerVersion :: IO String
 haskellLanguageServerVersion = do
   path <- getExecutablePath
-  let gitHashSection = case $(gitHash) of
-        x | x == "UNKNOWN" -> ""
-        x                  -> " (GIT hash: " <> x <> ")"
+  let gi = $$tGitInfoCwd
+      gitHashSection = " (GIT hash: " <> giHash gi <> ")"
   return $ "haskell-language-server version: " <> haskellLanguageServerNumericVersion
              <> " (GHC: " <> VERSION_ghc
              <> ") (PATH: " <> path <> ")"
              <> gitHashSection
-

--- a/src/Ide/Arguments.hs
+++ b/src/Ide/Arguments.hs
@@ -17,7 +17,7 @@ module Ide.Arguments
   ) where
 
 import           Data.Version
-import           GitHash                       (tGitInfoCwd, giHash)
+import           GitHash                       (tGitInfoCwdTry, giHash)
 import           Development.IDE               (IdeState)
 import           Development.IDE.Main          (Command (..), commandP)
 import           Ide.Types                     (IdePlugins)
@@ -141,8 +141,10 @@ haskellLanguageServerNumericVersion = showVersion version
 haskellLanguageServerVersion :: IO String
 haskellLanguageServerVersion = do
   path <- getExecutablePath
-  let gi = $$tGitInfoCwd
-      gitHashSection = " (GIT hash: " <> giHash gi <> ")"
+  let gi = $$tGitInfoCwdTry
+      gitHashSection = case gi of
+        Right gi -> " (GIT hash: " <> giHash gi <> ")"
+        Left _   -> ""
   return $ "haskell-language-server version: " <> haskellLanguageServerNumericVersion
              <> " (GHC: " <> VERSION_ghc
              <> ") (PATH: " <> path <> ")"

--- a/src/Ide/Version.hs
+++ b/src/Ide/Version.hs
@@ -9,7 +9,7 @@ module Ide.Version where
 
 import           Data.Maybe                    (listToMaybe)
 import           Data.Version
-import           GitHash                       (tGitInfoCwd, giCommitCount)
+import           GitHash                       (tGitInfoCwdTry, giCommitCount)
 import           Options.Applicative.Simple    (simpleVersion)
 import qualified Paths_haskell_language_server as Meta
 import           System.Directory
@@ -21,8 +21,10 @@ import           Text.ParserCombinators.ReadP
 -- >>> hlsVersion
 hlsVersion :: String
 hlsVersion =
-  let gi = $$tGitInfoCwd
-      commitCount = show $ giCommitCount gi
+  let gi = $$tGitInfoCwdTry
+      commitCount = case gi of
+        Right gi -> show $ giCommitCount gi
+        Left _   -> "UNKNOWN"
   in concat $ concat
     [ [$(simpleVersion Meta.version)]
       -- Leave out number of commits for --depth=1 clone

--- a/src/Ide/Version.hs
+++ b/src/Ide/Version.hs
@@ -9,7 +9,7 @@ module Ide.Version where
 
 import           Data.Maybe                    (listToMaybe)
 import           Data.Version
-import           Development.GitRev            (gitCommitCount)
+import           GitHash                       (tGitInfoCwd, giCommitCount)
 import           Options.Applicative.Simple    (simpleVersion)
 import qualified Paths_haskell_language_server as Meta
 import           System.Directory
@@ -21,7 +21,8 @@ import           Text.ParserCombinators.ReadP
 -- >>> hlsVersion
 hlsVersion :: String
 hlsVersion =
-  let commitCount = $gitCommitCount
+  let gi = $$tGitInfoCwd
+      commitCount = show $ giCommitCount gi
   in concat $ concat
     [ [$(simpleVersion Meta.version)]
       -- Leave out number of commits for --depth=1 clone


### PR DESCRIPTION
* [After diagnose the relese build was failing](https://github.com/haskell/haskell-language-server/pull/2606#issuecomment-1017227934) for alpine+ghc with integer-simple due to a new package requiring integer-gmp (https://hackage.haskell.org/package/mod)
* Pinged @maerwald and kindly added in ghcup the missinf ghc versions for alpine with integer-gmp (https://github.com/haskell/ghcup-metadata/pull/15)
* So we can remove the existing workaround here and let haskell/action download the new bindists

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2615"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

