### PR TITLE
LSP window message log recorder

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -16,7 +16,7 @@ import           Ide.Arguments                (Arguments (..),
 import           Ide.Main                     (defaultMain)
 import qualified Ide.Main                     as IdeMain
 import qualified Plugins
-import           Prettyprinter                (Pretty (pretty))
+import           Prettyprinter                (Pretty (pretty), vcat)
 import Development.IDE.Plugin.LSPWindowShowMessageRecorder (makeLspShowMessageRecorder)
 import Data.Text (Text)
 import Ide.PluginUtils (pluginDescToIdePlugins)
@@ -59,4 +59,10 @@ main = do
       defaultMain (cmapWithPrio LogIdeMain recorder) args (pluginDescToIdePlugins [lspRecorderPlugin] <> plugins)
 
 renderDoc :: Doc a -> Text
-renderDoc = renderStrict . layoutPretty defaultLayoutOptions
+renderDoc d = renderStrict $ layoutPretty defaultLayoutOptions $ vcat
+    ["Unhandled exception, please check your setup and/or the [issue tracker](" <> issueTrackerUrl <> "): "
+    ,d
+    ]
+
+issueTrackerUrl :: Doc a
+issueTrackerUrl = "https://github.com/haskell/haskell-language-server/issues"

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -202,6 +202,7 @@ library
         Development.IDE.Plugin.Completions.Types
         Development.IDE.Plugin.CodeAction
         Development.IDE.Plugin.CodeAction.ExactPrint
+        Development.IDE.Plugin.LSPWindowShowMessageRecorder
         Development.IDE.Plugin.HLS
         Development.IDE.Plugin.HLS.GhcIde
         Development.IDE.Plugin.Test

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -254,7 +254,7 @@ getInitialGhcLibDirDefault recorder rootDir = do
   case libDirRes of
       CradleSuccess libdir -> pure $ Just $ LibDir libdir
       CradleFail err -> do
-        log Warning $ LogGetInitialGhcLibDirDefaultCradleFail err rootDir hieYaml cradle
+        log Error $ LogGetInitialGhcLibDirDefaultCradleFail err rootDir hieYaml cradle
         pure Nothing
       CradleNone -> do
         log Warning LogGetInitialGhcLibDirDefaultCradleNone

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -99,6 +99,7 @@ import           HieDb.Types
 import           HieDb.Utils
 import           System.Random                        (RandomGen)
 import qualified System.Random                        as Random
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 
 data Log
   = LogSettingInitialDynFlags
@@ -845,7 +846,7 @@ should be filtered out, such that we dont have to re-compile everything.
 -- | Set the cache-directory based on the ComponentOptions and a list of
 -- internal packages.
 -- For the exact reason, see Note [Avoiding bad interface files].
-setCacheDirs :: MonadIO m => Recorder (WithPriority Log) -> CacheDirs -> DynFlags -> m DynFlags
+setCacheDirs :: MonadUnliftIO m => Recorder (WithPriority Log) -> CacheDirs -> DynFlags -> m DynFlags
 setCacheDirs recorder CacheDirs{..} dflags = do
     logWith recorder Info $ LogInterfaceFilesCacheDir (fromMaybe cacheDir hiCacheDir)
     pure $ dflags

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -628,14 +628,14 @@ readHieFileForSrcFromDisk recorder file = do
   ShakeExtras{withHieDb} <- ask
   row <- MaybeT $ liftIO $ withHieDb (\hieDb -> HieDb.lookupHieFileFromSource hieDb $ fromNormalizedFilePath file)
   let hie_loc = HieDb.hieModuleHieFile row
-  logWith recorder Logger.Debug $ LogLoadingHieFile file
+  liftIO $ logWith recorder Logger.Debug $ LogLoadingHieFile file
   exceptToMaybeT $ readHieFileFromDisk recorder hie_loc
 
 readHieFileFromDisk :: Recorder (WithPriority Log) -> FilePath -> ExceptT SomeException IdeAction Compat.HieFile
 readHieFileFromDisk recorder hie_loc = do
   nc <- asks ideNc
   res <- liftIO $ tryAny $ loadHieFile (mkUpdater nc) hie_loc
-  let log = logWith recorder
+  let log = (liftIO .) . logWith recorder
   case res of
     Left e -> log Logger.Debug $ LogLoadingHieFileFail hie_loc e
     Right _ -> log Logger.Debug $ LogLoadingHieFileSuccess hie_loc

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -71,9 +71,6 @@ instance Pretty Log where
       "Cancelled request" <+> viaShow requestId
     LogSession log -> pretty log
 
-issueTrackerUrl :: T.Text
-issueTrackerUrl = "https://github.com/haskell/haskell-language-server/issues"
-
 -- used to smuggle RankNType WithHieDb through dbMVar
 newtype WithHieDbShield = WithHieDbShield WithHieDb
 
@@ -184,20 +181,11 @@ runLanguageServer recorder options inH outH getHieDbLoc defaultConfig onConfigur
 
             let handleServerException (Left e) = do
                     log Error $ LogReactorThreadException e
-                    sendErrorMessage e
                     exitClientMsg
                 handleServerException (Right _) = pure ()
 
-                sendErrorMessage (e :: SomeException) = do
-                    LSP.runLspT env $ LSP.sendNotification SWindowShowMessage $
-                        ShowMessageParams MtError $ T.unlines
-                        [ "Unhandled exception, please [report](" <> issueTrackerUrl <> "): "
-                        , T.pack(show e)
-                        ]
-
                 exceptionInHandler e = do
                     log Error $ LogReactorMessageActionException e
-                    sendErrorMessage e
 
                 checkCancelled _id act k =
                     flip finally (clearReqId _id) $

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -31,7 +31,7 @@ import           Data.Text.Lazy.Encoding               (decodeUtf8)
 import qualified Data.Text.Lazy.IO                     as LT
 import           Data.Typeable                         (typeOf)
 import           Development.IDE                       (Action, GhcVersion (..),
-                                                        Priority (Debug), Rules,
+                                                        Priority (Debug, Error), Rules,
                                                         ghcVersion,
                                                         hDuplicateTo')
 import           Development.IDE.Core.Debouncer        (Debouncer,
@@ -336,7 +336,7 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
                 _mlibdir <-
                     setInitialDynFlags (cmapWithPrio LogSession recorder) dir argsSessionLoadingOptions
                         -- TODO: should probably catch/log/rethrow at top level instead
-                        `catchAny` (\e -> log Debug (LogSetInitialDynFlagsException e) >> pure Nothing)
+                        `catchAny` (\e -> log Error (LogSetInitialDynFlagsException e) >> pure Nothing)
 
                 sessionLoader <- loadSessionWithOptions (cmapWithPrio LogSession recorder) argsSessionLoadingOptions dir
                 config <- LSP.runLspT env LSP.getConfig

--- a/ghcide/src/Development/IDE/Plugin/LSPWindowShowMessageRecorder.hs
+++ b/ghcide/src/Development/IDE/Plugin/LSPWindowShowMessageRecorder.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE GADTs #-}
+
+module Development.IDE.Plugin.LSPWindowShowMessageRecorder (makeLspShowMessageRecorder) where
+
+import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Data.Foldable (for_)
+import Data.IORef
+import Data.IORef.Extra (atomicModifyIORef'_)
+import Data.Text (Text)
+import Development.IDE.Types.Logger
+import Ide.Types (PluginDescriptor (pluginNotificationHandlers), defaultPluginDescriptor, mkPluginNotificationHandler)
+import Language.LSP.Server (LanguageContextEnv, getLspEnv)
+import qualified Language.LSP.Server as LSP
+import Language.LSP.Types (MessageType (..), SMethod (SInitialized, SWindowShowMessage), ShowMessageParams (..))
+
+-- | Creates a recorder that logs to the LSP stream via WindowShowMessage notifications.
+--   The recorder won't attempt to send messages until the LSP stream is initialized.
+makeLspShowMessageRecorder ::
+  IO (Recorder (WithPriority Text), PluginDescriptor c)
+makeLspShowMessageRecorder = do
+  envRef <- newIORef Nothing
+  -- messages logged before the LSP stream is initialized will be sent when it is
+  backLogRef <- newIORef []
+  let recorder = Recorder $ \it -> do
+        mbenv <- liftIO $ readIORef envRef
+        case mbenv of
+          Nothing -> liftIO $ atomicModifyIORef'_ backLogRef (it :)
+          Just env -> sendMsg env it
+      -- the plugin captures the language context, so it can be used to send messages
+      plugin =
+        (defaultPluginDescriptor "LSPWindowShowMessageRecorder")
+          { pluginNotificationHandlers = mkPluginNotificationHandler SInitialized $ \_ _ _ -> do
+              env <- getLspEnv
+              liftIO $ writeIORef envRef $ Just env
+              -- flush the backlog
+              backLog <- liftIO $ atomicModifyIORef' backLogRef ([],)
+              for_ (reverse backLog) $ sendMsg env
+          }
+  return (recorder, plugin)
+
+sendMsg :: MonadUnliftIO m => LanguageContextEnv config -> WithPriority Text -> m ()
+sendMsg env WithPriority {..} =
+  LSP.runLspT env $
+    LSP.sendNotification
+      SWindowShowMessage
+      ShowMessageParams
+        { _xtype = priorityToLsp priority,
+          _message = payload
+        }
+
+priorityToLsp :: Priority -> MessageType
+priorityToLsp =
+  \case
+    Debug -> MtLog
+    Info -> MtInfo
+    Warning -> MtWarning
+    Error -> MtError

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -81,6 +81,7 @@ library
     , stm-containers
     , time
     , transformers
+    , unliftio
     , unordered-containers
 
   if flag(embed-files)

--- a/hls-graph/src/Development/IDE/Graph/Internal/Types.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Types.hs
@@ -36,6 +36,7 @@ import qualified ListT
 import           StmContainers.Map             (Map)
 import qualified StmContainers.Map             as SMap
 import           System.Time.Extra             (Seconds)
+import UnliftIO (MonadUnliftIO)
 
 
 unwrapDynamic :: forall a . Typeable a => Dynamic -> a
@@ -62,7 +63,7 @@ data SRules = SRules {
 -- ACTIONS
 
 newtype Action a = Action {fromAction :: ReaderT SAction IO a}
-    deriving newtype (Monad, Applicative, Functor, MonadIO, MonadFail, MonadThrow, MonadCatch, MonadMask)
+    deriving newtype (Monad, Applicative, Functor, MonadIO, MonadFail, MonadThrow, MonadCatch, MonadMask, MonadUnliftIO)
 
 data SAction = SAction {
     actionDatabase :: !Database,


### PR DESCRIPTION
This PR adds a new `Recorder` that emits LSP `WindowShowMessage` notifications, and then uses it to surface errors to the user. 

<img width="558" alt="image" src="https://user-images.githubusercontent.com/26626/156890151-9addf215-237d-47aa-9746-3eb6ee28076a.png">


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2750"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

