### PR TITLE
Restore eval plugin build for GHC 9.2

### DIFF
--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -46,7 +46,6 @@ constraints:
     +ignore-plugins-ghc-bounds
     -brittany
     -class
-    -eval
     -haddockComments
     -hlint
     -retrie

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -95,6 +95,14 @@ import           System.IO.Extra                   (fixIO, newTempFileWithin)
 
 -- GHC API imports
 -- GHC API imports
+#if MIN_VERSION_ghc(9,2,0)
+import           GHC                               (Anchor (anchor),
+                                                    EpaComment (EpaComment),
+                                                    EpaCommentTok (EpaBlockComment, EpaLineComment),
+                                                    epAnnComments,
+                                                    priorComments)
+import           GHC.Hs                            (LEpaComment)
+#endif
 import           GHC                               (GetDocsFailure (..),
                                                     mgModSummaries,
                                                     parsedSource)
@@ -873,7 +881,12 @@ parseFileContents env customPreprocessor filename ms = do
      PFailedWithErrorMessages msgs -> throwE $ diagFromErrMsgs "parser" dflags $ msgs dflags
      POk pst rdr_module ->
          let
+#if MIN_VERSION_ghc(9,2,1)
+             -- TODO: we need to export the annotations here 
+             hpm_annotations = ()
+#else
              hpm_annotations = mkApiAnns pst
+#endif
              (warns, errs) = getMessages' pst dflags
          in
            do

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -881,12 +881,7 @@ parseFileContents env customPreprocessor filename ms = do
      PFailedWithErrorMessages msgs -> throwE $ diagFromErrMsgs "parser" dflags $ msgs dflags
      POk pst rdr_module ->
          let
-#if MIN_VERSION_ghc(9,2,1)
-             -- TODO: we need to export the annotations here 
-             hpm_annotations = ()
-#else
              hpm_annotations = mkApiAnns pst
-#endif
              (warns, errs) = getMessages' pst dflags
          in
            do

--- a/ghcide/src/Development/IDE/GHC/Compat/Parser.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Parser.hs
@@ -41,6 +41,8 @@ module Development.IDE.GHC.Compat.Parser (
 #if !MIN_VERSION_ghc(9,2,0)
     Anno.AnnotationComment(..),
 #endif
+    pattern EpaLineComment,
+    pattern EpaBlockComment
     ) where
 
 #if MIN_VERSION_ghc(9,0,0)
@@ -162,4 +164,9 @@ mkApiAnns pst =
      Map.fromList ((SrcLoc.noSrcSpan,comment_q pst)
                   :annotations_comments pst))
 #endif
+#endif
+
+#if !MIN_VERSION_ghc(9,2,0)
+pattern EpaLineComment a = Anno.AnnLineComment a
+pattern EpaBlockComment a = Anno.AnnBlockComment a
 #endif

--- a/ghcide/src/Development/IDE/GHC/Compat/Parser.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Parser.hs
@@ -51,12 +51,18 @@ import qualified GHC.Parser.Annotation           as Anno
 import qualified GHC.Parser.Lexer                as Lexer
 import           GHC.Types.SrcLoc                (PsSpan (..))
 #if MIN_VERSION_ghc(9,2,0)
