### PR TITLE
Fix flaky test 

### DIFF
--- a/ghcide/src/Development/IDE/Core/FileExists.hs
+++ b/ghcide/src/Development/IDE/Core/FileExists.hs
@@ -131,14 +131,6 @@ fromChange FcChanged = Nothing
 -------------------------------------------------------------------------------------
 
 -- | Returns True if the file exists
---   Note that a file is not considered to exist unless it is saved to disk.
---   In particular, VFS existence is not enough.
---   Consider the following example:
---     1. The file @A.hs@ containing the line @import B@ is added to the files of interest
---        Since @B.hs@ is neither open nor exists, GetLocatedImports finds Nothing
---     2. The editor creates a new buffer @B.hs@
---        Unless the editor also sends a @DidChangeWatchedFile@ event, ghcide will not pick it up
---        Most editors, e.g. VSCode, only send the event when the file is saved to disk.
 getFileExists :: NormalizedFilePath -> Action Bool
 getFileExists fp = use_ GetFileExists fp
 

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -423,6 +423,10 @@ diagnosticTests = testGroup "diagnostics"
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       expectDiagnostics [("ModuleB.hs", [])]
   , testCase "add missing module (non workspace)" $
+    -- By default lsp-test sends FileWatched notifications for all files, which we don't want
+    -- as non workspace modules will not be watched by the LSP server.
+    -- To work around this, we tell lsp-test that our client doesn't have the
+    -- FileWatched capability, which is enough to disable the notifications
     withTempDir $ \tmpDir -> runInDir'' lspTestCapsNoFileWatches tmpDir "." "." [] $ do
       let contentB = T.unlines
             [ "module ModuleB where"

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -95,7 +95,7 @@ import           System.Process.Extra                     (CreateProcess (cwd),
 import           Test.QuickCheck
 -- import Test.QuickCheck.Instances ()
 import           Control.Concurrent.Async
-import           Control.Lens                             (to, (^.))
+import           Control.Lens                             (to, (^.), (.~))
 import           Control.Monad.Extra                      (whenJust)
 import           Data.Function                            ((&))
 import           Data.IORef
@@ -133,6 +133,7 @@ import           Test.Tasty.Ingredients.Rerun
 import           Test.Tasty.QuickCheck
 import           Text.Printf                              (printf)
 import           Text.Regex.TDFA                          ((=~))
+import Language.LSP.Types.Lens (workspace, didChangeWatchedFiles)
 
 data Log
   = LogGhcIde Ghcide.Log
@@ -421,9 +422,8 @@ diagnosticTests = testGroup "diagnostics"
       let contentA = T.unlines [ "module ModuleA where" ]
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       expectDiagnostics [("ModuleB.hs", [])]
-  , ignoreTestBecause "Flaky #2831" $ testSessionWait "add missing module (non workspace)" $ do
-      -- need to canonicalize in Mac Os
-      tmpDir <- liftIO $ canonicalizePath =<< getTemporaryDirectory
+  , testCase "add missing module (non workspace)" $
+    withTempDir $ \tmpDir -> runInDir'' lspTestCapsNoFileWatches tmpDir "." "." [] $ do
       let contentB = T.unlines
             [ "module ModuleB where"
             , "import ModuleA ()"
@@ -6306,7 +6306,18 @@ withLongTimeout = bracket_ (setEnv "LSP_TIMEOUT" "120" True) (unsetEnv "LSP_TIME
 
 -- | Takes a directory as well as relative paths to where we should launch the executable as well as the session root.
 runInDir' :: FilePath -> FilePath -> FilePath -> [String] -> Session a -> IO a
-runInDir' dir startExeIn startSessionIn extraOptions s = do
+runInDir' = runInDir'' lspTestCaps
+
+runInDir''
+    :: ClientCapabilities
+    -> FilePath
+    -> FilePath
+    -> FilePath
+    -> [String]
+    -> Session b
+    -> IO b
+runInDir'' lspCaps dir startExeIn startSessionIn extraOptions s = do
+
   ghcideExe <- locateGhcideExecutable
   let startDir = dir </> startExeIn
   let projDir = dir </> startSessionIn
@@ -6326,9 +6337,10 @@ runInDir' dir startExeIn startSessionIn extraOptions s = do
   -- Only sets HOME if it wasn't already set.
   setEnv "HOME" "/homeless-shelter" False
   conf <- getConfigFromEnv
-  runSessionWithConfig conf cmd lspTestCaps projDir $ do
+  runSessionWithConfig conf cmd lspCaps projDir $ do
       configureCheckProject False
       s
+
 
 getConfigFromEnv :: IO SessionConfig
 getConfigFromEnv = do
@@ -6346,6 +6358,9 @@ getConfigFromEnv = do
 
 lspTestCaps :: ClientCapabilities
 lspTestCaps = fullCaps { _window = Just $ WindowClientCapabilities (Just True) Nothing Nothing }
+
+lspTestCapsNoFileWatches :: ClientCapabilities
+lspTestCapsNoFileWatches = lspTestCaps & workspace . Lens._Just . didChangeWatchedFiles .~ Nothing
 
 openTestDataDoc :: FilePath -> Session TextDocumentIdentifier
 openTestDataDoc path = do


### PR DESCRIPTION
"add missing modules (non workspace)" became flaky after the recent changes to snapshot VFS data.

The test calls `createDoc` to open a `module B imports A` where `A` does not exist, then waits for the missing module error and calls `createDoc` to open a `module A`. Importantly, both `B` and `A` live outside the workspace and thus are not subject to `FileWatched` notifications. 

Unfortunately, the test wasn't testing the right thing because `createDoc` sends a `FileWatched` notification right before sending a `DidOpen` notification! This was causing a race condition, where the `FileWatched` notification triggers a build that may or may not run the `FileExists ModuleA` key:
* If it does, then the key will resolve to `False` since `ModuleA` exists neither in the file system nor in VFS, and the test will fail since the key will not get rebuilt again (nothing dirties it).
* If the build gets aborted before it does, then the key will get computed in the next build (for the `DidOpen` notification) and will return true because the file now exists in VFS.

I imagine that the test was passing before since the VFS state would get updated concurrently, and the race condition would not get triggered in practice.

To fix the test, we simply tell `lsp-test` not to send `FileWatched` notifications.

I also found an old comment stating that "VFS existence is not enough, a file must exist in disk". This is clearly not true anymore, so I have deleted it.

Fixes #2831 

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2835"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

