### PR TITLE
Add .txt files as extra-source-files for hls-change-type-signature-plugin

### DIFF
--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -15,6 +15,7 @@ extra-source-files:
   LICENSE
   README.md
   test/testdata/*.hs
+  test/testdata/*.txt
   test/testdata/*.yaml
 
 library


### PR DESCRIPTION
`hls-change-type-signature-plugin` appears to have a few `.txt` files that are necessary for running tests, but those files haven't been added to `extra-source-files` in `hls-change-type-signature-plugin`.

This appears to be causing errors when we try to build `hls-change-type-signature-plugin` in Nixpkgs: https://hydra.nixos.org/build/175155441/nixlog/1.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2887"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

