### PR TITLE
Fix #2693

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -5583,8 +5583,7 @@ simpleSubDirectoryTest =
     expectNoMoreDiagnostics 0.5
 
 simpleMultiTest :: TestTree
-simpleMultiTest =  knownBrokenForGhcVersions [GHC92] "#2693" $
-  testCase "simple-multi-test" $ withLongTimeout $ runWithExtraFiles "multi" $ \dir -> do
+simpleMultiTest = testCase "simple-multi-test" $ withLongTimeout $ runWithExtraFiles "multi" $ \dir -> do
     let aPath = dir </> "a/A.hs"
         bPath = dir </> "b/B.hs"
     adoc <- openDoc aPath "haskell"
@@ -5614,7 +5613,7 @@ simpleMultiTest2 = testCase "simple-multi-test2" $ runWithExtraFiles "multi" $ \
 
 -- Now with 3 components
 simpleMultiTest3 :: TestTree
-simpleMultiTest3 = knownBrokenForGhcVersions [GHC92] "#2693" $
+simpleMultiTest3 =
   testCase "simple-multi-test3" $ runWithExtraFiles "multi" $ \dir -> do
     let aPath = dir </> "a/A.hs"
         bPath = dir </> "b/B.hs"


### PR DESCRIPTION
We need to update the package database state in the `HscEnv` after we update
its `DynFlags`. `setSessionDynFlags` handles this for us.


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2780"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

