### PR TITLE
Build hls-alternate-number-format-plugin with stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -71,7 +71,6 @@ flags:
     pedantic: true
 
     ignore-plugins-ghc-bounds: true
-    alternateNumberFormat: false
     brittany: false
     eval: false
     haddockComments: false


### PR DESCRIPTION
It looks hls-alternate-number-format-plugin missed in stack.yaml

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2891"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

