### PR TITLE
Fix test failure for AlternateNumberFormat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,7 +224,7 @@ jobs:
         name: Test hls-module-name-plugin test suite
         run: cabal test hls-module-name-plugin --test-options="$TEST_OPTS" || cabal test hls-module-name-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-module-name-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.1'
+      - if: matrix.test
         name: Test hls-alternate-number-format-plugin test suite
         run: cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS" || cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-alternate-number-format-plugin --test-options="$TEST_OPTS"
 

--- a/plugins/hls-alternate-number-format-plugin/README.md
+++ b/plugins/hls-alternate-number-format-plugin/README.md
@@ -44,3 +44,7 @@ To generate suggestions, the plugin leverages the `Numeric` package which provid
 
 ### 1.0.1.1
 - Buildable with GHC 9.2
+
+### 1.0.2.0
+- Test Suite upgraded for 9.2 semantics (GHC2021)
+- Fix SYB parsing with GHC 9.2

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-alternate-number-format-plugin
-version:            1.0.1.1
+version:            1.0.2.0
 synopsis:           Provide Alternate Number Formats plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -21,6 +21,7 @@ library
   exposed-modules:  Ide.Plugin.AlternateNumberFormat, Ide.Plugin.Conversion
   other-modules:    Ide.Plugin.Literals
   hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
       aeson
     , base                 >=4.12 && < 5

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
@@ -7,7 +7,6 @@ module Ide.Plugin.AlternateNumberFormat (descriptor, Log(..)) where
 import           Control.Lens                    ((^.))
 import           Control.Monad.Except            (ExceptT, MonadIO, liftIO)
 import qualified Data.HashMap.Strict             as HashMap
