### PR TITLE
Nix flake fix dev shells

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -108,7 +108,7 @@ jobs:
     # We only build nix dev shell for current GHC version because some are
     # failing with different GHC version on darwin.
     - name: Build development shell with nix dependencies for current GHC version
-      run: nix develop --print-build-logs .#haskell-language-server-dev --profile dev
+      run: nix develop --print-build-logs .#all-nix-dev-shells --profile dev
     - name: Push development shell
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: cachix push haskell-language-server dev

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -103,8 +103,12 @@ jobs:
         authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
     - name: Build development shell
       run: nix develop --print-build-logs --profile dev
-    - name: Build all development shell
-      run: nix develop --print-build-logs .#all-dev-shells --profile dev
+    - name: Build all development shell (without nix dependencies)
+      run: nix develop --print-build-logs .#all-simple-dev-shells --profile dev
+    # We only build nix dev shell for current GHC version because some are
+    # failing with different GHC version on darwin.
+    - name: Build development shell with nix dependencies for current GHC version
+      run: nix develop --print-build-logs .#haskell-language-server-dev --profile dev
     - name: Push development shell
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: cachix push haskell-language-server dev

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -103,15 +103,15 @@ jobs:
         authToken: ${{ secrets.HLS_CACHIX_AUTH_TOKEN }}
     - name: Build development shell
       run: nix develop --print-build-logs --profile dev
-    - name: Build development shell (GHC 9.0.1)
-      run: nix develop --print-build-logs .#haskell-language-server-901-dev --profile dev
+    - name: Build all development shell
+      run: nix develop --print-build-logs .#all-dev-shells --profile dev
     - name: Push development shell
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: cachix push haskell-language-server dev
     - name: Build binaries
       run: nix build --print-build-logs
-    - name: Build binaries (GHC 9.0.1)
-      run: nix build --print-build-logs .#haskell-language-server-901
+    - name: Build all binaries
+      run: nix build --print-build-logs all-haskell-language-server
     - name: Push binaries
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -111,7 +111,7 @@ jobs:
     - name: Build binaries
       run: nix build --print-build-logs
     - name: Build all binaries
-      run: nix build --print-build-logs all-haskell-language-server
+      run: nix build --print-build-logs .#all-haskell-language-server
     - name: Push binaries
       if: ${{ env.HAS_TOKEN == 'true' }}
       run: nix path-info --json | jq -r '.[].path' | cachix push haskell-language-server

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -10,6 +10,8 @@ let
   hpkgsOverride = hself: hsuper:
     with pkgs.haskell.lib;
     {
+      hlsDisabledPlugins = disabledPlugins;
+
       fourmolu = hself.fourmolu_0_4_0_0;
       primitive-extras = hself.primitive-extras_0_10_1_2;
 

--- a/configuration-ghc-921.nix
+++ b/configuration-ghc-921.nix
@@ -5,6 +5,11 @@ let
   disabledPlugins = [
     "hls-brittany-plugin"
     "hls-stylish-haskell-plugin"
+    "hls-hlint-plugin"
+    "hls-haddock-comments-plugin"
+    "hls-alternate-number-format-plugin"
+    "hls-eval-plugin"
+    "hls-tactics-plugin"
   ];
 
   hpkgsOverride = hself: hsuper:
@@ -22,11 +27,12 @@ let
         hself.callCabal2nixWithOptions "haskell-language-server" ./.
         (pkgs.lib.concatStringsSep " " [
           "-f-brittany"
-          "-f-stylishhaskell"
+          "-f-stylishHaskell"
           "-f-hlint"
           "-f-haddockComments"
           "-f-alternateNumberFormat"
           "-f-eval"
+          "-f-tactics"
         ]) { };
 
       # YOLO

--- a/configuration-ghc-921.nix
+++ b/configuration-ghc-921.nix
@@ -19,6 +19,8 @@ let
   hpkgsOverride = hself: hsuper:
     with pkgs.haskell.lib;
     {
+      hlsDisabledPlugins = disabledPlugins;
+
       fourmolu = hself.callCabal2nix "fourmolu" inputs.fourmolu {};
       primitive-extras = hself.primitive-extras_0_10_1_2;
       ghc-exactprint = hself.callCabal2nix "ghc-exactprint" inputs.ghc-exactprint {};

--- a/configuration-ghc-921.nix
+++ b/configuration-ghc-921.nix
@@ -24,7 +24,10 @@ let
       ghc-exactprint = hself.callCabal2nix "ghc-exactprint" inputs.ghc-exactprint {};
       constraints-extras = hself.callCabal2nix "constraints-extras" inputs.constraints-extras {};
       retrie = hself.callCabal2nix "retrie" inputs.retrie {};
+
+      # Hlint is still broken
       hlint = doJailbreak (hself.callCabal2nix "hlint" inputs.hlint {});
+      hiedb = hself.hiedb_0_4_1_0;
 
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =

--- a/configuration-ghc-921.nix
+++ b/configuration-ghc-921.nix
@@ -7,8 +7,6 @@ let
     "hls-stylish-haskell-plugin"
     "hls-hlint-plugin"
     "hls-haddock-comments-plugin"
-    "hls-alternate-number-format-plugin"
-    "hls-eval-plugin"
     "hls-tactics-plugin"
     # That one is not technically a plugin, but by putting it in this list, we
     # get it removed from the top level list of requirement and it is not pull
@@ -39,8 +37,6 @@ let
           "-f-stylishHaskell"
           "-f-hlint"
           "-f-haddockComments"
-          "-f-alternateNumberFormat"
-          "-f-eval"
           "-f-tactics"
         ]) { };
 

