### PR TITLE
hls-pragmas-plugin requires ghcide >= 1.7

### DIFF
--- a/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
+++ b/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
@@ -25,7 +25,7 @@ library
     , extra
     , fuzzy
     , ghc
-    , ghcide                ^>=1.6 || ^>=1.7
+    , ghcide                ^>=1.7
     , hls-plugin-api        ^>=1.3 || ^>=1.4
     , lens
     , lsp


### PR DESCRIPTION
Otherwise `Development.IDE.printOutputable` is not available.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2884"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