-import           Data.List                       (intercalate)
 import           Data.Text                       (Text)
 import qualified Data.Text                       as T
 import           Development.IDE                 (GetParsedModule (GetParsedModule),

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
@@ -127,5 +127,5 @@ requestLiterals state = handleMaybeM "Error: Could not Collect Literals"
                 . use CollectLiterals
 
 logIO :: (MonadIO m, Show a) => IdeState -> a -> m ()
-logIO state = liftIO . Logger.logError (ideLogger state) . T.pack . show
+logIO state = liftIO . Logger.logDebug (ideLogger state) . T.pack . show
 

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
@@ -7,6 +7,7 @@ module Ide.Plugin.AlternateNumberFormat (descriptor, Log(..)) where
 import           Control.Lens                    ((^.))
 import           Control.Monad.Except            (ExceptT, MonadIO, liftIO)
 import qualified Data.HashMap.Strict             as HashMap
+import           Data.List                       (intercalate)
 import           Data.Text                       (Text)
 import qualified Data.Text                       as T
 import           Development.IDE                 (GetParsedModule (GetParsedModule),
@@ -22,8 +23,7 @@ import           Development.IDE.Types.Logger    as Logger
 import           GHC.Generics                    (Generic)
 import           Ide.Plugin.Conversion           (FormatType, alternateFormat,
                                                   toFormatTypes)
-import           Ide.Plugin.Literals             (Literal (..), collectLiterals,
-                                                  getSrcSpan, getSrcText)
+import           Ide.Plugin.Literals
 import           Ide.PluginUtils                 (handleMaybe, handleMaybeM,
                                                   response)
 import           Ide.Types
@@ -126,7 +126,13 @@ requestLiterals state = handleMaybeM "Error: Could not Collect Literals"
                 . runAction "AlternateNumberFormat.CollectLiterals" state
                 . use CollectLiterals
 
+getPm :: MonadIO m => IdeState -> NormalizedFilePath -> ExceptT String m ParsedModule
+getPm state = handleMaybeM "Error: Could not pm"
+                . liftIO
+                . runAction "AlternateNumberFormat.pm" state
+                . use GetParsedModule
+
 
 logIO :: (MonadIO m, Show a) => IdeState -> a -> m ()
-logIO state = liftIO . Logger.logDebug (ideLogger state) . T.pack . show
+logIO state = liftIO . Logger.logError (ideLogger state) . T.pack . show
 

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
@@ -126,13 +126,6 @@ requestLiterals state = handleMaybeM "Error: Could not Collect Literals"
                 . runAction "AlternateNumberFormat.CollectLiterals" state
                 . use CollectLiterals
 
-getPm :: MonadIO m => IdeState -> NormalizedFilePath -> ExceptT String m ParsedModule
-getPm state = handleMaybeM "Error: Could not pm"
-                . liftIO
-                . runAction "AlternateNumberFormat.pm" state
-                . use GetParsedModule
-
-
 logIO :: (MonadIO m, Show a) => IdeState -> a -> m ()
 logIO state = liftIO . Logger.logError (ideLogger state) . T.pack . show
 

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/Literals.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/Literals.hs
@@ -14,7 +14,7 @@ import           Data.Maybe                    (maybeToList)
 import           Data.Text                     (Text)
 import qualified Data.Text                     as T
 import           Development.IDE.GHC.Compat    hiding (getSrcSpan)
-import           Development.IDE.GHC.Util      (prettyPrint, unsafePrintSDoc)
+import           Development.IDE.GHC.Util      (unsafePrintSDoc)
 import           Development.IDE.Graph.Classes (NFData (rnf))
 import qualified GHC.Generics                  as GHC
 import           Generics.SYB                  (Data, Typeable, everything,
@@ -94,30 +94,3 @@ fromSourceText :: SourceText -> Maybe Text
 fromSourceText = \case
   SourceText s -> Just $ T.pack s
   NoSourceText -> Nothing
-
--- mostly for debugging purposes
-literalToString :: HsLit p -> String
-literalToString = \case
-  HsChar _ c        -> "Char: " <> show c
-  HsCharPrim _ c    -> "CharPrim: " <> show c
-  HsString _ fs     -> "String: " <> show fs
-  HsStringPrim _ bs -> "StringPrim: " <> show bs
-  HsInt _ il        -> "Int: " <> show il
-  HsIntPrim _ n     -> "IntPrim: " <> show n
-  HsWordPrim _ n    -> "WordPrim: " <> show n
-  HsInt64Prim _ n   -> "Int64Prim: " <> show n
-  HsWord64Prim _ n  -> "Word64Prim: " <> show n
-  HsInteger _ n ty  -> "Integer: " <> show n <> " Type: " <> tyToLiteral ty
-  HsRat _ fl ty     -> "Rat: " <> show fl <> " Type: " <> tyToLiteral ty
-  HsFloatPrim _ fl  -> "FloatPrim: " <> show fl
-  HsDoublePrim _ fl -> "DoublePrim: " <>  show fl
-  _                 -> "XHsLit"
-  where
-    tyToLiteral :: Type -> String
-    tyToLiteral = unsafePrintSDoc .  ppr
-
-overLitToString :: OverLitVal -> String
-overLitToString = \case
-     HsIntegral int -> case int of { IL{il_value} -> "IntegralOverLit: " <> show il_value}
-     HsFractional frac -> case frac of { fl -> "RationalOverLit: " <> show (rationalFromFractionalLit fl)}
-     HsIsString _ str -> "HIsString: " <> show str

--- a/plugins/hls-alternate-number-format-plugin/test/Main.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/Main.hs
@@ -23,7 +23,6 @@ main = defaultTestRunner test
 alternateNumberFormatPlugin :: PluginDescriptor IdeState
 alternateNumberFormatPlugin = AlternateNumberFormat.descriptor mempty "alternateNumberFormat"
 
-
 -- NOTE: For whatever reason, this plugin does not play nice with creating Code Actions on time.
 -- As a result tests will mostly pass if `import Prelude` is added at the top. We (mostly fendor) surmise this has something
 -- to do with how
@@ -37,36 +36,18 @@ test = testGroup "alternateNumberFormat" [
     , codeActionFloatHex "TFracDtoHF" 4 13
     , codeActionDecimal "TIntHtoD" 3 13
     , codeActionDecimal "TFracHFtoD" 4 13
-    , codeActionProperties "TFindLiteralIntPattern" [(3, 25), (4,25)] $ \actions -> do
+    , codeActionProperties "TFindLiteralIntPattern" [(4, 25), (5,25)] $ \actions -> do
         liftIO $ length actions @?= 4
-    , codeActionProperties "TFindLiteralIntCase" [(3, 29)] $ \actions -> do
+    , codeActionProperties "TFindLiteralIntCase" [(4, 29)] $ \actions -> do
         liftIO $ length actions @?= 2
-    , codeActionProperties "TFindLiteralIntCase2" [(4, 21)] $ \actions -> do
+    , codeActionProperties "TFindLiteralIntCase2" [(5, 21)] $ \actions -> do
         liftIO $ length actions @?= 2
-    , codeActionProperties "TFindLiteralDoReturn" [(5, 10)] $ \actions -> do
+    , codeActionProperties "TFindLiteralDoReturn" [(6, 10)] $ \actions -> do
         liftIO $ length actions @?= 2
-    , codeActionProperties "TFindLiteralDoLet" [(5, 13), (6, 13)] $ \actions -> do
+    , codeActionProperties "TFindLiteralDoLet" [(6, 13), (7, 13)] $ \actions -> do
         liftIO $ length actions @?= 4
-    , codeActionProperties "TFindLiteralList" [(3, 28)] $ \actions -> do
+    , codeActionProperties "TFindLiteralList" [(4, 28)] $ \actions -> do
         liftIO $ length actions @?= 2
-    , codeActionProperties "TExpectNoBinaryFormat" [(3, 12)] $ \actions -> do
-        liftIO $ length actions @?= 2
-        liftIO $ actions `doesNotContain` binaryRegex @? "Contains binary codeAction"
-    , codeActionProperties "TExpectBinaryFormat" [(4, 10)] $ \actions -> do
-        liftIO $ length actions @?= 3
-        liftIO $ actions `contains` binaryRegex @? "Does not contain binary codeAction"
-    , codeActionProperties "TExpectNoHexFloatFormat" [(3, 14)] $ \actions -> do
-        liftIO $ length actions @?= 1
-        liftIO $ actions `doesNotContain` hexFloatRegex @? "Contains hex float codeAction"
-    , codeActionProperties "TExpectHexFloatFormat" [(4, 12)] $ \actions -> do
-        liftIO $ length actions @?= 2
-        liftIO $ actions `contains` hexFloatRegex @? "Does not contain hex float codeAction"
-    , codeActionProperties "TExpectNoNumDecimalFormat" [(3, 16)] $ \actions -> do
-        liftIO $ length actions @?= 2
-        liftIO $ actions `doesNotContain` numDecimalRegex @? "Contains numDecimal codeAction"
-    , codeActionProperties "TExpectNumDecimalFormat" [(4, 14)] $ \actions -> do
-        liftIO $ length actions @?= 5
-        liftIO $ actions `contains` numDecimalRegex @? "Contains numDecimal codeAction"
     , conversions
     ]
 

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectBinaryFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectBinaryFormat.hs
@@ -1,4 +1,0 @@
-{-# LANGUAGE BinaryLiterals #-}
-module TExpectBinaryFormat where
-
-binary = 459

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectHexFloatFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectHexFloatFormat.hs
@@ -1,4 +1,0 @@
-{-# LANGUAGE HexFloatLiterals #-}
-module TExpectHexFloatFormat where
-
-hexFloat = 459.123

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectNoBinaryFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectNoBinaryFormat.hs
@@ -1,3 +1,0 @@
-module TExpectNoBinaryFormat where
-
-noBinary = 459

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectNoHexFloatFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectNoHexFloatFormat.hs
@@ -1,3 +1,0 @@
-module TExpectNoHexFloatFormat where
-
-noHexFloat = 459.123

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectNoNumDecimalFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectNoNumDecimalFormat.hs
@@ -1,3 +1,0 @@
-module TExpectNoNumDecimalFormat where
-
-noNumDecimal = 499999

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectNumDecimalFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TExpectNumDecimalFormat.hs
@@ -1,4 +1,0 @@
-{-# LANGUAGE NumDecimals #-}
-module TExpectNumDecimalFormat where
-
-numDecimal = 499999

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralDoLet.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralDoLet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoBinaryLiterals #-}
 module TFindLiteralDoLet where
 
 doLet :: IO ()

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralDoReturn.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralDoReturn.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoBinaryLiterals #-}
 module TFindLiteralDoReturn where
 
 doReturn :: IO Integer

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralIntCase.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralIntCase.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoBinaryLiterals #-}
 module TFindLiteralIntCase where
 
 caseExpression x = case x + 34 of

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralIntCase2.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralIntCase2.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoBinaryLiterals #-}
 module TFindLiteralIntCase where
 
 caseExpression x = case x of

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralIntPattern.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralIntPattern.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoBinaryLiterals #-}
 module TFindLiteralIntPattern where
 
 patternMatchingFunction 1 = "one"

--- a/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralList.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/testdata/TFindLiteralList.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoBinaryLiterals #-}
 module TFindLiteralList where
 
 listTest = [reverse $ show 57]


### PR DESCRIPTION
This fixes alternate number format test-suite for 9.2.1 and enables it in github workflows. The plugin is already enabled in 9.2.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2752"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

