### PR TITLE
ghcide: remove redundant env NIX_GHC_LIBDIR

### DIFF
--- a/ghcide/session-loader/Development/IDE/Session/VersionCheck.hs
+++ b/ghcide/session-loader/Development/IDE/Session/VersionCheck.hs
@@ -5,13 +5,11 @@
 -- See https://github.com/haskell/ghcide/pull/697
 module Development.IDE.Session.VersionCheck (ghcVersionChecker) where
 
-import           Data.Maybe
-import           GHC.Check
+import GHC.Check
 -- Only use this for checking against the compile time GHC libDir!
 -- Use getRuntimeGhcLibDir from hie-bios instead for everything else
 -- otherwise binaries will not be distributable since paths will be baked into them
 import qualified GHC.Paths
-import           System.Environment
 
 ghcVersionChecker :: GhcVersionChecker
-ghcVersionChecker = $$(makeGhcVersionChecker (fromMaybe GHC.Paths.libdir <$> lookupEnv "NIX_GHC_LIBDIR"))
+ghcVersionChecker = $$(makeGhcVersionChecker (return GHC.Paths.libdir))


### PR DESCRIPTION
- fixes #1777 


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2819"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