-import           GHC                             (pm_extra_src_files,
+import           GHC                             (Anchor (anchor),
+                                                  EpAnnComments (priorComments),
+                                                  EpaComment (EpaComment),
+                                                  EpaCommentTok (..),
+                                                  epAnnComments,
+                                                  pm_extra_src_files,
                                                   pm_mod_summary,
                                                   pm_parsed_source)
 import qualified GHC
 import qualified GHC.Driver.Config               as Config
-import           GHC.Hs                          (hpm_module, hpm_src_files)
+import           GHC.Hs                          (LEpaComment, hpm_module,
+                                                  hpm_src_files)
 import           GHC.Parser.Lexer                hiding (initParserState)
 #endif
 #else
@@ -100,6 +106,8 @@ initParserState =
 #endif
 
 #if MIN_VERSION_ghc(9,2,0)
+-- GHC 9.2 does not have ApiAnns anymore packaged in ParsedModule. Now the
+-- annotations are found in the ast.
 type ApiAnns = ()
 #else
 type ApiAnns = Anno.ApiAnns

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -79,7 +79,6 @@ library
     , pretty-simple
     , QuickCheck
     , safe-exceptions
-    , temporary
     , text
     , time
     , transformers

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -676,7 +676,7 @@ doTypeCmd dflags arg = do
 
 parseExprMode :: Text -> (TcRnExprMode, T.Text)
 parseExprMode rawArg = case T.break isSpace rawArg of
-#if !MIN_VERSION_ghc(9,0,0)
+#if !MIN_VERSION_ghc(9,2,0)
     ("+v", rest) -> (TM_NoInst, T.strip rest)
 #endif
     ("+d", rest) -> (TM_Default, T.strip rest)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -77,8 +77,6 @@ import           GHC                             (ClsInst,
                                                   typeKind)
 #if MIN_VERSION_ghc(9,2,0)
 import           GHC                             (Fixity)
-#else
-import           GHC                             (setLogAction)
 #endif
 import qualified GHC.LanguageExtensions.Type     as LangExt (Extension (..))
 

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Rules.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Rules.hs
@@ -104,21 +104,12 @@ evalParsedModuleRule = defineEarlyCutoff $ RuleNoDiagnostics $ \GetEvalComments 
 
                         -- since Haddock parsing is unset explicitly in 'getParsedModuleWithComments',
                         -- we can concentrate on these two
-#if MIN_VERSION_ghc(9,2,0)
                         case bdy of
                             EpaLineComment cmt ->
                                 mempty { lineComments = Map.singleton curRan (RawLineComment cmt) }
                             EpaBlockComment cmt ->
                                 mempty { blockComments = Map.singleton curRan $ RawBlockComment cmt }
                             _ -> mempty
-#else
-                        case bdy of
-                            AnnLineComment cmt ->
-                                mempty { lineComments = Map.singleton curRan (RawLineComment cmt) }
-                            AnnBlockComment cmt ->
-                                mempty { blockComments = Map.singleton curRan $ RawBlockComment cmt }
-                            _ -> mempty
-#endif
                 _ -> mempty
             )
             $ apiAnnComments' pm

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Rules.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Rules.hs
@@ -36,6 +36,9 @@ import           Development.IDE.GHC.Compat
 import qualified Development.IDE.GHC.Compat           as SrcLoc
 import qualified Development.IDE.GHC.Compat.Util      as FastString
 import           Development.IDE.Graph                (alwaysRerun)
+#if MIN_VERSION_ghc(9,2,0)
+import           GHC.Parser.Annotation
+#endif
 import           Ide.Plugin.Eval.Types
 
 
@@ -53,14 +56,36 @@ queueForEvaluation ide nfp = do
     EvaluatingVar var <- getIdeGlobalState ide
     modifyIORef var (Set.insert nfp)
 
