### PR TITLE
Enable hls-eval-plugin test on ghc-9.2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
         name: Test hls-pragmas-plugin
         run: cabal test hls-pragmas-plugin --test-options="$TEST_OPTS" || cabal test hls-pragmas-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-pragmas-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.2'
+      - if: matrix.test
         name: Test hls-eval-plugin
         run: cabal test hls-eval-plugin --test-options="$TEST_OPTS" || cabal test hls-eval-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-eval-plugin --test-options="$TEST_OPTS"
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ packages:
 - ./plugins/hls-call-hierarchy-plugin
 - ./plugins/hls-class-plugin
 # - ./plugins/hls-haddock-comments-plugin
-# - ./plugins/hls-eval-plugin
+- ./plugins/hls-eval-plugin
 - ./plugins/hls-explicit-imports-plugin
 - ./plugins/hls-qualify-imported-names-plugin
 - ./plugins/hls-refine-imports-plugin
@@ -73,7 +73,6 @@ flags:
     ignore-plugins-ghc-bounds: true
     alternateNumberFormat: false
     brittany: false
-    eval: false
     haddockComments: false
     retrie: false
     splice: false


### PR DESCRIPTION
Surprised #2669 didn't enable the test.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2893"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

