### PR TITLE
Update Archlinux installation section

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -136,18 +136,9 @@ To install, download the `haskell-language-server-wrapper` executable for your p
 ## Arch Linux
 
 The preferred method of installation for development purposes is to use the [haskell-language-server-static](https://aur.archlinux.org/packages/haskell-language-server-static) package from AUR.
-This package contains statically linked binaries for each supported GHC version and `haskell-language-server-wrapper` for automatic GHC version selection.
+This package contains pre-built binaries for each supported GHC version and `haskell-language-server-wrapper` for automatic GHC version selection.
 It is updated regularly, requires no additional dependencies, and is independent of other haskell packages you may have on your system, including GHC.
-Its size is relatively large (approx. 900 MB), but if this is a problem for you, during installation you can disable the GHC versions you will not be using by editing the PKGBUILD file.
 
-Alternatively, if you want to use **dynamically linked** Haskell packages from `pacman`,
-you can install the latest pre-compiled version of `haskell-language-server` from [[community]](https://archlinux.org/packages/community/x86_64/haskell-language-server/):
-
-```bash
-sudo pacman -S haskell-language-server
-```
-
-In this case, `haskell-language-server` is compiled against the GHC distributed to Arch Linux, so you will need maintain a system wide Haskell development environment, and install GHC from `pacman` as well.
 See [ArchWiki](https://wiki.archlinux.org/index.php/Haskell) for the details of Haskell infrastructure on Arch Linux.
 
 ## Fedora


### PR DESCRIPTION
Updated Archlinux installation section:
- re-worded AUR package section to be more accurate wrt distribution changes in 1.7.0.0,
- removed the mention of the "official" package (it hasn't been updated beyond 1.3.0.0 and is practically unmaintained; its usefulness for the actual development is very limited)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2933"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

