### PR TITLE
Cleanup hls-hlint-plugin

### DIFF
--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -25,11 +25,6 @@ flag pedantic
   default:     False
   manual:      True
 
-flag ghc-lib
-   default:     True
-   manual:      True
-   description: Use ghc-lib types (requires hlint to be built with ghc-lib)
-
 library
   exposed-modules:    Ide.Plugin.Hlint
   hs-source-dirs:     src
@@ -65,7 +60,6 @@ library
     , ghc-lib-parser
     , ghc-lib-parser-ex
 
-  cpp-options:   -DHLINT_ON_GHC_LIB
   ghc-options:
     -Wall -Wredundant-constraints -Wno-name-shadowing
     -Wno-unticked-promoted-constructors

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -66,7 +66,9 @@ import           "ghc-lib" GHC                                      hiding
                                                                      ms_hspp_opts)
 import qualified "ghc-lib" GHC
 import           "ghc-lib-parser" GHC.LanguageExtensions            (Extension)
+#if MIN_GHC_API_VERSION(9,0,0)
 import           "ghc-lib-parser" GHC.Types.SrcLoc                  (BufSpan)
+#else
 import           Language.Haskell.GhclibParserEx.GHC.Driver.Session as GhclibParserEx (readExtension)
 import           System.FilePath                                    (takeFileName)
 import           System.IO                                          (IOMode (WriteMode),
@@ -315,7 +317,7 @@ getHlintConfig pId =
     <$> usePropertyAction #flags pId properties
 
 runHlintAction
- :: (Hashable k, Show k, Show (RuleResult k), Typeable k, Typeable (RuleResult k), NFData k, NFData (RuleResult k))
+ :: (Eq k, Hashable k, Show k, Show (RuleResult k), Typeable k, Typeable (RuleResult k), NFData k, NFData (RuleResult k))
  => IdeState
  -> NormalizedFilePath -> String -> k -> IO (Maybe (RuleResult k))
 runHlintAction ideState normalizedFilePath desc rule = runAction desc ideState $ use rule normalizedFilePath


### PR DESCRIPTION
Since we have turned to `ghc-lib-parser` on every ghc version, some code is not required.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2921"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