--- a/configuration-ghc-921.nix
+++ b/configuration-ghc-921.nix
@@ -10,6 +10,10 @@ let
     "hls-alternate-number-format-plugin"
     "hls-eval-plugin"
     "hls-tactics-plugin"
+    # That one is not technically a plugin, but by putting it in this list, we
+    # get it removed from the top level list of requirement and it is not pull
+    # in the nix shell.
+    "shake-bench"
   ];
 
   hpkgsOverride = hself: hsuper:

--- a/flake.lock
+++ b/flake.lock
@@ -110,6 +110,18 @@
         "url": "https://hackage.haskell.org/package/hlint-3.3.6/hlint-3.3.6.tar.gz"
       }
     },
+    "implicit-hie-cradle": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-2NmucBBI7Qi1UGXWG27XFZRCeqeRiwVFWmJKZnp6R5U=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/implicit-hie-cradle-0.3.0.5/implicit-hie-cradle-0.3.0.5.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/implicit-hie-cradle-0.3.0.5/implicit-hie-cradle-0.3.0.5.tar.gz"
+      }
+    },
     "lsp": {
       "flake": false,
       "locked": {
@@ -216,6 +228,7 @@
         "ghc-exactprint": "ghc-exactprint",
         "gitignore": "gitignore",
         "hlint": "hlint",
+        "implicit-hie-cradle": "implicit-hie-cradle",
         "lsp": "lsp",
         "lsp-test": "lsp-test",
         "lsp-types": "lsp-types",

--- a/flake.nix
+++ b/flake.nix
@@ -315,10 +315,9 @@
         # Copied from https://github.com/NixOS/nixpkgs/blob/210784b7c8f3d926b7db73bdad085f4dc5d79418/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix#L16
         mkExe = hpkgs:
           with pkgs.haskell.lib;
-          (justStaticExecutables (overrideCabal hpkgs.haskell-language-server
+          (enableSharedExecutables (overrideCabal hpkgs.haskell-language-server
             (_: {
               postInstall = ''
-                remove-references-to -t ${hpkgs.ghc} $out/bin/haskell-language-server
                 remove-references-to -t ${hpkgs.shake.data} $out/bin/haskell-language-server
                 remove-references-to -t ${hpkgs.js-jquery.data} $out/bin/haskell-language-server
                 remove-references-to -t ${hpkgs.js-dgtable.data} $out/bin/haskell-language-server

--- a/flake.nix
+++ b/flake.nix
@@ -245,12 +245,8 @@
             packages = p:
               with builtins;
               map (name: p.${name}) (attrNames
-                (if hpkgs.ghc.version == "9.0.1" then
-                  removeAttrs hlsSources ghc901Config.disabledPlugins
-                else if hpkgs.ghc.version == "9.2.1" then
-                  removeAttrs hlsSources ghc921Config.disabledPlugins
-                else
-                  hlsSources));
+              # Disable dependencies should not be part of the shell.
+              (removeAttrs hlsSources (hpkgs.hlsDisabledPlugins or [])));
             # For theses tools packages, we use ghcDefault
             # This removes a rebuild with a different GHC version
             # Theses programs are tools, used as binary, independently of the

--- a/flake.nix
+++ b/flake.nix
@@ -365,7 +365,7 @@
           all-haskell-language-server = linkFarmFromDrvs "all-haskell-language-server" (lib.unique (builtins.attrValues allPackages));
 
           # Same for all shells 
-          all-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues devShells)));
+          all-nix-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues [nixDevShells.haskell-language-server-dev-nix])));
 
           all-simple-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues simpleDevShells)));
           docs = docs;

