### PR TITLE
Allow import all constructors

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -1739,7 +1739,7 @@ data ImportStyle
       --
       -- import M (P(..))
       --
-      -- @P@ __must__ be a data type.
+      -- @P@ can be a data type or a class.
   deriving Show
 
 importStyles :: IdentInfo -> NonEmpty ImportStyle
@@ -1750,7 +1750,7 @@ importStyles IdentInfo {parent, rendered, isDatacon}
     -- top-level exports.
   = ImportViaParent rendered p
       :| [ImportTopLevel rendered | not isDatacon]
-      <> [ImportAllConstructors p | isDatacon]
+      <> [ImportAllConstructors p]
   | otherwise
   = ImportTopLevel rendered :| []
 
@@ -1765,7 +1765,7 @@ renderImportStyle (ImportAllConstructors p) = p <> "(..)"
 unImportStyle :: ImportStyle -> (Maybe String, String)
 unImportStyle (ImportTopLevel x)    = (Nothing, T.unpack x)
 unImportStyle (ImportViaParent x y) = (Just $ T.unpack y, T.unpack x)
-unImportStyle (ImportAllConstructors x) = (Just $ T.unpack x, "..")
+unImportStyle (ImportAllConstructors x) = (Just $ T.unpack x, wildCardSymbol)
 
 
 quickFixImportKind' :: T.Text -> ImportStyle -> CodeActionKind

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -19,6 +19,8 @@ module Development.IDE.Plugin.CodeAction.ExactPrint (
   extendImport,
   hideSymbol,
   liftParseAST,
+
+  wildCardSymbol
 ) where
 
 import           Control.Applicative
@@ -380,6 +382,9 @@ extendImportTopLevel thing (L l it@ImportDecl{..})
 #endif
 extendImportTopLevel _ _ = lift $ Left "Unable to extend the import list"
 
+wildCardSymbol :: String
+wildCardSymbol = ".."
+
 -- | Add an identifier with its parent to import list
 --
 -- extendImportViaParent "Bar" "Cons" AST:
@@ -390,6 +395,11 @@ extendImportTopLevel _ _ = lift $ Left "Unable to extend the import list"
 -- import A () --> import A (Bar(Cons))
 -- import A (Foo, Bar) --> import A (Foo, Bar(Cons))
 -- import A (Foo, Bar()) --> import A (Foo, Bar(Cons))
+--
+-- extendImportViaParent "Bar" ".." AST:
+-- import A () --> import A (Bar(..))
+-- import A (Foo, Bar) -> import A (Foo, Bar(..))
+-- import A (Foo, Bar()) -> import A (Foo, Bar(..))
 extendImportViaParent ::
   DynFlags ->
   -- | parent (already parenthesized if needs)
@@ -425,6 +435,19 @@ extendImportViaParent df parent child (L l it@ImportDecl{..})
 #endif
     -- ThingWith ie lies' => ThingWith ie (lies' ++ [child])
     | parent == unIEWrappedName ie
