### PR TITLE
Typo fix, dependecies -> dependencies

### DIFF
--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -89,7 +89,7 @@ instance Pretty Log where
     LogCouldNotIdentifyReverseDeps path ->
       "Could not identify reverse dependencies for" <+> viaShow path
     (LogTypeCheckingReverseDeps path reverseDepPaths) ->
-      "Typechecking reverse dependecies for"
+      "Typechecking reverse dependencies for"
       <+> viaShow path
       <> ":"
       <+> pretty (fmap (fmap show) reverseDepPaths)


### PR DESCRIPTION
Quick typo fix, "dependecies" -> "dependencies"

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2934"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

