### PR TITLE
Flake ghc 92

### DIFF
--- a/configuration-ghc-921.nix
+++ b/configuration-ghc-921.nix
@@ -1,0 +1,42 @@
+# nix version of cabal-ghc901.project
+{ pkgs, hackage }:
+
+let
+  disabledPlugins = [
+    "hls-brittany-plugin"
+    "hls-stylish-haskell-plugin"
+  ];
+
+  hpkgsOverride = hself: hsuper:
+    with pkgs.haskell.lib;
+    {
+      fourmolu = hself.callCabal2nix "fourmolu" hackage.fourmolu {};
+      primitive-extras = hself.primitive-extras_0_10_1_2;
+      ghc-exactprint = hself.callCabal2nix "ghc-exactprint" hackage.ghc-exactprint {};
+      constraints-extras = hself.callCabal2nix "constraints-extras" hackage.constraints-extras {};
+      retrie = hself.callCabal2nix "retrie" hackage.retrie {};
+      hlint = doJailbreak (hself.callCabal2nix "hlint" hackage.hlint {});
+
+      # Re-generate HLS drv excluding some plugins
+      haskell-language-server =
+        hself.callCabal2nixWithOptions "haskell-language-server" ./.
+        (pkgs.lib.concatStringsSep " " [
+          "-f-brittany"
+          "-f-stylishhaskell"
+          "-f-hlint"
+          "-f-haddockComments"
+          "-f-alternateNumberFormat"
+          "-f-eval"
+        ]) { };
+
+      # YOLO
+      mkDerivation = args:
+        hsuper.mkDerivation (args // {
+          jailbreak = true;
+          doCheck = false;
+        });
+    };
+in {
+  inherit disabledPlugins;
+  tweakHpkgs = hpkgs: hpkgs.extend hpkgsOverride;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,17 @@
 {
   "nodes": {
+    "constraints-extras": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-WGDSpT37RrHwpQtExGkL5eEmBk/s9b0rxtT9DYqSGg4=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/constraints-extras-0.3.2.1/constraints-extras-0.3.2.1.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/constraints-extras-0.3.2.1/constraints-extras-0.3.2.1.tar.gz"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -46,6 +58,30 @@
         "type": "github"
       }
     },
+    "fourmolu": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-uo5UE2SzrimnZl+JjJ30Hlg/nIw1OXJTPFIgkQopaI0=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/fourmolu-0.5.0.1/fourmolu-0.5.0.1.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/fourmolu-0.5.0.1/fourmolu-0.5.0.1.tar.gz"
+      }
+    },
+    "ghc-exactprint": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-8OWLBQj0WYi1f91EE3d5Pq+lTjY+FQei37NEedDtKeo=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.4.1/ghc-exactprint-1.4.1.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.4.1/ghc-exactprint-1.4.1.tar.gz"
+      }
+    },
     "gitignore": {
       "flake": false,
       "locked": {
@@ -64,18 +100,35 @@
     },
     "hackage-sources": {
       "inputs": {
+        "constraints-extras": "constraints-extras",
+        "fourmolu": "fourmolu",
+        "ghc-exactprint": "ghc-exactprint",
+        "hlint": "hlint",
         "lsp": "lsp",
         "lsp-test": "lsp-test",
-        "lsp-types": "lsp-types"
+        "lsp-types": "lsp-types",
+        "retrie": "retrie"
       },
       "locked": {
-        "narHash": "sha256-p6aOFA/SahtoQC2FLWxltQ3Fy9pXElKq0FGCgNsehSc=",
+        "narHash": "sha256-gVzFEW0y/uPHJaGJ6w7VZc3QDhH6latvmYHJuzaXDa0=",
         "path": "./flake_hackage",
         "type": "path"
       },
       "original": {
         "path": "./flake_hackage",
         "type": "path"
+      }
+    },
+    "hlint": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-Kz6adx97kY7ojoDlw3y0R6LQ0h/EtXGR5+N07/b6uGk=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/hlint-3.3.6/hlint-3.3.6.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/hlint-3.3.6/hlint-3.3.6.tar.gz"
       }
     },
     "lsp": {
@@ -161,6 +214,18 @@
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
         "type": "github"
+      }
+    },
+    "retrie": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-SrUyFea9Qr2SYeNVDJfWZfCguJV2rHK2mO/FO4xLFaY=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/retrie-1.2.0.1/retrie-1.2.0.1.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/retrie-1.2.0.1/retrie-1.2.0.1.tar.gz"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -62,7 +62,23 @@
         "type": "github"
       }
     },
