### PR TITLE
Build Alternate Number Format Plugin with GHC 9.2

### DIFF
--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -44,7 +44,6 @@ constraints:
   -- These plugins don't build/work on GHC92 yet
   haskell-language-server
     +ignore-plugins-ghc-bounds
-    -alternateNumberFormat
     -brittany
     -class
     -eval

--- a/ghcide/src/Development/IDE/GHC/Compat/Core.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Core.hs
@@ -141,6 +141,9 @@ module Development.IDE.GHC.Compat.Core (
     ImportSpec(..),
     -- * SourceText
     SourceText(..),
+#if !MIN_VERSION_ghc(9,2,0)
+    rationalFromFractionalLit,
+#endif
     -- * Name
     tyThingParent_maybe,
     -- * Ways
@@ -1075,4 +1078,9 @@ collectHsBindsBinders x = GHC.collectHsBindsBinders CollNoDictBinders x
 #if !MIN_VERSION_ghc(9,2,0)
 pattern HsLet xlet localBinds expr <- GHC.HsLet xlet (SrcLoc.unLoc -> localBinds) expr
 pattern LetStmt xlet localBinds <- GHC.LetStmt xlet (SrcLoc.unLoc -> localBinds)
+#endif
+
+#if !MIN_VERSION_ghc(9,2,0)
+rationalFromFractionalLit :: FractionalLit -> Rational
+rationalFromFractionalLit = fl_value
 #endif

--- a/plugins/hls-alternate-number-format-plugin/README.md
+++ b/plugins/hls-alternate-number-format-plugin/README.md
@@ -38,3 +38,9 @@ To generate suggestions, the plugin leverages the `Numeric` package which provid
 ## Changelog
 ### 1.0.0.0
 - First Release
+
+### 1.0.1.0
+- Dependency upgrades
+
+### 1.0.1.1
+- Buildable with GHC 9.2

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-alternate-number-format-plugin
-version:            1.0.1.0
+version:            1.0.1.1
 synopsis:           Provide Alternate Number Formats plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/Literals.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/Literals.hs
@@ -85,7 +85,7 @@ fromIntegralLit :: RealSrcSpan -> IntegralLit -> Maybe Literal
 fromIntegralLit s IL{..} = fmap (\txt' -> IntLiteral s txt' il_value) (fromSourceText il_text)
 
 fromFractionalLit  :: RealSrcSpan -> FractionalLit -> Maybe Literal
-fromFractionalLit s FL{..} = fmap (\txt' -> FracLiteral s txt' fl_value) (fromSourceText fl_text)
+fromFractionalLit s fl@FL{fl_text} = fmap (\txt' -> FracLiteral s txt' (rationalFromFractionalLit fl)) (fromSourceText fl_text)
 
 fromSourceText :: SourceText -> Maybe Text
 fromSourceText = \case
@@ -116,5 +116,5 @@ literalToString = \case
 overLitToString :: OverLitVal -> String
 overLitToString = \case
      HsIntegral int -> case int of { IL{il_value} -> "IntegralOverLit: " <> show il_value}
-     HsFractional frac -> case frac of { FL{fl_value} -> "RationalOverLit: " <> show fl_value}
+     HsFractional frac -> case frac of { fl -> "RationalOverLit: " <> show (rationalFromFractionalLit fl)}
      HsIsString _ str -> "HIsString: " <> show str


### PR DESCRIPTION
Didn't realize `hls-alternate-number-format-plugin` wasn't able to work with 9.2 yet. Added a `compat` function for upgrade. 

For reference, 9.2 updates the `FractionalLit` data type and the conversion from `FractionalLit -> Rational` is hidden behind the helper `rationalFromFractionalLit`. 

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2696"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