-#if MIN_VERSION_ghc(9,0,0)
+#if MIN_VERSION_ghc(9,2,0)
+getAnnotations :: Development.IDE.GHC.Compat.Located HsModule -> [LEpaComment]
+getAnnotations (L _ m@(HsModule { hsmodAnn = anns'})) =
+    priorComments annComments <> getFollowingComments annComments
+     <> concatMap getCommentsForDecl (hsmodImports m)
+     <> concatMap getCommentsForDecl (hsmodDecls m)
+       where
+         annComments = epAnnComments anns'
+
+getCommentsForDecl :: GenLocated (SrcSpanAnn' (EpAnn ann)) e
+                            -> [LEpaComment]
+getCommentsForDecl (L (SrcSpanAnn (EpAnn _ _ cs) _) _) = priorComments cs <> getFollowingComments cs
+getCommentsForDecl (L (SrcSpanAnn (EpAnnNotUsed) _) _) = []
+
+apiAnnComments' :: ParsedModule -> [SrcLoc.RealLocated EpaCommentTok]
+apiAnnComments' pm = do
+  L span (EpaComment c _) <- getAnnotations $ pm_parsed_source pm
+  pure (L (anchor span) c)
+
 pattern RealSrcSpanAlready :: SrcLoc.RealSrcSpan -> SrcLoc.RealSrcSpan
 pattern RealSrcSpanAlready x = x
-apiAnnComments' :: SrcLoc.ApiAnns -> [SrcLoc.RealLocated AnnotationComment]
-apiAnnComments' = apiAnnRogueComments
+#elif MIN_VERSION_ghc(9,0,0)
+apiAnnComments' :: ParsedModule -> [SrcLoc.RealLocated AnnotationComment]
+apiAnnComments' = apiAnnRogueComments . pm_annotations
+
+pattern RealSrcSpanAlready :: SrcLoc.RealSrcSpan -> SrcLoc.RealSrcSpan
+pattern RealSrcSpanAlready x = x
 #else
-apiAnnComments' :: SrcLoc.ApiAnns -> [SrcLoc.Located AnnotationComment]
-apiAnnComments' = concat . Map.elems . snd
+apiAnnComments' :: ParsedModule -> [SrcLoc.Located AnnotationComment]
+apiAnnComments' = concat . Map.elems . snd . pm_annotations
 
 pattern RealSrcSpanAlready :: SrcLoc.RealSrcSpan -> SrcSpan
 pattern RealSrcSpanAlready x = SrcLoc.RealSrcSpan x Nothing
@@ -68,7 +93,7 @@ pattern RealSrcSpanAlready x = SrcLoc.RealSrcSpan x Nothing
 
 evalParsedModuleRule :: Rules ()
 evalParsedModuleRule = defineEarlyCutoff $ RuleNoDiagnostics $ \GetEvalComments nfp -> do
-    (ParsedModule{..}, posMap) <- useWithStale_ GetParsedModuleWithComments nfp
+    (pm, posMap) <- useWithStale_ GetParsedModuleWithComments nfp
     let comments = foldMap (\case
                 L (RealSrcSpanAlready real) bdy
                     | FastString.unpackFS (srcSpanFile real) ==
@@ -79,15 +104,24 @@ evalParsedModuleRule = defineEarlyCutoff $ RuleNoDiagnostics $ \GetEvalComments 
 
                         -- since Haddock parsing is unset explicitly in 'getParsedModuleWithComments',
                         -- we can concentrate on these two
+#if MIN_VERSION_ghc(9,2,0)
+                        case bdy of
+                            EpaLineComment cmt ->
+                                mempty { lineComments = Map.singleton curRan (RawLineComment cmt) }
+                            EpaBlockComment cmt ->
+                                mempty { blockComments = Map.singleton curRan $ RawBlockComment cmt }
+                            _ -> mempty
+#else
                         case bdy of
                             AnnLineComment cmt ->
                                 mempty { lineComments = Map.singleton curRan (RawLineComment cmt) }
                             AnnBlockComment cmt ->
                                 mempty { blockComments = Map.singleton curRan $ RawBlockComment cmt }
                             _ -> mempty
+#endif
                 _ -> mempty
             )
-            $ apiAnnComments' pm_annotations
+            $ apiAnnComments' pm
         -- we only care about whether the comments are null
         -- this is valid because the only dependent is NeedsCompilation
         fingerPrint = fromString $ if nullComments comments then "" else "1"

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -261,7 +261,7 @@ diffOffConfig =
     unObject (Object obj) = obj
     unObject _            = undefined
 
-evalInFile :: FilePath -> T.Text -> T.Text -> IO ()
+evalInFile :: HasCallStack => FilePath -> T.Text -> T.Text -> IO ()
 evalInFile fp e expected = runSessionWithServer evalPlugin testDataDir $ do
   doc <- openDoc fp "haskell"
   origin <- documentContents doc

--- a/plugins/hls-eval-plugin/test/testdata/T10.ghc92.expected
+++ b/plugins/hls-eval-plugin/test/testdata/T10.ghc92.expected
@@ -1,0 +1,11 @@
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module T10 where
+import GHC.TypeNats ( type (+) )
+
+type Dummy = 1 + 1
+
+-- >>> type N = 1
+-- >>> type M = 40
+-- >>> :kind! N + M + 1
+-- N + M + 1 :: Natural
+-- = 42

--- a/plugins/hls-eval-plugin/test/testdata/T10.ghc92.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T10.ghc92.expected.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module T10 where
+import GHC.TypeNats ( type (+) )
+
+type Dummy = 1 + 1
+
+-- >>> type N = 1
+-- >>> type M = 40
+-- >>> :kind! N + M + 1
+-- N + M + 1 :: Natural
+-- = 42

--- a/plugins/hls-eval-plugin/test/testdata/T11.ghc92.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T11.ghc92.expected.hs
@@ -1,0 +1,4 @@
+module T11 where
+
+-- >>> :kind! a
+-- Not in scope: type variable `a'

--- a/plugins/hls-eval-plugin/test/testdata/T11.ghc92_expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T11.ghc92_expected.hs
@@ -1,0 +1,4 @@
+module T11 where
+
+-- >>> :kind! a
+-- Not in scope: type variable `a'

--- a/plugins/hls-eval-plugin/test/testdata/T12.ghc92.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T12.ghc92.expected.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module T12 where
+import GHC.TypeNats ( type (+) )
+
+type Dummy = 1 + 1
+
+-- >>> type N = 1
+-- >>> type M = 40
+-- >>> :kind N + M + 1
+-- N + M + 1 :: Natural

--- a/plugins/hls-eval-plugin/test/testdata/T12.ghc92_expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T12.ghc92_expected.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE DataKinds, TypeOperators #-}
+module T12 where
+import GHC.TypeNats ( type (+) )
+
+type Dummy = 1 + 1
+
+-- >>> type N = 1
+-- >>> type M = 40
+-- >>> :kind N + M + 1
+-- N + M + 1 :: Natural

--- a/plugins/hls-eval-plugin/test/testdata/T13.ghc92.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T13.ghc92.expected.hs
@@ -1,0 +1,4 @@
+module T13 where
+
+-- >>> :kind a
+-- Not in scope: type variable `a'

--- a/plugins/hls-eval-plugin/test/testdata/T13.ghc92_expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T13.ghc92_expected.hs
@@ -1,0 +1,4 @@
+module T13 where
+
+-- >>> :kind a
+-- Not in scope: type variable `a'

--- a/plugins/hls-eval-plugin/test/testdata/T15.ghc92_expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T15.ghc92_expected.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeApplications #-}
+module T15 where
+
+foo :: Show a => a -> String
+foo = show
+
+-- >>> :type  +v  foo @Int
+-- foo @Int :: Show Int => Int -> String

--- a/plugins/hls-eval-plugin/test/testdata/T17.ghc92.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T17.ghc92.expected.hs
@@ -1,0 +1,4 @@
+module T17 where
+
+-- >>> :type  +no 42
+-- parse error on input `+'

--- a/plugins/hls-eval-plugin/test/testdata/T17.ghc92_expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T17.ghc92_expected.hs
@@ -1,0 +1,4 @@
+module T17 where
+
+-- >>> :type  +no 42
+-- parse error on input ‘+’

--- a/plugins/hls-eval-plugin/test/testdata/T20.ghc92.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T20.ghc92.expected.hs
@@ -1,0 +1,7 @@
+module T20 where
+import Data.Word (Word)
+
+default (Word)
+
+-- >>> :type  +d   40+ 2 
+-- 40+ 2 :: Word

--- a/plugins/hls-eval-plugin/test/testdata/T20.ghc92_expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T20.ghc92_expected.hs
@@ -1,0 +1,7 @@
+module T20 where
+import Data.Word (Word)
+
+default (Word)
+
+-- >>> :type  +d   40+ 2 
+-- 40+ 2 :: Integer

--- a/plugins/hls-eval-plugin/test/testdata/TFlags.ghc92.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TFlags.ghc92.expected.hs
@@ -1,0 +1,62 @@
+-- Support for language options
+
+{-# LANGUAGE ScopedTypeVariables #-}
+module TFlags where
+
+-- Language options set in the module source (ScopedTypeVariables)
+-- also apply to tests so this works fine
+-- >>> f = (\(c::Char) -> [c])
+
+{- Multiple options can be set with a single `:set`
+
+>>> :set -XMultiParamTypeClasses -XFlexibleInstances
+>>> class Z a b c
+-}
+
+{-
+
+Options apply only in the section where they are defined (unless they are in the setup section), so this will fail:
+
+>>> class L a b c
+Too many parameters for class `L'
+(Enable MultiParamTypeClasses to allow multi-parameter classes)
+In the class declaration for `L'
+-}
+
+
+{-
+Options apply to all tests in the same section after their declaration.
+
+Not set yet:
+
+>>> class D
+No parameters for class `D'
+(Enable MultiParamTypeClasses to allow no-parameter classes)
+In the class declaration for `D'
+
+Now it works:
+
+>>>:set -XMultiParamTypeClasses
+>>> class C
+
+It still works
+
+>>> class F
+-}
+
+{- Now -package flag is handled correctly:
+
+>>> :set -package ghc-prim
+>>> import GHC.Prim
+
+-}
+
+
+{- Invalid option/flags are reported, but valid ones will be reflected
+
+>>> :set -XRank2Types -XAbsent -XDatatypeContexts -XWrong -fprint-nothing-at-all
+<interactive>: warning:
+    -XDatatypeContexts is deprecated: It was widely considered a misfeature, and has been removed from the Haskell language.
+Some flags have not been recognized: -XAbsent, -XWrong, -fprint-nothing-at-all
+
+-}

--- a/test/functional/Progress.hs
+++ b/test/functional/Progress.hs
@@ -33,7 +33,7 @@ tests =
                 let path = "diagnostics" </> "Foo.hs"
                 _ <- openDoc path "haskell"
                 expectProgressMessages [pack ("Setting up testdata (for " ++ path ++ ")"), "Processing", "Indexing"] []
-        , requiresEvalPlugin $ testCase "eval plugin sends progress reports" $
+        ,  knownBrokenForGhcVersions [GHC92] "No evaluation status with GHC 9.2" $ requiresEvalPlugin $ testCase "eval plugin sends progress reports" $
             runSession hlsCommand progressCaps "plugins/hls-eval-plugin/test/testdata" $ do
               doc <- openDoc "T1.hs" "haskell"
               lspId <- sendRequest STextDocumentCodeLens (CodeLensParams Nothing Nothing doc)


### PR DESCRIPTION
The eval plugin is building again and working partially. The codelens
(and evaluation) only happen for code in module comment, code appearing
in the top level comments / haddock are ignored. I need to walk the AST
to locate them.

This is work in progress for #2179.

![HLS_evalplugin](https://user-images.githubusercontent.com/9705357/151890157-23db231c-a082-4db2-8e48-bc2f4ebca90d.gif)


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2669"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

