### PR TITLE
Unify showSDocUnsafe

### DIFF
--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1301,7 +1301,7 @@ getDocsBatch hsc_env _mod _names = do
 #endif
                                   Map.findWithDefault mempty name amap))
     case res of
-        Just x  -> return $ map (first $ T.unpack . showGhc) x
+        Just x  -> return $ map (first $ T.unpack . printOutputableText) x
         Nothing -> throwErrors
 #if MIN_VERSION_ghc(9,2,0)
                      $ Error.getErrorMessages msgs

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1301,7 +1301,7 @@ getDocsBatch hsc_env _mod _names = do
 #endif
                                   Map.findWithDefault mempty name amap))
     case res of
-        Just x  -> return $ map (first $ T.unpack . printOutputableText) x
+        Just x  -> return $ map (first $ T.unpack . printOutputable) x
         Nothing -> throwErrors
 #if MIN_VERSION_ghc(9,2,0)
                      $ Error.getErrorMessages msgs

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -13,6 +13,8 @@ module Development.IDE.GHC.Compat.Outputable (
     mkPrintUnqualified,
     mkPrintUnqualifiedDefault,
     PrintUnqualified(..),
+    defaultUserStyle,
+    withPprStyle,
     -- * Parser errors
     PsWarning,
     PsError,
@@ -43,7 +45,8 @@ import           GHC.Types.SourceError
 import           GHC.Types.SrcLoc
 import           GHC.Unit.State
 import           GHC.Utils.Error                 hiding (mkWarnMsg)
-import           GHC.Utils.Outputable
+import           GHC.Utils.Outputable            as Out hiding (defaultUserStyle)
+import qualified GHC.Utils.Outputable            as Out
 import           GHC.Utils.Panic
 #elif MIN_VERSION_ghc(9,0,0)
 import           GHC.Driver.Session
@@ -52,14 +55,16 @@ import           GHC.Types.Name.Reader           (GlobalRdrEnv)
 import           GHC.Types.SrcLoc
 import           GHC.Utils.Error                 as Err hiding (mkWarnMsg)
 import qualified GHC.Utils.Error                 as Err
-import           GHC.Utils.Outputable            as Out
+import           GHC.Utils.Outputable            as Out hiding (defaultUserStyle)
+import qualified GHC.Utils.Outputable            as Out
 #else
 import           Development.IDE.GHC.Compat.Core (GlobalRdrEnv)
 import           DynFlags
 import           ErrUtils                        hiding (mkWarnMsg)
 import qualified ErrUtils                        as Err
 import           HscTypes
-import           Outputable                      as Out
+import           Outputable                      as Out hiding (defaultUserStyle)
+import qualified Outputable                      as Out
 import           SrcLoc
 #endif
 
@@ -177,4 +182,11 @@ mkWarnMsg =
   const Error.mkWarnMsg
 #else
   Err.mkWarnMsg
+#endif
+
+defaultUserStyle :: PprStyle
+#if MIN_VERSION_ghc(9,0,0)
+defaultUserStyle = Out.defaultUserStyle
+#else
+defaultUserStyle = Out.defaultUserStyle unsafeGlobalDynFlags
 #endif

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -8,9 +8,7 @@ module Development.IDE.GHC.Compat.Outputable (
     showSDocForUser,
     ppr, pprPanic, text, vcat, (<+>), ($$), empty, hang, nest,
     printSDocQualifiedUnsafe,
-    printNameWithoutUniques,
     printWithoutUniques,
-    printSDocAllTheWay,
     mkPrintUnqualified,
     mkPrintUnqualifiedDefault,
     PrintUnqualified(..),
@@ -85,16 +83,6 @@ printWithoutUniques =
       dflags = unsafeGlobalDynFlags `gopt_set` Opt_SuppressUniques
 #endif
 
-printNameWithoutUniques :: Outputable a => a -> String
-printNameWithoutUniques =
-#if MIN_VERSION_ghc(9,2,0)
-  renderWithContext (defaultSDocContext { sdocSuppressUniques = True }) . ppr
-#else
-  printSDocAllTheWay dyn . ppr
-  where
-    dyn = unsafeGlobalDynFlags `gopt_set` Opt_SuppressUniques
-#endif
-
 printSDocQualifiedUnsafe :: PrintUnqualified -> SDoc -> String
 #if MIN_VERSION_ghc(9,2,0)
 printSDocQualifiedUnsafe unqual doc =
@@ -108,14 +96,9 @@ printSDocQualifiedUnsafe unqual doc =
     showSDocForUser unsafeGlobalDynFlags unqual doc
 #endif
 
-printSDocAllTheWay :: DynFlags -> SDoc -> String
-#if MIN_VERSION_ghc(9,2,0)
-printSDocAllTheWay dflags sdoc = renderWithContext ctxt sdoc
-  where
-    ctxt = initSDocContext dflags (mkUserStyle neverQualify AllTheWay)
-#else
-printSDocAllTheWay dflags sdoc = oldRenderWithStyle dflags sdoc (oldMkUserStyle dflags Out.neverQualify Out.AllTheWay)
 
+#if MIN_VERSION_ghc(9,2,0)
+#else
 #if  MIN_VERSION_ghc(9,0,0)
 oldRenderWithStyle dflags sdoc sty = Out.renderWithStyle (initSDocContext dflags sty) sdoc
 oldMkUserStyle _ = Out.mkUserStyle

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -4,6 +4,7 @@ module Development.IDE.GHC.Compat.Outputable (
     SDoc,
     Outputable,
     showSDoc,
+    showSDocUnsafe,
     showSDocForUser,
     ppr, pprPanic, text, vcat, (<+>), ($$), empty, hang, nest,
     printSDocQualifiedUnsafe,
@@ -80,7 +81,7 @@ printWithoutUniques =
 #else
   go . ppr
     where
-      go sdoc = oldRenderWithStyle dflags sdoc (mkUserStyle dflags neverQualify AllTheWay)
+      go sdoc = oldRenderWithStyle dflags sdoc (oldMkUserStyle dflags neverQualify AllTheWay)
       dflags = unsafeGlobalDynFlags `gopt_set` Opt_SuppressUniques
 #endif
 

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -67,6 +67,10 @@ import qualified Outputable                      as Out
 import           SrcLoc
 #endif
 
+-- | A compatible function to print `Outputable` instances
+-- without unique symbols.
+--
+-- It print with a user-friendly style like: `a_a4ME` as `a`.
 printWithoutUniques :: Outputable a => a -> String
 printWithoutUniques =
 #if MIN_VERSION_ghc(9,2,0)
@@ -96,10 +100,7 @@ printSDocQualifiedUnsafe unqual doc =
     showSDocForUser unsafeGlobalDynFlags unqual doc
 #endif
 
-
-#if MIN_VERSION_ghc(9,2,0)
-#else
-#if  MIN_VERSION_ghc(9,0,0)
+#if MIN_VERSION_ghc(9,0,0) && !MIN_VERSION_ghc(9,2,0)
 oldRenderWithStyle dflags sdoc sty = Out.renderWithStyle (initSDocContext dflags sty) sdoc
 oldMkUserStyle _ = Out.mkUserStyle
 oldMkErrStyle _ = Out.mkErrStyle
@@ -107,8 +108,7 @@ oldMkErrStyle _ = Out.mkErrStyle
 oldFormatErrDoc :: DynFlags -> Err.ErrDoc -> Out.SDoc
 oldFormatErrDoc dflags = Err.formatErrDoc dummySDocContext
   where dummySDocContext = initSDocContext dflags Out.defaultUserStyle
-
-#else
+#elif !MIN_VERSION_ghc(9,2,0)
 oldRenderWithStyle :: DynFlags -> Out.SDoc -> Out.PprStyle -> String
 oldRenderWithStyle = Out.renderWithStyle
 
@@ -120,7 +120,6 @@ oldMkErrStyle = Out.mkErrStyle
 
 oldFormatErrDoc :: DynFlags -> Err.ErrDoc -> Out.SDoc
 oldFormatErrDoc = Err.formatErrDoc
-#endif
 #endif
 
 pprWarning :: PsWarning -> MsgEnvelope DecoratedSDoc

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -108,7 +108,7 @@ oldMkErrStyle _ = Out.mkErrStyle
 oldFormatErrDoc :: DynFlags -> Err.ErrDoc -> Out.SDoc
 oldFormatErrDoc dflags = Err.formatErrDoc dummySDocContext
   where dummySDocContext = initSDocContext dflags Out.defaultUserStyle
-#elif !MIN_VERSION_ghc(9,2,0)
+#elif !MIN_VERSION_ghc(9,0,0)
 oldRenderWithStyle :: DynFlags -> Out.SDoc -> Out.PprStyle -> String
 oldRenderWithStyle = Out.renderWithStyle
 

--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -4,11 +4,11 @@ module Development.IDE.GHC.Compat.Outputable (
     SDoc,
     Outputable,
     showSDoc,
-    showSDocUnsafe,
     showSDocForUser,
     ppr, pprPanic, text, vcat, (<+>), ($$), empty, hang, nest,
     printSDocQualifiedUnsafe,
     printNameWithoutUniques,
+    printWithoutUniques,
     printSDocAllTheWay,
     mkPrintUnqualified,
     mkPrintUnqualifiedDefault,
@@ -66,6 +66,22 @@ import           HscTypes
 import           Outputable                      as Out hiding (defaultUserStyle)
 import qualified Outputable                      as Out
 import           SrcLoc
+#endif
+
+printWithoutUniques :: Outputable a => a -> String
+printWithoutUniques =
+#if MIN_VERSION_ghc(9,2,0)
+  renderWithContext (defaultSDocContext
+    {
+      sdocStyle = defaultUserStyle
+    , sdocSuppressUniques = True
+    , sdocCanUseUnicode = True
+    }) . ppr
+#else
+  go . ppr
+    where
+      go sdoc = oldRenderWithStyle dflags sdoc (mkUserStyle dflags neverQualify AllTheWay)
+      dflags = unsafeGlobalDynFlags `gopt_set` Opt_SuppressUniques
 #endif
 
 printNameWithoutUniques :: Outputable a => a -> String

--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -209,8 +209,3 @@ instance (NFData (HsModule a)) where
 
 instance Show OccName where show = prettyPrint
 instance Hashable OccName where hashWithSalt s n = hashWithSalt s (getKey $ getUnique n)
-
-#if !MIN_VERSION_ghc(8,10,0)
-instance Outputable SDoc where
-  ppr = id
-#endif

--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -209,3 +209,8 @@ instance (NFData (HsModule a)) where
 
 instance Show OccName where show = prettyPrint
 instance Hashable OccName where hashWithSalt s n = hashWithSalt s (getKey $ getUnique n)
+
+#if !MIN_VERSION_ghc(8,10,0)
+instance Outputable SDoc where
+  ppr = id
+#endif

--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -39,6 +39,7 @@ import           Data.Aeson
 import           Data.Bifunctor             (Bifunctor (..))
 import           Data.Hashable
 import           Data.String                (IsString (fromString))
+import           Data.Text                  (unpack)
 #if MIN_VERSION_ghc(9,0,0)
 import          GHC.ByteCode.Types
 #else
@@ -46,27 +47,27 @@ import          ByteCodeTypes
 #endif
 
 -- Orphan instances for types from the GHC API.
-instance Show CoreModule where show = show . printOutputable
+instance Show CoreModule where show = unpack . printOutputable
 instance NFData CoreModule where rnf = rwhnf
-instance Show CgGuts where show = show . printOutputable . cg_module
+instance Show CgGuts where show = unpack . printOutputable . cg_module
 instance NFData CgGuts where rnf = rwhnf
 instance Show ModDetails where show = const "<moddetails>"
 instance NFData ModDetails where rnf = rwhnf
 instance NFData SafeHaskellMode where rnf = rwhnf
-instance Show Linkable where show = show . printOutputable
+instance Show Linkable where show = unpack . printOutputable
 instance NFData Linkable where rnf (LM a b c) = rnf a `seq` rnf b `seq` rnf c
 instance NFData Unlinked where
   rnf (DotO f) = rnf f
   rnf (DotA f) = rnf f
   rnf (DotDLL f) = rnf f
   rnf (BCOs a b) = seqCompiledByteCode a `seq` liftRnf rwhnf b
-instance Show PackageFlag where show = show . printOutputable
-instance Show InteractiveImport where show = show . printOutputable
-instance Show PackageName  where show = show . printOutputable
+instance Show PackageFlag where show = unpack . printOutputable
+instance Show InteractiveImport where show = unpack . printOutputable
+instance Show PackageName  where show = unpack . printOutputable
 
 #if !MIN_VERSION_ghc(9,0,1)
-instance Show ComponentId  where show = show . printOutputable
-instance Show SourcePackageId  where show = show . printOutputable
+instance Show ComponentId  where show = unpack . printOutputable
+instance Show SourcePackageId  where show = unpack . printOutputable
 
 instance Show GhcPlugins.InstalledUnitId where
     show = installedUnitIdString
@@ -76,7 +77,7 @@ instance NFData GhcPlugins.InstalledUnitId where rnf = rwhnf . installedUnitIdFS
 instance Hashable GhcPlugins.InstalledUnitId where
   hashWithSalt salt = hashWithSalt salt . installedUnitIdString
 #else
-instance Show UnitId where show = show . printOutputable
+instance Show UnitId where show = unpack . printOutputable
 deriving instance Ord SrcSpan
 deriving instance Ord UnhelpfulSpanReason
 #endif
@@ -86,7 +87,7 @@ instance NFData SB.StringBuffer where rnf = rwhnf
 instance Show Module where
     show = moduleNameString . moduleName
 
-instance Outputable a => Show (GenLocated SrcSpan a) where show = show . printOutputable
+instance Outputable a => Show (GenLocated SrcSpan a) where show = unpack . printOutputable
 
 instance (NFData l, NFData e) => NFData (GenLocated l e) where
     rnf (L l e) = rnf l `seq` rnf e
@@ -207,5 +208,5 @@ instance (NFData (HsModule a)) where
 #endif
   rnf = rwhnf
 
-instance Show OccName where show = show . printOutputable
+instance Show OccName where show = unpack . printOutputable
 instance Hashable OccName where hashWithSalt s n = hashWithSalt s (getKey $ getUnique n)

--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -46,27 +46,27 @@ import          ByteCodeTypes
 #endif
 
 -- Orphan instances for types from the GHC API.
-instance Show CoreModule where show = printOutputable
+instance Show CoreModule where show = show . printOutputable
 instance NFData CoreModule where rnf = rwhnf
-instance Show CgGuts where show = printOutputable . cg_module
+instance Show CgGuts where show = show . printOutputable . cg_module
 instance NFData CgGuts where rnf = rwhnf
 instance Show ModDetails where show = const "<moddetails>"
 instance NFData ModDetails where rnf = rwhnf
 instance NFData SafeHaskellMode where rnf = rwhnf
-instance Show Linkable where show = printOutputable
+instance Show Linkable where show = show . printOutputable
 instance NFData Linkable where rnf (LM a b c) = rnf a `seq` rnf b `seq` rnf c
 instance NFData Unlinked where
   rnf (DotO f) = rnf f
   rnf (DotA f) = rnf f
   rnf (DotDLL f) = rnf f
   rnf (BCOs a b) = seqCompiledByteCode a `seq` liftRnf rwhnf b
-instance Show PackageFlag where show = printOutputable
-instance Show InteractiveImport where show = printOutputable
-instance Show PackageName  where show = printOutputable
+instance Show PackageFlag where show = show . printOutputable
+instance Show InteractiveImport where show = show . printOutputable
+instance Show PackageName  where show = show . printOutputable
 
 #if !MIN_VERSION_ghc(9,0,1)
-instance Show ComponentId  where show = printOutputable
-instance Show SourcePackageId  where show = printOutputable
+instance Show ComponentId  where show = show . printOutputable
+instance Show SourcePackageId  where show = show . printOutputable
 
 instance Show GhcPlugins.InstalledUnitId where
     show = installedUnitIdString
@@ -76,7 +76,7 @@ instance NFData GhcPlugins.InstalledUnitId where rnf = rwhnf . installedUnitIdFS
 instance Hashable GhcPlugins.InstalledUnitId where
   hashWithSalt salt = hashWithSalt salt . installedUnitIdString
 #else
-instance Show UnitId where show = printOutputable
+instance Show UnitId where show = show . printOutputable
 deriving instance Ord SrcSpan
 deriving instance Ord UnhelpfulSpanReason
 #endif
@@ -86,7 +86,7 @@ instance NFData SB.StringBuffer where rnf = rwhnf
 instance Show Module where
     show = moduleNameString . moduleName
 
-instance Outputable a => Show (GenLocated SrcSpan a) where show = printOutputable
+instance Outputable a => Show (GenLocated SrcSpan a) where show = show . printOutputable
 
 instance (NFData l, NFData e) => NFData (GenLocated l e) where
     rnf (L l e) = rnf l `seq` rnf e
@@ -207,5 +207,5 @@ instance (NFData (HsModule a)) where
 #endif
   rnf = rwhnf
 
-instance Show OccName where show = printOutputable
+instance Show OccName where show = show . printOutputable
 instance Hashable OccName where hashWithSalt s n = hashWithSalt s (getKey $ getUnique n)

--- a/ghcide/src/Development/IDE/GHC/Orphans.hs
+++ b/ghcide/src/Development/IDE/GHC/Orphans.hs
@@ -46,27 +46,27 @@ import          ByteCodeTypes
 #endif
 
 -- Orphan instances for types from the GHC API.
-instance Show CoreModule where show = prettyPrint
+instance Show CoreModule where show = printOutputable
 instance NFData CoreModule where rnf = rwhnf
-instance Show CgGuts where show = prettyPrint . cg_module
+instance Show CgGuts where show = printOutputable . cg_module
 instance NFData CgGuts where rnf = rwhnf
 instance Show ModDetails where show = const "<moddetails>"
 instance NFData ModDetails where rnf = rwhnf
 instance NFData SafeHaskellMode where rnf = rwhnf
-instance Show Linkable where show = prettyPrint
+instance Show Linkable where show = printOutputable
 instance NFData Linkable where rnf (LM a b c) = rnf a `seq` rnf b `seq` rnf c
 instance NFData Unlinked where
   rnf (DotO f) = rnf f
   rnf (DotA f) = rnf f
   rnf (DotDLL f) = rnf f
   rnf (BCOs a b) = seqCompiledByteCode a `seq` liftRnf rwhnf b
-instance Show PackageFlag where show = prettyPrint
-instance Show InteractiveImport where show = prettyPrint
-instance Show PackageName  where show = prettyPrint
+instance Show PackageFlag where show = printOutputable
+instance Show InteractiveImport where show = printOutputable
+instance Show PackageName  where show = printOutputable
 
 #if !MIN_VERSION_ghc(9,0,1)
-instance Show ComponentId  where show = prettyPrint
-instance Show SourcePackageId  where show = prettyPrint
+instance Show ComponentId  where show = printOutputable
+instance Show SourcePackageId  where show = printOutputable
 
 instance Show GhcPlugins.InstalledUnitId where
     show = installedUnitIdString
@@ -76,7 +76,7 @@ instance NFData GhcPlugins.InstalledUnitId where rnf = rwhnf . installedUnitIdFS
 instance Hashable GhcPlugins.InstalledUnitId where
   hashWithSalt salt = hashWithSalt salt . installedUnitIdString
 #else
-instance Show UnitId where show = prettyPrint
+instance Show UnitId where show = printOutputable
 deriving instance Ord SrcSpan
 deriving instance Ord UnhelpfulSpanReason
 #endif
@@ -86,7 +86,7 @@ instance NFData SB.StringBuffer where rnf = rwhnf
 instance Show Module where
     show = moduleNameString . moduleName
 
-instance Outputable a => Show (GenLocated SrcSpan a) where show = prettyPrint
+instance Outputable a => Show (GenLocated SrcSpan a) where show = printOutputable
 
 instance (NFData l, NFData e) => NFData (GenLocated l e) where
     rnf (L l e) = rnf l `seq` rnf e
@@ -207,5 +207,5 @@ instance (NFData (HsModule a)) where
 #endif
   rnf = rwhnf
 
-instance Show OccName where show = prettyPrint
+instance Show OccName where show = printOutputable
 instance Hashable OccName where hashWithSalt s n = hashWithSalt s (getKey $ getUnique n)

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -27,8 +27,7 @@ module Development.IDE.GHC.Util(
     dontWriteHieFiles,
     disableWarningsAsErrors,
     traceAst,
-    printOutputable,
-    printOutputableText
+    printOutputable
     ) where
 
 #if MIN_VERSION_ghc(9,2,0)
@@ -133,7 +132,7 @@ bytestringToStringBuffer (PS buf cur len) = StringBuffer{..}
 
 -- | Pretty print a 'RdrName' wrapping operators in parens
 printRdrName :: RdrName -> String
-printRdrName name = printOutputable $ parenSymOcc rn (ppr rn)
+printRdrName name = show $ printOutputable $ parenSymOcc rn (ppr rn)
   where
     rn = rdrNameOcc name
 
@@ -324,19 +323,6 @@ instance Outputable SDoc where
 -- This is the most common print utility, will print with a user-friendly style like: `a_a4ME` as `a`.
 --
 -- It internal using `showSDocUnsafe` with `unsafeGlobalDynFlags`.
---
--- You may prefer `printOutputableText` if `Text` is expected to return.
-printOutputable :: Outputable a => a -> String
-printOutputable = printWithoutUniques
+printOutputable :: Outputable a => a -> T.Text
+printOutputable = T.pack . printWithoutUniques
 {-# INLINE printOutputable #-}
-
--- | Print a GHC value in `defaultUserStyle` without unique symbols.
---
--- This is the most common print utility, will print with a user-friendly style like: `a_a4ME` as `a`.
---
--- It internal using `showSDocUnsafe` with `unsafeGlobalDynFlags`.
---
--- You may prefer `printOutputable` if `String` is expected to return.
-printOutputableText :: Outputable a => a -> T.Text
-printOutputableText = T.pack . printOutputable
-{-# INLINE printOutputableText #-}

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -7,7 +7,6 @@ module Development.IDE.GHC.Util(
     modifyDynFlags,
     evalGhcEnv,
     -- * GHC wrappers
-    prettyPrint,
     printRdrName,
     Development.IDE.GHC.Util.printName,
     ParseResult(..), runParser,
@@ -30,6 +29,7 @@ module Development.IDE.GHC.Util(
     traceAst,
     showGhc,
     showGhcWithUniques,
+    prettyPrint,
     prettyPrintWithUniques
     ) where
 
@@ -314,20 +314,45 @@ traceAst lbl x
 #endif
             , "file://" ++ htmlDumpFileName]
 
+-- Should in `Development.IDE.GHC.Orphans`,
+-- leave it here to prevent cyclic module dependency
 #if !MIN_VERSION_ghc(8,10,0)
 instance Outputable SDoc where
   ppr = id
 #endif
 
+-- | Print a GHC value by default `showSDocUnsafe`.
+--
+-- You may prefer `prettyPrint` unless you know what you are doing.
+--
+-- It internal using `unsafeGlobalDynFlags`.
+--
+-- `String` version of `showGhcWithUniques`.
 prettyPrintWithUniques :: Outputable a => a -> String
 prettyPrintWithUniques = showSDocUnsafe . ppr
 
--- | Pretty print a GHC value using 'unsafeGlobalDynFlags '.
+-- | Print a GHC value in `defaultUserStyle` without unique symbols.
+--
+-- This is the most common print utility, will print with a user friendly style like: `a_a4ME` as `a`.
+--
+-- It internal using `unsafeGlobalDynFlags`.
+--
+-- `String` version of `showGhc`.
 prettyPrint :: Outputable a => a -> String
 prettyPrint = printWithoutUniques
 
+-- | Print a GHC value by default `showSDocUnsafe`.
+--
+-- You may prefer `showGhc` unless you know what you are doing.
+--
+-- It internal using `unsafeGlobalDynFlags`.
 showGhcWithUniques :: Outputable a => a -> T.Text
 showGhcWithUniques = T.pack . showSDocUnsafe . ppr
 
+-- | Print a GHC value in `defaultUserStyle` without unique symbols.
+--
+-- This is the most common print utility, will print with a user friendly style like: `a_a4ME` as `a`.
+--
+-- It internal using `unsafeGlobalDynFlags`.
 showGhc :: Outputable a => a -> T.Text
 showGhc = T.pack . printWithoutUniques

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -314,6 +314,11 @@ traceAst lbl x
 #endif
             , "file://" ++ htmlDumpFileName]
 
+#if !MIN_VERSION_ghc(8,10,0)
+instance Outputable SDoc where
+  ppr = id
+#endif
+
 prettyPrintWithUniques :: Outputable a => a -> String
 prettyPrintWithUniques = showSDocUnsafe . ppr
 

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -132,7 +132,7 @@ bytestringToStringBuffer (PS buf cur len) = StringBuffer{..}
 
 -- | Pretty print a 'RdrName' wrapping operators in parens
 printRdrName :: RdrName -> String
-printRdrName name = show $ printOutputable $ parenSymOcc rn (ppr rn)
+printRdrName name = T.unpack $ printOutputable $ parenSymOcc rn (ppr rn)
   where
     rn = rdrNameOcc name
 

--- a/ghcide/src/Development/IDE/LSP/Outline.hs
+++ b/ghcide/src/Development/IDE/LSP/Outline.hs
@@ -21,6 +21,7 @@ import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error      (rangeToRealSrcSpan,
                                                  realSrcSpanToRange)
 import           Development.IDE.Types.Location
+import           Development.IDE.GHC.Util       (showGhc)
 import           Language.LSP.Server            (LspM)
 import           Language.LSP.Types             (DocumentSymbol (..),
                                                  DocumentSymbolParams (DocumentSymbolParams, _textDocument),
@@ -31,7 +32,6 @@ import           Language.LSP.Types             (DocumentSymbol (..),
                                                  type (|?) (InL), uriToFilePath)
 #if MIN_VERSION_ghc(9,2,0)
 import Data.List.NonEmpty (nonEmpty, toList)
-import Development.IDE.GHC.Util (showGhc)
 #endif
 
 moduleOutline

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -50,8 +50,7 @@ import           Development.IDE.GHC.Error
 import           Development.IDE.GHC.ExactPrint
 import           Development.IDE.GHC.Util                          (printOutputable,
                                                                     printRdrName,
-                                                                    traceAst,
-                                                                    printOutputable)
+                                                                    traceAst)
 import           Development.IDE.Plugin.CodeAction.Args
 import           Development.IDE.Plugin.CodeAction.ExactPrint
 import           Development.IDE.Plugin.CodeAction.PositionIndexed

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -544,7 +544,7 @@ suggestDeleteUnusedBinding
       isTheBinding span = srcSpanToRange span == Just _range
 
       isSameName :: IdP GhcPs -> String -> Bool
-      isSameName x name = show (printOutputable x) == name
+      isSameName x name = T.unpack (printOutputable x) == name
 
 data ExportsAs = ExportName | ExportPattern | ExportFamily | ExportAll
   deriving (Eq)
@@ -1045,12 +1045,12 @@ disambiguateSymbol pm fileContents Diagnostic {..} (T.unpack -> symbol) = \case
          in Right <$> [ if parensed
                 then Rewrite (rangeToSrcSpan "<dummy>" _range) $ \df ->
                     liftParseAST @(HsExpr GhcPs) df $
-                    show $ printOutputable $
+                    T.unpack $ printOutputable $
                         HsVar @GhcPs noExtField $
                             reLocA $ L (mkGeneralSrcSpan  "") rdr
                 else Rewrite (rangeToSrcSpan "<dummy>" _range) $ \df ->
                     liftParseAST @RdrName df $
-                    show $ printOutputable $ L (mkGeneralSrcSpan  "") rdr
+                    T.unpack $ printOutputable $ L (mkGeneralSrcSpan  "") rdr
             ]
 findImportDeclByRange :: [LImportDecl GhcPs] -> Range -> Maybe (LImportDecl GhcPs)
 findImportDeclByRange xs range = find (\(L (locA -> l) _)-> srcSpanToRange l == Just range) xs
@@ -1615,32 +1615,32 @@ smallerRangesForBindingExport lies b =
     b' = wrapOperatorInParens . unqualify $ b
 #if !MIN_VERSION_ghc(9,2,0)
     ranges' (L _ (IEThingWith _ thing _  inners labels))
-      | show (printOutputable thing) == b' = []
+      | T.unpack (printOutputable thing) == b' = []
       | otherwise =
-          [ locA l' | L l' x <- inners, show (printOutputable x) == b']
-          ++ [ l' | L l' x <- labels, show (printOutputable x) == b']
+          [ locA l' | L l' x <- inners, T.unpack (printOutputable x) == b']
+          ++ [ l' | L l' x <- labels, T.unpack (printOutputable x) == b']
 #else
     ranges' (L _ (IEThingWith _ thing _  inners))
-      | show (printOutputable thing) == b' = []
+      | T.unpack (printOutputable thing) == b' = []
       | otherwise =
-          [ locA l' | L l' x <- inners, show (printOutputable x) == b']
+          [ locA l' | L l' x <- inners, T.unpack (printOutputable x) == b']
 #endif
     ranges' _ = []
 
 rangesForBinding' :: String -> LIE GhcPs -> [SrcSpan]
-rangesForBinding' b (L (locA -> l) x@IEVar{}) | show (printOutputable x) == b = [l]
-rangesForBinding' b (L (locA -> l) x@IEThingAbs{}) | show (printOutputable x) == b = [l]
-rangesForBinding' b (L (locA -> l) (IEThingAll _ x)) | show (printOutputable x) == b = [l]
+rangesForBinding' b (L (locA -> l) x@IEVar{}) | T.unpack (printOutputable x) == b = [l]
+rangesForBinding' b (L (locA -> l) x@IEThingAbs{}) | T.unpack (printOutputable x) == b = [l]
+rangesForBinding' b (L (locA -> l) (IEThingAll _ x)) | T.unpack (printOutputable x) == b = [l]
 #if !MIN_VERSION_ghc(9,2,0)
 rangesForBinding' b (L l (IEThingWith _ thing _  inners labels))
 #else
 rangesForBinding' b (L (locA -> l) (IEThingWith _ thing _  inners))
 #endif
-    | show (printOutputable thing) == b = [l]
+    | T.unpack (printOutputable thing) == b = [l]
     | otherwise =
-        [ locA l' | L l' x <- inners, show (printOutputable x) == b]
+        [ locA l' | L l' x <- inners, T.unpack (printOutputable x) == b]
 #if !MIN_VERSION_ghc(9,2,0)
-        ++ [ l' | L l' x <- labels, show (printOutputable x) == b]
+        ++ [ l' | L l' x <- labels, T.unpack (printOutputable x) == b]
 #endif
 rangesForBinding' _ _ = []
 

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -51,7 +51,7 @@ import           Development.IDE.GHC.ExactPrint
 import           Development.IDE.GHC.Util                          (printOutputable,
                                                                     printRdrName,
                                                                     traceAst,
-                                                                    printOutputableText)
+                                                                    printOutputable)
 import           Development.IDE.Plugin.CodeAction.Args
 import           Development.IDE.Plugin.CodeAction.ExactPrint
 import           Development.IDE.Plugin.CodeAction.PositionIndexed
@@ -545,7 +545,7 @@ suggestDeleteUnusedBinding
       isTheBinding span = srcSpanToRange span == Just _range
 
       isSameName :: IdP GhcPs -> String -> Bool
-      isSameName x name = printOutputable x == name
+      isSameName x name = show (printOutputable x) == name
 
 data ExportsAs = ExportName | ExportPattern | ExportFamily | ExportAll
   deriving (Eq)
@@ -1012,7 +1012,7 @@ occursUnqualified symbol ImportDecl{..}
 occursUnqualified _ _ = False
 
 symbolOccursIn :: T.Text -> IE GhcPs -> Bool
-symbolOccursIn symb = any ((== symb). printOutputableText) . ieNames
+symbolOccursIn symb = any ((== symb). printOutputable) . ieNames
 
 targetModuleName :: ModuleTarget -> ModuleName
 targetModuleName ImplicitPrelude{} = mkModuleName "Prelude"
@@ -1046,12 +1046,12 @@ disambiguateSymbol pm fileContents Diagnostic {..} (T.unpack -> symbol) = \case
          in Right <$> [ if parensed
                 then Rewrite (rangeToSrcSpan "<dummy>" _range) $ \df ->
                     liftParseAST @(HsExpr GhcPs) df $
-                    printOutputable $
+                    show $ printOutputable $
                         HsVar @GhcPs noExtField $
                             reLocA $ L (mkGeneralSrcSpan  "") rdr
                 else Rewrite (rangeToSrcSpan "<dummy>" _range) $ \df ->
                     liftParseAST @RdrName df $
-                    printOutputable $ L (mkGeneralSrcSpan  "") rdr
+                    show $ printOutputable $ L (mkGeneralSrcSpan  "") rdr
             ]
 findImportDeclByRange :: [LImportDecl GhcPs] -> Range -> Maybe (LImportDecl GhcPs)
 findImportDeclByRange xs range = find (\(L (locA -> l) _)-> srcSpanToRange l == Just range) xs
@@ -1422,7 +1422,7 @@ newImport modName mSymbol mQual hiding = NewImport impStmt
      symImp
             | Just symbol <- mSymbol
               , symOcc <- mkVarOcc $ T.unpack symbol =
-              " (" <> printOutputableText (parenSymOcc symOcc $ ppr symOcc) <> ")"
+              " (" <> printOutputable (parenSymOcc symOcc $ ppr symOcc) <> ")"
             | otherwise = ""
      impStmt =
        "import "
@@ -1616,32 +1616,32 @@ smallerRangesForBindingExport lies b =
     b' = wrapOperatorInParens . unqualify $ b
 #if !MIN_VERSION_ghc(9,2,0)
     ranges' (L _ (IEThingWith _ thing _  inners labels))
-      | printOutputable thing == b' = []
+      | show (printOutputable thing) == b' = []
       | otherwise =
-          [ locA l' | L l' x <- inners, printOutputable x == b']
-          ++ [ l' | L l' x <- labels, printOutputable x == b']
+          [ locA l' | L l' x <- inners, show (printOutputable x) == b']
+          ++ [ l' | L l' x <- labels, show (printOutputable x) == b']
 #else
     ranges' (L _ (IEThingWith _ thing _  inners))
-      | printOutputable thing == b' = []
+      | show (printOutputable thing) == b' = []
       | otherwise =
-          [ locA l' | L l' x <- inners, printOutputable x == b']
+          [ locA l' | L l' x <- inners, show (printOutputable x) == b']
 #endif
     ranges' _ = []
 
 rangesForBinding' :: String -> LIE GhcPs -> [SrcSpan]
-rangesForBinding' b (L (locA -> l) x@IEVar{}) | printOutputable x == b = [l]
-rangesForBinding' b (L (locA -> l) x@IEThingAbs{}) | printOutputable x == b = [l]
-rangesForBinding' b (L (locA -> l) (IEThingAll _ x)) | printOutputable x == b = [l]
+rangesForBinding' b (L (locA -> l) x@IEVar{}) | show (printOutputable x) == b = [l]
+rangesForBinding' b (L (locA -> l) x@IEThingAbs{}) | show (printOutputable x) == b = [l]
+rangesForBinding' b (L (locA -> l) (IEThingAll _ x)) | show (printOutputable x) == b = [l]
 #if !MIN_VERSION_ghc(9,2,0)
 rangesForBinding' b (L l (IEThingWith _ thing _  inners labels))
 #else
 rangesForBinding' b (L (locA -> l) (IEThingWith _ thing _  inners))
 #endif
-    | printOutputable thing == b = [l]
+    | show (printOutputable thing) == b = [l]
     | otherwise =
-        [ locA l' | L l' x <- inners, printOutputable x == b]
+        [ locA l' | L l' x <- inners, show (printOutputable x) == b]
 #if !MIN_VERSION_ghc(9,2,0)
-        ++ [ l' | L l' x <- labels, printOutputable x == b]
+        ++ [ l' | L l' x <- labels, show (printOutputable x) == b]
 #endif
 rangesForBinding' _ _ = []
 

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -50,12 +50,12 @@ import           Development.IDE.GHC.Error
 import           Development.IDE.GHC.ExactPrint
 import           Development.IDE.GHC.Util                          (prettyPrint,
                                                                     printRdrName,
-                                                                    traceAst, showGhc)
+                                                                    traceAst,
+                                                                    showGhc)
 import           Development.IDE.Plugin.CodeAction.Args
 import           Development.IDE.Plugin.CodeAction.ExactPrint
 import           Development.IDE.Plugin.CodeAction.PositionIndexed
 import           Development.IDE.Plugin.TypeLenses                 (suggestSignature)
-import           Development.IDE.Spans.Common
 import           Development.IDE.Types.Exports
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -355,8 +355,8 @@ extendImportTopLevel thing (L l it@ImportDecl{..})
     top <- uniqueSrcSpanT
     let rdr = reLocA $ L src $ mkRdrUnqual $ mkVarOcc thing
     let alreadyImported =
-          showGhc (occName (unLoc rdr))
-            `elem` map (showGhc @OccName) (listify (const True) lies)
+          printOutputableText (occName (unLoc rdr))
+            `elem` map (printOutputableText @OccName) (listify (const True) lies)
     when alreadyImported $
       lift (Left $ thing <> " already imported")
 
@@ -456,8 +456,8 @@ extendImportViaParent df parent child (L l it@ImportDecl{..})
         childRdr <- pure $ setEntryDP childRdr $ SameLine $ if hasSibling then 1 else 0
 #endif
         let alreadyImported =
-              showGhc (occName (unLoc childRdr))
-                `elem` map (showGhc @OccName) (listify (const True) lies')
+              printOutputableText (occName (unLoc childRdr))
+                `elem` map (printOutputableText @OccName) (listify (const True) lies')
         when alreadyImported $
           lift (Left $ child <> " already included in " <> parent <> " imports")
 
@@ -542,7 +542,7 @@ addCommaInImportList lies x = do
 #endif
 
 unIEWrappedName :: IEWrappedName (IdP GhcPs) -> String
-unIEWrappedName (occName -> occ) = prettyPrint $ parenSymOcc occ (ppr occ)
+unIEWrappedName (occName -> occ) = printOutputable $ parenSymOcc occ (ppr occ)
 
 hasParen :: String -> Bool
 hasParen ('(' : _) = True

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -355,8 +355,8 @@ extendImportTopLevel thing (L l it@ImportDecl{..})
     top <- uniqueSrcSpanT
     let rdr = reLocA $ L src $ mkRdrUnqual $ mkVarOcc thing
     let alreadyImported =
-          showNameWithoutUniques (occName (unLoc rdr))
-            `elem` map (showNameWithoutUniques @OccName) (listify (const True) lies)
+          showGhc (occName (unLoc rdr))
+            `elem` map (showGhc @OccName) (listify (const True) lies)
     when alreadyImported $
       lift (Left $ thing <> " already imported")
 
@@ -456,8 +456,8 @@ extendImportViaParent df parent child (L l it@ImportDecl{..})
         childRdr <- pure $ setEntryDP childRdr $ SameLine $ if hasSibling then 1 else 0
 #endif
         let alreadyImported =
-              showNameWithoutUniques (occName (unLoc childRdr))
-                `elem` map (showNameWithoutUniques @OccName) (listify (const True) lies')
+              showGhc (occName (unLoc childRdr))
+                `elem` map (showGhc @OccName) (listify (const True) lies')
         when alreadyImported $
           lift (Left $ child <> " already included in " <> parent <> " imports")
 
@@ -542,7 +542,7 @@ addCommaInImportList lies x = do
 #endif
 
 unIEWrappedName :: IEWrappedName (IdP GhcPs) -> String
-unIEWrappedName (occName -> occ) = showSDocUnsafe $ parenSymOcc occ (ppr occ)
+unIEWrappedName (occName -> occ) = prettyPrint $ parenSymOcc occ (ppr occ)
 
 hasParen :: String -> Bool
 hasParen ('(' : _) = True

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -355,8 +355,8 @@ extendImportTopLevel thing (L l it@ImportDecl{..})
     top <- uniqueSrcSpanT
     let rdr = reLocA $ L src $ mkRdrUnqual $ mkVarOcc thing
     let alreadyImported =
-          printOutputableText (occName (unLoc rdr))
-            `elem` map (printOutputableText @OccName) (listify (const True) lies)
+          printOutputable (occName (unLoc rdr))
+            `elem` map (printOutputable @OccName) (listify (const True) lies)
     when alreadyImported $
       lift (Left $ thing <> " already imported")
 
@@ -456,8 +456,8 @@ extendImportViaParent df parent child (L l it@ImportDecl{..})
         childRdr <- pure $ setEntryDP childRdr $ SameLine $ if hasSibling then 1 else 0
 #endif
         let alreadyImported =
-              printOutputableText (occName (unLoc childRdr))
-                `elem` map (printOutputableText @OccName) (listify (const True) lies')
+              printOutputable (occName (unLoc childRdr))
+                `elem` map (printOutputable @OccName) (listify (const True) lies')
         when alreadyImported $
           lift (Left $ child <> " already included in " <> parent <> " imports")
 
@@ -542,7 +542,7 @@ addCommaInImportList lies x = do
 #endif
 
 unIEWrappedName :: IEWrappedName (IdP GhcPs) -> String
-unIEWrappedName (occName -> occ) = printOutputable $ parenSymOcc occ (ppr occ)
+unIEWrappedName (occName -> occ) = show $ printOutputable $ parenSymOcc occ (ppr occ)
 
 hasParen :: String -> Bool
 hasParen ('(' : _) = True

--- a/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -542,7 +542,7 @@ addCommaInImportList lies x = do
 #endif
 
 unIEWrappedName :: IEWrappedName (IdP GhcPs) -> String
-unIEWrappedName (occName -> occ) = show $ printOutputable $ parenSymOcc occ (ppr occ)
+unIEWrappedName (occName -> occ) = T.unpack $ printOutputable $ parenSymOcc occ (ppr occ)
 
 hasParen :: String -> Bool
 hasParen ('(' : _) = True

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -27,7 +27,7 @@ import qualified Development.IDE.Core.Shake                   as Shake
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error                    (rangeToSrcSpan)
 import           Development.IDE.GHC.ExactPrint               (GetAnnotatedParsedSource (GetAnnotatedParsedSource))
-import           Development.IDE.GHC.Util                     (printOutputableText)
+import           Development.IDE.GHC.Util                     (printOutputable)
 import           Development.IDE.Graph
 import           Development.IDE.Plugin.CodeAction            (newImport,
                                                                newImportToEdit)
@@ -213,7 +213,7 @@ extendImportHandler ideState edit@ExtendImport {..} = do
           <> "’ from "
           <> importName
           <> " (at "
-          <> printOutputableText srcSpan
+          <> printOutputable srcSpan
           <> ")"
     void $ LSP.sendRequest SWorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing wedit) (\_ -> pure ())
   return $ Right Null

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -27,7 +27,7 @@ import qualified Development.IDE.Core.Shake                   as Shake
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error                    (rangeToSrcSpan)
 import           Development.IDE.GHC.ExactPrint               (GetAnnotatedParsedSource (GetAnnotatedParsedSource))
-import           Development.IDE.GHC.Util                     (prettyPrint)
+import           Development.IDE.GHC.Util                     (showGhc)
 import           Development.IDE.Graph
 import           Development.IDE.Plugin.CodeAction            (newImport,
                                                                newImportToEdit)
@@ -213,7 +213,7 @@ extendImportHandler ideState edit@ExtendImport {..} = do
           <> "’ from "
           <> importName
           <> " (at "
-          <> T.pack (prettyPrint srcSpan)
+          <> showGhc srcSpan
           <> ")"
     void $ LSP.sendRequest SWorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing wedit) (\_ -> pure ())
   return $ Right Null

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -27,7 +27,7 @@ import qualified Development.IDE.Core.Shake                   as Shake
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error                    (rangeToSrcSpan)
 import           Development.IDE.GHC.ExactPrint               (GetAnnotatedParsedSource (GetAnnotatedParsedSource))
-import           Development.IDE.GHC.Util                     (showGhc)
+import           Development.IDE.GHC.Util                     (printOutputableText)
 import           Development.IDE.Graph
 import           Development.IDE.Plugin.CodeAction            (newImport,
                                                                newImportToEdit)
@@ -213,7 +213,7 @@ extendImportHandler ideState edit@ExtendImport {..} = do
           <> "’ from "
           <> importName
           <> " (at "
-          <> showGhc srcSpan
+          <> printOutputableText srcSpan
           <> ")"
     void $ LSP.sendRequest SWorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing wedit) (\_ -> pure ())
   return $ Right Null

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -214,7 +214,7 @@ mkCompl
         pprLineCol :: SrcLoc -> T.Text
         pprLineCol (UnhelpfulLoc fs) = T.pack $ unpackFS fs
         pprLineCol (RealSrcLoc loc _) =
-            "line " <> showGhc (srcLocLine loc) <> ", column " <> showGhc (srcLocCol loc)
+            "line " <> printOutputableText (srcLocLine loc) <> ", column " <> printOutputableText (srcLocCol loc)
 
 
 mkAdditionalEditsCommand :: PluginId -> ExtendImport -> Command
@@ -226,7 +226,7 @@ mkNameCompItem doc thingParent origName provenance thingType isInfix docs !imp =
   where
     compKind = occNameToComKind typeText origName
     isTypeCompl = isTcOcc origName
-    label = stripPrefix $ showGhc origName
+    label = stripPrefix $ printOutputableText origName
     insertText = case isInfix of
             Nothing -> case getArgText <$> thingType of
                             Nothing      -> label
@@ -235,7 +235,7 @@ mkNameCompItem doc thingParent origName provenance thingType isInfix docs !imp =
 
             Just Surrounded -> label
     typeText
-          | Just t <- thingType = Just . stripForall $ showGhc t
+          | Just t <- thingType = Just . stripForall $ printOutputableText t
           | otherwise = Nothing
     additionalTextEdits =
       imp <&> \x ->
@@ -244,7 +244,7 @@ mkNameCompItem doc thingParent origName provenance thingType isInfix docs !imp =
             thingParent,
             importName = showModName $ unLoc $ ideclName $ unLoc x,
             importQual = getImportQual x,
-            newThing = showGhc origName
+            newThing = printOutputableText origName
           }
 
     stripForall :: T.Text -> T.Text
@@ -295,7 +295,7 @@ showForSnippet x = T.pack $ renderWithContext ctxt $ GHC.ppr x -- FIXme
     where
         ctxt = defaultSDocContext{sdocStyle = mkUserStyle neverQualify AllTheWay}
 #else
-showForSnippet x = showGhc x
+showForSnippet x = printOutputableText x
 #endif
 
 mkModCompl :: T.Text -> CompletionItem
@@ -350,7 +350,7 @@ cacheDataProducer uri env curMod globalEnv inScopeEnv limports = do
   let
       packageState = hscEnv env
       curModName = moduleName curMod
-      curModNameText = showGhc curModName
+      curModNameText = printOutputableText curModName
 
       importMap = Map.fromList [ (l, imp) | imp@(L (locA -> (RealSrcSpan l _)) _) <- limports ]
 
@@ -386,7 +386,7 @@ cacheDataProducer uri env curMod globalEnv inScopeEnv limports = do
                 -- or if it doesn't have a real location
                 loc <- realSpan $ is_dloc spec
                 Map.lookup loc importMap
-          compItem <- toCompItem par curMod (showGhc $ is_mod spec) n originalImportDecl
+          compItem <- toCompItem par curMod (printOutputableText $ is_mod spec) n originalImportDecl
           let unqual
                 | is_qual spec = []
                 | otherwise = compItem
@@ -498,12 +498,12 @@ localCompletionsForParsedModule uri pm@ParsedModule{pm_parsed_source = L _ HsMod
 findRecordCompl :: Uri -> ParsedModule -> Provenance -> TyClDecl GhcPs -> [CompItem]
 findRecordCompl uri pmod mn DataDecl {tcdLName, tcdDataDefn} = result
     where
-        result = [mkRecordSnippetCompItem uri (Just $ showGhc $ unLoc tcdLName)
-                        (showGhc . unLoc $ con_name) field_labels mn doc Nothing
+        result = [mkRecordSnippetCompItem uri (Just $ printOutputableText $ unLoc tcdLName)
+                        (printOutputableText . unLoc $ con_name) field_labels mn doc Nothing
                  | ConDeclH98{..} <- unLoc <$> dd_cons tcdDataDefn
                  , Just  con_details <- [getFlds con_args]
                  , let field_names = concatMap extract con_details
-                 , let field_labels = showGhc <$> field_names
+                 , let field_labels = printOutputableText <$> field_names
                  , (not . List.null) field_labels
                  ]
         doc = SpanDocText (getDocumentation [pmod] $ reLoc tcdLName) (SpanDocUris Nothing Nothing)
@@ -804,7 +804,7 @@ prefixes =
 safeTyThingForRecord :: TyThing -> Maybe (T.Text, [T.Text])
 safeTyThingForRecord (AnId _) = Nothing
 safeTyThingForRecord (AConLike dc) =
-    let ctxStr =   showGhc . occName . conLikeName $ dc
+    let ctxStr =   printOutputableText . occName . conLikeName $ dc
         field_names = T.pack . unpackFS . flLabel <$> conLikeFieldLabels dc
     in
         Just (ctxStr, field_names)

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -55,7 +55,7 @@ import           Data.Version                         (showVersion)
 import           Development.IDE.Types.Shake          (WithHieDb)
 import           HieDb                                hiding (pointCommand)
 import           System.Directory                     (doesFileExist)
-import Development.IDE.GHC.Util (showGhc)
+import Development.IDE.GHC.Util (printOutputableText)
 
 -- | Gives a Uri for the module, given the .hie file location and the the module info
 -- The Bool denotes if it is a boot module
@@ -230,13 +230,13 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
         prettyNames :: [T.Text]
         prettyNames = map prettyName names
         prettyName (Right n, dets) = T.unlines $
-          wrapHaskell (showGhc n <> maybe "" (" :: " <>) ((prettyType <$> identType dets) <|> maybeKind))
+          wrapHaskell (printOutputableText n <> maybe "" (" :: " <>) ((prettyType <$> identType dets) <|> maybeKind))
           : definedAt n
           ++ maybeToList (prettyPackageName n)
           ++ catMaybes [ T.unlines . spanDocToMarkdown <$> lookupNameEnv dm n
                        ]
-          where maybeKind = fmap showGhc $ safeTyThingType =<< lookupNameEnv km n
-        prettyName (Left m,_) = showGhc m
+          where maybeKind = fmap printOutputableText $ safeTyThingType =<< lookupNameEnv km n
+        prettyName (Left m,_) = printOutputableText m
 
         prettyPackageName n = do
           m <- nameModule_maybe n
@@ -248,15 +248,15 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
 
         prettyTypes = map (("_ :: "<>) . prettyType) types
         prettyType t = case kind of
-          HieFresh -> showGhc t
-          HieFromDisk full_file -> showGhc $ hieTypeToIface $ recoverFullType t (hie_types full_file)
+          HieFresh -> printOutputableText t
+          HieFromDisk full_file -> printOutputableText $ hieTypeToIface $ recoverFullType t (hie_types full_file)
 
         definedAt name =
           -- do not show "at <no location info>" and similar messages
           -- see the code of 'pprNameDefnLoc' for more information
           case nameSrcLoc name of
             UnhelpfulLoc {} | isInternalName name || isSystemName name -> []
-            _ -> ["*Defined " <> showGhc (pprNameDefnLoc name) <> "*"]
+            _ -> ["*Defined " <> printOutputableText (pprNameDefnLoc name) <> "*"]
 
 typeLocationsAtPoint
   :: forall m
@@ -381,7 +381,7 @@ toUri = fromNormalizedUri . filePathToUri' . toNormalizedFilePath'
 
 defRowToSymbolInfo :: Res DefRow -> Maybe SymbolInformation
 defRowToSymbolInfo (DefRow{..}:.(modInfoSrcFile -> Just srcFile))
-  = Just $ SymbolInformation (showGhc defNameOcc) kind Nothing Nothing loc Nothing
+  = Just $ SymbolInformation (printOutputableText defNameOcc) kind Nothing Nothing loc Nothing
   where
     kind
       | isVarOcc defNameOcc = SkVariable

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -55,6 +55,7 @@ import           Data.Version                         (showVersion)
 import           Development.IDE.Types.Shake          (WithHieDb)
 import           HieDb                                hiding (pointCommand)
 import           System.Directory                     (doesFileExist)
+import Development.IDE.GHC.Util (showGhc)
 
 -- | Gives a Uri for the module, given the .hie file location and the the module info
 -- The Bool denotes if it is a boot module
@@ -229,7 +230,7 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
         prettyNames :: [T.Text]
         prettyNames = map prettyName names
         prettyName (Right n, dets) = T.unlines $
-          wrapHaskell (showNameWithoutUniques n <> maybe "" (" :: " <>) ((prettyType <$> identType dets) <|> maybeKind))
+          wrapHaskell (showGhc n <> maybe "" (" :: " <>) ((prettyType <$> identType dets) <|> maybeKind))
           : definedAt n
           ++ maybeToList (prettyPackageName n)
           ++ catMaybes [ T.unlines . spanDocToMarkdown <$> lookupNameEnv dm n
@@ -255,7 +256,7 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
           -- see the code of 'pprNameDefnLoc' for more information
           case nameSrcLoc name of
             UnhelpfulLoc {} | isInternalName name || isSystemName name -> []
-            _ -> ["*Defined " <> T.pack (showSDocUnsafe $ pprNameDefnLoc name) <> "*"]
+            _ -> ["*Defined " <> showGhc (pprNameDefnLoc name) <> "*"]
 
 typeLocationsAtPoint
   :: forall m

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -3,9 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 
 module Development.IDE.Spans.Common (
-  showGhc
-, showNameWithoutUniques
-, unqualIEWrapName
+  unqualIEWrapName
 , safeTyThingId
 , safeTyThingType
 , SpanDoc(..)
@@ -34,18 +32,18 @@ import qualified Documentation.Haddock.Types  as H
 type DocMap = NameEnv SpanDoc
 type KindMap = NameEnv TyThing
 
-showGhc :: Outputable a => a -> T.Text
-showGhc = showSD . withPprStyle defaultUserStyle . ppr
+-- showGhc :: Outputable a => a -> T.Text
+-- showGhc = showSD . withPprStyle defaultUserStyle . ppr
 
-showSD :: SDoc -> T.Text
-showSD = T.pack . unsafePrintSDoc
+-- showSD :: SDoc -> T.Text
+-- showSD = T.pack . unsafePrintSDoc
 
-showNameWithoutUniques :: Outputable a => a -> T.Text
-showNameWithoutUniques = T.pack . printNameWithoutUniques
+-- showNameWithoutUniques :: Outputable a => a -> T.Text
+-- showNameWithoutUniques = T.pack . printNameWithoutUniques
 
 -- | Shows IEWrappedName, without any modifier, qualifier or unique identifier.
 unqualIEWrapName :: IEWrappedName RdrName -> T.Text
-unqualIEWrapName = showNameWithoutUniques . rdrNameOcc . ieWrappedName
+unqualIEWrapName = showGhc . rdrNameOcc . ieWrappedName
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/Support/HieExtras.hs
 safeTyThingType :: TyThing -> Maybe Type

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -35,7 +35,7 @@ type DocMap = NameEnv SpanDoc
 type KindMap = NameEnv TyThing
 
 showGhc :: Outputable a => a -> T.Text
-showGhc = showSD . ppr
+showGhc = showSD . withPprStyle defaultUserStyle . ppr
 
 showSD :: SDoc -> T.Text
 showSD = T.pack . unsafePrintSDoc
@@ -62,7 +62,7 @@ safeTyThingId _                                = Nothing
 -- Possible documentation for an element in the code
 data SpanDoc
   = SpanDocString HsDocString SpanDocUris
-  | SpanDocText   [T.Text] SpanDocUris
+  | SpanDocText   [T.Text] SpanDocUris
   deriving stock (Eq, Show, Generic)
   deriving anyclass NFData
 

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -34,7 +34,7 @@ type KindMap = NameEnv TyThing
 
 -- | Shows IEWrappedName, without any modifier, qualifier or unique identifier.
 unqualIEWrapName :: IEWrappedName RdrName -> T.Text
-unqualIEWrapName = printOutputableText . rdrNameOcc . ieWrappedName
+unqualIEWrapName = printOutputable . rdrNameOcc . ieWrappedName
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/Support/HieExtras.hs
 safeTyThingType :: TyThing -> Maybe Type

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -34,7 +34,7 @@ type KindMap = NameEnv TyThing
 
 -- | Shows IEWrappedName, without any modifier, qualifier or unique identifier.
 unqualIEWrapName :: IEWrappedName RdrName -> T.Text
-unqualIEWrapName = showGhc . rdrNameOcc . ieWrappedName
+unqualIEWrapName = printOutputableText . rdrNameOcc . ieWrappedName
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/Support/HieExtras.hs
 safeTyThingType :: TyThing -> Maybe Type

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -32,15 +32,6 @@ import qualified Documentation.Haddock.Types  as H
 type DocMap = NameEnv SpanDoc
 type KindMap = NameEnv TyThing
 
--- showGhc :: Outputable a => a -> T.Text
--- showGhc = showSD . withPprStyle defaultUserStyle . ppr
-
--- showSD :: SDoc -> T.Text
--- showSD = T.pack . unsafePrintSDoc
-
--- showNameWithoutUniques :: Outputable a => a -> T.Text
--- showNameWithoutUniques = T.pack . printNameWithoutUniques
-
 -- | Shows IEWrappedName, without any modifier, qualifier or unique identifier.
 unqualIEWrapName :: IEWrappedName RdrName -> T.Text
 unqualIEWrapName = showGhc . rdrNameOcc . ieWrappedName

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -27,7 +27,7 @@ import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
 import           Development.IDE.GHC.Error
-import           Development.IDE.GHC.Util        (printOutputableText)
+import           Development.IDE.GHC.Util        (printOutputable)
 import           Development.IDE.Spans.Common
 import           System.Directory
 import           System.FilePath
@@ -93,8 +93,8 @@ getDocumentationsTryGhc env mod names = do
             src <- toFileUriText $ lookupSrcHtmlForModule env mod
             return (doc, src)
           Nothing -> pure (Nothing, Nothing)
-      let docUri = (<> "#" <> selector <> printOutputableText name) <$> docFu
-          srcUri = (<> "#" <> printOutputableText name) <$> srcFu
+      let docUri = (<> "#" <> selector <> printOutputable name) <$> docFu
+          srcUri = (<> "#" <> printOutputable name) <$> srcFu
           selector
             | isValName name = "v:"
             | otherwise = "t:"

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -27,7 +27,7 @@ import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
 import           Development.IDE.GHC.Error
-import           Development.IDE.GHC.Util        (showGhc)
+import           Development.IDE.GHC.Util        (printOutputableText)
 import           Development.IDE.Spans.Common
 import           System.Directory
 import           System.FilePath
@@ -93,8 +93,8 @@ getDocumentationsTryGhc env mod names = do
             src <- toFileUriText $ lookupSrcHtmlForModule env mod
             return (doc, src)
           Nothing -> pure (Nothing, Nothing)
-      let docUri = (<> "#" <> selector <> showGhc name) <$> docFu
-          srcUri = (<> "#" <> showGhc name) <$> srcFu
+      let docUri = (<> "#" <> selector <> printOutputableText name) <$> docFu
+          srcUri = (<> "#" <> printOutputableText name) <$> srcFu
           selector
             | isValName name = "v:"
             | otherwise = "t:"

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -27,12 +27,12 @@ import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
 import           Development.IDE.GHC.Error
+import           Development.IDE.GHC.Util        (showGhc)
 import           Development.IDE.Spans.Common
 import           System.Directory
 import           System.FilePath
 
 import           Language.LSP.Types              (filePathToUri, getUri)
-import Development.IDE.GHC.Util (showGhc)
 
 mkDocMap
   :: HscEnv

--- a/ghcide/src/Development/IDE/Spans/Documentation.hs
+++ b/ghcide/src/Development/IDE/Spans/Documentation.hs
@@ -32,6 +32,7 @@ import           System.Directory
 import           System.FilePath
 
 import           Language.LSP.Types              (filePathToUri, getUri)
+import Development.IDE.GHC.Util (showGhc)
 
 mkDocMap
   :: HscEnv
@@ -92,8 +93,8 @@ getDocumentationsTryGhc env mod names = do
             src <- toFileUriText $ lookupSrcHtmlForModule env mod
             return (doc, src)
           Nothing -> pure (Nothing, Nothing)
-      let docUri = (<> "#" <> selector <> showNameWithoutUniques name) <$> docFu
-          srcUri = (<> "#" <> showNameWithoutUniques name) <$> srcFu
+      let docUri = (<> "#" <> selector <> showGhc name) <$> docFu
+          srcUri = (<> "#" <> showGhc name) <$> srcFu
           selector
             | isValName name = "v:"
             | otherwise = "t:"

--- a/ghcide/src/Development/IDE/Types/Exports.hs
+++ b/ghcide/src/Development/IDE/Types/Exports.hs
@@ -178,7 +178,7 @@ unpackAvail mn
   | otherwise = const []
   where
     !mod = pack $ moduleNameString mn
-    f id@IdentInfo {..} = (pack (prettyPrint name), moduleNameText,[id])
+    f id@IdentInfo {..} = (pack (occNameString name), moduleNameText,[id])
 
 
 identInfoToKeyVal :: IdentInfo -> (ModuleNameText, IdentInfo)

--- a/ghcide/src/Development/IDE/Types/Exports.hs
+++ b/ghcide/src/Development/IDE/Types/Exports.hs
@@ -178,7 +178,7 @@ unpackAvail mn
   | otherwise = const []
   where
     !mod = pack $ moduleNameString mn
-    f id@IdentInfo {..} = (pack (occNameString name), moduleNameText,[id])
+    f id@IdentInfo {..} = (printOutputable name, moduleNameText,[id])
 
 
 identInfoToKeyVal :: IdentInfo -> (ModuleNameText, IdentInfo)

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4288,11 +4288,7 @@ findDefinitionAndHoverTests = let
   , test  no     yes    outL45     outSig        "top-level signature              #767"
   , test  broken broken innL48     innSig        "inner     signature              #767"
   , test  no     yes    holeL60    hleInfo       "hole without internal name       #831"
-  , if ghcVersion >= GHC92 then
-        -- Broken on GHC 9.2 and above due to printing of uniques
-        test  no     yes    holeL65    []        "hole with variable"
-    else
-        test  no     yes    holeL65    hleInfo2  "hole with variable"
+  , test  no     yes    holeL65    hleInfo2      "hole with variable"
   , test  no     skip   cccL17     docLink       "Haddock html links"
   , testM yes    yes    imported   importedSig   "Imported symbol"
   , testM yes    yes    reexported reexportedSig "Imported symbol (reexported)"

--- a/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
+++ b/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
@@ -19,7 +19,7 @@ import           Development.IDE.Core.RuleTypes (GetParsedModule (GetParsedModul
 import           Development.IDE.Core.Service   (IdeState, runAction)
 import           Development.IDE.Core.Shake     (use)
 import           Development.IDE.GHC.Compat
-import           Development.IDE.GHC.Util       (showGhc)
+import           Development.IDE.GHC.Util       (printOutputableText)
 import           Generics.SYB                   (extQ, something)
 import           Ide.PluginUtils                (getNormalizedFilePath,
                                                  handleMaybeM, response)
@@ -134,7 +134,7 @@ findSigLocOfStringDecl decls expectedType declName = something (const Nothing `e
 -- | Pretty Print the Type Signature (to validate GHC Error Message)
 sigToText :: Sig GhcPs -> Maybe Text
 sigToText = \case
-  ts@TypeSig {} -> Just $ stripSignature $ showGhc ts
+  ts@TypeSig {} -> Just $ stripSignature $ printOutputableText ts
   _             -> Nothing
 
 stripSignature :: Text -> Text

--- a/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
+++ b/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
@@ -19,7 +19,7 @@ import           Development.IDE.Core.RuleTypes (GetParsedModule (GetParsedModul
 import           Development.IDE.Core.Service   (IdeState, runAction)
 import           Development.IDE.Core.Shake     (use)
 import           Development.IDE.GHC.Compat
-import           Development.IDE.GHC.Util       (printOutputableText)
+import           Development.IDE.GHC.Util       (printOutputable)
 import           Generics.SYB                   (extQ, something)
 import           Ide.PluginUtils                (getNormalizedFilePath,
                                                  handleMaybeM, response)
@@ -134,7 +134,7 @@ findSigLocOfStringDecl decls expectedType declName = something (const Nothing `e
 -- | Pretty Print the Type Signature (to validate GHC Error Message)
 sigToText :: Sig GhcPs -> Maybe Text
 sigToText = \case
-  ts@TypeSig {} -> Just $ stripSignature $ printOutputableText ts
+  ts@TypeSig {} -> Just $ stripSignature $ printOutputable ts
   _             -> Nothing
 
 stripSignature :: Text -> Text

--- a/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
+++ b/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
@@ -19,7 +19,7 @@ import           Development.IDE.Core.RuleTypes (GetParsedModule (GetParsedModul
 import           Development.IDE.Core.Service   (IdeState, runAction)
 import           Development.IDE.Core.Shake     (use)
 import           Development.IDE.GHC.Compat
-import           Development.IDE.GHC.Util       (prettyPrint)
+import           Development.IDE.GHC.Util       (showGhc)
 import           Generics.SYB                   (extQ, something)
 import           Ide.PluginUtils                (getNormalizedFilePath,
                                                  handleMaybeM, response)
@@ -134,7 +134,7 @@ findSigLocOfStringDecl decls expectedType declName = something (const Nothing `e
 -- | Pretty Print the Type Signature (to validate GHC Error Message)
 sigToText :: Sig GhcPs -> Maybe Text
 sigToText = \case
-  ts@TypeSig {} -> Just $ stripSignature $ T.pack $ prettyPrint ts
+  ts@TypeSig {} -> Just $ stripSignature $ showGhc ts
   _             -> Nothing
 
 stripSignature :: Text -> Text

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -522,7 +522,7 @@ evals mark_exception (st, fp) df stmts = do
 
 prettyWarn :: Warn -> String
 prettyWarn Warn{..} =
-    show (printOutputable $ SrcLoc.getLoc warnMsg) <> ": warning:\n"
+    T.unpack (printOutputable $ SrcLoc.getLoc warnMsg) <> ": warning:\n"
     <> "    " <> SrcLoc.unLoc warnMsg
 
 runGetSession :: MonadIO m => IdeState -> NormalizedFilePath -> m HscEnv

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -50,7 +50,7 @@ import           Development.IDE                 (GetModSummary (..),
                                                   NeedsCompilation (NeedsCompilation),
                                                   evalGhcEnv,
                                                   hscEnvWithImportPaths,
-                                                  prettyPrint, runAction,
+                                                  printOutputable, runAction,
                                                   textToStringBuffer,
                                                   toNormalizedFilePath',
                                                   uriToFilePath', useNoFile_,
@@ -83,7 +83,7 @@ import qualified GHC.LanguageExtensions.Type     as LangExt (Extension (..))
 
 import           Development.IDE.Core.FileStore  (setSomethingModified)
 import           Development.IDE.Types.Shake     (toKey)
-import           Development.IDE.GHC.Util        (showGhc)
+import           Development.IDE.GHC.Util        (printOutputableText)
 import           Ide.Plugin.Config               (Config)
 #if MIN_VERSION_ghc(9,2,0)
 import           GHC.Types.SrcLoc                (UnhelpfulSpanReason (UnhelpfulInteractive))
@@ -284,7 +284,7 @@ runEvalCmd plId st EvalParams{..} =
 
                 -- load the module in the interactive environment
                 loadResult <- perf "loadModule" $ load LoadAllTargets
-                dbg "LOAD RESULT" $ showGhc loadResult
+                dbg "LOAD RESULT" $ printOutputableText loadResult
                 case loadResult of
                     Failed -> liftIO $ do
                         let err = ""
@@ -523,7 +523,7 @@ evals mark_exception (st, fp) df stmts = do
 
 prettyWarn :: Warn -> String
 prettyWarn Warn{..} =
-    prettyPrint (SrcLoc.getLoc warnMsg) <> ": warning:\n"
+    printOutputable (SrcLoc.getLoc warnMsg) <> ": warning:\n"
     <> "    " <> SrcLoc.unLoc warnMsg
 
 runGetSession :: MonadIO m => IdeState -> NormalizedFilePath -> m HscEnv

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -82,6 +82,7 @@ import qualified GHC.LanguageExtensions.Type     as LangExt (Extension (..))
 
 import           Development.IDE.Core.FileStore  (setSomethingModified)
 import           Development.IDE.Types.Shake     (toKey)
+import           Development.IDE.GHC.Util        (showGhc)
 import           Ide.Plugin.Config               (Config)
 #if MIN_VERSION_ghc(9,2,0)
 import           GHC.Types.SrcLoc                (UnhelpfulSpanReason (UnhelpfulInteractive))
@@ -97,7 +98,7 @@ import           Ide.Plugin.Eval.Parse.Comments  (commentsToSections)
 import           Ide.Plugin.Eval.Parse.Option    (parseSetFlags)
 import           Ide.Plugin.Eval.Rules           (queueForEvaluation)
 import           Ide.Plugin.Eval.Types
-import           Ide.Plugin.Eval.Util            (asS, gStrictTry, isLiterate,
+import           Ide.Plugin.Eval.Util            (gStrictTry, isLiterate,
                                                   logWith, response', timed)
 import           Ide.PluginUtils                 (handleMaybe, handleMaybeM,
                                                   response)
@@ -282,7 +283,7 @@ runEvalCmd plId st EvalParams{..} =
 
                 -- load the module in the interactive environment
                 loadResult <- perf "loadModule" $ load LoadAllTargets
-                dbg "LOAD RESULT" $ asS loadResult
+                dbg "LOAD RESULT" $ showGhc loadResult
                 case loadResult of
                     Failed -> liftIO $ do
                         let err = ""

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -83,7 +83,6 @@ import qualified GHC.LanguageExtensions.Type     as LangExt (Extension (..))
 
 import           Development.IDE.Core.FileStore  (setSomethingModified)
 import           Development.IDE.Types.Shake     (toKey)
-import           Development.IDE.GHC.Util        (printOutputableText)
 import           Ide.Plugin.Config               (Config)
 #if MIN_VERSION_ghc(9,2,0)
 import           GHC.Types.SrcLoc                (UnhelpfulSpanReason (UnhelpfulInteractive))
@@ -284,7 +283,7 @@ runEvalCmd plId st EvalParams{..} =
 
                 -- load the module in the interactive environment
                 loadResult <- perf "loadModule" $ load LoadAllTargets
-                dbg "LOAD RESULT" $ printOutputableText loadResult
+                dbg "LOAD RESULT" $ printOutputable loadResult
                 case loadResult of
                     Failed -> liftIO $ do
                         let err = ""
@@ -523,7 +522,7 @@ evals mark_exception (st, fp) df stmts = do
 
 prettyWarn :: Warn -> String
 prettyWarn Warn{..} =
-    printOutputable (SrcLoc.getLoc warnMsg) <> ": warning:\n"
+    show (printOutputable $ SrcLoc.getLoc warnMsg) <> ": warning:\n"
     <> "    " <> SrcLoc.unLoc warnMsg
 
 runGetSession :: MonadIO m => IdeState -> NormalizedFilePath -> m HscEnv

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
@@ -19,7 +19,7 @@ import           Data.String                     (fromString)
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
 import qualified Development.IDE.GHC.Compat.Util as EnumSet
-import           Development.IDE.GHC.Util        (prettyPrint)
+import           Development.IDE.GHC.Util        (printOutputable)
 
 import           GHC.LanguageExtensions.Type     (Extension (..))
 import           Ide.Plugin.Eval.Util            (gStrictTry)
@@ -67,7 +67,7 @@ pkgNames_ =
     mapMaybe
         ( \case
             ExposePackage _ (PackageArg n) _  -> Just n
-            ExposePackage _ (UnitIdArg uid) _ -> Just $ prettyPrint uid
+            ExposePackage _ (UnitIdArg uid) _ -> Just $ printOutputable uid
             _                                 -> Nothing
         )
 
@@ -148,7 +148,7 @@ deriving instance Read Extension
 -- Partial display of DynFlags contents, for testing purposes
 showDynFlags :: DynFlags -> String
 showDynFlags df =
-    prettyPrint . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
+    printOutputable . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
         [ ("extensions", ppr . extensions $ df)
         , ("extensionFlags", ppr . EnumSet.toList . extensionFlags $ df)
         , ("importPaths", vList $ importPaths df)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
@@ -16,6 +16,7 @@ module Ide.Plugin.Eval.GHC (
 import           Data.List                       (isPrefixOf)
 import           Data.Maybe                      (mapMaybe)
 import           Data.String                     (fromString)
+import qualified Data.Text                       as T
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
 import qualified Development.IDE.GHC.Compat.Util as EnumSet
@@ -67,7 +68,7 @@ pkgNames_ =
     mapMaybe
         ( \case
             ExposePackage _ (PackageArg n) _  -> Just n
-            ExposePackage _ (UnitIdArg uid) _ -> Just $ show $ printOutputable uid
+            ExposePackage _ (UnitIdArg uid) _ -> Just $ T.unpack $ printOutputable uid
             _                                 -> Nothing
         )
 
@@ -148,7 +149,7 @@ deriving instance Read Extension
 -- Partial display of DynFlags contents, for testing purposes
 showDynFlags :: DynFlags -> String
 showDynFlags df =
-    show . printOutputable . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
+    T.unpack . printOutputable . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
         [ ("extensions", ppr . extensions $ df)
         , ("extensionFlags", ppr . EnumSet.toList . extensionFlags $ df)
         , ("importPaths", vList $ importPaths df)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
@@ -19,7 +19,7 @@ import           Data.String                     (fromString)
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
 import qualified Development.IDE.GHC.Compat.Util as EnumSet
-import           Development.IDE.GHC.Util        (showGhc)
+import           Development.IDE.GHC.Util        (prettyPrint)
 
 import           GHC.LanguageExtensions.Type     (Extension (..))
 import           Ide.Plugin.Eval.Util            (gStrictTry)
@@ -67,7 +67,7 @@ pkgNames_ =
     mapMaybe
         ( \case
             ExposePackage _ (PackageArg n) _  -> Just n
-            ExposePackage _ (UnitIdArg uid) _ -> Just $ showGhc uid
+            ExposePackage _ (UnitIdArg uid) _ -> Just $ prettyPrint uid
             _                                 -> Nothing
         )
 

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
@@ -67,7 +67,7 @@ pkgNames_ =
     mapMaybe
         ( \case
             ExposePackage _ (PackageArg n) _  -> Just n
-            ExposePackage _ (UnitIdArg uid) _ -> Just $ printOutputable uid
+            ExposePackage _ (UnitIdArg uid) _ -> Just $ show $ printOutputable uid
             _                                 -> Nothing
         )
 
@@ -148,7 +148,7 @@ deriving instance Read Extension
 -- Partial display of DynFlags contents, for testing purposes
 showDynFlags :: DynFlags -> String
 showDynFlags df =
-    printOutputable . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
+    show . printOutputable . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
         [ ("extensions", ppr . extensions $ df)
         , ("extensionFlags", ppr . EnumSet.toList . extensionFlags $ df)
         , ("importPaths", vList $ importPaths df)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
@@ -19,9 +19,10 @@ import           Data.String                     (fromString)
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
 import qualified Development.IDE.GHC.Compat.Util as EnumSet
+import           Development.IDE.GHC.Util        (showGhc)
 
 import           GHC.LanguageExtensions.Type     (Extension (..))
-import           Ide.Plugin.Eval.Util            (asS, gStrictTry)
+import           Ide.Plugin.Eval.Util            (gStrictTry)
 
 {- $setup
 >>> import GHC
@@ -66,7 +67,7 @@ pkgNames_ =
     mapMaybe
         ( \case
             ExposePackage _ (PackageArg n) _  -> Just n
-            ExposePackage _ (UnitIdArg uid) _ -> Just $ asS uid
+            ExposePackage _ (UnitIdArg uid) _ -> Just $ showGhc uid
             _                                 -> Nothing
         )
 
@@ -147,7 +148,7 @@ deriving instance Read Extension
 -- Partial display of DynFlags contents, for testing purposes
 showDynFlags :: DynFlags -> String
 showDynFlags df =
-    showSDocUnsafe . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
+    prettyPrint . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
         [ ("extensions", ppr . extensions $ df)
         , ("extensionFlags", ppr . EnumSet.toList . extensionFlags $ df)
         , ("importPaths", vList $ importPaths df)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
@@ -4,7 +4,6 @@
 
 -- |Debug utilities
 module Ide.Plugin.Eval.Util (
-    asS,
     timed,
     isLiterate,
     response',
@@ -20,8 +19,7 @@ import           Data.String                     (IsString (fromString))
 import qualified Data.Text                       as T
 import           Development.IDE                 (IdeState, Priority (..),
                                                   ideLogger, logPriority)
-import           Development.IDE.GHC.Compat      (Outputable, ppr,
-                                                  showSDocUnsafe)
+import           Development.IDE.GHC.Compat      (Outputable, ppr)
 import           Development.IDE.GHC.Compat.Util (MonadCatch, catch)
 import           GHC.Exts                        (toList)
 import           GHC.Stack                       (HasCallStack, callStack,
@@ -32,9 +30,6 @@ import           Language.LSP.Types
 import           System.FilePath                 (takeExtension)
 import           System.Time.Extra               (duration, showDuration)
 import           UnliftIO.Exception              (catchAny)
-
-asS :: Outputable a => a -> String
-asS = showSDocUnsafe . ppr
 
 timed :: MonadIO m => (t -> String -> m a) -> t -> m b -> m b
 timed out name op = do

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
@@ -19,7 +19,6 @@ import           Data.String                     (IsString (fromString))
 import qualified Data.Text                       as T
 import           Development.IDE                 (IdeState, Priority (..),
                                                   ideLogger, logPriority)
-import           Development.IDE.GHC.Compat      (Outputable, ppr)
 import           Development.IDE.GHC.Compat.Util (MonadCatch, catch)
 import           GHC.Exts                        (toList)
 import           GHC.Stack                       (HasCallStack, callStack,

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -197,7 +197,7 @@ exportedModuleStrings :: ParsedModule -> [String]
 exportedModuleStrings ParsedModule{pm_parsed_source = L _ HsModule{..}}
   | Just export <- hsmodExports,
     exports <- unLoc export
-    = map (show . printOutputable) exports
+    = map (T.unpack . printOutputable) exports
 exportedModuleStrings _ = []
 
 minimalImportsRule :: Recorder (WithPriority Log) -> Rules ()

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -197,7 +197,7 @@ exportedModuleStrings :: ParsedModule -> [String]
 exportedModuleStrings ParsedModule{pm_parsed_source = L _ HsModule{..}}
   | Just export <- hsmodExports,
     exports <- unLoc export
-    = map printOutputable exports
+    = map (show . printOutputable) exports
 exportedModuleStrings _ = []
 
 minimalImportsRule :: Recorder (WithPriority Log) -> Rules ()
@@ -210,7 +210,7 @@ minimalImportsRule recorder = define (cmapWithPrio LogShake recorder) $ \Minimal
   (imports, mbMinImports) <- liftIO $ extractMinimalImports hsc tmr
   let importsMap =
         Map.fromList
-          [ (realSrcSpanStart l, printOutputableText i)
+          [ (realSrcSpanStart l, printOutputable i)
             | L (locA -> RealSrcSpan l _) i <- fromMaybe [] mbMinImports
           ]
       res =

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -210,7 +210,7 @@ minimalImportsRule recorder = define (cmapWithPrio LogShake recorder) $ \Minimal
   (imports, mbMinImports) <- liftIO $ extractMinimalImports hsc tmr
   let importsMap =
         Map.fromList
-          [ (realSrcSpanStart l, T.pack (prettyPrint i))
+          [ (realSrcSpanStart l, showGhc i)
             | L (locA -> RealSrcSpan l _) i <- fromMaybe [] mbMinImports
           ]
       res =

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -197,7 +197,7 @@ exportedModuleStrings :: ParsedModule -> [String]
 exportedModuleStrings ParsedModule{pm_parsed_source = L _ HsModule{..}}
   | Just export <- hsmodExports,
     exports <- unLoc export
-    = map prettyPrint exports
+    = map printOutputable exports
 exportedModuleStrings _ = []
 
 minimalImportsRule :: Recorder (WithPriority Log) -> Rules ()
@@ -210,7 +210,7 @@ minimalImportsRule recorder = define (cmapWithPrio LogShake recorder) $ \Minimal
   (imports, mbMinImports) <- liftIO $ extractMinimalImports hsc tmr
   let importsMap =
         Map.fromList
-          [ (realSrcSpanStart l, showGhc i)
+          [ (realSrcSpanStart l, printOutputableText i)
             | L (locA -> RealSrcSpan l _) i <- fromMaybe [] mbMinImports
           ]
       res =

--- a/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
@@ -42,7 +42,7 @@ import           Development.IDE                  as D (Diagnostic (Diagnostic, 
                                                         Range (Range), Uri,
                                                         getFileContents,
                                                         getParsedModule,
-                                                        prettyPrint, runAction,
+                                                        showGhc, runAction,
                                                         srcSpanToRange,
                                                         toNormalizedUri,
                                                         uriToFilePath',
@@ -151,7 +151,7 @@ suggestAddPragma mDynflags Diagnostic {_message} = genPragma _message
     disabled
       | Just dynFlags <- mDynflags =
         -- GHC does not export 'OnOff', so we have to view it as string
-        catMaybes $ T.stripPrefix "Off " . T.pack . prettyPrint <$> extensions dynFlags
+        catMaybes $ T.stripPrefix "Off " . showGhc <$> extensions dynFlags
       | otherwise =
         -- When the module failed to parse, we don't have access to its
         -- dynFlags. In that case, simply don't disable any pragmas.

--- a/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
@@ -42,7 +42,7 @@ import           Development.IDE                  as D (Diagnostic (Diagnostic, 
                                                         Range (Range), Uri,
                                                         getFileContents,
                                                         getParsedModule,
-                                                        printOutputableText, runAction,
+                                                        printOutputable, runAction,
                                                         srcSpanToRange,
                                                         toNormalizedUri,
                                                         uriToFilePath',
@@ -151,7 +151,7 @@ suggestAddPragma mDynflags Diagnostic {_message} = genPragma _message
     disabled
       | Just dynFlags <- mDynflags =
         -- GHC does not export 'OnOff', so we have to view it as string
-        catMaybes $ T.stripPrefix "Off " . printOutputableText <$> extensions dynFlags
+        catMaybes $ T.stripPrefix "Off " . printOutputable <$> extensions dynFlags
       | otherwise =
         -- When the module failed to parse, we don't have access to its
         -- dynFlags. In that case, simply don't disable any pragmas.

--- a/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
@@ -42,7 +42,7 @@ import           Development.IDE                  as D (Diagnostic (Diagnostic, 
                                                         Range (Range), Uri,
                                                         getFileContents,
                                                         getParsedModule,
-                                                        showGhc, runAction,
+                                                        printOutputableText, runAction,
                                                         srcSpanToRange,
                                                         toNormalizedUri,
                                                         uriToFilePath',
@@ -151,7 +151,7 @@ suggestAddPragma mDynflags Diagnostic {_message} = genPragma _message
     disabled
       | Just dynFlags <- mDynflags =
         -- GHC does not export 'OnOff', so we have to view it as string
-        catMaybes $ T.stripPrefix "Off " . showGhc <$> extensions dynFlags
+        catMaybes $ T.stripPrefix "Off " . printOutputableText <$> extensions dynFlags
       | otherwise =
         -- When the module failed to parse, we don't have access to its
         -- dynFlags. In that case, simply don't disable any pragmas.

--- a/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
+++ b/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
@@ -232,7 +232,7 @@ refineImportsRule recorder = define (cmapWithPrio LogShake recorder) $ \RefineIm
   let res =
         [ (i, Just
                 . T.intercalate "\n"
-                . map (showGhc . constructImport i)
+                . map (printOutputableText . constructImport i)
                 . Map.toList
                 $ filteredInnerImports)
         -- for every minimal imports
@@ -251,7 +251,7 @@ refineImportsRule recorder = define (cmapWithPrio LogShake recorder) $ \RefineIm
     -- Check if a name is exposed by AvailInfo (the available information of a module)
     containsAvail :: LIE GhcRn -> AvailInfo -> Bool
     containsAvail name avail =
-      any (\an -> prettyPrint an == (prettyPrint . ieName . unLoc $ name))
+      any (\an -> printOutputable an == (printOutputable . ieName . unLoc $ name))
         $ availNamesWithSelectors avail
 
 --------------------------------------------------------------------------------

--- a/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
+++ b/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
@@ -232,7 +232,7 @@ refineImportsRule recorder = define (cmapWithPrio LogShake recorder) $ \RefineIm
   let res =
         [ (i, Just
                 . T.intercalate "\n"
-                . map (T.pack . prettyPrint . constructImport i)
+                . map (showGhc . constructImport i)
                 . Map.toList
                 $ filteredInnerImports)
         -- for every minimal imports

--- a/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
+++ b/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
@@ -232,7 +232,7 @@ refineImportsRule recorder = define (cmapWithPrio LogShake recorder) $ \RefineIm
   let res =
         [ (i, Just
                 . T.intercalate "\n"
-                . map (printOutputableText . constructImport i)
+                . map (printOutputable . constructImport i)
                 . Map.toList
                 $ filteredInnerImports)
         -- for every minimal imports

--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -167,7 +167,7 @@ runRetrieCmd state RunRetrieParams{originatingFile = uri, ..} =
 extractImports :: ModSummary -> [HsBindLR GhcRn GhcRn] -> RewriteSpec -> [ImportSpec]
 extractImports ModSummary{ms_mod} topLevelBinds (Unfold thing)
   | Just FunBind {fun_matches}
-  <- find (\case FunBind{fun_id = L _ n} -> prettyPrint n == thing ; _ -> False) topLevelBinds
+  <- find (\case FunBind{fun_id = L _ n} -> printOutputable n == thing ; _ -> False) topLevelBinds
   , names <- listify p fun_matches
   =
     [ AddImport {..}
@@ -249,7 +249,7 @@ suggestBindRewrites ::
   [(T.Text, CodeActionKind, RunRetrieParams)]
 suggestBindRewrites originatingFile pos ms_mod FunBind {fun_id = L l' rdrName}
   | pos `isInsideSrcSpan` l' =
-    let pprName = prettyPrint rdrName
+    let pprName = printOutputable rdrName
         pprNameText = T.pack pprName
         unfoldRewrite restrictToOriginatingFile =
             let rewrites = [Unfold (qualify ms_mod pprName)]
@@ -273,7 +273,7 @@ suggestTypeRewrites ::
   TyClDecl pass ->
   [(T.Text, CodeActionKind, RunRetrieParams)]
 suggestTypeRewrites originatingFile ms_mod SynDecl {tcdLName = L _ rdrName} =
-    let pprName = prettyPrint rdrName
+    let pprName = printOutputable rdrName
         pprNameText = T.pack pprName
         unfoldRewrite restrictToOriginatingFile =
             let rewrites = [TypeForward (qualify ms_mod pprName)]
@@ -330,7 +330,7 @@ suggestRuleRewrites originatingFile pos ms_mod (L _ HsRules {rds_rules}) =
 suggestRuleRewrites _ _ _ _ = []
 
 qualify :: GHC.Module -> String -> String
-qualify ms_mod x = prettyPrint ms_mod <> "." <> x
+qualify ms_mod x = printOutputable ms_mod <> "." <> x
 
 -------------------------------------------------------------------------------
 -- Retrie driving code

--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -167,7 +167,7 @@ runRetrieCmd state RunRetrieParams{originatingFile = uri, ..} =
 extractImports :: ModSummary -> [HsBindLR GhcRn GhcRn] -> RewriteSpec -> [ImportSpec]
 extractImports ModSummary{ms_mod} topLevelBinds (Unfold thing)
   | Just FunBind {fun_matches}
-  <- find (\case FunBind{fun_id = L _ n} -> printOutputable n == thing ; _ -> False) topLevelBinds
+  <- find (\case FunBind{fun_id = L _ n} -> show (printOutputable n) == thing ; _ -> False) topLevelBinds
   , names <- listify p fun_matches
   =
     [ AddImport {..}
@@ -249,8 +249,8 @@ suggestBindRewrites ::
   [(T.Text, CodeActionKind, RunRetrieParams)]
 suggestBindRewrites originatingFile pos ms_mod FunBind {fun_id = L l' rdrName}
   | pos `isInsideSrcSpan` l' =
-    let pprName = printOutputable rdrName
-        pprNameText = T.pack pprName
+    let pprNameText = printOutputable rdrName
+        pprName = show pprNameText
         unfoldRewrite restrictToOriginatingFile =
             let rewrites = [Unfold (qualify ms_mod pprName)]
                 description = "Unfold " <> pprNameText <> describeRestriction restrictToOriginatingFile
@@ -273,8 +273,8 @@ suggestTypeRewrites ::
   TyClDecl pass ->
   [(T.Text, CodeActionKind, RunRetrieParams)]
 suggestTypeRewrites originatingFile ms_mod SynDecl {tcdLName = L _ rdrName} =
-    let pprName = printOutputable rdrName
-        pprNameText = T.pack pprName
+    let pprNameText = printOutputable rdrName
+        pprName = show pprNameText
         unfoldRewrite restrictToOriginatingFile =
             let rewrites = [TypeForward (qualify ms_mod pprName)]
                 description = "Unfold " <> pprNameText <> describeRestriction restrictToOriginatingFile
@@ -330,7 +330,7 @@ suggestRuleRewrites originatingFile pos ms_mod (L _ HsRules {rds_rules}) =
 suggestRuleRewrites _ _ _ _ = []
 
 qualify :: GHC.Module -> String -> String
-qualify ms_mod x = printOutputable ms_mod <> "." <> x
+qualify ms_mod x = show (printOutputable ms_mod) <> "." <> x
 
 -------------------------------------------------------------------------------
 -- Retrie driving code

--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -167,7 +167,7 @@ runRetrieCmd state RunRetrieParams{originatingFile = uri, ..} =
 extractImports :: ModSummary -> [HsBindLR GhcRn GhcRn] -> RewriteSpec -> [ImportSpec]
 extractImports ModSummary{ms_mod} topLevelBinds (Unfold thing)
   | Just FunBind {fun_matches}
-  <- find (\case FunBind{fun_id = L _ n} -> show (printOutputable n) == thing ; _ -> False) topLevelBinds
+  <- find (\case FunBind{fun_id = L _ n} -> T.unpack (printOutputable n) == thing ; _ -> False) topLevelBinds
   , names <- listify p fun_matches
   =
     [ AddImport {..}
@@ -250,7 +250,7 @@ suggestBindRewrites ::
 suggestBindRewrites originatingFile pos ms_mod FunBind {fun_id = L l' rdrName}
   | pos `isInsideSrcSpan` l' =
     let pprNameText = printOutputable rdrName
-        pprName = show pprNameText
+        pprName = T.unpack pprNameText
         unfoldRewrite restrictToOriginatingFile =
             let rewrites = [Unfold (qualify ms_mod pprName)]
                 description = "Unfold " <> pprNameText <> describeRestriction restrictToOriginatingFile
@@ -274,7 +274,7 @@ suggestTypeRewrites ::
   [(T.Text, CodeActionKind, RunRetrieParams)]
 suggestTypeRewrites originatingFile ms_mod SynDecl {tcdLName = L _ rdrName} =
     let pprNameText = printOutputable rdrName
-        pprName = show pprNameText
+        pprName = T.unpack pprNameText
         unfoldRewrite restrictToOriginatingFile =
             let rewrites = [TypeForward (qualify ms_mod pprName)]
                 description = "Unfold " <> pprNameText <> describeRestriction restrictToOriginatingFile
@@ -330,7 +330,7 @@ suggestRuleRewrites originatingFile pos ms_mod (L _ HsRules {rds_rules}) =
 suggestRuleRewrites _ _ _ _ = []
 
 qualify :: GHC.Module -> String -> String
-qualify ms_mod x = show (printOutputable ms_mod) <> "." <> x
+qualify ms_mod x = T.unpack (printOutputable ms_mod) <> "." <> x
 
 -------------------------------------------------------------------------------
 -- Retrie driving code

--- a/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
@@ -19,7 +19,8 @@ import           Control.DeepSeq
 import           Control.Exception
 import           Data.Either (fromRight)
 import qualified Debug.Trace
-import           Development.IDE.GHC.Compat (PlainGhcException, Outputable(..), SDoc, showSDocUnsafe)
+import           Development.IDE.GHC.Compat (PlainGhcException, Outputable(..), SDoc)
+import           Development.IDE.GHC.Util (prettyPrint)
 import           System.IO.Unsafe  (unsafePerformIO)
 
 ------------------------------------------------------------------------------
@@ -30,7 +31,7 @@ unsafeRender = unsafeRender' . ppr
 
 unsafeRender' :: SDoc -> String
 unsafeRender' sdoc = unsafePerformIO $ do
-  let z = showSDocUnsafe sdoc
+  let z = prettyPrint sdoc
   -- We might not have unsafeGlobalDynFlags (like during testing), in which
   -- case GHC panics. Instead of crashing, let's just fail to print.
   !res <- try @PlainGhcException $ evaluate $ deepseq z z

--- a/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
@@ -31,7 +31,7 @@ unsafeRender = unsafeRender' . ppr
 
 unsafeRender' :: SDoc -> String
 unsafeRender' sdoc = unsafePerformIO $ do
-  let z = printOutputable sdoc
+  let z = show $ printOutputable sdoc
   -- We might not have unsafeGlobalDynFlags (like during testing), in which
   -- case GHC panics. Instead of crashing, let's just fail to print.
   !res <- try @PlainGhcException $ evaluate $ deepseq z z

--- a/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
@@ -20,7 +20,7 @@ import           Control.Exception
 import           Data.Either (fromRight)
 import qualified Debug.Trace
 import           Development.IDE.GHC.Compat (PlainGhcException, Outputable(..), SDoc)
-import           Development.IDE.GHC.Util (prettyPrint)
+import           Development.IDE.GHC.Util (printOutputable)
 import           System.IO.Unsafe  (unsafePerformIO)
 
 ------------------------------------------------------------------------------
@@ -31,7 +31,7 @@ unsafeRender = unsafeRender' . ppr
 
 unsafeRender' :: SDoc -> String
 unsafeRender' sdoc = unsafePerformIO $ do
-  let z = prettyPrint sdoc
+  let z = printOutputable sdoc
   -- We might not have unsafeGlobalDynFlags (like during testing), in which
   -- case GHC panics. Instead of crashing, let's just fail to print.
   !res <- try @PlainGhcException $ evaluate $ deepseq z z

--- a/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/Debug.hs
@@ -18,6 +18,7 @@ module Wingman.Debug
 import           Control.DeepSeq
 import           Control.Exception
 import           Data.Either (fromRight)
+import qualified Data.Text as T
 import qualified Debug.Trace
 import           Development.IDE.GHC.Compat (PlainGhcException, Outputable(..), SDoc)
 import           Development.IDE.GHC.Util (printOutputable)
@@ -31,7 +32,7 @@ unsafeRender = unsafeRender' . ppr
 
 unsafeRender' :: SDoc -> String
 unsafeRender' sdoc = unsafePerformIO $ do
-  let z = show $ printOutputable sdoc
+  let z = T.unpack $ printOutputable sdoc
   -- We might not have unsafeGlobalDynFlags (like during testing), in which
   -- case GHC panics. Instead of crashing, let's just fail to print.
   !res <- try @PlainGhcException $ evaluate $ deepseq z z


### PR DESCRIPTION
We choose `printOutputable :: Outputable a => a -> Text` finally.

---

Extends #2828, this pr wrapped `showSDocUnsafe` and  unified all `SDoc` printing functions into the following four functions
1. `showGhc` has `defaultUserStyle` and `suppressUnique`, we'd use this as much as we can to print ghc internal.
2. `showGhcWithUniques` is the alias of `showSDocUnsafe`, it may have different behavior under different ghc versions, like #2716.
3. `prettyPrint` sames as `showGhc` but return `String` instead of `Text`.
4. `prettyPrintWithUnique`, the `String` version of `showGhcWithUniques`.


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2830"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

