### PR TITLE
Fix `cabal install` commands for local HLS build in docs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,13 +168,13 @@ Dynamically linked binaries (including`ghci`) use the system linker instead of t
 The easiest way to obtain a dynamically linked HLS binary is to build HLS locally. With `cabal` this can be done as follows:
 
 ```bash
-cabal update && cabal install pkg:haskell-language-server
+cabal update && cabal install :pkg:haskell-language-server
 ```
 
 If you are compiling with a ghc version with a specific `cabal-ghc${ghcVersion}.project` in the repo you will have to use it. For example for ghc-9.0.x:
 
 ```bash
-cabal update && cabal install pkg:haskell-language-server --project-file=cabal-ghc90.project
+cabal update && cabal install :pkg:haskell-language-server --project-file=cabal-ghc90.project
 ```
 
 Or with `stack`:


### PR DESCRIPTION
The existing command errors:

```
$ cabal install pkg:haskell-language-server
cabal: Internal error in target matching. It should always be possible to find
a syntax that's sufficiently qualified to give an unambiguous match. However
when matching 'pkg:haskell-language-server' we found haskell-language-server
(named-package) which does not have an unambiguous syntax. The possible syntax
and the targets they match are as follows:
'haskell-language-server' which matches haskell-language-server
(named-package)
'pkg:haskell-language-server' which matches haskell-language-server
(named-package), pkg:haskell-language-server (unknown-component),
:pkg:pkg:lib:pkg:file:haskell-language-server (unknown-file)
':pkg:haskell-language-server' which matches haskell-language-server
(named-package)
```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2807"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