--- a/flake.nix
+++ b/flake.nix
@@ -365,6 +365,8 @@
           all-haskell-language-server = linkFarmFromDrvs "all-haskell-language-server" (lib.unique (builtins.attrValues allPackages));
 
           # Same for all shells 
+          # We try to build as much as possible, but not much shells are
+          # working (especially on darwing), so this list is limited.
           all-nix-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues [nixDevShells.haskell-language-server-dev-nix])));
 
           all-simple-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues simpleDevShells)));

--- a/flake.nix
+++ b/flake.nix
@@ -238,7 +238,7 @@
 
         # Create a development shell of hls project
         # See https://github.com/NixOS/nixpkgs/blob/5d4a430472cafada97888cc80672fab255231f57/pkgs/development/haskell-modules/make-package-set.nix#L319
-        mkDevShell = hpkgs:
+        mkDevShell = hpkgs: cabalProject:
           with pkgs;
           hpkgs.shellFor {
             doBenchmark = true;
@@ -277,6 +277,8 @@
               export DYLD_LIBRARY_PATH=${gmp}/lib:${zlib}/lib:${ncurses}/lib:${capstone}/lib
               export PATH=$PATH:$HOME/.local/bin
               ${(pre-commit-check ghcDefault).shellHook}
+
+              alias cabal='cabal --project-file=${cabalProject}'
             '';
           };
         # Create a hls executable
@@ -295,15 +297,15 @@
             }));
       in with pkgs; rec {
 
-        packages = {
-          # dev shell
-          haskell-language-server-dev = mkDevShell ghcDefault;
-          haskell-language-server-884-dev = mkDevShell ghc884;
-          haskell-language-server-8107-dev = mkDevShell ghc8107;
-          haskell-language-server-901-dev = mkDevShell ghc901;
-          haskell-language-server-921-dev = mkDevShell ghc921;
+        devShells = {
+          haskell-language-server-dev = mkDevShell ghcDefault "cabal.project";
+          haskell-language-server-884-dev = mkDevShell ghc884 "cabal.project";
+          haskell-language-server-8107-dev = mkDevShell ghc8107 "cabal.project";
+          haskell-language-server-901-dev = mkDevShell ghc901 "cabal-ghc90.project";
+          haskell-language-server-921-dev = mkDevShell ghc921 "cabal-ghc921.project";
+        };
 
-          # hls package
+        packages = {
           haskell-language-server = mkExe ghcDefault;
           haskell-language-server-884 = mkExe ghc884;
           haskell-language-server-8107 = mkExe ghc8107;
@@ -316,6 +318,6 @@
 
         defaultPackage = packages.haskell-language-server;
 
-        devShell = packages.haskell-language-server-dev;
+        devShell = devShells.haskell-language-server-dev;
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -367,7 +367,7 @@
           # Same for all shells 
           # We try to build as much as possible, but not much shells are
           # working (especially on darwing), so this list is limited.
-          all-nix-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues [nixDevShells.haskell-language-server-dev-nix])));
+          all-nix-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique [nixDevShells.haskell-language-server-dev-nix]));
 
           all-simple-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues simpleDevShells)));
           docs = docs;

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,10 @@
       url = "https://hackage.haskell.org/package/hlint-3.3.6/hlint-3.3.6.tar.gz";
       flake = false;
     };
