### PR TITLE
Drop bytestring-encoding

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -95,7 +95,6 @@ library
         hslogger,
         Diff ^>=0.4.0,
         vector,
-        bytestring-encoding,
         opentelemetry >=0.6.1,
         heapsize ==0.3.*,
         unliftio,


### PR DESCRIPTION
Applying the patch suggested by @Bodigrim https://github.com/haskell/haskell-language-server/issues/2583#issuecomment-1019375604

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2628"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

