### PR TITLE
Upgrade to hie-bios 0.9.0

### DIFF
--- a/cabal-ghc90.project
+++ b/cabal-ghc90.project
@@ -63,3 +63,8 @@ allow-newer:
   -- ghc-9.0.2 specific
   -- for ghcide:test via ghc-typelits-knownnat
   ghc-typelits-natnormalise:ghc-bignum
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell/hie-bios.git
+    tag: 2e4161151980f65676de3eae2a71ec2bbb5006be

--- a/cabal-ghc90.project
+++ b/cabal-ghc90.project
@@ -36,7 +36,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-01-24T21:03:03Z
+index-state: 2022-02-25T21:47:10Z
 
 constraints:
   -- These plugins don't work on GHC9 yet
@@ -63,8 +63,3 @@ allow-newer:
   -- ghc-9.0.2 specific
   -- for ghcide:test via ghc-typelits-knownnat
   ghc-typelits-natnormalise:ghc-bignum
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell/hie-bios.git
-    tag: 2e4161151980f65676de3eae2a71ec2bbb5006be

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -38,7 +38,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-01-24T21:03:03Z
+index-state: 2022-02-25T21:47:10Z
 
 constraints:
   -- These plugins don't build/work on GHC92 yet
@@ -105,8 +105,3 @@ allow-newer:
 
 allow-older:
   primitive-extras:primitive-unlifted
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell/hie-bios.git
-    tag: 2e4161151980f65676de3eae2a71ec2bbb5006be

--- a/cabal-ghc921.project
+++ b/cabal-ghc921.project
@@ -105,3 +105,8 @@ allow-newer:
 
 allow-older:
   primitive-extras:primitive-unlifted
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell/hie-bios.git
+    tag: 2e4161151980f65676de3eae2a71ec2bbb5006be

--- a/cabal.project
+++ b/cabal.project
@@ -50,3 +50,8 @@ allow-newer:
     -- for shake-bench
     Chart-diagrams:diagrams-core,
     SVGFonts:diagrams-core
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell/hie-bios.git
+    tag: 2e4161151980f65676de3eae2a71ec2bbb5006be

--- a/cabal.project
+++ b/cabal.project
@@ -41,7 +41,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-01-24T21:03:03Z
+index-state: 2022-02-25T21:47:10Z
 
 constraints:
     hyphenation +embed
@@ -50,8 +50,3 @@ allow-newer:
     -- for shake-bench
     Chart-diagrams:diagrams-core,
     SVGFonts:diagrams-core
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell/hie-bios.git
-    tag: 2e4161151980f65676de3eae2a71ec2bbb5006be

--- a/flake.nix
+++ b/flake.nix
@@ -112,8 +112,8 @@
             with haskell.lib; {
               # Patches don't apply
               github = overrideCabal hsuper.github (drv: { patches = []; });
-              # GHCIDE requires hie-bios >=0.8 && <0.9.0
-              hie-bios = hself.hie-bios_0_8_0;
+              # GHCIDE requires hie-bios ^>=0.9.0
+              hie-bios = hself.hie-bios_0_9_0;
               # We need an older version
               hiedb = hself.hiedb_0_4_1_0;
 

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,10 @@
       url = "https://hackage.haskell.org/package/implicit-hie-cradle-0.3.0.5/implicit-hie-cradle-0.3.0.5.tar.gz";
       flake = false;
     };
+    hie-bios = {
+      url = "https://hackage.haskell.org/package/hie-bios-0.9.0/hie-bios-0.9.0.tar.gz";
+      flake = false;
+    };
   };
   outputs =
     inputs@{ self, nixpkgs, flake-compat, flake-utils, pre-commit-hooks, gitignore, ... }:
@@ -364,7 +368,7 @@
           # distributed using nix.
           all-haskell-language-server = linkFarmFromDrvs "all-haskell-language-server" (lib.unique (builtins.attrValues allPackages));
 
-          # Same for all shells 
+          # Same for all shells
           # We try to build as much as possible, but not much shells are
           # working (especially on darwing), so this list is limited.
           all-nix-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique [nixDevShells.haskell-language-server-dev-nix]));

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
               # Patches don't apply
               github = overrideCabal hsuper.github (drv: { patches = []; });
               # GHCIDE requires hie-bios ^>=0.9.0
-              hie-bios = hself.hie-bios_0_9_0;
+              hie-bios = hself.callCabal2nix "hie-bios" inputs.hie-bios {};
               # We need an older version
               hiedb = hself.hiedb_0_4_1_0;
 

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -104,7 +104,7 @@ library
         ghc-check >=0.5.0.4,
         ghc-paths,
         cryptohash-sha1 >=0.11.100 && <0.12,
