### PR TITLE
Use T.decodeUtf8 + BS.readFile instead of T.readFile

### DIFF
--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -91,7 +91,6 @@ import           Data.Maybe
 import qualified Data.Rope.UTF16                              as Rope
 import qualified Data.Set                                     as Set
 import qualified Data.Text                                    as T
-import qualified Data.Text.IO                                 as T
 import qualified Data.Text.Encoding                           as T
 import           Data.Time                                    (UTCTime (..))
 import           Data.Tuple.Extra
@@ -528,7 +527,7 @@ persistentHieFileRule = addPersistentRule GetHieAst $ \file -> runMaybeT $ do
   (currentSource,ver) <- liftIO $ do
     mvf <- getVirtualFile vfs $ filePathToUri' file
     case mvf of
-      Nothing -> (,Nothing) <$> T.readFile (fromNormalizedFilePath file)
+      Nothing -> (,Nothing) . T.decodeUtf8 <$> BS.readFile (fromNormalizedFilePath file)
       Just vf -> pure (Rope.toText $ _text vf, Just $ _lsp_version vf)
   let refmap = Compat.generateReferencesMap . Compat.getAsts . Compat.hie_asts $ res
       del = deltaFromDiff (T.decodeUtf8 $ Compat.hie_hs_src res) currentSource

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -38,12 +38,13 @@ import           Control.Monad.Trans.Except
 import           Data.Aeson.Types                                   (FromJSON (..),
                                                                      ToJSON (..),
                                                                      Value (..))
+import qualified Data.ByteString                                    as BS
 import           Data.Default
 import qualified Data.HashMap.Strict                                as Map
 import           Data.Hashable
 import           Data.Maybe
 import qualified Data.Text                                          as T
-import qualified Data.Text.IO                                       as T
+import qualified Data.Text.Encoding                                 as T
 import           Data.Typeable
 import           Development.IDE                                    hiding
                                                                     (Error)
@@ -509,7 +510,7 @@ applyHint ide nfp mhint =
     liftIO $ logm $ "applyHint:apply=" ++ show commands
     let fp = fromNormalizedFilePath nfp
     (_, mbOldContent) <- liftIO $ runAction' $ getFileContents nfp
-    oldContent <- maybe (liftIO $ T.readFile fp) return mbOldContent
+    oldContent <- maybe (liftIO $ fmap T.decodeUtf8 $ BS.readFile fp) return mbOldContent
     modsum <- liftIO $ runAction' $ use_ GetModSummary nfp
     let dflags = ms_hspp_opts $ msrModSummary modsum
     -- Setting a environment variable with the libdir used by ghc-exactprint.

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -18,6 +18,7 @@ library
   build-depends:
     , aeson
     , base                  >=4.12    && <5
+    , bytestring
     , containers
     , deepseq
     , directory

--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -32,6 +32,7 @@ import           Data.Aeson                           (FromJSON (..),
                                                        Value (Null),
                                                        genericParseJSON)
 import qualified Data.Aeson                           as Aeson
+import qualified Data.ByteString                      as BS
 import           Data.Bifunctor                       (Bifunctor (first),
                                                        second)
 import           Data.Coerce
@@ -44,7 +45,7 @@ import           Data.IORef.Extra                     (atomicModifyIORef'_,
 import           Data.List.Extra                      (find, nubOrdOn)
 import           Data.String                          (IsString (fromString))
 import qualified Data.Text                            as T
-import qualified Data.Text.IO                         as T
+import qualified Data.Text.Encoding                   as T
 import           Data.Typeable                        (Typeable)
 import           Development.IDE                      hiding (pluginHandlers)
 import           Development.IDE.Core.PositionMapping
@@ -385,7 +386,7 @@ callRetrie state session rewrites origin restrictToOriginatingFile = do
             runAction "Retrie.GetFileContents" state $ getFileContents nt
           case mbContentsVFS of
             Just contents -> return contents
-            Nothing       -> T.readFile (fromNormalizedFilePath nt)
+            Nothing       -> T.decodeUtf8 <$> BS.readFile (fromNormalizedFilePath nt)
         if any (T.isPrefixOf "#if" . T.toLower) (T.lines contents)
           then do
             fixitiesRef <- newIORef mempty


### PR DESCRIPTION
As documentation (https://hackage.haskell.org/package/text-2.0/docs/Data-Text-IO.html#v:readFile) explains, `T.readFile` is almost always a mistake. It's highly unlikely that files we try to read with `T.readFile` are in a locale encoding and not in UTF-8. Moreover, with `text-2.0` `fmap T.decodeUtf8 . BS.readFile` is up to 10x faster than `T.readFile`.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2637"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