+    , child == wildCardSymbol = do
+#if MIN_VERSION_ghc(9,2,0)
+        let it' = it{ideclHiding = Just (hide, lies)}
+            thing = IEThingWith newl twIE (IEWildcard 2) []
+            newl = (\ann -> ann ++ [(AddEpAnn AnnDotdot d0)]) <$> l'''
+            lies = L l' $ reverse pre ++ [L l'' thing] ++ xs
+        return $ L l it'
+#else
+        let thing = L l'' (IEThingWith noExtField twIE (IEWildcard 2)  [] [])
+        modifyAnnsT (Map.map (\ann -> ann{annsDP = (G AnnDotdot, dp00) : annsDP ann}))
+        return $ L l it{ideclHiding = Just (hide, L l' $ reverse pre ++ [thing] ++ xs)}
+#endif
+    | parent == unIEWrappedName ie
     , hasSibling <- not $ null lies' =
       do
         srcChild <- uniqueSrcSpanT
@@ -449,9 +472,7 @@ extendImportViaParent df parent child (L l it@ImportDecl{..})
             lies = L l' $ reverse pre ++
                 [L l'' (IEThingWith l''' twIE NoIEWildcard (over _last fixLast lies' ++ [childLIE]))] ++ xs
             fixLast = if hasSibling then first addComma else id
-        return $ if hasSibling
-            then L l it'
-            else L l it'
+        return $ L l it'
 #endif
   go hide l' pre (x : xs) = go hide l' (x : pre) xs
   go hide l' pre []

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -330,6 +330,7 @@ extendImport :: Maybe String -> String -> LImportDecl GhcPs -> Rewrite
 extendImport mparent identifier lDecl@(L l _) =
   Rewrite (locA l) $ \df -> do
     case mparent of
+      -- This will also work for `ImportAllConstructors`
       Just parent -> extendImportViaParent df parent identifier lDecl
       _           -> extendImportTopLevel identifier lDecl
 

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1817,7 +1817,7 @@ extendImportTests = testGroup "extend import actions"
                     , "f = Foo 1"
                     ])
             (Range (Position 3 4) (Position 3 6))
-            ["Add Foo(Foo) to the import list of ModuleA"]
+            ["Add Foo(Foo) to the import list of ModuleA", "Add Foo(..) to the import list of ModuleA"]
             (T.unlines
                     [ "module ModuleB where"
                     , "import ModuleA(Foo (Foo))"
@@ -1997,11 +1997,14 @@ suggestImportTests = testGroup "suggest import actions"
     , test False []         "f ExitSuccess = ()"          []                "import System.Exit (ExitSuccess)"
       -- don't suggest data constructor when we only need the type
     , test False []         "f :: Bar"                    []                "import Bar (Bar(Bar))"
+      -- don't suggest all data constructors for the data type
+    , test False []         "f :: Bar"                    []                "import Bar (Bar(..))"
     ]
   , testGroup "want suggestion"
     [ wantWait  []          "f = foo"                     []                "import Foo (foo)"
     , wantWait  []          "f = Bar"                     []                "import Bar (Bar(Bar))"
     , wantWait  []          "f :: Bar"                    []                "import Bar (Bar)"
+    , wantWait  []          "f = Bar"                     []                "import Bar (Bar(..))"
     , test True []          "f = nonEmpty"                []                "import Data.List.NonEmpty (nonEmpty)"
     , test True []          "f = (:|)"                    []                "import Data.List.NonEmpty (NonEmpty((:|)))"
     , test True []          "f :: Natural"                ["f = undefined"] "import Numeric.Natural (Natural)"
@@ -2045,28 +2048,10 @@ suggestImportTests = testGroup "suggest import actions"
       ]                     "f = T.putStrLn"              []                "import qualified Data.Text.IO as T"
     ]
   , expectFailBecause "importing pattern synonyms is unsupported" $ test True [] "k (Some x) = x" [] "import B (pattern Some)"
-  , testGroup "Import with all constructors"
-    [ testCase "new import" $
-        testAllCons
-          []
-          ["import A", "import A (Foo(Foo))", "import A (Foo(..))"]
-    , testCase "extened import" $
-        testAllCons
-          ["import A()"]
-          ["Add Foo(Foo) to the import list of A", "Add Foo(..) to the import list of A"]
-    ]
   ]
   where
     test = test' False
     wantWait = test' True True
-
-    getActions doc defLine waitForCheckProject = do
-      waitForProgressDone
-      _ <- waitForDiagnostics
-      -- there isn't a good way to wait until the whole project is checked atm
-      when waitForCheckProject $ liftIO $ sleep 0.5
-      let range = Range (Position defLine 0) (Position defLine maxBound)
-      getCodeActions doc range
 
     test' waitForCheckProject wanted imps def other newImp = testSessionWithExtraFiles "hover" (T.unpack def) $ \dir -> do
       configureCheckProject waitForCheckProject
