### PR TITLE
Fix flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,6 +98,18 @@
         "type": "github"
       }
     },
+    "hie-bios": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-nd+FfUQVZNxJfKZkAWA3dF0JwRgXntL+1gGvyNHDbKc=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/hie-bios-0.9.0/hie-bios-0.9.0.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/hie-bios-0.9.0/hie-bios-0.9.0.tar.gz"
+      }
+    },
     "hlint": {
       "flake": false,
       "locked": {
@@ -227,6 +239,7 @@
         "fourmolu": "fourmolu",
         "ghc-exactprint": "ghc-exactprint",
         "gitignore": "gitignore",
+        "hie-bios": "hie-bios",
         "hlint": "hlint",
         "implicit-hie-cradle": "implicit-hie-cradle",
         "lsp": "lsp",


### PR DESCRIPTION
https://github.com/haskell/haskell-language-server/pull/2738 updated
`flake.nix` but not `flake.lock`.

`nix develop` will just modify `flake.lock` locally, but `nix-shell`
will actually fail without this.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2743"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

