### PR TITLE
Fix off by one indexing error in openingBacktick

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -732,7 +732,7 @@ isUsedAsInfix line prefixMod prefixText pos
 
 openingBacktick :: T.Text -> T.Text -> T.Text -> Position -> Bool
 openingBacktick line prefixModule prefixText Position { _character=(fromIntegral -> c) }
-  | backtickIndex < 0 || backtickIndex > T.length line = False
+  | backtickIndex < 0 || backtickIndex >= T.length line = False
   | otherwise = (line `T.index` backtickIndex) == '`'
     where
     backtickIndex :: Int


### PR DESCRIPTION
Apply the fix suggested by @Bodigrim in https://github.com/haskell/haskell-language-server/issues/2602#issuecomment-1019344264

Fixes https://github.com/haskell/haskell-language-server/issues/2602

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2629"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

