### PR TITLE
Optionally publish packages definitely in the hackage workflow

### DIFF
--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -8,8 +8,12 @@ concurrency:
 on:
   workflow_dispatch:
     inputs:
-      upload-candidates:
+      upload:
         description: 'Whether packages should be uploaded'
+        required: true
+        default: 'false'
+      publish:
+        description: 'Wheter packages should be published as definitive'
         required: true
         default: 'false'
   push:
@@ -20,7 +24,7 @@ jobs:
   check-and-upload-tarballs:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: ${{ github.event.inputs.upload-candidates != 'false' }}
+      fail-fast: ${{ github.event.inputs.upload != 'false' }}
       matrix:
         package: ["hie-compat", "hls-graph", "shake-bench",
                   "hls-plugin-api", "ghcide", "hls-test-utils",
@@ -138,8 +142,10 @@ jobs:
           name: ${{ matrix.package }}
           path: ${{ steps.generate-dist-tarball.outputs.path }}
 
-  upload-candidate:
-    if: github.event.inputs.upload-candidates != 'false'
+  upload-package:
+    # Runs triggered by *-hackage branches will upload packages
+    # cause inputs are blank when the workflow is not triggered manually
+    if: github.event.inputs.upload != 'false'
     needs: check-and-upload-tarballs
     runs-on: ubuntu-latest
     steps:
@@ -156,4 +162,5 @@ jobs:
         with:
           hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
           packagesPath: packages
-          publish: false
+          # runs triggered by *-hackage branches will not publish packages definitely
+          publish: {{ github.event.inputs.publish == 'true' }}

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -45,7 +45,7 @@ and it is being used in nix environments.
 - [ ] create ${version}-hackage branch to trigger the hackage github workflow which will upload all changed packages to hackage as candidates
 - [ ] for new plugins or packages, update hackage uploaders to add the author of the plugin/package and some hls maintainer(s) other than the owner of the hackage api key used to upload them (it has to be done by the owner of the api key, actually @pepeiborra)
 - [ ] check manually candidates in hackage
-- [ ] publish them definitely
+- [ ] publish them definitely triggering a manual run of the hackage workflow setting the upload and publish inputs to `true`
 
 ### ghcup release
 


### PR DESCRIPTION
Via a manual run setting publish=="true"

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2689"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

