### PR TITLE
Add HLS Cachix to `nixConfig` in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -381,4 +381,13 @@
 
         devShell = devShells.haskell-language-server-dev;
       });
+
+  nixConfig = {
+    extra-substituters = [
+      "https://haskell-language-server.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "haskell-language-server.cachix.org-1:juFfHrwkOxqIOZShtC4YC1uT1bBcq2RSvC7OMKx0Nz8="
+    ];
+  };
 }


### PR DESCRIPTION
Just a minor convenience thingy

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2841"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

