### PR TITLE
Fix min bound for ghc-exactprint dependency in hls-class-plugin

### DIFF
--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -28,7 +28,7 @@ library
     , base            >=4.12 && <5
     , containers
     , ghc
-    , ghc-exactprint
+    , ghc-exactprint  >= 0.6.4
     , ghcide          ^>=1.6
     , hls-plugin-api  ^>=1.3
     , lens


### PR DESCRIPTION
Earlier versions of ghc-exactprint lead to a build error:
```
[1 of 1] Compiling Ide.Plugin.Class ( src/Ide/Plugin/Class.hs, dist/dist-sandbox-fb36eb2d/build/Ide/Plugin/Class.o )

src/Ide/Plugin/Class.hs:36:59: error:
    Module `Language.Haskell.GHC.ExactPrint.Utils' does not export `rs'
   |
36 | import           Language.Haskell.GHC.ExactPrint.Utils   (rs)
   |                                                           ^^

```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2710"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

