### PR TITLE
Disable alpine build by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Builds
 
 on:
   workflow_dispatch:
+    inputs:
+      alpine:
+        description: 'Use alpine to build a fully static executable for linux'
+        required: false
+        default: 'false'
   release:
     types: [created]
   push:
@@ -11,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: ${{ (startsWith(matrix.os,'ubuntu') && 'alpine:3.12') || '' }}
+    container: ${{ (github.event.inputs.alpine == 'true' && startsWith(matrix.os,'ubuntu') && 'alpine:3.12') || '' }}
     defaults:
       run:
         shell: ${{ (startsWith(matrix.os,'windows') && 'bash') || 'sh' }}
@@ -35,7 +40,7 @@ jobs:
 
     steps:
     - name: Install system dependencies
-      if: runner.os == 'Linux'
+      if: github.event.inputs.alpine == 'true' && runner.os == 'Linux'
       run: |
         apk add --no-cache curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz gzip tar perl git bash sudo binutils-gold
         apk add --no-cache zlib zlib-dev zlib-static gmp gmp-dev ncurses-static

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -53,7 +53,7 @@ fi
 # Shorten binary names
 sed -i.bak -e 's/haskell-language-server/hls/g' \
 	   -e 's/haskell_language_server/hls/g' \
-	   haskell-language-server.cabal cabal.project
+	   haskell-language-server.cabal $CABAL_PROJECT
 sed -i.bak -e 's/Paths_haskell_language_server/Paths_hls/g' \
 	   src/**/*.hs exe/*.hs
 
@@ -77,4 +77,3 @@ cp "$(cabal list-bin ${args[@]} exe:hls-wrapper)" "$CI_PROJECT_DIR/out/haskell-l
 cp dist-newstyle/cache/plan.json "$CI_PROJECT_DIR/out/plan.json"
 
 cd "$CI_PROJECT_DIR/out/"
-

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -259,7 +259,7 @@ common tactic
     cpp-options: -Dtactic
 
 common hlint
-  if flag(hlint)
+  if flag(hlint) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
     build-depends: hls-hlint-plugin ^>=1.0.0.2
     cpp-options: -Dhlint
 


### PR DESCRIPTION
* As commented in https://github.com/haskell/haskell-language-server/issues/2617#issuecomment-1019289588
* It seems binaries from the alpine build cant load files containing template haskell, checked in wsl/ubuntu by myself and in native ubuntu by @kokobd

```
Unexpected usage error
Dynamic loading not supported
```

![imagen](https://user-images.githubusercontent.com/54035/150644276-55c20153-0b9e-40d8-9f1d-48b7bd99110c.png)

* That behaviour was not noted explicitly in the pr (#2463) or the issue about (#2461)
* We have pending the release of 1.6.0 for January
* So this pr disables it until we clarificate the situation to unblock the release

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2638"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

