### PR TITLE
test: repro for #2662: extend import list miss separator

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1520,6 +1520,20 @@ extendImportTests = testGroup "extend import actions"
                     , "import ModuleA as A (stuffB, (.*))"
                     , "main = print (stuffB .* stuffB)"
                     ])
+        , testSession "extend single line import with infix constructor" $ template
+            []
+            ("ModuleB.hs", T.unlines
+                    [ "module ModuleB where"
+                    , "import Data.List.NonEmpty (fromList)"
+                    , "main = case (fromList []) of _ :| _ -> pure ()"
+                    ])
+            (Range (Position 2 5) (Position 2 6))
+            ["Add NonEmpty((:|)) to the import list of Data.List.NonEmpty"]
+            (T.unlines
+                    [ "module ModuleB where"
+                    , "import Data.List.NonEmpty (fromList, NonEmpty ((:|)))"
+                    , "main = case (fromList []) of _ :| _ -> pure ()"
+                    ])
         , testSession "extend single line import with type" $ template
             [("ModuleA.hs", T.unlines
                     [ "module ModuleA where"

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1534,6 +1534,22 @@ extendImportTests = testGroup "extend import actions"
                     , "import Data.List.NonEmpty (fromList, NonEmpty ((:|)))"
                     , "main = case (fromList []) of _ :| _ -> pure ()"
                     ])
+        , testSession "extend single line import with prefix constructor" $ template
+            []
+            ("ModuleB.hs", T.unlines
+                    [ "module ModuleB where"
+                    , "import Prelude hiding (Maybe(..))"
+                    , "import Data.Maybe (catMaybes)"
+                    , "x = Just 10"
+                    ])
+            (Range (Position 3 5) (Position 2 6))
+            ["Add Maybe(Just) to the import list of Data.Maybe"]
+            (T.unlines
+                    [ "module ModuleB where"
+                    , "import Prelude hiding (Maybe(..))"
+                    , "import Data.Maybe (catMaybes, Maybe (Just))"
+                    , "x = Just 10"
+                    ])
         , testSession "extend single line import with type" $ template
             [("ModuleA.hs", T.unlines
                     [ "module ModuleA where"

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1520,7 +1520,7 @@ extendImportTests = testGroup "extend import actions"
                     , "import ModuleA as A (stuffB, (.*))"
                     , "main = print (stuffB .* stuffB)"
                     ])
-        , ignoreForGHC92 "missing comma. #2662" $ testSession "extend single line import with infix constructor" $ template
+        , knownBrokenForGhcVersions [GHC92] "missing comma. #2662" $ testSession "extend single line import with infix constructor" $ template
             []
             ("ModuleB.hs", T.unlines
                     [ "module ModuleB where"
@@ -1534,7 +1534,7 @@ extendImportTests = testGroup "extend import actions"
                     , "import Data.List.NonEmpty (fromList, NonEmpty ((:|)))"
                     , "main = case (fromList []) of _ :| _ -> pure ()"
                     ])
-        , ignoreForGHC92 "missing comma. #2662" $ testSession "extend single line import with prefix constructor" $ template
+        , knownBrokenForGhcVersions [GHC92] "missing comma. #2662" $ testSession "extend single line import with prefix constructor" $ template
             []
             ("ModuleB.hs", T.unlines
                     [ "module ModuleB where"

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1520,7 +1520,7 @@ extendImportTests = testGroup "extend import actions"
                     , "import ModuleA as A (stuffB, (.*))"
                     , "main = print (stuffB .* stuffB)"
                     ])
-        , testSession "extend single line import with infix constructor" $ template
+        , ignoreForGHC92 "missing comma. #2662" $ testSession "extend single line import with infix constructor" $ template
             []
             ("ModuleB.hs", T.unlines
                     [ "module ModuleB where"
@@ -1534,7 +1534,7 @@ extendImportTests = testGroup "extend import actions"
                     , "import Data.List.NonEmpty (fromList, NonEmpty ((:|)))"
                     , "main = case (fromList []) of _ :| _ -> pure ()"
                     ])
-        , testSession "extend single line import with prefix constructor" $ template
+        , ignoreForGHC92 "missing comma. #2662" $ testSession "extend single line import with prefix constructor" $ template
             []
             ("ModuleB.hs", T.unlines
                     [ "module ModuleB where"


### PR DESCRIPTION
This is a repro for #2662.

I've tested with GHC 8.10.7, 9.0.2 and 9.2.1, using nix:

(Note: I do have to `export PATH` so it point to the correct `ghcide`. Is that the intended workflow or I missed something?)

GHC 9.2.1:

The import part is:

```diff
- "module ModuleB where\nimport Data.List.NonEmpty (fromList, NonEmpty ((:|)))\nmain = case (fromList []) of _ :| _ -> pure ()\n"
+ "module ModuleB where\nimport Data.List.NonEmpty (fromListNonEmpty ((:|)))\nmain = case (fromList []) of _ :| _ -> pure ()\n"
```

```
$ nix-shell -p haskell.compiler.ghc921 -p cabal-install -p zlib    

[nix-shell:~/srcs/haskell-language-server]$ export PATH=/home/guillaume/srcs/haskell-language-server/dist-newstyle/build/x86_64-linux/ghc-9.2.1/ghcide-1.6.0.0/x/ghcide/build/ghcide/:$PATH

[nix-shell:~/srcs/haskell-language-server]$ ls /home/guillaume/srcs/haskell-language-server/dist-newstyle/build/x86_64-linux/ghc-9.2.1/ghcide-1.6.0.0/x/ghcide/build/ghcide/
autogen  ghcide  ghcide-tmp

[nix-shell:~/srcs/haskell-language-server]$ cabal run --project-file ./cabal-ghc921.project ghcide:ghcide-tests -- -p 'infix constru'
Up to date
ghcide
  code actions
    extend import actions
      with checkAll
        extend single line import with infix constructor: FAIL (1.10s)
          test/exe/Main.hs:1827:
          expected: "module ModuleB where\nimport Data.List.NonEmpty (fromList, NonEmpty ((:|)))\nmain = case (fromList []) of _ :| _ -> pure ()\n"
           but got: "module ModuleB where\nimport Data.List.NonEmpty (fromListNonEmpty ((:|)))\nmain = case (fromList []) of _ :| _ -> pure ()\n"
          Use -p '/infix constru/&&/with checkAll.extend single line import with infix constructor/' to rerun this test only.
      without checkAll
        extend single line import with infix constructor: FAIL (1.11s)
          test/exe/Main.hs:1827:
          expected: "module ModuleB where\nimport Data.List.NonEmpty (fromList, NonEmpty ((:|)))\nmain = case (fromList []) of _ :| _ -> pure ()\n"
           but got: "module ModuleB where\nimport Data.List.NonEmpty (fromListNonEmpty ((:|)))\nmain = case (fromList []) of _ :| _ -> pure ()\n"
          Use -p '/infix constru/&&/without checkAll.extend single line import with infix constructor/' to rerun this test only.

2 out of 2 tests failed (2.22s)
```

GHC 9.0:

```
$ nix-shell -p haskell.compiler.ghc902 -p cabal-install -p zlib

[nix-shell:~/srcs/haskell-language-server]$ export PATH=/home/guillaume/srcs/haskell-language-server/dist-newstyle/build/x86_64-linux/ghc-9.0.2/ghcide-1.6.0.0/x/ghcide/build/ghcide:$PATH

[nix-shell:~/srcs/haskell-language-server]$ which ghcide
/home/guillaume/srcs/haskell-language-server/dist-newstyle/build/x86_64-linux/ghc-9.0.2/ghcide-1.6.0.0/x/ghcide/build/ghcide/ghcide

[nix-shell:~/srcs/haskell-language-server]$ cabal run --project-file ./cabal-ghc90.project ghcide:ghcide-tests -- -p 'infix constru'
Up to date
ghcide
  code actions
    extend import actions
      with checkAll
        extend single line import with infix constructor: OK (1.16s)
      without checkAll
        extend single line import with infix constructor: OK (1.14s)

All 2 tests passed (2.31s)
```

GHC 8.10.7:

```
λ narwal haskell-language-server → λ git repro_2662 → nix-shell -p haskell.compiler.ghc8107 -p cabal-install -p zlib

[nix-shell:~/srcs/haskell-language-server]$ export PATH=/home/guillaume/srcs/haskell-language-server/dist-newstyle/build/x86_64-linux/ghc-8.10.7/ghcide-1.6.0.0/x/ghcide/build/ghcide:$PATH
[nix-shell:~/srcs/haskell-language-server]$ which ghcide
/home/guillaume/srcs/haskell-language-server/dist-newstyle/build/x86_64-linux/ghc-8.10.7/ghcide-1.6.0.0/x/ghcide/build/ghcide/ghcide

[nix-shell:~/srcs/haskell-language-server]$ cabal run --project-file ghcide:ghcide-tests -- -p 'infix constru'
The given project file 'ghcide:ghcide-tests' does not exist.

[nix-shell:~/srcs/haskell-language-server]$ cabal run ghcide:ghcide-tests -- -p 'infix constru'
Resolving dependencies...
Up to date
ghcide
  code actions
    extend import actions
      with checkAll
        extend single line import with infix constructor: OK (1.06s)
      without checkAll
        extend single line import with infix constructor: OK (1.05s)

All 2 tests passed (2.11s)
```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2664"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

