### PR TITLE
Support stylish-haskell with ghc9.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
         name: Test hls-splice-plugin
         run: cabal test hls-splice-plugin --test-options="$TEST_OPTS" || cabal test hls-splice-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-splice-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.0.1'  && matrix.ghc != '9.0.2' && matrix.ghc != '9.2.2'
+      - if: matrix.test && matrix.ghc != '9.2.2'
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS"
 

--- a/cabal-ghc90.project
+++ b/cabal-ghc90.project
@@ -35,6 +35,13 @@ package *
   ghc-options: -haddock
   test-show-details: direct
 
+
+-- stylish-haskell 9.0
+source-repository-package
+  type: git
+  location: https://github.com/July541/stylish-haskell.git
+  tag: b08a85716b991359a46a32e8e7ba5780664d31ae
+
 write-ghc-environment-files: never
 
 index-state: 2022-03-08T10:53:01Z
@@ -42,7 +49,7 @@ index-state: 2022-03-08T10:53:01Z
 constraints:
   -- These plugins don't work on GHC9 yet
   -- Add a plugin needs remove the -flag but also update ghc bounds in hls.cabal
-  haskell-language-server +ignore-plugins-ghc-bounds -stylishhaskell,
+  haskell-language-server +ignore-plugins-ghc-bounds,
   ghc-lib-parser ^>= 9.0
 
 -- although we are not building all plugins cabal solver phase is run for all packages
@@ -56,10 +63,6 @@ allow-newer:
   data-tree-print:base,
   -- https://github.com/lspitzner/butcher/pull/8
   butcher:base,
-
-  stylish-haskell:Cabal,
-  stylish-haskell:ghc-lib-parser,
-  stylish-haskell:aeson,
 
   -- ghc-9.0.2 specific
   -- for ghcide:test via ghc-typelits-knownnat

--- a/configuration-ghc-901.nix
+++ b/configuration-ghc-901.nix
@@ -4,7 +4,6 @@
 let
   disabledPlugins = [
     "hls-brittany-plugin"
-    "hls-stylish-haskell-plugin"
   ];
 
   hpkgsOverride = hself: hsuper:
@@ -20,7 +19,6 @@ let
         hself.callCabal2nixWithOptions "haskell-language-server" ./.
         (pkgs.lib.concatStringsSep " " [
           "-f-brittany"
-          "-f-stylishhaskell"
         ]) { };
 
       # YOLO

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -21,7 +21,7 @@ packages:
 - ./plugins/hls-splice-plugin
 - ./plugins/hls-tactics-plugin
 - ./plugins/hls-brittany-plugin
-# - ./plugins/hls-stylish-haskell-plugin
+- ./plugins/hls-stylish-haskell-plugin
 - ./plugins/hls-floskell-plugin
 - ./plugins/hls-fourmolu-plugin
 - ./plugins/hls-pragmas-plugin
@@ -65,6 +65,10 @@ extra-deps:
 - statestack-0.3
 - operational-0.2.4.1
 
+# stylish-haskell 9.0
+- github: July541/stylish-haskell
+  commit: b08a85716b991359a46a32e8e7ba5780664d31ae
+
 # currently needed for ghcide>extra, etc.
 allow-newer: true
 
@@ -84,7 +88,6 @@ flags:
     pedantic: true
 
     ignore-plugins-ghc-bounds: true
-    stylishHaskell: false
 
   retrie:
     BuildExecutable: false

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -21,7 +21,7 @@ packages:
 - ./plugins/hls-splice-plugin
 - ./plugins/hls-tactics-plugin
 - ./plugins/hls-brittany-plugin
-# - ./plugins/hls-stylish-haskell-plugin
+- ./plugins/hls-stylish-haskell-plugin
 - ./plugins/hls-floskell-plugin
 - ./plugins/hls-fourmolu-plugin
 - ./plugins/hls-pragmas-plugin
@@ -87,6 +87,10 @@ extra-deps:
 - unix-2.7.2.2
 - Win32-2.12.0.1
 
+# stylish-haskell 9.0
+- github: July541/stylish-haskell
+  commit: b08a85716b991359a46a32e8e7ba5780664d31ae
+
 # currently needed for ghcide>extra, etc.
 allow-newer: true
 
@@ -106,7 +110,6 @@ flags:
     pedantic: true
 
     ignore-plugins-ghc-bounds: true
-    stylishHaskell: false
 
   retrie:
     BuildExecutable: false


### PR DESCRIPTION
I have a fork that include stylish-haskell compile with ghc 9.0 https://github.com/July541/stylish-haskell/tree/ghc-9.0, and this pr uses the fork directly.

CI looks well https://github.com/July541/stylish-haskell/actions/runs/2142857127

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2820"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

