### PR TITLE
Fix flaky boot def test

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -5553,6 +5553,13 @@ bootTests = testGroup "boot"
         -- Dirty the cache
         liftIO $ runInDir dir $ do
             cDoc <- createDoc cPath "haskell" cSource
+            -- We send a hover request then wait for either the hover response or
+            -- `ghcide/reference/ready` notification.
+            -- Once we receive one of the above, we wait for the other that we
+            -- haven't received yet.
+            -- If we don't wait for the `ready` notification it is possible 
+            -- that the `getDefinitions` request/response in the outer ghcide 
+            -- session will find no definitions.
             let hoverParams = HoverParams cDoc (Position 4 3) Nothing
             hoverRequestId <- sendRequest STextDocumentHover hoverParams
             let parseReadyMessage = satisfy $ \case

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -5554,11 +5554,6 @@ bootTests = testGroup "boot"
         liftIO $ runInDir dir $ do
             cDoc <- createDoc cPath "haskell" cSource
             _ <- getHover cDoc $ Position 4 3
-            ~() <- skipManyTill anyMessage $ satisfyMaybe $ \case
-                FromServerMess (SCustomMethod "ghcide/reference/ready") (NotMess NotificationMessage{_params = fp}) -> do
-                    A.Success fp' <- pure $ fromJSON fp
-                    if equalFilePath fp' cPath then pure () else Nothing
-                _ -> Nothing
             closeDoc cDoc
         cdoc <- createDoc cPath "haskell" cSource
         locs <- getDefinitions cdoc (Position 7 4)

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -5561,9 +5561,10 @@ bootTests = testGroup "boot"
                   _ -> False
             let parseHoverResponse = responseForId STextDocumentHover hoverRequestId
             hoverResponseOrReadyMessage <- skipManyTill anyMessage ((Left <$> parseHoverResponse) <|> (Right <$> parseReadyMessage))
-            case hoverResponseOrReadyMessage of
-              Left _ -> void $ skipManyTill anyMessage parseReadyMessage
-              Right _ -> void $ skipManyTill anyMessage parseHoverResponse 
+            _ <- skipManyTill anyMessage $ 
+              case hoverResponseOrReadyMessage of
+                Left _ -> void parseReadyMessage
+                Right _ -> void parseHoverResponse
             closeDoc cDoc
         cdoc <- createDoc cPath "haskell" cSource
         locs <- getDefinitions cdoc (Position 7 4)


### PR DESCRIPTION
Should fix #2677

I could not reproduce it locally, but I found in the logs that it is possible for `getHover` to eat a `ghcide/reference/ready` custom message. If that happens the `skipManyTill` `ghcide/references/ready` will be starving until timeout. Not sure why this happens more often (or only?) on the 9.0.2 ubuntu-latest tests.

The fix skips messages until the hover response or `ghcide/reference/ready`, and depending on which was received skips messages until receiving the other.

In all the other places I could find where something similar happens they either do `getHover` or `skipManyTill` `ghcide/references/ready` but not both, and so that's why we don't see these problems in other tests.

As a side note at first I didn't realize more than one ghcide process was being run so the logs were very confusing.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2686"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

