### PR TITLE
bench: Add more metrics

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Test.hs
+++ b/ghcide/src/Development/IDE/Plugin/Test.hs
@@ -28,6 +28,7 @@ import           Development.IDE.Core.OfInterest      (getFilesOfInterest)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Service
 import           Development.IDE.Core.Shake
+import           Development.IDE.Core.Rules
 import           Development.IDE.GHC.Compat
 import           Development.IDE.Graph                (Action)
 import qualified Development.IDE.Graph                as Graph
@@ -64,6 +65,7 @@ data TestRequest
     | GarbageCollectDirtyKeys CheckParents Age    -- ^ :: [String] (list of keys collected)
     | GetStoredKeys                  -- ^ :: [String] (list of keys in store)
     | GetFilesOfInterest             -- ^ :: [FilePath]
+    | GetRebuildsCount               -- ^ :: Int (number of times we recompiled with GHC)
     deriving Generic
     deriving anyclass (FromJSON, ToJSON)
 
@@ -131,6 +133,9 @@ testRequestHandler s GetStoredKeys = do
 testRequestHandler s GetFilesOfInterest = do
     ff <- liftIO $ getFilesOfInterest s
     return $ Right $ toJSON $ map fromNormalizedFilePath $ HM.keys ff
+testRequestHandler s GetRebuildsCount = do
+    count <- liftIO $ runAction "get build count" s getRebuildCount
+    return $ Right $ toJSON count
 
 getDatabaseKeys :: (Graph.Result -> Step)
     -> ShakeDatabase

--- a/ghcide/test/src/Development/IDE/Test.hs
+++ b/ghcide/test/src/Development/IDE/Test.hs
@@ -33,6 +33,7 @@ module Development.IDE.Test
   , getBuildKeysVisited
   , getBuildKeysChanged
   , getBuildEdgesCount
+  , getRebuildsCount
   , configureCheckProject
   , isReferenceReady
   , referenceReady) where
@@ -224,6 +225,9 @@ getBuildKeysChanged = tryCallTestPlugin GetBuildKeysChanged
 
 getBuildEdgesCount :: Session (Either ResponseError Int)
 getBuildEdgesCount = tryCallTestPlugin GetBuildEdgesCount
+
+getRebuildsCount :: Session (Either ResponseError Int)
+getRebuildsCount = tryCallTestPlugin GetRebuildsCount
 
 getInterfaceFilesDir :: TextDocumentIdentifier -> Session FilePath
 getInterfaceFilesDir TextDocumentIdentifier{_uri} = callTestPlugin (GetInterfaceFilesDir _uri)

--- a/shake-bench/shake-bench.cabal
+++ b/shake-bench/shake-bench.cabal
@@ -29,6 +29,7 @@ library
         filepath,
         lens,
         lens-aeson,
+        mtl,
         shake,
         text
   default-language: Haskell2010


### PR DESCRIPTION
Add columns to keep track of total GHC rebuilds, time for first response and
average time per response


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2814"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