-    "lsp-source": {
+    "hackage-sources": {
+      "inputs": {
+        "lsp": "lsp",
+        "lsp-test": "lsp-test",
+        "lsp-types": "lsp-types"
+      },
+      "locked": {
+        "narHash": "sha256-p6aOFA/SahtoQC2FLWxltQ3Fy9pXElKq0FGCgNsehSc=",
+        "path": "./flake_hackage",
+        "type": "path"
+      },
+      "original": {
+        "path": "./flake_hackage",
+        "type": "path"
+      }
+    },
+    "lsp": {
       "flake": false,
       "locked": {
         "narHash": "sha256-OcyNHNRh9j5nbJ8SjaNAWIEKuixAJlA7+vTimFY0c2c=",
@@ -74,7 +90,7 @@
         "url": "https://hackage.haskell.org/package/lsp-1.4.0.0/lsp-1.4.0.0.tar.gz"
       }
     },
-    "lsp-test-source": {
+    "lsp-test": {
       "flake": false,
       "locked": {
         "narHash": "sha256-IOmbQH6tKdu9kAyirvLx6xFS2N+/tbs6vZn0mNGm3No=",
@@ -86,7 +102,7 @@
         "url": "https://hackage.haskell.org/package/lsp-test-0.14.0.2/lsp-test-0.14.0.2.tar.gz"
       }
     },
-    "lsp-types-source": {
+    "lsp-types": {
       "flake": false,
       "locked": {
         "narHash": "sha256-K1CeV6o5mmrXubATCh19iFatJ1RtPwpY5lxD8rf/SIw=",
@@ -152,9 +168,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
-        "lsp-source": "lsp-source",
-        "lsp-test-source": "lsp-test-source",
-        "lsp-types-source": "lsp-types-source",
+        "hackage-sources": "hackage-sources",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,25 +22,16 @@
       flake = false;
     };
 
-    lsp-source = {
-      url = "https://hackage.haskell.org/package/lsp-1.4.0.0/lsp-1.4.0.0.tar.gz";
-      flake = false;
-    };
-    lsp-types-source = {
-      url = "https://hackage.haskell.org/package/lsp-types-1.4.0.0/lsp-types-1.4.0.0.tar.gz";
-      flake = false;
-    };
-    lsp-test-source = {
-      url = "https://hackage.haskell.org/package/lsp-test-0.14.0.2/lsp-test-0.14.0.2.tar.gz";
-      flake = false;
-    };
+    hackage-sources.url = "path:./flake_hackage";
   };
   outputs =
-    { self, nixpkgs, flake-compat, flake-utils, pre-commit-hooks, gitignore, lsp-source, lsp-types-source, lsp-test-source }:
+    { self, nixpkgs, flake-compat, flake-utils, pre-commit-hooks, gitignore, hackage-sources }:
     {
       overlay = final: prev:
         with prev;
         let
+          hackage = hackage-sources.inputs;
+
           haskellOverrides = hself: hsuper: {
             # we override mkDerivation here to apply the following
             # tweak to each haskell package:
@@ -88,9 +79,9 @@
               # We need an older version
               hiedb = hself.hiedb_0_4_1_0;
 
-              lsp = hsuper.callCabal2nix "lsp" lsp-source {};
-              lsp-types = hsuper.callCabal2nix "lsp-types" lsp-types-source {};
-              lsp-test = hsuper.callCabal2nix "lsp-test" lsp-test-source {};
+              lsp = hsuper.callCabal2nix "lsp" hackage.lsp {};
+              lsp-types = hsuper.callCabal2nix "lsp-types" hackage.lsp-types {};
+              lsp-test = hsuper.callCabal2nix "lsp-test" hackage.lsp-test {};
 
               implicit-hie-cradle = hself.callCabal2nix "implicit-hie-cradle"
                 (builtins.fetchTarball {

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,7 @@
     } // (flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ])
     (system:
       let
+        hackage = hackage-sources.inputs;
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ self.overlay ];
@@ -169,6 +170,7 @@
         };
 
         ghc901Config = (import ./configuration-ghc-901.nix) { inherit pkgs; };
+        ghc921Config = (import ./configuration-ghc-921.nix) { inherit pkgs hackage; };
 
         # GHC versions
         ghcDefault = pkgs.hlsHpkgs ("ghc"
@@ -177,6 +179,7 @@
         ghc884 = pkgs.hlsHpkgs "ghc884";
         ghc8107 = pkgs.hlsHpkgs "ghc8107";
         ghc901 = ghc901Config.tweakHpkgs (pkgs.hlsHpkgs "ghc901");
+        ghc921 = ghc921Config.tweakHpkgs (pkgs.hlsHpkgs "ghc921");
 
         # For markdown support
         myst-parser = pkgs.python3Packages.callPackage ./myst-parser.nix {};
@@ -211,6 +214,8 @@
               map (name: p.${name}) (attrNames
                 (if hpkgs.ghc.version == "9.0.1" then
                   removeAttrs hlsSources ghc901Config.disabledPlugins
+                else if hpkgs.ghc.version == "9.2.1" then
+                  removeAttrs hlsSources ghc921Config.disabledPlugins
                 else
                   hlsSources));
             buildInputs = [ gmp zlib ncurses capstone tracy (gen-hls-changelogs hpkgs) pythonWithPackages ]
@@ -253,12 +258,14 @@
           haskell-language-server-884-dev = mkDevShell ghc884;
           haskell-language-server-8107-dev = mkDevShell ghc8107;
           haskell-language-server-901-dev = mkDevShell ghc901;
+          haskell-language-server-921-dev = mkDevShell ghc921;
 
           # hls package
           haskell-language-server = mkExe ghcDefault;
           haskell-language-server-884 = mkExe ghc884;
           haskell-language-server-8107 = mkExe ghc8107;
           haskell-language-server-901 = mkExe ghc901;
+          haskell-language-server-921 = mkExe ghc921;
 
           # docs
           docs = docs;

--- a/flake_hackage/flake.nix
+++ b/flake_hackage/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Sources from hackage";
+
+  inputs = {
+    lsp = {
+      url = "https://hackage.haskell.org/package/lsp-1.4.0.0/lsp-1.4.0.0.tar.gz";
+      flake = false;
+    };
+    lsp-types = {
+      url = "https://hackage.haskell.org/package/lsp-types-1.4.0.0/lsp-types-1.4.0.0.tar.gz";
+      flake = false;
+    };
+    lsp-test = {
+      url = "https://hackage.haskell.org/package/lsp-test-0.14.0.2/lsp-test-0.14.0.2.tar.gz";
+      flake = false;
+    };
+  };
+
+  outputs = {self, ...}: {};
+}

--- a/flake_hackage/flake.nix
+++ b/flake_hackage/flake.nix
@@ -14,6 +14,30 @@
       url = "https://hackage.haskell.org/package/lsp-test-0.14.0.2/lsp-test-0.14.0.2.tar.gz";
       flake = false;
     };
+    ghc-exactprint = {
+      url = "https://hackage.haskell.org/package/ghc-exactprint-1.4.1/ghc-exactprint-1.4.1.tar.gz";
+      flake = false;
+    };
+
+    constraints-extras = {
+      url = "https://hackage.haskell.org/package/constraints-extras-0.3.2.1/constraints-extras-0.3.2.1.tar.gz";
+      flake = false;
+    };
+
+    retrie = {
+      url = "https://hackage.haskell.org/package/retrie-1.2.0.1/retrie-1.2.0.1.tar.gz";
+      flake = false;
+    };
+
+    fourmolu = {
+      url = "https://hackage.haskell.org/package/fourmolu-0.5.0.1/fourmolu-0.5.0.1.tar.gz";
+      flake = false;
+    };
+
+    hlint = {
+      url = "https://hackage.haskell.org/package/hlint-3.3.6/hlint-3.3.6.tar.gz";
+      flake = false;
+    };
   };
 
   outputs = {self, ...}: {};


### PR DESCRIPTION
This is (partial) flake support for GHC 9.2.

This is in a limited state, especially:

- I have not repaired the support for a few plugins.
- `nix develop .#....-dev` target is not working, it pulls a few dependencies which are not overiden. I'll give another pass soon.

But the cool thing is that it allows to build `haskell-language-server` from flake in another project. I've just updated my work project to GHC 9.2 and I'm enjoying HLS thank to this flake.

Tell me if you prefer to merge "partial" support or if I need to work on the currently broken tasks. I cannot guarantee that I'll allocate time to this soon.

However, users can find this MR and point their flake to this commit and immediately get HLS in their project.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2621"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

