### PR TITLE
[hls-graph] do not Spawn on  refresh

### DIFF
--- a/hls-graph/src/Development/IDE/Graph/Internal/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Database.hs
@@ -116,7 +116,7 @@ builder db@Database{..} stack keys = withRunInIO $ \(RunInIO run) -> do
                     let act = run (refresh db stack id s)
                         (force, val) = splitIO (join act)
                     SMap.focus (updateStatus $ Running current force val s) id databaseValues
-                    modifyTVar' toForce (Spawn force:)
+                    modifyTVar' toForce (Wait force:)
                     pure val
 
             pure (id, val)


### PR DESCRIPTION
Avoid spawning a new thread to schedule a build node dependencies. For performance reasons we want to spawn only the rule executions, while running the scheduler in the local thread.

Benchmark results: TBA

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2793"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