@@ -2076,7 +2061,13 @@ suggestImportTests = testGroup "suggest import actions"
       liftIO $ writeFileUTF8 (dir </> "hie.yaml") cradle
       liftIO $ writeFileUTF8 (dir </> "B.hs") $ unlines ["{-# LANGUAGE PatternSynonyms #-}", "module B where", "pattern Some x = Just x"]
       doc <- createDoc "Test.hs" "haskell" before
-      actions <- getActions doc (fromIntegral $ length imps + 1) waitForCheckProject
+      waitForProgressDone
+      _ <- waitForDiagnostics
+      -- there isn't a good way to wait until the whole project is checked atm
+      when waitForCheckProject $ liftIO $ sleep 0.5
+      let defLine = fromIntegral $ length imps + 1
+          range = Range (Position defLine 0) (Position defLine maxBound)
+      actions <- getCodeActions doc range
       if wanted
          then do
              action <- liftIO $ pickActionWithTitle newImp actions
@@ -2085,16 +2076,6 @@ suggestImportTests = testGroup "suggest import actions"
              liftIO $ after @=? contentAfterAction
           else
               liftIO $ [_title | InR CodeAction{_title} <- actions, _title == newImp ] @?= []
-
-    testAllCons imported expected = run' $ \dir -> do
-      configureCheckProject True
-      void $ createDoc (dir </> "A.hs")
-               "haskell"
-               (T.unlines ["module A where", "data Foo = Foo | Bar"])
-      doc <- createDoc (dir </> "Test.hs") "haskell" $ T.unlines (imported ++ ["f = Foo"])
-      actions <- getActions doc (fromIntegral $ length imported) True
-      let titles = [_title | InR CodeAction{_title} <- actions, _title `elem` expected]
-      liftIO $ sort expected @=? sort titles
 
 suggestImportDisambiguationTests :: TestTree
 suggestImportDisambiguationTests = testGroup "suggest import disambiguation actions"

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1513,7 +1513,108 @@ extendImportTests = testGroup "extend import actions"
   ]
   where
     tests overrideCheckProject =
