### PR TITLE
Fix hls-call-hierarchy-plugin tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
         name: Test hls-explicit-imports-plugin test suite
         run: cabal test hls-explicit-imports-plugin --test-options="$TEST_OPTS" || cabal test hls-explicit-imports-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-explicit-imports-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.os != 'windows-latest'
+      - if: matrix.test
         name: Test hls-call-hierarchy-plugin test suite
         run: cabal test hls-call-hierarchy-plugin --test-options="$TEST_OPTS" || cabal test hls-call-hierarchy-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-call-hierarchy-plugin --test-options="$TEST_OPTS"
 

--- a/plugins/hls-call-hierarchy-plugin/test/Main.hs
+++ b/plugins/hls-call-hierarchy-plugin/test/Main.hs
@@ -197,6 +197,7 @@ incomingCallsTests =
       testCase "xdata unavailable" $
         runSessionWithServer plugin testDataDir $ do
           doc <- createDoc "A.hs" "haskell" $ T.unlines ["a=3", "b=a"]
+          waitForKickDone
           [item] <- Test.prepareCallHierarchy (mkPrepareCallHierarchyParam doc 1 0)
           let expected = [CallHierarchyIncomingCall item (List [mkRange 1 2 1 3])]
           Test.prepareCallHierarchy (mkPrepareCallHierarchyParam doc 0 0) >>=
@@ -321,6 +322,7 @@ outgoingCallsTests =
       testCase "xdata unavailable" $ withTempDir $ \dir ->
         runSessionWithServer plugin dir $ do
           doc <- createDoc "A.hs" "haskell" $ T.unlines ["a=3", "b=a"]
+          waitForKickDone
           [item] <- Test.prepareCallHierarchy (mkPrepareCallHierarchyParam doc 0 1)
           let expected = [CallHierarchyOutgoingCall item (List [mkRange 1 2 1 3])]
           Test.prepareCallHierarchy (mkPrepareCallHierarchyParam doc 1 0) >>=
@@ -424,6 +426,7 @@ incomingCallTestCase :: T.Text -> Int -> Int -> [(Int, Int)] -> [Range] -> Asser
 incomingCallTestCase contents queryX queryY positions ranges = withTempDir $ \dir ->
   runSessionWithServer plugin dir $ do
     doc <- createDoc "A.hs" "haskell" contents
+    waitForKickDone
     items <- concatMapM (\((x, y), range) ->
       Test.prepareCallHierarchy (mkPrepareCallHierarchyParam doc x y)
           <&> map (, range)
@@ -443,6 +446,7 @@ incomingCallMultiFileTestCase :: FilePath -> Int -> Int -> M.Map FilePath [((Int
 incomingCallMultiFileTestCase filepath queryX queryY mp =
   runSessionWithServer plugin testDataDir $ do
     doc <- openDoc filepath "haskell"
+    waitForKickDone
     items <- fmap concat $ sequence $ M.elems $ M.mapWithKey (\fp pr ->
               openDoc fp "haskell" >>= \p ->
                 concatMapM (\((x, y), range) ->
@@ -463,6 +467,7 @@ outgoingCallTestCase :: T.Text -> Int -> Int -> [(Int, Int)] -> [Range] -> Asser
 outgoingCallTestCase contents queryX queryY positions ranges = withTempDir $ \dir ->
   runSessionWithServer plugin dir $ do
     doc <- createDoc "A.hs" "haskell" contents
+    waitForKickDone
     items <- concatMapM (\((x, y), range) ->
       Test.prepareCallHierarchy (mkPrepareCallHierarchyParam doc x y)
           <&> map (, range)
@@ -481,6 +486,7 @@ outgoingCallMultiFileTestCase :: FilePath -> Int -> Int -> M.Map FilePath [((Int
 outgoingCallMultiFileTestCase filepath queryX queryY mp =
   runSessionWithServer plugin testDataDir $ do
     doc <- openDoc filepath "haskell"
+    waitForKickDone
     items <- fmap concat $ sequence $ M.elems $ M.mapWithKey (\fp pr ->
               openDoc fp "haskell" >>= \p ->
                 concatMapM (\((x, y), range) ->
@@ -500,6 +506,7 @@ oneCaseWithCreate :: T.Text -> Int -> Int -> (Uri -> CallHierarchyItem) -> Asser
 oneCaseWithCreate contents queryX queryY expected = withTempDir $ \dir ->
   runSessionWithServer plugin dir $ do
     doc <- createDoc "A.hs" "haskell" contents
+    waitForKickDone
     Test.prepareCallHierarchy (mkPrepareCallHierarchyParam doc queryX queryY) >>=
       \case
         [item] -> liftIO $ item @?= expected (doc ^. L.uri)

--- a/plugins/hls-call-hierarchy-plugin/test/Main.hs
+++ b/plugins/hls-call-hierarchy-plugin/test/Main.hs
@@ -447,9 +447,10 @@ incomingCallMultiFileTestCase filepath queryX queryY mp =
   runSessionWithServer plugin testDataDir $ do
     doc <- openDoc filepath "haskell"
     waitForKickDone
-    items <- fmap concat $ sequence $ M.elems $ M.mapWithKey (\fp pr ->
-              openDoc fp "haskell" >>= \p ->
-                concatMapM (\((x, y), range) ->
+    items <- fmap concat $ sequence $ M.elems $ M.mapWithKey (\fp pr -> do
+              p <- openDoc fp "haskell"
+              waitForKickDone
+              concatMapM (\((x, y), range) ->
                   Test.prepareCallHierarchy (mkPrepareCallHierarchyParam p x y)
                     <&> map (, range)
                 ) pr) mp
@@ -487,9 +488,10 @@ outgoingCallMultiFileTestCase filepath queryX queryY mp =
   runSessionWithServer plugin testDataDir $ do
     doc <- openDoc filepath "haskell"
     waitForKickDone
-    items <- fmap concat $ sequence $ M.elems $ M.mapWithKey (\fp pr ->
-              openDoc fp "haskell" >>= \p ->
-                concatMapM (\((x, y), range) ->
+    items <- fmap concat $ sequence $ M.elems $ M.mapWithKey (\fp pr -> do
+              p <- openDoc fp "haskell"
+              waitForKickDone
+              concatMapM (\((x, y), range) ->
                   Test.prepareCallHierarchy (mkPrepareCallHierarchyParam p x y)
                     <&> map (, range)
                 ) pr) mp

--- a/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
+++ b/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
@@ -25,7 +25,7 @@ library
     , extra
     , fuzzy
     , ghc
-    , ghcide                ^>=1.6 || ^>=1.7
+    , ghcide                ^>=1.7
     , hls-plugin-api        ^>=1.3 || ^>=1.4
     , lens
     , lsp


### PR DESCRIPTION
Try to fix #2881.

This pr works fine on my machine, I'll rerun the test several times to evaluate the changes.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2888"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