-        hie-bios >= 0.8 && < 0.9.0,
+        hie-bios >= 0.9.0,
         implicit-hie-cradle ^>= 0.3.0.5 || ^>= 0.5,
         base16-bytestring >=0.1.1 && <1.1
     if os(windows)

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -104,7 +104,7 @@ library
         ghc-check >=0.5.0.4,
         ghc-paths,
         cryptohash-sha1 >=0.11.100 && <0.12,
-        hie-bios >= 0.9.0,
+        hie-bios ^>= 0.9.0,
         implicit-hie-cradle ^>= 0.3.0.5 || ^>= 0.5,
         base16-bytestring >=0.1.1 && <1.1
     if os(windows)

--- a/stack-8.10.6.yaml
+++ b/stack-8.10.6.yaml
@@ -42,8 +42,7 @@ extra-deps:
   - extra-1.7.10
   - floskell-0.10.5@sha256:77f0bc1569573d9666b10975a5357fef631d32266c071733739393ccae521dab,3803
   - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
-  - github: haskell/hie-bios
-    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
+  - hie-bios-0.9.0
   - hiedb-0.4.1.0
   - hlint-3.2.8
   - implicit-hie-0.1.2.6@sha256:f50a908979a574a881f753c0f9a5224f023f438b30fdefc5b7fa01803b07a280,2998

--- a/stack-8.10.6.yaml
+++ b/stack-8.10.6.yaml
@@ -42,7 +42,8 @@ extra-deps:
   - extra-1.7.10
   - floskell-0.10.5@sha256:77f0bc1569573d9666b10975a5357fef631d32266c071733739393ccae521dab,3803
   - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
-  - hie-bios-0.8.0
+  - github: haskell/hie-bios
+    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
   - hiedb-0.4.1.0
   - hlint-3.2.8
   - implicit-hie-0.1.2.6@sha256:f50a908979a574a881f753c0f9a5224f023f438b30fdefc5b7fa01803b07a280,2998

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -43,8 +43,7 @@ extra-deps:
   - extra-1.7.10
   - floskell-0.10.5@sha256:77f0bc1569573d9666b10975a5357fef631d32266c071733739393ccae521dab,3803
   - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
-  - github: haskell/hie-bios
-    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
+  - hie-bios-0.9.0
   - hiedb-0.4.1.0
   - hlint-3.2.8
   - implicit-hie-0.1.2.6@sha256:f50a908979a574a881f753c0f9a5224f023f438b30fdefc5b7fa01803b07a280,2998

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -43,7 +43,8 @@ extra-deps:
   - extra-1.7.10
   - floskell-0.10.5@sha256:77f0bc1569573d9666b10975a5357fef631d32266c071733739393ccae521dab,3803
   - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
-  - hie-bios-0.8.0
+  - github: haskell/hie-bios
+    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
   - hiedb-0.4.1.0
   - hlint-3.2.8
   - implicit-hie-0.1.2.6@sha256:f50a908979a574a881f753c0f9a5224f023f438b30fdefc5b7fa01803b07a280,2998

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -62,7 +62,8 @@ extra-deps:
   - haddock-library-1.10.0
   - hashable-1.3.0.0
   - heapsize-0.3.0
-  - hie-bios-0.8.0
+  - github: haskell/hie-bios
+    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
   - hlint-3.2.8
   - HsYAML-0.2.1.0@rev:1
   - HsYAML-aeson-0.2.0.0@rev:2
@@ -79,7 +80,7 @@ extra-deps:
   - optparse-applicative-0.15.1.0
   - ormolu-0.1.4.1
   - parser-combinators-1.2.1
-  - prettyprinter-1.7.1 
+  - prettyprinter-1.7.1
   - primitive-0.7.1.0
   - refinery-0.4.0.0
   - regex-base-0.94.0.0
@@ -115,7 +116,6 @@ extra-deps:
   - stm-hamt-1.2.0.6@sha256:fba86ccb4b45c5706c19b0e1315ba63dcac3b5d71de945ec001ba921fae80061,3972
   - primitive-extras-0.10.1
   - primitive-unlifted-0.1.3.1
-
 configure-options:
   ghcide:
     - --disable-library-for-ghci

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -62,8 +62,7 @@ extra-deps:
   - haddock-library-1.10.0
   - hashable-1.3.0.0
   - heapsize-0.3.0
-  - github: haskell/hie-bios
-    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
+  - hie-bios-0.9.0
   - hlint-3.2.8
   - HsYAML-0.2.1.0@rev:1
   - HsYAML-aeson-0.2.0.0@rev:2

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -52,7 +52,8 @@ extra-deps:
   - ghc-trace-events-0.1.2.1
   - haskell-src-exts-1.21.1
   - heapsize-0.3.0
