### PR TITLE
Fix hlint parsing file with disabled extension

### DIFF
--- a/plugins/hls-hlint-plugin/README.md
+++ b/plugins/hls-hlint-plugin/README.md
@@ -5,3 +5,9 @@
 This is typically done through an [HLint configuration file](https://github.com/ndmitchell/hlint#customizing-the-hints).
 You can also change the behavior of HLint by adding a list of flags to `haskell.plugin.hlint.config.flags`
 if your configuration is in a non-standard location or you want to change settings globally.
+
+## Known Differences from the `hlint` executable
+
+- The `hlint` executable by default turns on many extensions when parsing a file because it is not certain about the exact extensions that apply to the file (they may come from project files). This differs from HLS which uses only the extensions the file needs to parse the file. Hence it is possible for the `hlint` executable to report a parse error on a file, but the `hlint` plugin to work just fine on the same file. This does mean that the turning on/off of extensions in the hlint config may be ignored by the `hlint` plugin.
+- Hlint restrictions do not work (yet). This [PR](https://github.com/ndmitchell/hlint/pull/1340) should enable that functionality, but this requires a newer version of hlint to be used in HLS.
+

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -55,7 +55,6 @@ import           Development.IDE.Core.Shake                         (getDiagnost
 import qualified Refact.Apply                                       as Refact
 
 #ifdef HLINT_ON_GHC_LIB
-import           Data.List                                          (nub)
 import           Development.IDE.GHC.Compat                         (BufSpan,
                                                                      DynFlags,
                                                                      WarningFlag (Opt_WarnUnrecognisedPragmas),

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -134,8 +134,7 @@ suggestionsTests =
         changeDoc doc [change']
         testHlintDiagnostics doc
 
-    , knownBrokenForHlintOnGhcLib "hlint doesn't take in account cpp flag as ghc -D argument" $
-      testCase "[#554] hlint diagnostics works with CPP via ghc -XCPP argument" $ runHlintSession "cpp" $ do
+    , testCase "[#554] hlint diagnostics works with CPP via ghc -XCPP argument" $ runHlintSession "cpp" $ do
         doc <- openDoc "CppCond.hs" "haskell"
         testHlintDiagnostics doc
 

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -212,8 +212,7 @@ suggestionsTests =
             length diags @?= 1
             unusedExt ^. L.code @?= Just (InR "refact:Unused LANGUAGE pragma")
 
-    , knownBrokenForHlintOnGhcLib "[#1279] hlint uses a fixed set of extensions" $
-      testCase "hlint should not activate extensions like PatternSynonyms" $ runHlintSession "" $ do
+    , testCase "[#1279] hlint should not activate extensions like PatternSynonyms" $ runHlintSession "" $ do
         doc <- openDoc "PatternKeyword.hs" "haskell"
 
         waitForAllProgressDone


### PR DESCRIPTION
Seems to fix #1279

All I did was not use the extensions that hlint turns on by default, and only use extensions found via the mod summary. The mod summary seems to also include extensions listed under the `extensions` stanza in the cabal file.

Not fully certain this doesn't break somebody's workflow.

If someone turns on an extension in the `hlint.yaml` and expects `hlint` to always consider it on I think that will conflict with this fix because I don't know how to disambiguate between an extension that is turned on by default by `hlint` and an extension turned on by the user in the `hlint.yaml`.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2671"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

