### PR TITLE
Specialize ghcide indent style to .hs

### DIFF
--- a/ghcide/.editorconfig
+++ b/ghcide/.editorconfig
@@ -5,7 +5,9 @@ root = true
 
 [*]
 end_of_line = LF
-indent_style = space
-indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{hs,lhs}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This way `ghcide/.editorconfig` reproduces the root `.editorconfig`, except for line length restrictions.

Motivation: same as root, `ghcide/` contains some YAML files, which are de facto indented with 2 spaces.