### PR TITLE
ghcide needs prettyprinter-1.7 to build

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -72,7 +72,7 @@ library
         optparse-applicative,
         parallel,
         prettyprinter-ansi-terminal,
-        prettyprinter,
+        prettyprinter >= 1.7,
         random,
         regex-tdfa >= 1.3.1.0,
         retrie,


### PR DESCRIPTION
fails with prettyprinter 1.6
```
[37 of 77] Compiling Development.IDE.Types.Logger ( src/Development/IDE/Types/Logger.hs, dist/build/Development/IDE/Types/Logger.o )
src/Development/IDE/Types/Logger.hs:57:1: error:
    Could not find module `Prettyprinter'
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
57 | import           Prettyprinter                 as PrettyPrinterModule
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/Development/IDE/Types/Logger.hs:58:1: error:
    Could not find module `Prettyprinter.Render.Text'
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
58 | import           Prettyprinter.Render.Text     (renderStrict)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cabal: Failed to build ghcide-1.7.0.0 (which is required by
exe:haskell-language-server from haskell-language-server-1.7.0.0 and
exe:haskell-language-server-wrapper from haskell-language-server-1.7.0.0). See
the build log above for details.
```
from https://download.copr.fedorainfracloud.org/results/petersen/haskell-language-server/fedora-34-x86_64/04345531-haskell-language-server/

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2875"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

