### PR TITLE
Modify ghcide requirements of hls-change-type-signature-plugin

### DIFF
--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -22,10 +22,10 @@ library
   exposed-modules:  Ide.Plugin.ChangeTypeSignature
   hs-source-dirs:   src
   build-depends:
-    , base                 >=4.12 && < 5
-    , ghcide          ^>=1.6 || ^>=1.7
+    , base             >=4.12 && < 5
+    , ghcide          ^>=1.7
     , hls-plugin-api  ^>=1.3 || ^>=1.4
-    , lsp-types       
+    , lsp-types
     , regex-tdfa
     , syb
     , text


### PR DESCRIPTION
Reference #2884, I think hls-change-type-signature-plugin should also require ghcide >=1.7 since it uses `printOutputable`.

https://github.com/haskell/haskell-language-server/blob/6d319ba24d60d87677913a9c1a71279959c1b2c2/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs#L134-L138

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2889"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

