### PR TITLE
Restore concise type variables in ghc-9.2

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -13,6 +13,8 @@ module Development.IDE.GHC.Compat.Outputable (
     mkPrintUnqualified,
     mkPrintUnqualifiedDefault,
     PrintUnqualified(..),
+    defaultUserStyle,
+    withPprStyle,
     -- * Parser errors
     PsWarning,
     PsError,
@@ -43,7 +45,8 @@ import           GHC.Types.SourceError
 import           GHC.Types.SrcLoc
 import           GHC.Unit.State
 import           GHC.Utils.Error                 hiding (mkWarnMsg)
-import           GHC.Utils.Outputable
+import           GHC.Utils.Outputable            as Out hiding (defaultUserStyle)
+import qualified GHC.Utils.Outputable            as Out
 import           GHC.Utils.Panic
 #elif MIN_VERSION_ghc(9,0,0)
 import           GHC.Driver.Session
@@ -52,14 +55,16 @@ import           GHC.Types.Name.Reader           (GlobalRdrEnv)
 import           GHC.Types.SrcLoc
 import           GHC.Utils.Error                 as Err hiding (mkWarnMsg)
 import qualified GHC.Utils.Error                 as Err
-import           GHC.Utils.Outputable            as Out
+import           GHC.Utils.Outputable            as Out hiding (defaultUserStyle)
+import qualified GHC.Utils.Outputable            as Out
 #else
 import           Development.IDE.GHC.Compat.Core (GlobalRdrEnv)
 import           DynFlags
 import           ErrUtils                        hiding (mkWarnMsg)
 import qualified ErrUtils                        as Err
 import           HscTypes
-import           Outputable                      as Out
+import           Outputable                      as Out hiding (defaultUserStyle)
+import qualified Outputable                      as Out
 import           SrcLoc
 #endif
 
@@ -177,4 +182,11 @@ mkWarnMsg =
   const Error.mkWarnMsg
 #else
   Err.mkWarnMsg
+#endif
+
+defaultUserStyle :: PprStyle
+#if MIN_VERSION_ghc(9,0,0)
+defaultUserStyle = Out.defaultUserStyle
+#else
+defaultUserStyle = Out.defaultUserStyle unsafeGlobalDynFlags
 #endif

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -24,6 +24,7 @@ import qualified Data.Text                    as T
 import           GHC.Generics
 
 import           GHC
+import           GHC.Utils.Outputable         (withPprStyle, defaultUserStyle)
 
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Orphans  ()
@@ -35,7 +36,7 @@ type DocMap = NameEnv SpanDoc
 type KindMap = NameEnv TyThing
 
 showGhc :: Outputable a => a -> T.Text
-showGhc = showSD . ppr
+showGhc = showSD . withPprStyle defaultUserStyle . ppr
 
 showSD :: SDoc -> T.Text
 showSD = T.pack . unsafePrintSDoc
@@ -62,7 +63,7 @@ safeTyThingId _                                = Nothing
 -- Possible documentation for an element in the code
 data SpanDoc
   = SpanDocString HsDocString SpanDocUris
-  | SpanDocText   [T.Text] SpanDocUris
+  | SpanDocText   [T.Text] SpanDocUris
   deriving stock (Eq, Show, Generic)
   deriving anyclass NFData
 

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -24,7 +24,6 @@ import qualified Data.Text                    as T
 import           GHC.Generics
 
 import           GHC
-import           GHC.Utils.Outputable         (withPprStyle, defaultUserStyle)
 
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Orphans  ()

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4288,11 +4288,7 @@ findDefinitionAndHoverTests = let
   , test  no     yes    outL45     outSig        "top-level signature              #767"
   , test  broken broken innL48     innSig        "inner     signature              #767"
   , test  no     yes    holeL60    hleInfo       "hole without internal name       #831"
-  , if ghcVersion >= GHC92 then
-        -- Broken on GHC 9.2 and above due to printing of uniques
-        test  no     yes    holeL65    []        "hole with variable"
-    else
-        test  no     yes    holeL65    hleInfo2  "hole with variable"
+  , test  no     yes    holeL65    hleInfo2      "hole with variable"
   , test  no     skip   cccL17     docLink       "Haddock html links"
   , testM yes    yes    imported   importedSig   "Imported symbol"
   , testM yes    yes    reexported reexportedSig "Imported symbol (reexported)"


### PR DESCRIPTION
Close #2716.

GHC 9.2 changed the default `showSDocUnsafe` style from [`defaultUserStyle`](https://hackage.haskell.org/package/ghc-9.0.2/docs/src/GHC.Utils.Outputable.html#showSDoc) to [`defaultDumpStyle`](https://hackage.haskell.org/package/ghc-9.2.1/docs/src/GHC.Utils.Outputable.html#defaultSDocContext). This pr force `showGhc` with `defaultUserStyle`, hierarchy calling result shows the following functions are affected, but only [`atPoint`](https://github.com/haskell/haskell-language-server/blob/3c527431bc10879ffa80dfea23a80299992d87cc/ghcide/src/Development/IDE/Spans/AtPoint.hs#L249-L251)(The function returns type varibale) really render [`IfaceType`](https://hackage.haskell.org/package/ghc-9.2.1/docs/GHC-Iface-Type.html#t:IfaceType) type.

<img width="473" alt="image" src="https://user-images.githubusercontent.com/16057632/163336364-a10aec67-eca1-4fe6-96ac-af52a4aa9b1b.png">


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2828"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