-  - hie-bios-0.8.0
+  - github: haskell/hie-bios
+    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
   - hlint-3.2.8
   - HsYAML-aeson-0.2.0.0@rev:2
   - hoogle-5.0.17.11

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -52,8 +52,7 @@ extra-deps:
   - ghc-trace-events-0.1.2.1
   - haskell-src-exts-1.21.1
   - heapsize-0.3.0
-  - github: haskell/hie-bios
-    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
+  - hie-bios-0.9.0
   - hlint-3.2.8
   - HsYAML-aeson-0.2.0.0@rev:2
   - hoogle-5.0.17.11

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -45,6 +45,8 @@ extra-deps:
 - floskell-0.10.6
 - heapsize-0.3.0.1
 - hiedb-0.4.1.0
+- github: haskell/hie-bios
+  commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
 - implicit-hie-0.1.2.6
 - implicit-hie-cradle-0.3.0.5
 - monad-dijkstra-0.1.1.3

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -45,8 +45,7 @@ extra-deps:
 - floskell-0.10.6
 - heapsize-0.3.0.1
 - hiedb-0.4.1.0
-- github: haskell/hie-bios
-  commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
+- hie-bios-0.9.0
 - implicit-hie-0.1.2.6
 - implicit-hie-cradle-0.3.0.5
 - monad-dijkstra-0.1.1.3

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -45,6 +45,8 @@ extra-deps:
 - floskell-0.10.6
 - heapsize-0.3.0.1
 - hiedb-0.4.1.0
+- github: haskell/hie-bios
+  commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
 - implicit-hie-0.1.2.6
 - implicit-hie-cradle-0.3.0.5
 - monad-dijkstra-0.1.1.3

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -45,8 +45,7 @@ extra-deps:
 - floskell-0.10.6
 - heapsize-0.3.0.1
 - hiedb-0.4.1.0
-- github: haskell/hie-bios
-  commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
+- hie-bios-0.9.0
 - implicit-hie-0.1.2.6
 - implicit-hie-cradle-0.3.0.5
 - monad-dijkstra-0.1.1.3

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -50,8 +50,7 @@ extra-deps:
 - ghc-lib-parser-ex-9.2.0.1
 - heapsize-0.3.0.1
 - hiedb-0.4.1.0
-- github: haskell/hie-bios
-  commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
+- hie-bios-0.9.0
 - hspec-2.7.10       # for hls-test-utils
 - hspec-core-2.7.10  # for hls-test-utils
 - implicit-hie-0.1.2.6

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -50,6 +50,8 @@ extra-deps:
 - ghc-lib-parser-ex-9.2.0.1
 - heapsize-0.3.0.1
 - hiedb-0.4.1.0
+- github: haskell/hie-bios
+  commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
 - hspec-2.7.10       # for hls-test-utils
 - hspec-core-2.7.10  # for hls-test-utils
 - implicit-hie-0.1.2.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,8 +43,9 @@ extra-deps:
   - extra-1.7.10
   - floskell-0.10.5@sha256:77f0bc1569573d9666b10975a5357fef631d32266c071733739393ccae521dab,3803
   - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
-  - hie-bios-0.8.0
   - hiedb-0.4.1.0
+  - github: haskell/hie-bios
+    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
   - hlint-3.2.8
   - implicit-hie-0.1.2.6@sha256:f50a908979a574a881f753c0f9a5224f023f438b30fdefc5b7fa01803b07a280,2998
   - implicit-hie-cradle-0.3.0.5@sha256:5f5e575f549b2a9db664be7650b5c3c9226e313bddc46c79e2e83eb349f8e692,2610

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,8 +44,7 @@ extra-deps:
   - floskell-0.10.5@sha256:77f0bc1569573d9666b10975a5357fef631d32266c071733739393ccae521dab,3803
   - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
   - hiedb-0.4.1.0
-  - github: haskell/hie-bios
-    commit: 2e4161151980f65676de3eae2a71ec2bbb5006be
+  - hie-bios-0.9.0
   - hlint-3.2.8
   - implicit-hie-0.1.2.6@sha256:f50a908979a574a881f753c0f9a5224f023f438b30fdefc5b7fa01803b07a280,2998
   - implicit-hie-cradle-0.3.0.5@sha256:5f5e575f549b2a9db664be7650b5c3c9226e313bddc46c79e2e83eb349f8e692,2610


### PR DESCRIPTION
New hie-bios release!

Big thanks to @hasufell, @Kleidukos, @jneira and more who made this release possible.

Big Change:  https://github.com/haskell/hie-bios/pull/282

TLDR; hie-bios (consequentially HLS) will now honour the `with-compiler` field in `cabal.project`!

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2738"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

