### PR TITLE
ghcide requires ghc-exactprint >= 1.4

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -108,6 +108,9 @@ library
         hie-bios ^>= 0.9.1,
         implicit-hie-cradle ^>= 0.3.0.5 || ^>= 0.5,
         base16-bytestring >=0.1.1 && <1.1
+    if impl(ghc >= 9.2)
+      build-depends:
+        ghc-exactprint >= 1.4
     if os(windows)
       build-depends:
         Win32


### PR DESCRIPTION
E. g., `instance Default EpaLocation` is not present in `ghc-exactprint-1.3`.
https://hackage.haskell.org/package/ghc-exactprint-1.3.0/docs/Language-Haskell-GHC-ExactPrint-Orphans.html
vs.
https://hackage.haskell.org/package/ghc-exactprint-1.4.0/docs/Language-Haskell-GHC-ExactPrint-Orphans.html

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2876"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

