### PR TITLE
Tone down logging of plugin rules

### DIFF
--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -80,4 +80,4 @@ shutdown = shakeShut
 -- e.g., the ofInterestRule.
 runAction :: String -> IdeState -> Action a -> IO a
 runAction herald ide act =
-  join $ shakeEnqueue (shakeExtras ide) (mkDelayedAction herald Logger.Info act)
+  join $ shakeEnqueue (shakeExtras ide) (mkDelayedAction herald Logger.Debug act)

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -5492,7 +5492,8 @@ simpleSubDirectoryTest =
     expectNoMoreDiagnostics 0.5
 
 simpleMultiTest :: TestTree
-simpleMultiTest = testCase "simple-multi-test" $ withLongTimeout $ runWithExtraFiles "multi" $ \dir -> do
+simpleMultiTest =  knownBrokenForGhcVersions [GHC92] "#2693" $
+  testCase "simple-multi-test" $ withLongTimeout $ runWithExtraFiles "multi" $ \dir -> do
     let aPath = dir </> "a/A.hs"
         bPath = dir </> "b/B.hs"
     adoc <- openDoc aPath "haskell"


### PR DESCRIPTION
Lower the verbosity of most plugin build actions to `Debug`, e.g. log lines like:
```
2022-02-19 08:49:46.711648 [ThreadId 9491] INFO hls:	finish: Wingman.judgementForHole.TypeCheck (took 0.00s)
2022-02-19 08:49:46.711712 [ThreadId 9492] INFO hls:	finish: Wingman.judgementForHole.False (took 0.00s)
2022-02-19 08:49:46.712412 [ThreadId 9493] INFO hls:	finish: Wingman.getIdeDynflags.GetModSummaryWithoutTimestamps (took 0.00s)
2022-02-19 08:49:46.71311 [ThreadId 9494] INFO hls:	finish: Wingman.judgementForHole.GetHieAst (took 0.00s)
2022-02-19 08:49:46.713207 [ThreadId 9495] INFO hls:	finish: Wingman.judgementForHole.GetBindings (took 0.00s)
2022-02-19 08:49:46.713284 [ThreadId 9497] INFO hls:	finish: Wingman.judgementForHole.False (took 0.00s)
2022-02-19 08:49:46.713254 [ThreadId 9496] INFO hls:	finish: Wingman.judgementForHole.TypeCheck (took 0.00s)
2022-02-19 08:49:46.714026 [ThreadId 9498] INFO hls:	finish: Wingman.getIdeDynflags.GetModSummaryWithoutTimestamps (took 0.00s)
2022-02-19 08:49:46.714757 [ThreadId 9499] INFO hls:	finish: Wingman.judgementForHole.GetHieAst (took 0.00s)
2022-02-19 08:49:46.714845 [ThreadId 9500] INFO hls:	finish: Wingman.judgementForHole.GetBindings (took 0.00s)
2022-02-19 08:49:46.714929 [ThreadId 9501] INFO hls:	finish: Wingman.judgementForHole.TypeCheck (took 0.00s)
2022-02-19 08:49:46.71502 [ThreadId 9502] INFO hls:	finish: Wingman.judgementForHole.False (took 0.00s)
2022-02-19 08:49:46.715739 [ThreadId 9503] INFO hls:	finish: Wingman.getIdeDynflags.GetModSummaryWithoutTimestamps (took 0.00s)
2022-02-19 08:49:46.716417 [ThreadId 9504] INFO hls:	finish: Wingman.judgementForHole.GetHieAst (took 0.00s)
2022-02-19 08:49:46.716446 [ThreadId 9505] INFO hls:	finish: Wingman.judgementForHole.GetBindings (took 0.00s)
2022-02-19 08:49:46.716513 [ThreadId 9506] INFO hls:	finish: Wingman.judgementForHole.TypeCheck (took 0.00s)
2022-02-19 08:49:46.71658 [ThreadId 9507] INFO hls:	finish: Wingman.judgementForHole.False (took 0.00s)
2022-02-19 08:49:46.71738 [ThreadId 9508] INFO hls:	finish: Wingman.getIdeDynflags.GetModSummaryWithoutTimestamps (took 0.00s)
2022-02-19 08:49:46.718139 [ThreadId 9509] INFO hls:	finish: Wingman.judgementForHole.GetHieAst (took 0.00s)
2022-02-19 08:49:46.718165 [ThreadId 9510] INFO hls:	finish: Wingman.judgementForHole.GetBindings (took 0.00s)
2022-02-19 08:49:46.718209 [ThreadId 9511] INFO hls:	finish: Wingman.judgementForHole.TypeCheck (took 0.00s)
2022-02-19 08:49:46.71832 [ThreadId 9512] INFO hls:	finish: Wingman.judgementForHole.False (took 0.00s)
2022-02-19 08:49:46.719102 [ThreadId 9513] INFO hls:	finish: Wingman.getIdeDynflags.GetModSummaryWithoutTimestamps (took 0.00s)
2022-02-19 08:49:46.719752 [ThreadId 9514] INFO hls:	finish: Wingman.judgementForHole.GetHieAst (took 0.00s)
2022-02-19 08:49:46.719806 [ThreadId 9515] INFO hls:	finish: Wingman.judgementForHole.GetBindings (took 0.00s)
2022-02-19 08:49:46.719859 [ThreadId 9516] INFO hls:	finish: Wingman.judgementForHole.TypeCheck (took 0.00s)
2022-02-19 08:49:46.719932 [ThreadId 9517] INFO hls:	finish: Wingman.judgementForHole.False (took 0.00s)
2022-02-19 08:49:46.991796 [ThreadId 9539] INFO hls:	finish: RefineImports (took 0.00s)
2022-02-19 08:49:46.992232 [ThreadId 9532] INFO hls:	finish: HaddockComments.GetAnnotatedParsedSource (took 0.00s)
2022-02-19 08:49:46.992635 [ThreadId 9538] INFO hls:	finish: importLens (took 0.00s)
2022-02-19 08:49:46.993622 [ThreadId 9540] INFO hls:	finish: splice.codeAction.GitHieAst (took 0.00s)
2022-02-19 08:49:46.993758 [ThreadId 9541] INFO hls:	finish: Wingman.getIdeDynflags.GetModSummaryWithoutTimestamps (took 0.00s)
2022-02-19 08:49:46.994396 [ThreadId 9543] INFO hls:	finish: Pragmas.GhcSession (took 0.00s)
2022-02-19 08:49:46.994685 [ThreadId 9545] INFO hls:	finish: Pragmas.GetFileContents (took 0.00s)
2022-02-19 08:49:46.99481 [ThreadId 9544] INFO hls:	finish: retrie (took 0.00s)
2022-02-19 08:49:46.994852 [ThreadId 9547] INFO hls:	finish: Pragmas.GetParsedModule (took 0.00s)
2022-02-19 08:49:46.995105 [ThreadId 9546] INFO hls:	finish: Wingman.judgementForHole.GetHieAst (took 0.00s)
2022-02-19 08:49:46.995404 [ThreadId 9548] INFO hls:	finish: Wingman.judgementForHole.GetBindings (took 0.00s)
2022-02-19 08:49:46.995711 [ThreadId 9550] INFO hls:	finish: Wingman.judgementForHole.False (took 0.00s)
2022-02-19 08:49:46.995643 [ThreadId 9549] INFO hls:	finish: Wingman.judgementForHole.TypeCheck (took 0.00s)
2022-02-19 08:49:46.995938 [ThreadId 9551] INFO hls:	finish: QualifyImportedNames.TypeCheck (took 0.00s)
2022-02-19 08:49:46.996289 [ThreadId 9552] INFO hls:	finish: Hlint.GetFileContents (took 0.00s)
2022-02-19 08:49:46.996325 [ThreadId 9554] INFO hls:	finish: Hlint.GetModSummary (took 0.00s)
2022-02-19 08:49:46.996526 [ThreadId 9553] INFO hls:	finish: AlternateNumberFormat.CollectLiterals (took 0.00s)
2022-02-19 08:49:46.99667 [ThreadId 9542] INFO hls:	finish: GhcideCodeActions.getParsedModule (took 0.00s)
```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2723"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

