### PR TITLE
Fix multiline eval plugin padding

### DIFF
--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -358,8 +358,9 @@ runTests EvalConfig{..} e@(_st, _) tests = do
         dbg "TEST RESULTS" rs
 
         let checkedResult = testCheck eval_cfg_diff (section, test) rs
+        let resultLines = concatMap T.lines checkedResult
 
-        let edit = asEdit (sectionFormat section) test (map pad checkedResult)
+        let edit = asEdit (sectionFormat section) test (map pad resultLines)
         dbg "TEST EDIT" edit
         return edit
 

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -68,6 +68,7 @@ tests =
   , goldenWithEval "Refresh an evaluation" "T5" "hs"
   , goldenWithEval "Refresh an evaluation w/ lets" "T6" "hs"
   , goldenWithEval "Refresh a multiline evaluation" "T7" "hs"
+  , goldenWithEval "Evaluate a multi-line show result" "TMultiResult" "hs" -- Do not escape from comments!
   , testCase "Semantic and Lexical errors are reported" $ do
       evalInFile "T8.hs" "-- >>> noFunctionWithThisName" "-- Variable not in scope: noFunctionWithThisName"
       evalInFile "T8.hs" "-- >>> res = \"a\" + \"bc\"" $

--- a/plugins/hls-eval-plugin/test/testdata/TMultiResult.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TMultiResult.expected.hs
@@ -1,0 +1,13 @@
+module TMultiResult where
+-- test multiline show instance (see #2907)
+
+data Multiline = M {l1 :: String, l2 :: String} deriving Read
+
+instance Show Multiline where
+  show m = "M {\n  l1=" <> show (l1 m) <> ",\n  l2=" <> show (l2 m) <> "\n}"
+
+-- >>> M "first line" "second line"
+-- M {
+--   l1="first line",
+--   l2="second line"
+-- }

--- a/plugins/hls-eval-plugin/test/testdata/TMultiResult.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TMultiResult.hs
@@ -1,0 +1,9 @@
+module TMultiResult where
+-- test multiline show instance (see #2907)
+
+data Multiline = M {l1 :: String, l2 :: String} deriving Read
+
+instance Show Multiline where
+  show m = "M {\n  l1=" <> show (l1 m) <> ",\n  l2=" <> show (l2 m) <> "\n}"
+
+-- >>> M "first line" "second line"


### PR DESCRIPTION
- fix multiline eval padding (`concatMap lines`)
- add test for multiline show instance

---

- closes #2907

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2910"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

