### PR TITLE
Restore compat. with prettyprinter 1.6

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,5 +1,6 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main(main) where
@@ -23,7 +24,11 @@ import           Ide.Types                    (PluginDescriptor (pluginNotificat
 import           Language.LSP.Server          as LSP
 import           Language.LSP.Types           as LSP
 import qualified Plugins
+#if MIN_VERSION_prettyprinter(1,7,0)
 import           Prettyprinter                (Pretty (pretty), vsep)
+#else
+import           Data.Text.Prettyprint.Doc    (Pretty (pretty), vsep)
+#endif
 
 data Log
   = LogIdeMain IdeMain.Log

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.7.0.0
+version:            1.7.0.1
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -72,7 +72,7 @@ library
         optparse-applicative,
         parallel,
         prettyprinter-ansi-terminal,
-        prettyprinter >= 1.7,
+        prettyprinter >= 1.6,
         random,
         regex-tdfa >= 1.3.1.0,
         retrie,

--- a/ghcide/src/Development/IDE/Types/Logger.hs
+++ b/ghcide/src/Development/IDE/Types/Logger.hs
@@ -1,6 +1,7 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE CPP        #-}
 {-# LANGUAGE RankNTypes #-}
 -- | This is a compatibility module that abstracts over the
 -- concrete choice of logging framework so users can plug in whatever
@@ -54,8 +55,13 @@ import           Language.LSP.Types            (LogMessageParams (..),
                                                 MessageType (..),
                                                 SMethod (SWindowLogMessage, SWindowShowMessage),
                                                 ShowMessageParams (..))
+#if MIN_VERSION_prettyprinter(1,7,0)
 import           Prettyprinter                 as PrettyPrinterModule
 import           Prettyprinter.Render.Text     (renderStrict)
+#else
+import           Data.Text.Prettyprint.Doc     as PrettyPrinterModule
+import           Data.Text.Prettyprint.Doc.Render.Text (renderStrict)
+#endif
 import           System.IO                     (Handle, IOMode (AppendMode),
                                                 hClose, hFlush, hSetEncoding,
                                                 openFile, stderr, utf8)

--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -65,7 +65,6 @@ extra-deps:
   - monad-dijkstra-0.1.1.2
   - opentelemetry-0.6.1
   - opentelemetry-extra-0.6.1
-  - prettyprinter-1.7.1
   - refinery-0.4.0.0
   - retrie-1.1.0.0
   - semigroups-0.18.5


### PR DESCRIPTION
I intend to continue supporting LTS 16 for a little longer.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2877"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

