### PR TITLE
Serialize Core

### DIFF
--- a/ghcide/exe/Arguments.hs
+++ b/ghcide/exe/Arguments.hs
@@ -15,6 +15,7 @@ data Arguments = Arguments
     ,argsOTMemoryProfiling          :: Bool
     ,argsTesting                    :: Bool
     ,argsDisableKick                :: Bool
+    ,argsVerifyCoreFile             :: Bool
     ,argsThreads                    :: Int
     ,argsVerbose                    :: Bool
     ,argsCommand                    :: Command
@@ -37,6 +38,7 @@ arguments plugins = Arguments
       <*> switch (long "ot-memory-profiling" <> help "Record OpenTelemetry info to the eventlog. Needs the -l RTS flag to have an effect")
       <*> switch (long "test" <> help "Enable additional lsp messages used by the testsuite")
       <*> switch (long "test-no-kick" <> help "Disable kick. Useful for testing cancellation")
+      <*> switch (long "verify-core-file" <> help "Verify core trips by roundtripping after serialization. Slow, only useful for testing purposes")
       <*> option auto (short 'j' <> help "Number of threads (0: automatic)" <> metavar "NUM" <> value 0 <> showDefault)
       <*> switch (short 'd' <> long "verbose" <> help "Include internal events in logging output")
       <*> (commandP plugins <|> lspCommand <|> checkCommand)

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -142,6 +142,7 @@ main = withTelemetryLogger $ \telemetryLogger -> do
                 , optCheckParents = pure $ checkParents config
                 , optCheckProject = pure $ checkProject config
                 , optRunSubset = not argsConservativeChangeTracking
+                , optVerifyCoreFile = argsVerifyCoreFile
                 }
         , IDEMain.argsMonitoring = OpenTelemetry.monitoring <> EKG.monitoring logger argsMonitoringPort
         }

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -180,6 +180,7 @@ library
         Development.IDE.GHC.Compat.Units
         Development.IDE.GHC.Compat.Util
         Development.IDE.Core.Compile
+        Development.IDE.GHC.CoreFile
         Development.IDE.GHC.Dump
         Development.IDE.GHC.Error
         Development.IDE.GHC.ExactPrint

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1313,7 +1313,7 @@ parseRuntimeDeps anns = mkModuleEnv $ mapMaybe go anns
       = Just (mod, bs)
     go _ = Nothing
 
--- | checkLinkableDependencies compares the core files in the shake store to
+-- | checkLinkableDependencies compares the core files in the Values store to
 -- the runtime dependencies of the module, to check if any of them are out of date
 -- Hopefully 'runtime_deps' will be empty if the module didn't actually use TH
 -- See Note [Recompilation avoidance in the presence of TH]

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -45,6 +45,7 @@ import           Control.Lens                      hiding (List, (<.>))
 import           Control.Monad.Except
 import           Control.Monad.Extra
 import           Control.Monad.Trans.Except
+import qualified Control.Monad.Trans.State.Strict as S
 import           Data.Aeson                        (toJSON)
 import           Data.Bifunctor                    (first, second)
 import           Data.Binary
@@ -52,6 +53,8 @@ import qualified Data.ByteString                   as BS
 import           Data.Coerce
 import qualified Data.DList                        as DL
 import           Data.Functor
+import Data.Generics.Schemes
+import Data.Generics.Aliases
 import qualified Data.HashMap.Strict               as HashMap
 import           Data.IORef
 import           Data.IntMap                       (IntMap)
@@ -124,14 +127,11 @@ import           GHC                               (Anchor (anchor),
                                                     EpaCommentTok (EpaBlockComment, EpaLineComment),
                                                     epAnnComments,
                                                     priorComments)
+import           GHC                               (ModuleGraph, mgLookupModule, mgModSummaries)
 import qualified GHC                               as G
 import           GHC.Hs                            (LEpaComment)
 import qualified GHC.Types.Error                   as Error
 #endif
-import GHC (ModuleGraph, mgLookupModule, mgModSummaries)
-import qualified Control.Monad.Trans.State.Strict as S
-import Data.Generics.Schemes
-import Data.Generics.Aliases
 
 -- | Given a string buffer, return the string (after preprocessing) and the 'ParsedModule'.
 parseModule

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1313,7 +1313,7 @@ parseRuntimeDeps anns = mkModuleEnv $ mapMaybe go anns
       = Just (mod, bs)
     go _ = Nothing
 
--- | checkLinkableDependencies compares the core files in the Values store to
+-- | checkLinkableDependencies compares the core files in the build graph to
 -- the runtime dependencies of the module, to check if any of them are out of date
 -- Hopefully 'runtime_deps' will be empty if the module didn't actually use TH
 -- See Note [Recompilation avoidance in the presence of TH]

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -150,7 +150,7 @@ getModificationTimeImpl missingFileDiags file = do
 --   But interface files are private, in that only HLS writes them.
 --   So we implement watching ourselves, and bypass the need for alwaysRerun.
 isInterface :: NormalizedFilePath -> Bool
-isInterface f = takeExtension (fromNormalizedFilePath f) `elem` [".hi", ".hi-boot"]
+isInterface f = takeExtension (fromNormalizedFilePath f) `elem` [".hi", ".hi-boot", ".hie", ".hie-boot", ".core"]
 
 -- | Reset the GetModificationTime state of interface files
 resetInterfaceStore :: ShakeExtras -> NormalizedFilePath -> STM ()

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -17,6 +17,7 @@ module Development.IDE.Core.RuleTypes(
     ) where
 
 import           Control.DeepSeq
