### PR TITLE
simplify hlint plugin Cabal descriptor

### DIFF
--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -64,10 +64,6 @@ jobs:
       - name: Build `hls-graph` with flags
         run: cabal v2-build hls-graph --flags="embed-files stm-stats"
 
-      - if: matrix.ghc != '8.6.5' && matrix.ghc != '8.8.4'
-        name: Build `hie-compat` with flags
-        run: cabal v2-build hie-compat --flags="ghc-lib"
-
       - name: Build `ghcide` with flags
         run: cabal v2-build ghcide --flags="ghc-patched-unboxed-bytecode test-exe executable bench-exe"
 

--- a/cabal-ghc90.project
+++ b/cabal-ghc90.project
@@ -40,7 +40,6 @@ write-ghc-environment-files: never
 index-state: 2022-04-27T09:22:49Z
 
 constraints:
-  hls-hlint-plugin +ghc-lib
 
 -- although we are not building all plugins cabal solver phase is run for all packages
 -- this way we track explicitly all transitive dependencies which need support for ghc-9

--- a/cabal-ghc92.project
+++ b/cabal-ghc92.project
@@ -34,7 +34,8 @@ with-compiler: ghc-9.2.2
 tests: true
 
 package *
-  ghc-options: -haddock
+  -- ghc 8.10 cannot build ghc-lib 9.2 with --haddock
+  -- ghc-options: -haddock
   test-show-details: direct
 
 write-ghc-environment-files: never
@@ -50,8 +51,6 @@ constraints:
     -retrie
     -splice
     -tactic,
-  hls-hlint-plugin +ghc-lib,
-  -- # Use ghc-lib force instead of ghc itself
   ghc-lib-parser-ex -auto,
   hlint +ghc-lib,
   stylish-haskell +ghc-lib

--- a/cabal-ghc92.project
+++ b/cabal-ghc92.project
@@ -34,8 +34,7 @@ with-compiler: ghc-9.2.2
 tests: true
 
 package *
-  -- ghc 8.10 cannot build ghc-lib 9.2 with --haddock
-  -- ghc-options: -haddock
+  ghc-options: -haddock
   test-show-details: direct
 
 write-ghc-environment-files: never

--- a/cabal.project
+++ b/cabal.project
@@ -43,7 +43,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-03-08T10:53:01Z
+index-state: 2022-04-27T09:22:49Z
 
 constraints:
     hyphenation +embed,

--- a/cabal.project
+++ b/cabal.project
@@ -47,6 +47,8 @@ index-state: 2022-04-27T09:22:49Z
 
 constraints:
     hyphenation +embed,
+    -- remove this when hlint sets ghc-lib to true by default
+    -- https://github.com/ndmitchell/hlint/issues/1376
     hlint +ghc-lib
 
 allow-newer:

