### PR TITLE
fix: handle comma in extend import list with ghc 9.2

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -496,11 +496,12 @@ extendImportViaParent df parent child (L l it@ImportDecl{..})
           listAnn = epAnn srcParent [AddEpAnn AnnOpenP (epl 1), AddEpAnn AnnCloseP (epl 0)]
           x :: LIE GhcPs = reLocA $ L l'' $ IEThingWith listAnn parentLIE NoIEWildcard [childLIE]
 
-      x <- pure $ setEntryDP x (SameLine $ if (not (null pre)) then 1 else 0)
+      let hasSibling = not (null pre)
+      x <- pure $ setEntryDP x (SameLine $ if hasSibling then 1 else 0)
 
       let
 
-          fixLast = if not (null pre) then first addComma else id
+          fixLast = if hasSibling then first addComma else id
           lies' = over _last fixLast lies ++ [x]
           lies = reverse pre
       

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1520,7 +1520,7 @@ extendImportTests = testGroup "extend import actions"
                     , "import ModuleA as A (stuffB, (.*))"
                     , "main = print (stuffB .* stuffB)"
                     ])
-        , knownBrokenForGhcVersions [GHC92] "missing comma. #2662" $ testSession "extend single line import with infix constructor" $ template
+        , testSession "extend single line import with infix constructor" $ template
             []
             ("ModuleB.hs", T.unlines
                     [ "module ModuleB where"
@@ -1534,7 +1534,7 @@ extendImportTests = testGroup "extend import actions"
                     , "import Data.List.NonEmpty (fromList, NonEmpty ((:|)))"
                     , "main = case (fromList []) of _ :| _ -> pure ()"
                     ])
-        , knownBrokenForGhcVersions [GHC92] "missing comma. #2662" $ testSession "extend single line import with prefix constructor" $ template
+        , testSession "extend single line import with prefix constructor" $ template
             []
             ("ModuleB.hs", T.unlines
                     [ "module ModuleB where"


### PR DESCRIPTION
The comma annotation was missing.

Close #2662.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2697"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