+import           Control.Exception                            (assert)
 import           Control.Lens
 import           Data.Aeson.Types                             (Value)
 import           Data.Hashable
@@ -26,6 +27,7 @@ import           Data.Typeable
 import           Development.IDE.GHC.Compat                   hiding
                                                               (HieFileResult)
 import           Development.IDE.GHC.Compat.Util
+import           Development.IDE.GHC.CoreFile
 import           Development.IDE.GHC.Util
 import           Development.IDE.Graph
 import           Development.IDE.Import.DependencyInformation
@@ -43,8 +45,6 @@ import           Development.IDE.Types.Diagnostics
 import           GHC.Serialized                               (Serialized)
 import           Language.LSP.Types                           (Int32,
                                                                NormalizedFilePath)
-import           Development.IDE.GHC.CoreFile
-import           Control.Exception                            (assert)
 
 data LinkableType = ObjectLinkable | BCOLinkable
   deriving (Eq,Ord,Show, Generic)

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -99,7 +99,7 @@ import           Data.Tuple.Extra
 import           Development.IDE.Core.Compile
 import           Development.IDE.Core.FileExists hiding (LogShake, Log)
 import           Development.IDE.Core.FileStore               (getFileContents,
-                                                               resetInterfaceStore)
+                                                               getModTime)
 import           Development.IDE.Core.IdeConfiguration
 import           Development.IDE.Core.OfInterest hiding (LogShake, Log)
 import           Development.IDE.Core.PositionMapping
@@ -135,7 +135,7 @@ import           Ide.Plugin.Config
 import qualified Language.LSP.Server                          as LSP
 import           Language.LSP.Types                           (SMethod (SCustomMethod, SWindowShowMessage), ShowMessageParams (ShowMessageParams), MessageType (MtInfo))
 import           Language.LSP.VFS
