### PR TITLE
Don't refresh HieDb while querying hierarchy results

### DIFF
--- a/plugins/hls-call-hierarchy-plugin/README.md
+++ b/plugins/hls-call-hierarchy-plugin/README.md
@@ -23,6 +23,8 @@ Enabled by default. You can disable it in your editor settings whenever you like
 ```
 
 ## Change log
+### 1.0.3.0
+Remove force update `HieDb` logic in queries.
 ### 1.0.1.0
 - Support call from a type signature.
 - Support call from a function pattern.

--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-call-hierarchy-plugin
-version:            1.0.2.0
+version:            1.0.3.0
 synopsis:           Call hierarchy plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-call-hierarchy-plugin#readme>


### PR DESCRIPTION
These legacy codes are used to force update `hiedb` while querying hierarchy results, deleting now since users should save their changes before querying call hierarchy.

Will close #2843.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2844"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

