### PR TITLE
Avoid race conditions with VFS and VFS versions

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -46,7 +46,7 @@ main = do
     -- This plugin just installs a handler for the `initialized` notification, which then
     -- picks up the LSP environment and feeds it to our recorders
     let lspRecorderPlugin = (defaultPluginDescriptor "LSPRecorderCallback")
-          { pluginNotificationHandlers = mkPluginNotificationHandler LSP.SInitialized $ \_ _ _ -> do
+          { pluginNotificationHandlers = mkPluginNotificationHandler LSP.SInitialized $ \_ _ _ _ -> do
               env <- LSP.getLspEnv
               liftIO $ (cb1 <> cb2) env
           }

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -94,7 +94,7 @@ main = withTelemetryLogger $ \telemetryLogger -> do
     -- This plugin just installs a handler for the `initialized` notification, which then
     -- picks up the LSP environment and feeds it to our recorders
     let lspRecorderPlugin = (defaultPluginDescriptor "LSPRecorderCallback")
-          { pluginNotificationHandlers = mkPluginNotificationHandler LSP.SInitialized $ \_ _ _ -> do
+          { pluginNotificationHandlers = mkPluginNotificationHandler LSP.SInitialized $ \_ _ _ _ -> do
               env <- LSP.getLspEnv
               liftIO $ (cb1 <> cb2) env
           }

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -581,7 +581,9 @@ loadSessionWithOptions recorder SessionLoadingOptions{..} dir = do
 
           -- Invalidate all the existing GhcSession build nodes by restarting the Shake session
           invalidateShakeCache
-          restartShakeSession "new component" []
+
+          -- The VFS doesn't change on cradle edits, re-use the old one.
+          restartShakeSession VFSUnmodified "new component" []
 
           -- Typecheck all files in the project on startup
           checkProject <- getCheckProject

--- a/ghcide/src/Development/IDE.hs
+++ b/ghcide/src/Development/IDE.hs
@@ -40,7 +40,8 @@ import           Development.IDE.Core.Shake            as X (FastResult (..),
                                                              useWithStaleFast,
                                                              useWithStaleFast',
                                                              useWithStale_,
-                                                             use_, uses, uses_)
+                                                             use_, uses, uses_,
+                                                             VFSModified(..))
 import           Development.IDE.GHC.Compat            as X (GhcVersion (..),
                                                              ghcVersion)
 import           Development.IDE.GHC.Error             as X

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -558,7 +558,7 @@ getHieAstsRule recorder =
 persistentHieFileRule :: Recorder (WithPriority Log) -> Rules ()
 persistentHieFileRule recorder = addPersistentRule GetHieAst $ \file -> runMaybeT $ do
   res <- readHieFileForSrcFromDisk recorder file
-  vfsRef <- asks vfs
+  vfsRef <- asks vfsVar
   vfsData <- liftIO $ vfsMap <$> readTVarIO vfsRef
   (currentSource, ver) <- liftIO $ case M.lookup (filePathToUri' file) vfsData of
     Nothing -> (,Nothing) . T.decodeUtf8 <$> BS.readFile (fromNormalizedFilePath file)

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -421,7 +421,7 @@ diagnosticTests = testGroup "diagnostics"
       let contentA = T.unlines [ "module ModuleA where" ]
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       expectDiagnostics [("ModuleB.hs", [])]
-  , ignoreInWindowsBecause "Broken in windows" $ testSessionWait "add missing module (non workspace)" $ do
+  , ignoreTestBecause "Flaky #2831" $ testSessionWait "add missing module (non workspace)" $ do
       -- need to canonicalize in Mac Os
       tmpDir <- liftIO $ canonicalizePath =<< getTemporaryDirectory
       let contentB = T.unlines

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -6417,7 +6417,7 @@ unitTests recorder logger = do
         let plugins = pluginDescToIdePlugins $
                 [ (defaultPluginDescriptor $ fromString $ show i)
                     { pluginNotificationHandlers = mconcat
-                        [ mkPluginNotificationHandler LSP.STextDocumentDidOpen $ \_ _ _ ->
+                        [ mkPluginNotificationHandler LSP.STextDocumentDidOpen $ \_ _ _ _ ->
                             liftIO $ atomicModifyIORef_ orderRef (i:)
                         ]
                     }

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -54,7 +54,8 @@ import           Development.IDE                 (GetModSummary (..),
                                                   textToStringBuffer,
                                                   toNormalizedFilePath',
                                                   uriToFilePath', useNoFile_,
-                                                  useWithStale_, use_)
+                                                  useWithStale_, use_,
+                                                  VFSModified(..))
 import           Development.IDE.Core.Rules      (GhcSessionDepsConfig (..),
                                                   ghcSessionDepsDefinition)
 import           Development.IDE.GHC.Compat      hiding (typeKind, unitState)
@@ -203,7 +204,7 @@ runEvalCmd plId st EvalParams{..} =
 
             -- enable codegen
             liftIO $ queueForEvaluation st nfp
-            liftIO $ setSomethingModified st [toKey NeedsCompilation nfp] "Eval"
+            liftIO $ setSomethingModified VFSUnmodified st [toKey NeedsCompilation nfp] "Eval"
 
             session <- runGetSession st nfp
 


### PR DESCRIPTION
We need to take VFS snapshots as soon as we get a change notification.

Consider the following interleaving of events:

1. Change Notification A (updates LSP VFS)
2. Restart Shake Session (A changed) initiated
3. Change Notification B (updates LSP VFS)
4. Restart Shake Session (A changed) takes VFS snapshot and possibly performs more computation
5. Restart Shake Session (B changed)

In particular, between step 3 and 5, we took a snapshot for a previous build,
but this snapshot included changes from a newer VFS state that the build should
not have seen.

To fix this, we need to take snapshots as soon as a notification handler is
called, before forking any threads. This works because LSP calls all handlers
in a single threaded fashion and these handlers block message processing. It
is essential to do this on the LSP handler thread rather than the reactor thread
that GHCIDE sets up in order to maintin the property.


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2789"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

