### PR TITLE
Fix hanging redundant import on Unicode function 

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Util.hs
@@ -69,8 +69,6 @@ module Development.IDE.GHC.Compat.Util (
     stringToStringBuffer,
     nextChar,
     atEnd,
-    -- * Char
-    is_ident
     ) where
 
 #if MIN_VERSION_ghc(9,0,0)
@@ -83,7 +81,6 @@ import           GHC.Data.FastString
 import           GHC.Data.Maybe
 import           GHC.Data.Pair
 import           GHC.Data.StringBuffer
-import           GHC.Parser.CharClass    (is_ident)
 import           GHC.Types.Unique
 import           GHC.Types.Unique.DFM
 import           GHC.Utils.Fingerprint
@@ -93,7 +90,6 @@ import           GHC.Utils.Panic         hiding (try)
 #else
 import           Bag
 import           BooleanFormula
-import           Ctype                   (is_ident)
 import           EnumSet
 import qualified Exception
 import           FastString

--- a/ghcide/src/Development/IDE/Plugin/CodeAction.hs
+++ b/ghcide/src/Development/IDE/Plugin/CodeAction.hs
@@ -41,8 +41,8 @@ import qualified Data.Rope.UTF16                                   as Rope
 import qualified Data.Set                                          as S
 import qualified Data.Text                                         as T
 import           Data.Tuple.Extra                                  (fst3)
-import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Rules
+import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Service
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util
@@ -1606,8 +1606,11 @@ rangesForBindingImport _ _ = []
 wrapOperatorInParens :: String -> String
 wrapOperatorInParens x =
   case uncons x of
-    Just (h, _t) -> if is_ident h then x else "(" <> x <> ")"
-    Nothing      -> mempty
+    -- see #2483 and #2859
+    -- common lens functions use the _ prefix, and should not be wrapped in parens
+    Just ('_', _t) -> x
+    Just (h, _t)   -> if isAlpha h then x else "(" <> x <> ")"
+    Nothing        -> mempty
 
 smallerRangesForBindingExport :: [LIE GhcPs] -> String -> [Range]
 smallerRangesForBindingExport lies b =
@@ -1763,8 +1766,8 @@ renderImportStyle (ImportAllConstructors p) = p <> "(..)"
 
 -- | Used for extending import lists
 unImportStyle :: ImportStyle -> (Maybe String, String)
-unImportStyle (ImportTopLevel x)    = (Nothing, T.unpack x)
-unImportStyle (ImportViaParent x y) = (Just $ T.unpack y, T.unpack x)
+unImportStyle (ImportTopLevel x)        = (Nothing, T.unpack x)
+unImportStyle (ImportViaParent x y)     = (Just $ T.unpack y, T.unpack x)
 unImportStyle (ImportAllConstructors x) = (Just $ T.unpack x, wildCardSymbol)
 
 


### PR DESCRIPTION
Closes #2859

Revert partial changes from #2483

For redundant import actions, the code path ends up calling `wrapOperatorInParen` which under the hood makes a call to `is_ident` which is a low-level `Char -> Bool`. The function will panic when it's input falls out of ASCII range.

The fix is just to match directly on the '_' character. Outside of this codepath, the original
functionality has been restored (using `isAlpha`).

Also removes the now unnecessary `is_ident` compat layer.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2870"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

