### PR TITLE
hls-call-hierarchy-plugin Patch release

### DIFF
--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-call-hierarchy-plugin
-version:            1.0.3.0
+version:            1.0.3.1
 synopsis:           Call hierarchy plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-call-hierarchy-plugin#readme>


### PR DESCRIPTION
I want to make a Hackage release including the extended aeson compat. changes from #2868

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2873"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