--- a/cabal.project
+++ b/cabal.project
@@ -37,7 +37,8 @@ optional-packages: vendored/*/*.cabal
 tests: true
 
 package *
-  ghc-options: -haddock
+  -- ghc 8.10 cannot build ghc-lib 9.2 with --haddock
+  -- ghc-options: -haddock
   test-show-details: direct
 
 write-ghc-environment-files: never

--- a/cabal.project
+++ b/cabal.project
@@ -46,7 +46,8 @@ write-ghc-environment-files: never
 index-state: 2022-03-08T10:53:01Z
 
 constraints:
-    hyphenation +embed
+    hyphenation +embed,
+    hlint +ghc-lib
 
 allow-newer:
     -- for shake-bench

--- a/hie-compat/hie-compat.cabal
+++ b/hie-compat/hie-compat.cabal
@@ -25,7 +25,7 @@ library
   build-depends:
      base < 4.17, array, bytestring, containers, directory, filepath, transformers
   if flag(ghc-lib)
-    build-depends: ghc-lib
+    build-depends: ghc-lib < 9.0
   else
     build-depends: ghc, ghc-boot
   if (impl(ghc >= 9.0) && impl(ghc < 9.1))

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -25,19 +25,6 @@ flag pedantic
   default:     False
   manual:      True
 
-flag ghc-lib
-  default:     False
-  manual:      True
-  description:
-    Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported
-
-flag hlint34
-  default:     True
-  manual:      False
-  description:
-    Hlint-3.4 doesn't support versions ghc-lib < 9.0.1 nor ghc <= 8.6, so we can use hlint-3.2 for backwards compat
-    This flag can be removed when all dependencies support ghc-lib-9.0.* and we drop support for ghc-8.6
-
 library
   exposed-modules:    Ide.Plugin.Hlint
   hs-source-dirs:     src
@@ -56,7 +43,7 @@ library
     , ghc-exactprint        >=0.6.3.4
     , ghcide                ^>=1.7
     , hashable
-    , hlint
+    , hlint                 < 3.5
     , hls-plugin-api        ^>=1.4
     , hslogger
     , lens
@@ -69,41 +56,11 @@ library
     , transformers
     , unordered-containers
     , apply-refact          >=0.9.0.0
-    -- can be removed if https://github.com/ndmitchell/hlint/pull/1325#issue-1077062712 is merged
-    -- and https://github.com/haskell/haskell-language-server/pull/2464#issue-1077133441 is updated
-    -- accordingly
+    , ghc-lib
+    , ghc-lib-parser
     , ghc-lib-parser-ex
 
-  if (flag(hlint34))
-    -- This mirrors the logic in hlint.cabal for hlint-3.3
-    -- https://github.com/ndmitchell/hlint/blob/d3576de4529d8df6cca5a345f5b7e04474ff7bff/hlint.cabal#L79-L88
-    -- so we can make sure that we do the same thing as hlint
-    build-depends: hlint      ^>=3.4
-
-    if (!flag(ghc-lib) && impl(ghc >=9.0.1) && impl(ghc <9.1.0))
-      build-depends: ghc      ==9.0.*
-    else
-      build-depends:
-        , ghc-lib            ^>=9.2
-        , ghc-lib-parser-ex  ^>=9.2
-        , ghc-lib-parser     ^>=9.2
-
-      cpp-options:   -DHLINT_ON_GHC_LIB
-
-  else
-    -- This mirrors the logic in hlint.cabal for hlint-3.2
-    -- https://github.com/ndmitchell/hlint/blob/c7354e473c7d09213c8adc3dc94bf50a6eb4a42d/hlint.cabal#L79-L88
-    build-depends: hlint        ^>=3.2
-    if (!flag(ghc-lib) && impl(ghc >=8.10.1) && impl(ghc < 8.11.0))
-      build-depends: ghc >=8.10 && <9.0
-    else
-      build-depends:
-        , ghc
-        , ghc-lib            ^>=8.10.7.20210828
-        , ghc-lib-parser-ex  ^>=8.10
-
-      cpp-options:   -DHLINT_ON_GHC_LIB
-
+  cpp-options:   -DHLINT_ON_GHC_LIB
   ghc-options:
     -Wall -Wredundant-constraints -Wno-name-shadowing
     -Wno-unticked-promoted-constructors

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -25,6 +25,11 @@ flag pedantic
   default:     False
   manual:      True
 
+flag ghc-lib
+   default:     True
+   manual:      True
+   description: Use ghc-lib types (requires hlint to be built with ghc-lib)
+
 library
   exposed-modules:    Ide.Plugin.Hlint
   hs-source-dirs:     src

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -371,7 +371,7 @@ disableHlint = sendConfigurationChanged $ toJSON $ def { Plugin.plugins = Map.fr
 -- Although a given hlint version supports one direct ghc, we could use several versions of hlint
 -- each one supporting a different ghc version. It should be a temporary situation though.
 knownBrokenForHlintOnGhcLib :: String -> TestTree -> TestTree
-knownBrokenForHlintOnGhcLib = knownBrokenForGhcVersions [GHC86, GHC88, GHC90, GHC92]
+knownBrokenForHlintOnGhcLib = expectFailBecause
 
 -- 1's based
 data Point = Point {

--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -106,8 +106,6 @@ flags:
     BuildExecutable: false
   # Stack doesn't support automatic flags.
   # Until the formatters support ghc-lib-9, we need this flag disabled
-  hls-hlint-plugin:
-    hlint34: false
   hyphenation:
     embed: true
 

--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -104,10 +104,10 @@ flags:
     pedantic: true
   retrie:
     BuildExecutable: false
-  # Stack doesn't support automatic flags.
-  # Until the formatters support ghc-lib-9, we need this flag disabled
   hyphenation:
     embed: true
+  hlint:
+    ghc-lib: true
 
 nix:
   packages: [icu libcxx zlib]

--- a/stack-lts19.yaml
+++ b/stack-lts19.yaml
@@ -67,10 +67,6 @@ flags:
   retrie:
     BuildExecutable: false
   # Stack doesn't support automatic flags.
-  # Until the formatters support ghc-lib-9, we need this flag disabled
-  hls-hlint-plugin:
-    hlint34: true
-    ghc-lib: true
   hyphenation:
     embed: true
 

--- a/stack-lts19.yaml
+++ b/stack-lts19.yaml
@@ -69,6 +69,8 @@ flags:
   # Stack doesn't support automatic flags.
   hyphenation:
     embed: true
+  hlint:
+    ghc-lib: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -82,9 +82,6 @@ flags:
   retrie:
     BuildExecutable: false
   # Stack doesn't support automatic flags.
-  hls-hlint-plugin:
-    hlint34: true
-    ghc-lib: true
   # Use ghc-lib force instead of ghc itself
   ghc-lib-parser-ex:
     auto: false


### PR DESCRIPTION
While working on #2866 I noticed that `hls-hlint-plugin`requires per-ghc-version flags. This prevents `cabal install haskell-language-server` from working across ghc versions.

I think we can get rid of these flags:
- the `ghc-lib` flag is unnecessary, there is no downside to using ghc-lib always for maximum compatibility
- the `hlint34` flag is unnecessary, cabal should be able to use the right version

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2867"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

