### PR TITLE
Add a test for #2673

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4653,6 +4653,15 @@ nonLocalCompletionTests =
        ]
        (Position 3 6)
        [],
+    testGroup "ordering"
+      [completionTest "qualified has priority"
+        ["module A where"
+        ,"import qualified Data.ByteString as BS"
+        ,"f = BS.read"
+        ]
+        (Position 2 10)
+        [("readFile", CiFunction, "readFile ${1:FilePath}", True, True, Nothing)]
+        ],
     testGroup "auto import snippets"
       [ completionCommandTest
         "show imports not in list - simple"


### PR DESCRIPTION
I cannot reproduce #2673 locally. Let's see if CI can

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2676"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