+    implicit-hie-cradle = {
+      url = "https://hackage.haskell.org/package/implicit-hie-cradle-0.3.0.5/implicit-hie-cradle-0.3.0.5.tar.gz";
+      flake = false;
+    };
   };
   outputs =
     inputs@{ self, nixpkgs, flake-compat, flake-utils, pre-commit-hooks, gitignore, ... }:
@@ -113,11 +117,7 @@
               lsp-types = hsuper.callCabal2nix "lsp-types" inputs.lsp-types {};
               lsp-test = hsuper.callCabal2nix "lsp-test" inputs.lsp-test {};
 
-              implicit-hie-cradle = hself.callCabal2nix "implicit-hie-cradle"
-                (builtins.fetchTarball {
-                  url = "https://hackage.haskell.org/package/implicit-hie-cradle-0.3.0.5/implicit-hie-cradle-0.3.0.5.tar.gz";
-                  sha256 = "15a7g9x6cjk2b92hb2wilxx4550msxp1pmk5a2shiva821qaxnfq";
-                }) { };
+              implicit-hie-cradle = hself.callCabal2nix "implicit-hie-cradle" inputs.implicit-hie-cradle {};
 
               # https://github.com/NixOS/nixpkgs/issues/140774
               ormolu =

--- a/flake.nix
+++ b/flake.nix
@@ -327,14 +327,17 @@
               pname = old.pname + "-ghc${hpkgs.ghc.version}";
             });
       in with pkgs; rec {
-
-        devShells = {
+        # Developement shell with only compiler
+        simpleDevShells = {
           haskell-language-server-dev = mkDevShell ghcDefault "cabal.project";
           haskell-language-server-884-dev = mkDevShell ghc884 "cabal.project";
           haskell-language-server-8107-dev = mkDevShell ghc8107 "cabal.project";
           haskell-language-server-901-dev = mkDevShell ghc901 "cabal-ghc90.project";
           haskell-language-server-921-dev = mkDevShell ghc921 "cabal-ghc921.project";
+        };
 
+        # Developement shell, haskell packages are also provided by nix
+        nixDevShells = {
           haskell-language-server-dev-nix = mkDevShellWithNixDeps ghcDefault "cabal.project";
           haskell-language-server-884-dev-nix = mkDevShellWithNixDeps ghc884 "cabal.project";
           haskell-language-server-8107-dev-nix = mkDevShellWithNixDeps ghc8107 "cabal.project";
@@ -350,6 +353,8 @@
           haskell-language-server-921 = mkExe ghc921;
         };
 
+        devShells = simpleDevShells // nixDevShells;
+
         packages = allPackages // {
           # See https://github.com/NixOS/nix/issues/5591
           # nix flake cannot build a list/set of derivation in one command.
@@ -362,6 +367,7 @@
           # Same for all shells 
           all-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues devShells)));
 
+          all-simple-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues simpleDevShells)));
           docs = docs;
         };
 


### PR DESCRIPTION
This is a work in progress.

This clean and fixs the `nix develop` shells for GHC 9.2 and GHC 9.0.

See individual commits for details, but in summary:

- `nix develop .#haskell-language-server-ghc921-dev` now works.
- When entering the shell, it creates an alias for `cabal` which points to the correct `cabal-xxx.project`

I'm planning on testing on GHC 9.0 soon too (but right now it is building the world of dependencies).

Future commits to this MR will (hopefully) includes:

- Support for GHC 9.0
- I'd like to restore the CI steps related to nix/flake, as an optionnal step which can be triggered on demand by developers. It will also populate the cachix cache.
- Additional cleanups. I'm trying to remove all the explicit "hacks" `if version == ...`

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2655"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

