### PR TITLE
Fix a space leak in hls-graph

### DIFF
--- a/hls-graph/src/Development/IDE/Graph/Internal/Types.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Types.hs
@@ -120,12 +120,12 @@ getDatabaseValues = atomically
                   . databaseValues
 
 data Status
-    = Clean Result
+    = Clean !Result
     | Dirty (Maybe Result)
     | Running {
         runningStep   :: !Step,
         runningWait   :: !(IO ()),
-        runningResult :: Result,
+        runningResult :: Result,     -- LAZY
         runningPrev   :: !(Maybe Result)
         }
 
@@ -145,7 +145,7 @@ data Result = Result {
     resultVisited   :: !Step, -- ^ the step when it was last looked up
     resultDeps      :: !ResultDeps,
     resultExecution :: !Seconds, -- ^ How long it took, last time it ran
-    resultData      :: BS.ByteString
+    resultData      :: !BS.ByteString
     }
 
 data ResultDeps = UnknownDeps | AlwaysRerunDeps ![Key] | ResultDeps ![Key]


### PR DESCRIPTION
I found this space leak by running the edit benchmark with `+RTS -hc` to track down the monotonically increasing cost centre and then trying various things until ultimately locating the source of the leak. 

The thing that helped ultimately was an info table profile (`-hi`), only available with ghc 9.2.2 and requires building with `-finfo-table-map -fdistinct-constructor-tables`). Thanks @mpickering and @hasurahq for contributing this profiling mode!

Command line, for reference:

```
cabal build --project-file cabal-ghc921.project -w ghc-9.2 exe:ghcide && dist-newstyle/build/x86_64-osx/ghc-9.2.2/ghcide-1.6.0.1/x/ghcide-bench/build/ghcide-bench/ghcide-bench --ghcide dist-newstyle/build/x86_64-osx/ghc-9.2.2/ghcide-1.6.0.1/x/ghcide/build/ghcide/ghcide -s edit --ghcide-options "+RTS -hc  -l -RTS"
```

# Before

<img width="1415" alt="image" src="https://user-images.githubusercontent.com/26626/158018160-32381142-3f8b-4800-9620-1d33924a9ad3.png">
<img width="1222" alt="image" src="https://user-images.githubusercontent.com/26626/158018179-8c17029e-d501-4c11-8bdd-8707913f14d6.png">
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/26626/158018277-7447ac73-b496-4266-bdc5-b666b032c61c.png">

# After

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/26626/158018165-07a6ca7a-1b47-4044-89e0-2b3edf2f90d6.png">
<img width="1229" alt="image" src="https://user-images.githubusercontent.com/26626/158018282-306f53c7-3068-40d6-ab8f-2b785bd688ff.png">
