### PR TITLE
Change Type Family Export pattern

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -548,7 +548,7 @@ suggestDeleteUnusedBinding
       isSameName :: IdP GhcPs -> String -> Bool
       isSameName x name = showSDocUnsafe (ppr x) == name
 
-data ExportsAs = ExportName | ExportPattern | ExportAll
+data ExportsAs = ExportName | ExportPattern | ExportFamily | ExportAll
   deriving (Eq)
 
 getLocatedRange :: Located a -> Maybe Range
@@ -602,6 +602,7 @@ suggestExportUnusedTopBinding srcOpt ParsedModule{pm_parsed_source = L _ HsModul
     printExport :: ExportsAs -> T.Text -> T.Text
     printExport ExportName x    = parenthesizeIfNeeds False x
     printExport ExportPattern x = "pattern " <> x
+    printExport ExportFamily x  = parenthesizeIfNeeds True x
     printExport ExportAll x     = parenthesizeIfNeeds True x <> "(..)"
 
     isTopLevel :: Range -> Bool
@@ -613,7 +614,7 @@ suggestExportUnusedTopBinding srcOpt ParsedModule{pm_parsed_source = L _ HsModul
     exportsAs (TyClD _ SynDecl{tcdLName})      = Just (ExportName, reLoc tcdLName)
     exportsAs (TyClD _ DataDecl{tcdLName})     = Just (ExportAll, reLoc tcdLName)
     exportsAs (TyClD _ ClassDecl{tcdLName})    = Just (ExportAll, reLoc tcdLName)
-    exportsAs (TyClD _ FamDecl{tcdFam})        = Just (ExportName, reLoc $ fdLName tcdFam)
+    exportsAs (TyClD _ FamDecl{tcdFam})        = Just (ExportFamily, reLoc $ fdLName tcdFam)
     exportsAs _                                = Nothing
 
 suggestAddTypeAnnotationToSatisfyContraints :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -613,7 +613,7 @@ suggestExportUnusedTopBinding srcOpt ParsedModule{pm_parsed_source = L _ HsModul
     exportsAs (TyClD _ SynDecl{tcdLName})      = Just (ExportName, reLoc tcdLName)
     exportsAs (TyClD _ DataDecl{tcdLName})     = Just (ExportAll, reLoc tcdLName)
     exportsAs (TyClD _ ClassDecl{tcdLName})    = Just (ExportAll, reLoc tcdLName)
-    exportsAs (TyClD _ FamDecl{tcdFam})        = Just (ExportAll, reLoc $ fdLName tcdFam)
+    exportsAs (TyClD _ FamDecl{tcdFam})        = Just (ExportName, reLoc $ fdLName tcdFam)
     exportsAs _                                = Nothing
 
 suggestAddTypeAnnotationToSatisfyContraints :: Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -3466,7 +3466,7 @@ exportUnusedTests = testGroup "export unused actions"
         (Just $ T.unlines
               [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
               , "{-# LANGUAGE TypeFamilies #-}"
-              , "module A (Foo(..)) where"
+              , "module A (Foo) where"
               , "type family Foo p"])
     , testSession "unused typeclass" $ template
         (T.unlines

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -3530,7 +3530,7 @@ exportUnusedTests = testGroup "export unused actions"
               [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
               , "{-# LANGUAGE TypeFamilies #-}"
               , "{-# LANGUAGE TypeOperators #-}"
-              , "module A (type (:<)(..)) where"
+              , "module A (type (:<)) where"
               , "type family (:<)"])
     , testSession "typeclass operator" $ template
         (T.unlines
@@ -3543,7 +3543,7 @@ exportUnusedTests = testGroup "export unused actions"
         (Just $ T.unlines
               [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
               , "{-# LANGUAGE TypeOperators #-}"
-              , "module A (type (:<)) where"
+              , "module A (type (:<)(..)) where"
               , "class (:<) a"])
     , testSession "newtype operator" $ template
         (T.unlines


### PR DESCRIPTION
Per the issue noted by @googleson78 - this fixes #2635, which deals with exporting Type Families.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2643"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

