### PR TITLE
Compatibility with older aeson releases

### DIFF
--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -24,7 +24,7 @@ library
 
   hs-source-dirs:     src
   build-depends:
-    , aeson                 >=1.5.2.0
+    , aeson
     , base                  >=4.12 && <5
     , bytestring
     , containers

--- a/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy/Internal.hs
+++ b/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
@@ -189,6 +190,9 @@ mkSymbol = \case
 deriving instance Ord SymbolKind
 deriving instance Ord SymbolTag
 deriving instance Ord CallHierarchyItem
+#if !MIN_VERSION_aeson(1,5,2)
+deriving instance Ord Value
+#endif
 
 -- | Render incoming calls request.
 incomingCalls :: PluginMethodHandler IdeState CallHierarchyIncomingCalls


### PR DESCRIPTION
I want to build the call hierarchy plugin in a stockage LTS 16.11 system, which has an older version of `aeson`

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2868"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

