### PR TITLE
Update plugin support table

### DIFF
--- a/docs/supported-versions.md
+++ b/docs/supported-versions.md
@@ -34,11 +34,11 @@ Sometimes a plugin will be supported in the prebuilt binaries but not in a HLS b
 
 | Plugin                              | Unsupported GHC versions |
 |-------------------------------------|--------------------------|
-| `hls-alternate-number-plugin`       | 9.2                      |
+| `hls-alternate-number-plugin`       |                          |
 | `hls-brittany-plugin`               | 9.0.2(hackage), 9.2      |
 | `hls-call-hierarchy-plugin`         |                          |
-| `hls-class-plugin`                  | 9.2                      |
-| `hls-eval-plugin`                   | 9.2                      |
+| `hls-class-plugin`                  |                          |
+| `hls-eval-plugin`                   |                          |
 | `hls-explicit-imports-plugin`       |                          |
 | `hls-floskell-plugin`               |                          |
 | `hls-fourmolu-plugin`               |                          |
@@ -52,7 +52,7 @@ Sometimes a plugin will be supported in the prebuilt binaries but not in a HLS b
 | `hls-rename-plugin`                 |                          |
 | `hls-retrie-plugin`                 | 9.2                      |
 | `hls-splice-plugin`                 | 9.2                      |
-| `hls-stylish-haskell-plugin`        | 9.0, 9.2                 |
+| `hls-stylish-haskell-plugin`        | 9.0                      |
 | `hls-tactics-plugin`                | 9.2                      |
 | `hls-selection-range-plugin`        |                          |
 


### PR DESCRIPTION
I linked someone to it on IRC and I noticed that it was out of date.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2840"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