-import           System.Directory                             (makeAbsolute)
+import           System.Directory                             (makeAbsolute, doesFileExist)
 import           Data.Default                                 (def, Default)
 import           Ide.Plugin.Properties                        (HasProperty,
                                                                KeyNameProxy,
@@ -154,6 +154,9 @@ import qualified Development.IDE.Core.Shake as Shake
 import qualified Development.IDE.GHC.ExactPrint as ExactPrint hiding (LogShake)
 import qualified Development.IDE.Types.Logger as Logger
 import qualified Development.IDE.Types.Shake as Shake
+import           Development.IDE.GHC.CoreFile
+import           Data.Time.Clock.POSIX             (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
+import Control.Monad.IO.Unlift
 
 data Log
   = LogShake Shake.Log
@@ -673,9 +676,13 @@ typeCheckRuleDefinition hsc pm = do
   setPriority priorityTypeCheck
   IdeOptions { optDefer = defer } <- getIdeOptions
 
-  linkables_to_keep <- currentLinkables
+  unlift <- askUnliftIO
+  let dets = TypecheckHelpers
+           { getLinkablesToKeep = unliftIO unlift $ currentLinkables
+           , getLinkables = unliftIO unlift . uses_ GetLinkable
+           }
   addUsageDependencies $ liftIO $
-    typecheckModule defer hsc linkables_to_keep pm
+    typecheckModule defer hsc dets pm
   where
     addUsageDependencies :: Action (a, Maybe TcModuleResult) -> Action (a, Maybe TcModuleResult)
     addUsageDependencies a = do
@@ -752,7 +759,7 @@ ghcSessionDepsDefinition fullModSummary GhcSessionDepsConfig{..} env file = do
             depSessions <- map hscEnv <$> uses_ (GhcSessionDeps_ fullModSummary) deps
             ifaces <- uses_ GetModIface deps
 
-            let inLoadOrder = map hirHomeMod ifaces
+            let            inLoadOrder = map (\HiFileResult{..} -> HomeModInfo hirModIface hirModDetails Nothing) ifaces
             session' <- liftIO $ mergeEnvs hsc mss inLoadOrder depSessions
 
             Just <$> liftIO (newHscEnvEqWithImportPaths (envImportPaths env) session' [])
@@ -768,7 +775,7 @@ getModIfaceFromDiskRule recorder = defineEarlyCutoff (cmapWithPrio LogShake reco
     Just session -> do
       linkableType <- getLinkableType f
       ver <- use_ GetModificationTime f
-      se@ShakeExtras{ideNc} <- getShakeExtras
+      ShakeExtras{ideNc} <- getShakeExtras
       let m_old = case old of
             Shake.Succeeded (Just old_version) v -> Just (v, old_version)
             Shake.Stale _   (Just old_version) v -> Just (v, old_version)
@@ -777,9 +784,10 @@ getModIfaceFromDiskRule recorder = defineEarlyCutoff (cmapWithPrio LogShake reco
             { source_version = ver
             , old_value = m_old
             , get_file_version = use GetModificationTime_{missingFileDiagnostics = False}
+            , get_linkable_hashes = \fs -> map linkableHash <$> uses_ GetLinkable fs
             , regenerate = regenerateHiFile session f ms
             }
-      r <- loadInterface se (hscEnv session) ms linkableType recompInfo
+      r <- loadInterface (hscEnv session) ms linkableType recompInfo
       case r of
         (diags, Nothing) -> return (Nothing, (diags, Nothing))
         (diags, Just x) -> do
@@ -899,7 +907,7 @@ getModIfaceRule recorder = defineEarlyCutoff (cmapWithPrio LogShake recorder) $ 
       hsc <- hscEnv <$> use_ GhcSessionDeps f
       let compile = fmap ([],) $ use GenerateCore f
       se <- getShakeExtras
-      (diags, !hiFile) <- compileToObjCodeIfNeeded se hsc linkableType compile tmr
+      (diags, !hiFile) <- writeCoreFileIfNeeded se hsc linkableType compile tmr
       let fp = hiFileFingerPrint <$> hiFile
       hiDiags <- case hiFile of
         Just hiFile
@@ -912,10 +920,6 @@ getModIfaceRule recorder = defineEarlyCutoff (cmapWithPrio LogShake recorder) $ 
       let fp = hiFileFingerPrint <$> hiFile
       return (fp, ([], hiFile))
 
-  -- Record the linkable so we know not to unload it
-  whenJust (hm_linkable . hirHomeMod =<< mhmi) $ \(LM time mod _) -> do
-      compiledLinkables <- getCompiledLinkables <$> getIdeGlobalAction
-      liftIO $ void $ modifyVar' compiledLinkables $ \old -> extendModuleEnv old mod time
   pure res
 
 -- | Count of total times we asked GHC to recompile
@@ -960,13 +964,12 @@ regenerateHiFile sess f ms compNeeded = do
               Nothing -> pure (diags', Nothing)
               Just tmr -> do
 
-                -- compile writes .o file
                 let compile = liftIO $ compileModule (RunSimplifier True) hsc (pm_mod_summary pm) $ tmrTypechecked tmr
 
                 se <- getShakeExtras
 
                 -- Bang pattern is important to avoid leaking 'tmr'
-                (diags'', !res) <- compileToObjCodeIfNeeded se hsc compNeeded compile tmr
+                (diags'', !res) <- writeCoreFileIfNeeded se hsc compNeeded compile tmr
 
                 -- Write hi file
                 hiDiags <- case res of
@@ -994,18 +997,20 @@ regenerateHiFile sess f ms compNeeded = do
 
 
 -- | HscEnv should have deps included already
-compileToObjCodeIfNeeded :: ShakeExtras -> HscEnv -> Maybe LinkableType -> Action (IdeResult ModGuts) -> TcModuleResult -> Action (IdeResult HiFileResult)
-compileToObjCodeIfNeeded _ hsc Nothing _ tmr = do
+-- This writes the core file if a linkable is required
+-- The actual linkable will be generated on demand when required by `GetLinkable`
+writeCoreFileIfNeeded :: ShakeExtras -> HscEnv -> Maybe LinkableType -> Action (IdeResult ModGuts) -> TcModuleResult -> Action (IdeResult HiFileResult)
+writeCoreFileIfNeeded _ hsc Nothing _ tmr = do
   incrementRebuildCount
   res <- liftIO $ mkHiFileResultNoCompile hsc tmr
   pure ([], Just $! res)
-compileToObjCodeIfNeeded se hsc (Just linkableType) getGuts tmr = do
+writeCoreFileIfNeeded se hsc (Just _) getGuts tmr = do
   incrementRebuildCount
   (diags, mguts) <- getGuts
   case mguts of
     Nothing -> pure (diags, Nothing)
     Just guts -> do
-      (diags', !res) <- liftIO $ mkHiFileResultCompile se hsc tmr guts linkableType
+      (diags', !res) <- liftIO $ mkHiFileResultCompile se hsc tmr guts
       pure (diags++diags', res)
 
 getClientSettingsRule :: Recorder (WithPriority Log) -> Rules ()
@@ -1036,6 +1041,48 @@ usePropertyAction kn plId p = do
   pure $ useProperty kn p $ plcConfig pluginConfig
 
 -- ---------------------------------------------------------------------
+
+getLinkableRule :: Recorder (WithPriority Log) -> Rules ()
+getLinkableRule recorder =
+  defineEarlyCutoff (cmapWithPrio LogShake recorder) $ Rule $ \GetLinkable f -> do
+    ModSummaryResult{msrModSummary = ms} <- use_ GetModSummary f
+    HiFileResult{hirModIface, hirModDetails, hirCoreFp} <- use_ GetModIface f
+    let obj_file  = ml_obj_file (ms_location ms)
+        core_file = ml_core_file (ms_location ms)
+    -- Can't use `GetModificationTime` rule because the core file was possibly written in this
+    -- very session, so the results aren't reliable
+    core_t <- liftIO $ getModTime core_file
+    case hirCoreFp of
+      Nothing -> error "called GetLinkable for a file without a linkable"
+      Just (bin_core, hash) -> do
+        session <- use_ GhcSessionDeps f
+        ShakeExtras{ideNc} <- getShakeExtras
+        let namecache_updater = mkUpdater ideNc
+        linkableType <- getLinkableType f >>= \case
+          Nothing -> error "called GetLinkable for a file which doesn't need compilation"
+          Just t -> pure t
+        (warns, hmi) <- case linkableType of
+          -- Bytecode needs to be regenerated from the core file
+          BCOLinkable -> liftIO $ coreFileToLinkable linkableType (hscEnv session) ms hirModIface hirModDetails bin_core (posixSecondsToUTCTime core_t)
+          -- Object code can be read from the disk
+          ObjectLinkable -> do
+            -- object file is up to date if it is newer than the core file
+            -- Can't use a rule like 'GetModificationTime' or 'GetFileExists' because 'coreFileToLinkable' will write the object file, and
+            -- thus bump its modification time, forcing this rule to be rerun every time.
+            exists <- liftIO $ doesFileExist obj_file
+            mobj_time <- liftIO $
+              if exists
+              then Just <$> getModTime obj_file
+              else pure Nothing
+            case mobj_time of
+              Just obj_t
+                | obj_t >= core_t -> pure ([], Just $ HomeModInfo hirModIface hirModDetails (Just $ LM (posixSecondsToUTCTime obj_t) (ms_mod ms) [DotO obj_file]))
+              _ -> liftIO $ coreFileToLinkable linkableType (hscEnv session) ms hirModIface hirModDetails bin_core (error "object doesn't have time")
+        -- Record the linkable so we know not to unload it
+        whenJust (hm_linkable =<< hmi) $ \(LM time mod _) -> do
+            compiledLinkables <- getCompiledLinkables <$> getIdeGlobalAction
+            liftIO $ void $ modifyVar' compiledLinkables $ \old -> extendModuleEnv old mod time
+        return (hash <$ hmi, (warns, LinkableResult <$> hmi <*> pure hash))
 
 -- | For now we always use bytecode unless something uses unboxed sums and tuples along with TH
 getLinkableType :: NormalizedFilePath -> Action (Maybe LinkableType)
@@ -1069,7 +1116,6 @@ needsCompilationRule file = do
             (,) (map (fmap (msrModSummary . fst)) <$> usesWithStale GetModSummaryWithoutTimestamps revdeps)
                 (uses NeedsCompilation revdeps)
         pure $ computeLinkableType ms modsums (map join needsComps)
-
   pure (Just $ encodeLinkableType res, Just res)
   where
     computeLinkableType :: ModSummary -> [Maybe ModSummary] -> [Maybe LinkableType] -> Maybe LinkableType
@@ -1170,3 +1216,4 @@ mainRule recorder RulesConfig{..} = do
     persistentHieFileRule recorder
     persistentDocMapRule
     persistentImportMapRule
+    getLinkableRule recorder

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -1136,7 +1136,7 @@ uses_th_qq (ms_hspp_opts -> dflags) =
 -- Depends on whether it uses unboxed tuples or sums
 computeLinkableTypeForDynFlags :: DynFlags -> LinkableType
 computeLinkableTypeForDynFlags d
-#if defined(GHC_PATCHED_UNBOXED_BYTECODE)
+#if defined(GHC_PATCHED_UNBOXED_BYTECODE) || MIN_VERSION_ghc(9,2,0)
           = BCOLinkable
 #else
           | unboxed_tuples_or_sums = ObjectLinkable

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -784,7 +784,7 @@ getModIfaceFromDiskRule recorder = defineEarlyCutoff (cmapWithPrio LogShake reco
             { source_version = ver
             , old_value = m_old
             , get_file_version = use GetModificationTime_{missingFileDiagnostics = False}
-            , get_linkable_hashes = \fs -> map linkableHash <$> uses_ GetLinkable fs
+            , get_linkable_hashes = \fs -> map (snd . fromJust . hirCoreFp) <$> uses_ GetModIface fs
             , regenerate = regenerateHiFile session f ms
             }
       r <- loadInterface (hscEnv session) ms linkableType recompInfo

--- a/ghcide/src/Development/IDE/GHC/Compat.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat.hs
@@ -79,6 +79,7 @@ module Development.IDE.GHC.Compat(
     tidyExpr,
     emptyTidyEnv,
     corePrepExpr,
+    corePrepPgm,
     lintInteractiveExpr,
     icInteractiveModule,
     HomePackageTable,
@@ -93,6 +94,12 @@ module Development.IDE.GHC.Compat(
     module UniqSet,
     module UniqDFM,
     getDependentMods,
+    diffBinds,
+    flattenBinds,
+    mkRnEnv2,
+    emptyInScopeSet,
+    Unfolding(..),
+    noUnfolding,
 #if MIN_VERSION_ghc(9,2,0)
     loadExpr,
     byteCodeGen,
@@ -122,11 +129,12 @@ import           GHC                                   hiding (HasSrcSpan,
                                                         lookupName, exprType)
 #if MIN_VERSION_ghc(9,0,0)
 import GHC.Driver.Hooks (hscCompileCoreExprHook)
-import GHC.Core (CoreExpr, CoreProgram)
+import GHC.Core (CoreExpr, CoreProgram, Unfolding(..), noUnfolding, flattenBinds)
 import qualified GHC.Core.Opt.Pipeline as GHC
 import GHC.Core.Tidy (tidyExpr)
-import GHC.Types.Var.Env (emptyTidyEnv)
+import GHC.Types.Var.Env (emptyTidyEnv, mkRnEnv2, emptyInScopeSet)
 import qualified GHC.CoreToStg.Prep as GHC
+import GHC.CoreToStg.Prep (corePrepPgm)
 import GHC.Core.Lint (lintInteractiveExpr)
 #if MIN_VERSION_ghc(9,2,0)
 import GHC.Unit.Home.ModInfo (lookupHpt, HomePackageTable)
@@ -146,11 +154,11 @@ import GHC.Types.Unique.Set as UniqSet
 import GHC.Types.Unique.DFM  as UniqDFM
 #else
 import Hooks (hscCompileCoreExprHook)
-import CoreSyn (CoreExpr)
+import CoreSyn (CoreExpr, flattenBinds, Unfolding(..), noUnfolding)
 import qualified SimplCore as GHC
 import CoreTidy (tidyExpr)
-import VarEnv (emptyTidyEnv)
-import CorePrep (corePrepExpr)
+import VarEnv (emptyTidyEnv, mkRnEnv2, emptyInScopeSet)
+import CorePrep (corePrepExpr, corePrepPgm)
 import CoreLint (lintInteractiveExpr)
 import ByteCodeGen (coreExprToBCOs)
 import HscTypes (icInteractiveModule, HomePackageTable, lookupHpt, Dependencies(dep_mods))
@@ -234,6 +242,8 @@ import GHC.ByteCode.Types
 import GHC.Linker.Loader (loadDecls)
 import GHC.Data.Maybe
 import GHC.CoreToStg
+import GHC.Core.Utils
+import GHC.Types.Var.Env
 #endif
 
 type ModIfaceAnnotation = Annotation

--- a/ghcide/src/Development/IDE/GHC/Compat/Core.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Core.hs
@@ -305,6 +305,7 @@ module Development.IDE.GHC.Compat.Core (
     -- * Panic
     PlainGhcException,
     panic,
+    panicDoc,
     -- * Other
     GHC.CoreModule(..),
     GHC.SafeHaskellMode(..),

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -6,7 +6,7 @@ module Development.IDE.GHC.Compat.Outputable (
     showSDoc,
     showSDocUnsafe,
     showSDocForUser,
-    ppr, pprPanic, text, vcat, (<+>), ($$), empty, hang, nest,
+    ppr, pprPanic, text, vcat, (<+>), ($$), empty, hang, nest, punctuate,
     printSDocQualifiedUnsafe,
     printWithoutUniques,
     mkPrintUnqualified,

--- a/ghcide/src/Development/IDE/GHC/CoreFile.hs
+++ b/ghcide/src/Development/IDE/GHC/CoreFile.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+-- | CoreFiles let us serialize Core to a file in order to later recover it
+-- without reparsing or retypechecking
+module Development.IDE.GHC.CoreFile
+  ( CoreFile
+  , codeGutsToCoreFile
+  , typecheckCoreFile
+  , readBinCoreFile
+  , writeBinCoreFile
+  , getImplicitBinds) where
+
+import Data.IORef
+import Data.Foldable
+import Data.List (isPrefixOf)
+import Control.Monad.IO.Class
+import Control.Monad
+import Data.Maybe
+
+import Development.IDE.GHC.Compat
+
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Utils.Binary
+import GHC.Core
+import GHC.CoreToIface
+import GHC.IfaceToCore
+import GHC.Iface.Env
+import GHC.Iface.Binary
+import GHC.Types.Id.Make
+
+#if MIN_VERSION_ghc(9,2,0)
+import GHC.Types.TypeEnv
+#else
+import GHC.Driver.Types
+#endif
+
+#elif MIN_VERSION_ghc(8,6,0)
+import Binary
+import CoreSyn
+import ToIface
+import TcIface
+import IfaceEnv
+import BinIface
+import HscTypes
+import IdInfo
+import Var
+import Unique
+import MkId
+#endif
+
+-- | Initial ram buffer to allocate for writing interface files
+initBinMemSize :: Int
+initBinMemSize = 1024 * 1024
+
+newtype CoreFile = CoreFile { cf_bindings :: [TopIfaceBinding IfaceId] }
+
+-- | Like IfaceBinding, but lets us serialize internal names as well
+data TopIfaceBinding v
+  = TopIfaceNonRec v IfaceExpr
+  | TopIfaceRec    [(v, IfaceExpr)]
+  deriving (Functor, Foldable, Traversable)
+
+-- | GHC doesn't export 'tcIdDetails', 'tcIfaceInfo', or 'tcIfaceType',
+-- but it does export 'tcIfaceDecl'
+-- so we use `IfaceDecl` as a container for all of these
+-- invariant: 'IfaceId' is always a 'IfaceId' constructor
+type IfaceId = IfaceDecl
+
+instance Binary (TopIfaceBinding IfaceId) where
+  put_ bh (TopIfaceNonRec d e) = do
+    putByte bh 0
+    put_ bh d
+    put_ bh e
+  put_ bh (TopIfaceRec vs) = do
+    putByte bh 1
+    put_ bh vs
+  get bh = do
+    t <- getByte bh
+    case t of
+      0 -> TopIfaceNonRec <$> get bh <*> get bh
+      1 -> TopIfaceRec <$> get bh
+      _ -> error "Binary TopIfaceBinding"
+
+instance Binary CoreFile where
+  put_ bh (CoreFile a) = put_ bh a
+  get bh = CoreFile <$> get bh
+
+readBinCoreFile
+  :: NameCacheUpdater
+  -> FilePath
+  -> IO CoreFile
+readBinCoreFile name_cache fat_hi_path = do
+    bh <- readBinMem fat_hi_path
+    getWithUserData name_cache bh
+
+-- | Write a core file
+writeBinCoreFile :: FilePath -> CoreFile -> IO ()
+writeBinCoreFile core_path fat_iface = do
+    bh <- openBinMem initBinMemSize
+
+    let quietTrace =
+#if MIN_VERSION_ghc(9,2,0)
+          QuietBinIFace
+#else
+          (const $ pure ())
+#endif
+
+    putWithUserData quietTrace bh fat_iface
+
+    -- And send the result to the file
+    writeBinMem bh core_path
+
+-- Implicit binds aren't tidied, so we can't serialise them.
+-- This isn't a problem however since we can regenerate them from the
+-- original ModIface
+codeGutsToCoreFile :: CgGuts -> CoreFile
+codeGutsToCoreFile CgGuts{..} = CoreFile (map (toIfaceTopBind cg_module) $ filter isNotImplictBind cg_binds)
+
+-- | Implicit binds can be generated from the interface and are not tidied,
+-- so we must filter them out
+isNotImplictBind :: CoreBind -> Bool
+isNotImplictBind bind = any (not . isImplicitId) $ bindBindings bind
+
+bindBindings :: CoreBind -> [Var]
+bindBindings (NonRec b _) = [b]
+bindBindings (Rec bnds) = map fst bnds
+
+getImplicitBinds :: TyCon -> [CoreBind]
+getImplicitBinds tc = cls_binds ++ getTyConImplicitBinds tc
+  where
+    cls_binds = maybe [] getClassImplicitBinds (tyConClass_maybe tc)
+
+getTyConImplicitBinds :: TyCon -> [CoreBind]
+getTyConImplicitBinds tc
+  | isNewTyCon tc = []  -- See Note [Compulsory newtype unfolding] in MkId
+  | otherwise     = map get_defn (mapMaybe dataConWrapId_maybe (tyConDataCons tc))
+
+getClassImplicitBinds :: Class -> [CoreBind]
+getClassImplicitBinds cls
+  = [ NonRec op (mkDictSelRhs cls val_index)
+    | (op, val_index) <- classAllSelIds cls `zip` [0..] ]
+
+get_defn :: Id -> CoreBind
+get_defn id = NonRec id (unfoldingTemplate (realIdUnfolding id))
+
+toIfaceTopBndr :: Module -> Id -> IfaceId
+toIfaceTopBndr mod id
+  = IfaceId (mangleDeclName mod $ getName id)
+            (toIfaceType (idType id))
+            (toIfaceIdDetails (idDetails id))
+            (toIfaceIdInfo (idInfo id))
+
+toIfaceTopBind :: Module -> Bind Id -> TopIfaceBinding IfaceId
+toIfaceTopBind mod (NonRec b r) = TopIfaceNonRec (toIfaceTopBndr mod b) (toIfaceExpr r)
+toIfaceTopBind mod (Rec prs)    = TopIfaceRec [(toIfaceTopBndr mod b, toIfaceExpr r) | (b,r) <- prs]
+
+typecheckCoreFile :: Module -> IORef TypeEnv -> CoreFile -> IfG CoreProgram
+typecheckCoreFile this_mod type_var (CoreFile prepd_binding) =
+  initIfaceLcl this_mod (text "typecheckCoreFile") NotBoot $ do
+    tcTopIfaceBindings type_var prepd_binding
+
+-- | Internal names can't be serialized, so we mange them
+-- to an external name and restore at deserialization time
+-- This is necessary because we rely on stuffing TopIfaceBindings into
+-- a IfaceId because we don't have access to 'tcIfaceType' etc..
+mangleDeclName :: Module -> Name -> Name
+mangleDeclName mod name
+  | isExternalName name = name
+  | otherwise = mkExternalName (nameUnique name) (mangleModule mod) (nameOccName name) (nameSrcSpan name)
+
+-- | Mangle the module name too to avoid conflicts
+mangleModule :: Module -> Module
+mangleModule mod = mkModule (moduleUnit mod) (mkModuleName $ "GHCIDEINTERNAL" ++ moduleNameString (moduleName mod))
+
+isGhcideModule :: Module -> Bool
+isGhcideModule mod = "GHCIDEINTERNAL" `isPrefixOf` (moduleNameString $ moduleName mod)
+
+-- Is this a fake external name that we need to make into an internal name?
+isGhcideName :: Name -> Bool
+isGhcideName = isGhcideModule . nameModule
+
+tcTopIfaceBindings :: IORef TypeEnv -> [TopIfaceBinding IfaceId]
+          -> IfL [CoreBind]
+tcTopIfaceBindings ty_var ver_decls
+   = do
+     int <- mapM (traverse $ tcIfaceId) ver_decls
+     let all_ids = concatMap toList int
+     liftIO $ modifyIORef ty_var (flip extendTypeEnvList $ map AnId all_ids)
+     extendIfaceIdEnv all_ids $ mapM tc_iface_bindings int
+
+tcIfaceId :: IfaceId -> IfL Id
+tcIfaceId = fmap getIfaceId . tcIfaceDecl False <=< unmangle_decl_name
+  where
+    unmangle_decl_name ifid@IfaceId{ ifName = name }
+    -- Check if the name is mangled
+      | isGhcideName name = do
+        name' <- newIfaceName (mkVarOcc $ getOccString name)
+        pure $ ifid{ ifName = name' }
+      | otherwise = pure ifid
+    -- invariant: 'IfaceId' is always a 'IfaceId' constructor
+    getIfaceId (AnId id) = id
+    getIfaceId _ = error "tcIfaceId: got non Id"
+
+tc_iface_bindings :: TopIfaceBinding Id -> IfL CoreBind
+tc_iface_bindings (TopIfaceNonRec v e) = do
+  e' <- tcIfaceExpr e
+  pure $ NonRec v e'
+tc_iface_bindings (TopIfaceRec vs) = do
+  vs' <- traverse (\(v, e) -> (,) <$> pure v <*> tcIfaceExpr e) vs
+  pure $ Rec vs'

--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -210,3 +210,8 @@ instance (NFData (HsModule a)) where
 
 instance Show OccName where show = unpack . printOutputable
 instance Hashable OccName where hashWithSalt s n = hashWithSalt s (getKey $ getUnique n)
+
+instance Show HomeModInfo where show = show . mi_module . hm_iface
+
+instance NFData HomeModInfo where
+  rnf (HomeModInfo iface dets link) = rwhnf iface `seq` rnf dets `seq` rnf link

--- a/ghcide/src/Development/IDE/Types/Options.hs
+++ b/ghcide/src/Development/IDE/Types/Options.hs
@@ -83,6 +83,8 @@ data IdeOptions = IdeOptions
   , optProgressStyle      :: ProgressReportingStyle
   , optRunSubset          :: Bool
       -- ^ Experimental feature to re-run only the subset of the Shake graph that has changed
+  , optVerifyCoreFile     :: Bool
+    -- ^ Verify core files after serialization
   }
 
 data OptHaddockParse = HaddockParse | NoHaddockParse
@@ -135,6 +137,7 @@ defaultIdeOptions session = IdeOptions
     ,optSkipProgress = defaultSkipProgress
     ,optProgressStyle = Explicit
     ,optRunSubset = True
+    ,optVerifyCoreFile = False
     ,optMaxDirtyAge = 100
     }
 

--- a/ghcide/test/data/THCoreFile/THA.hs
+++ b/ghcide/test/data/THCoreFile/THA.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TemplateHaskell #-}
+module THA where
+import Language.Haskell.TH
+import Control.Monad (when)
+
+th_a :: DecsQ
+th_a = do
+  when (show (StrictConstructor1 123 True 4567) /= "StrictConstructor1 123 True 4567") $ error "TH validation error"
+  when (show (StrictConstructor2 123 True 4567) /= "StrictConstructor2 123 True 4567") $ error "TH validation error"
+  when (show (StrictConstructor3 123 True 4567) /= "StrictConstructor3 123 True 4567") $ error "TH validation error"
+  when (show (classMethod 'z') /= "True") $ error "TH validation error"
+  when (show (classMethod 'a') /= "False") $ error "TH validation error"
+  [d| a = () |]
+
+data StrictType1 = StrictConstructor1 !Int !Bool Int deriving Show
+data StrictType2 = StrictConstructor2 !Int !Bool !Int deriving Show
+data StrictType3 = StrictConstructor3 !Int !Bool !Int deriving Show
+
+class SingleMethodClass a where
+  classMethod :: a -> Bool
+
+instance SingleMethodClass Char where
+  classMethod = (== 'z')

--- a/ghcide/test/data/THCoreFile/THB.hs
+++ b/ghcide/test/data/THCoreFile/THB.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE TemplateHaskell #-}
+module THB where
+import THA
+import Control.Monad (when)
+
+$(do
+  -- Need to verify in both defining module and usage module"
+  when (show (StrictConstructor1 123 True 4567) /= "StrictConstructor1 123 True 4567") $ error "TH validation error"
+  when (show (StrictConstructor2 123 True 4567) /= "StrictConstructor2 123 True 4567") $ error "TH validation error"
+  when (show (StrictConstructor3 123 True 4567) /= "StrictConstructor3 123 True 4567") $ error "TH validation error"
+  when (show (classMethod 'z') /= "True") $ error "TH validation error"
+  when (show (classMethod 'a') /= "False") $ error "TH validation error"
+  th_a)

--- a/ghcide/test/data/THCoreFile/THC.hs
+++ b/ghcide/test/data/THCoreFile/THC.hs
@@ -1,0 +1,5 @@
+module THC where
+import THB
+
+c ::()
+c = a

--- a/ghcide/test/data/THCoreFile/hie.yaml
+++ b/ghcide/test/data/THCoreFile/hie.yaml
@@ -1,0 +1,1 @@
+cradle: {direct: {arguments: ["-package template-haskell", "THA", "THB", "THC"]}}

--- a/ghcide/test/data/THUnboxed/THA.hs
+++ b/ghcide/test/data/THUnboxed/THA.hs
@@ -1,9 +1,16 @@
-{-# LANGUAGE TemplateHaskell, UnboxedTuples #-}
+{-# LANGUAGE TemplateHaskell, UnboxedTuples, BangPatterns #-}
 module THA where
 import Language.Haskell.TH
 
-f :: Int -> (# Int, Int #)
-f x = (# x , x+1 #)
+data Foo = Foo !Int !Char !String
+  deriving Show
+
+newtype Bar = Bar Int
+  deriving Show
+
+
+f :: Int -> (# Int, Int, Foo, Bar#)
+f x = (# x , x+1 , Foo x 'a' "test", Bar 1 #)
 
 th_a :: DecsQ
-th_a = case f 1 of (# a , b #) -> [d| a = () |]
+th_a = case f 1 of (# a , b, Foo _ _ _, Bar !_ #) -> [d| a = () |]

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4622,6 +4622,7 @@ thTests =
         return ()
     , thReloadingTest False
     , thLoadingTest
+    , thCoreTest
     , ignoreInWindowsBecause "Broken in windows" $ thReloadingTest True
     -- Regression test for https://github.com/haskell/haskell-language-server/issues/891
     , thLinkingTest False
@@ -4676,6 +4677,12 @@ thLoadingTest :: TestTree
 thLoadingTest = testCase "Loading linkables" $ runWithExtraFiles "THLoading" $ \dir -> do
     let thb = dir </> "THB.hs"
     _ <- openDoc thb "haskell"
+    expectNoMoreDiagnostics 1
+
+thCoreTest :: TestTree
+thCoreTest = testCase "Verifying TH core files" $ runWithExtraFiles "THCoreFile" $ \dir -> do
+    let thc = dir </> "THC.hs"
+    _ <- openDoc thc "haskell"
     expectNoMoreDiagnostics 1
 
 -- | test that TH is reevaluated on typecheck
@@ -6604,7 +6611,7 @@ runInDir'' lspCaps dir startExeIn startSessionIn extraOptions s = do
 
   shakeProfiling <- getEnv "SHAKE_PROFILING"
   let cmd = unwords $
-       [ghcideExe, "--lsp", "--test", "--verbose", "-j2", "--cwd", startDir
+       [ghcideExe, "--lsp", "--test", "--verify-core-file", "--verbose", "-j2", "--cwd", startDir
        ] ++ ["--shake-profiling=" <> dir | Just dir <- [shakeProfiling]
        ] ++ extraOptions
   -- HIE calls getXgdDirectory which assumes that HOME is set.

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -81,6 +81,7 @@ library
     , stm-containers
     , time
     , transformers
+    , unliftio
     , unordered-containers
 
   if flag(embed-files)

--- a/hls-graph/src/Development/IDE/Graph/Internal/Types.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Types.hs
@@ -38,6 +38,7 @@ import qualified StmContainers.Map             as SMap
 import           System.Time.Extra             (Seconds)
 import qualified Data.HashSet as Set
 import Data.List (intercalate)
+import UnliftIO (MonadUnliftIO)
 
 
 unwrapDynamic :: forall a . Typeable a => Dynamic -> a
@@ -64,7 +65,7 @@ data SRules = SRules {
 -- ACTIONS
 
 newtype Action a = Action {fromAction :: ReaderT SAction IO a}
-    deriving newtype (Monad, Applicative, Functor, MonadIO, MonadFail, MonadThrow, MonadCatch, MonadMask)
+    deriving newtype (Monad, Applicative, Functor, MonadIO, MonadFail, MonadThrow, MonadCatch, MonadMask, MonadUnliftIO)
 
 data SAction = SAction {
     actionDatabase :: !Database,

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -45,18 +45,22 @@ import qualified Data.Text                       as T
 import           Data.Time                       (getCurrentTime)
 import           Data.Typeable                   (Typeable)
 import           Development.IDE                 (GetModSummary (..),
+                                                  GetDependencyInformation (..),
+                                                  GetLinkable (..),
                                                   GhcSessionIO (..), IdeState,
                                                   ModSummaryResult (..),
                                                   NeedsCompilation (NeedsCompilation),
                                                   VFSModified (..), evalGhcEnv,
                                                   hscEnvWithImportPaths,
                                                   printOutputable, runAction,
+                                                  linkableHomeMod,
                                                   textToStringBuffer,
                                                   toNormalizedFilePath',
                                                   uriToFilePath', useNoFile_,
-                                                  useWithStale_, use_)
+                                                  useWithStale_, use_, uses_)
 import           Development.IDE.Core.Rules      (GhcSessionDepsConfig (..),
                                                   ghcSessionDepsDefinition)
+import           Development.IDE.Import.DependencyInformation ( reachableModules )
 import           Development.IDE.GHC.Compat      hiding (typeKind, unitState)
 import qualified Development.IDE.GHC.Compat      as Compat
 import qualified Development.IDE.GHC.Compat      as SrcLoc
@@ -294,10 +298,19 @@ runEvalCmd plId st EvalParams{..} =
                         setContext [Compat.IIModule modName]
                         Right <$> getSession
             evalCfg <- lift $ getEvalConfig plId
+
+            -- Get linkables for all modules below us
+            -- This can be optimised to only get the linkables for the symbols depended on by
+            -- the statement we are parsing
+            lbs <- liftIO $ runAction "eval: GetLinkables" st $ do
+              linkables_needed <- reachableModules <$> use_ GetDependencyInformation nfp
+              uses_ GetLinkable linkables_needed
+            let hscEnv'' = hscEnv' { hsc_HPT  = addListToHpt (hsc_HPT hscEnv') [(moduleName $ mi_module $ hm_iface hm, hm) | lb <- lbs, let hm = linkableHomeMod lb] }
+
             edits <-
                 perf "edits" $
                     liftIO $
-                        evalGhcEnv hscEnv' $
+                        evalGhcEnv hscEnv'' $
                             runTests
                                 evalCfg
                                 (st, fp)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -304,7 +304,7 @@ runEvalCmd plId st EvalParams{..} =
             -- the statement we are parsing
             lbs <- liftIO $ runAction "eval: GetLinkables" st $ do
               linkables_needed <- reachableModules <$> use_ GetDependencyInformation nfp
-              uses_ GetLinkable linkables_needed
+              uses_ GetLinkable (filter (/= nfp) linkables_needed) -- We don't need the linkable for the current module
             let hscEnv'' = hscEnv' { hsc_HPT  = addListToHpt (hsc_HPT hscEnv') [(moduleName $ mi_module $ hm_iface hm, hm) | lb <- lbs, let hm = linkableHomeMod lb] }
 
             edits <-

--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -458,9 +458,9 @@ callRetrie state session rewrites origin restrictToOriginatingFile = do
             let fs = occNameFS n
         ]
     fixFixities f pm = do
-      HiFileResult {hirHomeMod} <-
+      HiFileResult {hirModIface} <-
         useOrFail "GetModIface" NoTypeCheck GetModIface f
-      let fixities = fixityEnvFromModIface $ hm_iface hirHomeMod
+      let fixities = fixityEnvFromModIface hirModIface
       res <- transformA pm (fix fixities)
       return (fixities, res)
     fixAnns ParsedModule {..} =


### PR DESCRIPTION
Serialize core to core files
    
Add a `.hi.core` file format to which we serialize out compiled core after generating it.
This core is then read back in on subsequent runs and compiled to bytecode.

This greatly speeds up startup times when we need compilation, as we can simply read bytecode
off the disk instead of having to recompile a lot of modules

This is based off Fat Interface files in GHC: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7502


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2813"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