-        [ testSession "extend single line import with value" $ template
+        [ testSession "extend all constructors for record field" $ template
+            [("ModuleA.hs", T.unlines
+                    [ "module ModuleA where"
+                    , "data A = B { a :: Int }"
+                    ])]
+            ("ModuleB.hs", T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA (A(B))"
+                    , "f = a"
+                    ])
+            (Range (Position 2 4) (Position 2 5))
+            [ "Add A(..) to the import list of ModuleA"
+            , "Add A(a) to the import list of ModuleA"
+            , "Add a to the import list of ModuleA"
+            ]
+            (T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA (A(..))"
+                    , "f = a"
+                    ])
+        , testSession "extend all constructors with sibling" $ template
+            [("ModuleA.hs", T.unlines
+                    [ "module ModuleA where"
+                    , "data Foo"
+                    , "data Bar"
+                    , "data A = B | C"
+                    ])]
+            ("ModuleB.hs", T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA ( Foo,  A (C) , Bar ) "
+                    , "f = B"
+                    ])
+            (Range (Position 2 4) (Position 2 5))
+            [ "Add A(..) to the import list of ModuleA"
+            , "Add A(B) to the import list of ModuleA"
+            ]
+            (T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA ( Foo,  A (..) , Bar ) "
+                    , "f = B"
+                    ])
+        , testSession "extend all constructors with comment" $ template
+            [("ModuleA.hs", T.unlines
+                    [ "module ModuleA where"
+                    , "data Foo"
+                    , "data Bar"
+                    , "data A = B | C"
+                    ])]
+            ("ModuleB.hs", T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA ( Foo,  A (C{-comment--}) , Bar ) "
+                    , "f = B"
+                    ])
+            (Range (Position 2 4) (Position 2 5))
+            [ "Add A(..) to the import list of ModuleA"
+            , "Add A(B) to the import list of ModuleA"
+            ]
+            (T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA ( Foo,  A (..{-comment--}) , Bar ) "
+                    , "f = B"
+                    ])
+        , testSession "extend all constructors for type operator" $ template
+            []
+            ("ModuleA.hs", T.unlines
+                    [ "module ModuleA where"
+                    , "import Data.Type.Equality ((:~:))"
+                    , "x :: (:~:) [] []"
+                    , "x = Refl"
+                    ])
+            (Range (Position 3 17) (Position 3 18))
+            [ "Add (:~:)(..) to the import list of Data.Type.Equality"
+            , "Add type (:~:)(Refl) to the import list of Data.Type.Equality"]
+            (T.unlines
+                    [ "module ModuleA where"
+                    , "import Data.Type.Equality ((:~:) (..))"
+                    , "x :: (:~:) [] []"
+                    , "x = Refl"
+                    ])
+        , testSession "extend all constructors for class" $ template
+            [("ModuleA.hs", T.unlines
+                    [ "module ModuleA where"
+                    , "class C a where"
+                    , "  m1 :: a -> a"
+                    , "  m2 :: a -> a"
+                    ])]
+            ("ModuleB.hs", T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA (C(m1))"
+                    , "b = m2"
+                    ])
+            (Range (Position 2 5) (Position 2 5))
+            [ "Add C(..) to the import list of ModuleA"
+            , "Add C(m2) to the import list of ModuleA"
+            , "Add m2 to the import list of ModuleA"
+            ]
+            (T.unlines
+                    [ "module ModuleB where"
+                    , "import ModuleA (C(..))"
+                    , "b = m2"
+                    ])
+        , testSession "extend single line import with value" $ template
             [("ModuleA.hs", T.unlines
                     [ "module ModuleA where"
                     , "stuffA :: Double"
@@ -1561,7 +1662,9 @@ extendImportTests = testGroup "extend import actions"
                     , "main = case (fromList []) of _ :| _ -> pure ()"
                     ])
             (Range (Position 2 5) (Position 2 6))
-            ["Add NonEmpty((:|)) to the import list of Data.List.NonEmpty"]
+            [ "Add NonEmpty((:|)) to the import list of Data.List.NonEmpty"
+            , "Add NonEmpty(..) to the import list of Data.List.NonEmpty"
+            ]
             (T.unlines
                     [ "module ModuleB where"
                     , "import Data.List.NonEmpty (fromList, NonEmpty ((:|)))"
@@ -1576,7 +1679,9 @@ extendImportTests = testGroup "extend import actions"
                     , "x = Just 10"
                     ])
             (Range (Position 3 5) (Position 2 6))
-            ["Add Maybe(Just) to the import list of Data.Maybe"]
+            [ "Add Maybe(Just) to the import list of Data.Maybe"
+            , "Add Maybe(..) to the import list of Data.Maybe"
+            ]
             (T.unlines
                     [ "module ModuleB where"
                     , "import Prelude hiding (Maybe(..))"
@@ -1614,7 +1719,9 @@ extendImportTests = testGroup "extend import actions"
                     , "b = Constructor"
                     ])
             (Range (Position 3 5) (Position 3 5))
-            ["Add A(Constructor) to the import list of ModuleA"]
+            [ "Add A(Constructor) to the import list of ModuleA"
+            , "Add A(..) to the import list of ModuleA"
+            ]
             (T.unlines
                     [ "module ModuleB where"
                     , "import ModuleA (A (Constructor))"
@@ -1633,7 +1740,9 @@ extendImportTests = testGroup "extend import actions"
                     , "b = Constructor"
                     ])
             (Range (Position 3 5) (Position 3 5))
-            ["Add A(Constructor) to the import list of ModuleA"]
+            [ "Add A(Constructor) to the import list of ModuleA"
+            , "Add A(..) to the import list of ModuleA"
+            ]
             (T.unlines
                     [ "module ModuleB where"
                     , "import ModuleA (A (Constructor{-Constructor-}))"
@@ -1653,7 +1762,9 @@ extendImportTests = testGroup "extend import actions"
                     , "b = ConstructorFoo"
                     ])
             (Range (Position 3 5) (Position 3 5))
-            ["Add A(ConstructorFoo) to the import list of ModuleA"]
+            [ "Add A(ConstructorFoo) to the import list of ModuleA"
+            , "Add A(..) to the import list of ModuleA"
+            ]
             (T.unlines
                     [ "module ModuleB where"
                     , "import ModuleA (A (ConstructorBar, ConstructorFoo), a)"
@@ -1715,8 +1826,10 @@ extendImportTests = testGroup "extend import actions"
                     , "b = m2"
                     ])
             (Range (Position 2 5) (Position 2 5))
-            ["Add C(m2) to the import list of ModuleA",
-             "Add m2 to the import list of ModuleA"]
+            [ "Add C(m2) to the import list of ModuleA"
+            , "Add m2 to the import list of ModuleA"
+            , "Add C(..) to the import list of ModuleA"
+            ]
             (T.unlines
                     [ "module ModuleB where"
                     , "import ModuleA (C(m1, m2))"
@@ -1735,8 +1848,10 @@ extendImportTests = testGroup "extend import actions"
                     , "b = m2"
                     ])
             (Range (Position 2 5) (Position 2 5))
-            ["Add m2 to the import list of ModuleA",
-             "Add C(m2) to the import list of ModuleA"]
+            [ "Add m2 to the import list of ModuleA"
+            , "Add C(m2) to the import list of ModuleA"
+            , "Add C(..) to the import list of ModuleA"
+            ]
             (T.unlines
                     [ "module ModuleB where"
                     , "import ModuleA (C(m1), m2)"
@@ -1777,7 +1892,8 @@ extendImportTests = testGroup "extend import actions"
                     , "x = Refl"
                     ])
             (Range (Position 3 17) (Position 3 18))
-            ["Add type (:~:)(Refl) to the import list of Data.Type.Equality"]
+            [ "Add type (:~:)(Refl) to the import list of Data.Type.Equality"
+            , "Add (:~:)(..) to the import list of Data.Type.Equality"]
             (T.unlines
                     [ "module ModuleA where"
                     , "import Data.Type.Equality ((:~:) (Refl))"
@@ -2046,6 +2162,8 @@ suggestImportTests = testGroup "suggest import actions"
       , "qualified Data.Functor as T"
       , "qualified Data.Data as T"
       ]                     "f = T.putStrLn"              []                "import qualified Data.Text.IO as T"
+    , test True []          "f = (.|.)"                   []                "import Data.Bits (Bits(..))"
+    , test True []          "f = empty"                   []                "import Control.Applicative (Alternative(..))"
     ]
   , expectFailBecause "importing pattern synonyms is unsupported" $ test True [] "k (Some x) = x" [] "import B (pattern Some)"
   ]


### PR DESCRIPTION
This is for #2734 

Brief intro:

With 
```haskell
Module A where
data Foo = Foo | Bar
```
it will suggest import `Foo(..)` now, like `import A(Foo(..))` and `Add Foo(..) to the import list of A`.

---

Note:
Support Now!
~~This doesn't work for record fields, ideally, we should support this.~~

Example:
```haskell
data Foo = Bar {a :: Int}
```
if we have `f = a`, we should also have `import A(Foo(..))`. Maybe we can extend
https://github.com/haskell/haskell-language-server/blob/621c2bb2173d5231082e5e4c4f157b2efb4f94c7/ghcide/src/Development/IDE/Types/Exports.hs#L64-L70
with a field to indicate `a`'s data type if `a` is a record field.


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2782"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

