### PR TITLE
WIP: restore support for nix for GHC 921

### DIFF
--- a/configuration-ghc-921.nix
+++ b/configuration-ghc-921.nix
@@ -1,0 +1,55 @@
+# nix version of cabal-ghc901.project
+{ pkgs, inputs }:
+
+let
+  disabledPlugins = [
+    "hls-brittany-plugin"
+    "hls-hlint-plugin"
+    "hls-haddock-comments-plugin"
+    "hls-tactics-plugin"
+    "hls-stylish-haskell-plugin"
+    "hls-class-plugin"
+    # That one is not technically a plugin, but by putting it in this list, we
+    # get it removed from the top level list of requirement and it is not pull
+    # in the nix shell.
+    "shake-bench"
+  ];
+
+  hpkgsOverride = hself: hsuper:
+    with pkgs.haskell.lib;
+    {
+      hlsDisabledPlugins = disabledPlugins;
+
+      fourmolu = hself.callCabal2nix "fourmolu" inputs.fourmolu {};
+      primitive-extras = hself.primitive-extras_0_10_1_2;
+      ghc-exactprint = hself.callCabal2nix "ghc-exactprint" inputs.ghc-exactprint {};
+      constraints-extras = hself.callCabal2nix "constraints-extras" inputs.constraints-extras {};
+      retrie = hself.callCabal2nix "retrie" inputs.retrie {};
+
+      # Hlint is still broken
+      hlint = doJailbreak (hself.callCabal2nix "hlint" inputs.hlint {});
+      hiedb = hself.hiedb_0_4_1_0;
+
+      # Re-generate HLS drv excluding some plugins
+      haskell-language-server =
+        hself.callCabal2nixWithOptions "haskell-language-server" ./.
+        (pkgs.lib.concatStringsSep " " [
+          "-f-brittany"
+          "-f-hlint"
+          "-f-haddockComments"
+          "-f-tactics"
+          "-f-stylishHaskell"
+          "-f-class"
+        ]) { };
+
+      # YOLO
+      mkDerivation = args:
+        hsuper.mkDerivation (args // {
+          jailbreak = true;
+          doCheck = false;
+        });
+    };
+in {
+  inherit disabledPlugins;
+  tweakHpkgs = hpkgs: hpkgs.extend hpkgsOverride;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -101,13 +101,13 @@
     "hie-bios": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-nd+FfUQVZNxJfKZkAWA3dF0JwRgXntL+1gGvyNHDbKc=",
+        "narHash": "sha256-5RqspT27rb/tMBwrKr4VfSSbq0+c0LMNuaKlTun0Kkk=",
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hie-bios-0.9.0/hie-bios-0.9.0.tar.gz"
+        "url": "https://hackage.haskell.org/package/hie-bios-0.9.1/hie-bios-0.9.1.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hie-bios-0.9.0/hie-bios-0.9.0.tar.gz"
+        "url": "https://hackage.haskell.org/package/hie-bios-0.9.1/hie-bios-0.9.1.tar.gz"
       }
     },
     "hlint": {


### PR DESCRIPTION
Support was broken by
https://github.com/haskell/haskell-language-server/pull/2866 where the
configuration-ghc-921 file was removed.

https://github.com/haskell/haskell-language-server/pull/2892 will indeed
restore these file and fix the build with GHC 922, but I was in need a
GHC 921 support at work.

WIP: do not merge it. I'm only creating that for reference.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2905"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

