### PR TITLE
Remove `getHspecFormattedConfig` which is no longer used

### DIFF
--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -44,7 +44,7 @@ library
     , ghcide                  ^>=1.6
     , hls-graph
     , hls-plugin-api          ^>=1.3
-    , hspec                   <2.8
+    , hspec                   <2.10
     , hspec-core
     , lens
     , lsp                     ^>=1.4

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -44,8 +44,6 @@ library
     , ghcide                  ^>=1.6
     , hls-graph
     , hls-plugin-api          ^>=1.3
-    , hspec                   <2.10
-    , hspec-core
     , lens
     , lsp                     ^>=1.4
     , lsp-test                ^>=0.14


### PR DESCRIPTION
Remove hspec dependency

Closes: https://github.com/haskell/haskell-language-server/issues/1835

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2721"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

