### PR TITLE
Support ghc-9.2.3

### DIFF
--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -80,11 +80,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ "9.2.2"
+        ghc: [ "9.2.3"
+             , "9.2.2"
              , "9.0.2"
-             , "9.0.1"
              , "8.10.7"
-             , "8.10.6"
              , "8.8.4"
              , "8.6.5"
              ]
@@ -118,7 +117,7 @@ jobs:
           cabal $cabalBuild || cabal $cabalBuild || cabal $cabalBuild
         env:
           # needed for GHC 9.2.2 https://github.com/digital-asset/ghc-lib/issues/352
-          CPATH:"/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ffi":$CPATH
+          CPATH: "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ffi:$CPATH"
 
       # We build ghcide with benchs and test enabled to include its dependencies in the cache
       # (including shake-bench)

--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: [ "9.2.2"
+        ghc: [ "9.2.3"
              , "9.0.2"
              , "8.10.7"
              , "8.8.4"
@@ -68,7 +68,7 @@ jobs:
         run: cabal v2-build ghcide --flags="ghc-patched-unboxed-bytecode test-exe executable bench-exe ekg"
 
       # we have to clean up warnings for 9.0 and 9.2 before enable -WAll
-      - if: matrix.ghc != '9.0.2' && matrix.ghc != '9.2.2'
+      - if: matrix.ghc != '9.0.2' && matrix.ghc != '9.2.3'
         name: Build with pedantic (-WError)
         run: cabal v2-build --flags="pedantic"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,11 +57,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: [ "9.2.2"
+        ghc: [ "9.2.3"
+             , "9.2.2"
              , "9.0.2"
-             , "9.0.1"
              , "8.10.7"
-             , "8.10.6"
              , "8.8.4"
              , "8.6.5"
              ]
@@ -71,7 +70,7 @@ jobs:
         include:
            # only test supported ghc major versions
            - os: ubuntu-latest
-             ghc: '9.2.2'
+             ghc: '9.2.3'
              test: true
            - os: ubuntu-latest
              ghc: '9.0.2'
@@ -86,7 +85,7 @@ jobs:
              ghc: '8.6.5'
              test: true
            - os: windows-latest
-             ghc: '9.2.2'
+             ghc: '9.2.3'
              test: true
            - os: windows-latest
              ghc: '9.0.2'
@@ -99,11 +98,9 @@ jobs:
              test: true
            # only build rest of supported ghc versions for windows
            - os: windows-latest
-             ghc: '9.0.1'
-           - os: windows-latest
-             ghc: '8.10.6'
-           - os: windows-latest
              ghc: '8.8.4'
+           - os: windows-latest
+             ghc: '9.2.2'
 
     steps:
       - uses: actions/checkout@v3
@@ -162,7 +159,7 @@ jobs:
           HLS_WRAPPER_TEST_EXE: hls-wrapper
         run: cabal test wrapper-test --test-options="$TEST_OPTS --rerun-log-file .tasty-rerun-log-wrapper" || cabal test wrapper-test --test-options="$TEST_OPTS  --rerun-log-file .tasty-rerun-log-wrapper" || cabal test wrapper-test --test-options="$TEST_OPTS  --rerun-log-file .tasty-rerun-log-wrapper"
 
-      - if: matrix.test && matrix.ghc != '9.2.2'
+      - if: matrix.test && matrix.ghc != '9.2.3'
         name: Test hls-brittany-plugin
         run: cabal test hls-brittany-plugin --test-options="$TEST_OPTS" || cabal test hls-brittany-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-brittany-plugin --test-options="$TEST_OPTS"
 
@@ -182,11 +179,11 @@ jobs:
         name: Test hls-eval-plugin
         run: cabal test hls-eval-plugin --test-options="$TEST_OPTS" || cabal test hls-eval-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-eval-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.2'
+      - if: matrix.test && matrix.ghc != '9.2.3'
         name: Test hls-haddock-comments-plugin
         run: cabal test hls-haddock-comments-plugin --test-options="$TEST_OPTS" || cabal test hls-haddock-comments-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-haddock-comments-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.2'
+      - if: matrix.test && matrix.ghc != '9.2.3'
         name: Test hls-splice-plugin
         run: cabal test hls-splice-plugin --test-options="$TEST_OPTS" || cabal test hls-splice-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-splice-plugin --test-options="$TEST_OPTS"
 
@@ -202,7 +199,7 @@ jobs:
         name: Test hls-fourmolu-plugin
         run: cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS" || cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.2'
+      - if: matrix.test && matrix.ghc != '9.2.3'
         name: Test hls-tactics-plugin test suite
         run: cabal test hls-tactics-plugin --test-options="$TEST_OPTS" || cabal test hls-tactics-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-tactics-plugin --test-options="$TEST_OPTS"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ variables:
       CABAL_PROJECT: cabal.project
     - GHC_VERSION: 9.2.2
       CABAL_PROJECT: cabal.project
-    - GHC_VERSION: 9.2.1
+    - GHC_VERSION: 9.2.3
       CABAL_PROJECT: cabal.project
 
 workflow:

--- a/bindist/ghcs
+++ b/bindist/ghcs
@@ -2,5 +2,5 @@
 8.8.4,cabal.project
 8.10.7,cabal.project
 9.0.2,cabal.project
-9.2.1,cabal.project
 9.2.2,cabal.project
+9.2.3,cabal.project

--- a/bindist/ghcs-Msys
+++ b/bindist/ghcs-Msys
@@ -1,4 +1,4 @@
 8.10.7,cabal.project
 9.0.2,cabal.project
 9.2.2,cabal.project
-9.2.1,cabal.project
+9.2.3,cabal.project

--- a/cabal.project
+++ b/cabal.project
@@ -44,7 +44,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-04-30T21:02:45Z
+index-state: 2022-05-31T11:08:53Z
 
 constraints:
   hyphenation +embed,
@@ -67,26 +67,5 @@ allow-newer:
   -- ghc-9.2
   ----------
   hiedb:base,
-  retrie:ghc-exactprint,
 
-  -- for brittany
-  -- https://github.com/lspitzner/multistate/pull/8
-  multistate:base,
-  -- https://github.com/lspitzner/data-tree-print/pull/3
-  data-tree-print:base,
-  -- https://github.com/lspitzner/butcher/pull/8
-  butcher:base,
-
-  -- for shake-bench
-  Chart:lens,
-  Chart-diagrams:lens,
-
-  -- for ekg
-  ekg-core:base,
-  ekg-core:ghc-prim,
-  ekg-wai:base,
-  ekg-wai:time,
-
-  -- for shake-bench
-  Chart-diagrams:diagrams-core,
-  SVGFonts:diagrams-core
+  ekg-wai:time

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -13,7 +13,7 @@ description:
     A library for building Haskell IDE's on top of the GHC API.
 homepage:           https://github.com/haskell/haskell-language-server/tree/master/ghcide#readme
 bug-reports:        https://github.com/haskell/haskell-language-server/issues
-tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.6 || == 8.10.7 || == 9.0.1 || == 9.0.2 || == 9.2.1 || == 9.2.2
+tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.2 || == 9.2.3
 extra-source-files: README.md CHANGELOG.md
                     test/data/**/*.project
                     test/data/**/*.cabal

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -14,7 +14,7 @@ copyright:          The Haskell IDE Team
 license:            Apache-2.0
 license-file:       LICENSE
 build-type:         Simple
-tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.6 || == 8.10.7 || == 9.0.2 || == 9.2.2
+tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.2 || == 9.2.3
 extra-source-files:
   README.md
   ChangeLog.md

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -28,7 +28,7 @@ library
     , hls-plugin-api  ^>=1.3 || ^>=1.4
     , lens
     , lsp
-    , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || ^>= 0.4
+    , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || ^>= 0.5
     , text
 
   default-language: Haskell2010

--- a/stack-lts19.yaml
+++ b/stack-lts19.yaml
@@ -39,9 +39,9 @@ extra-deps:
 - Cabal-3.6.0.0
 - floskell-0.10.6@sha256:e77d194189e8540abe2ace2c7cb8efafc747ca35881a2fefcbd2d40a1292e036,3819
 - fourmolu-0.6.0.0
-- ghc-lib-9.2.2.20220307
-- ghc-lib-parser-9.2.2.20220307
-- ghc-lib-parser-ex-9.2.0.3
+- ghc-lib-9.2.3.20220527
+- ghc-lib-parser-9.2.3.20220527
+- ghc-lib-parser-ex-9.2.0.4
 - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
 - hiedb-0.4.1.0@sha256:fb20c657d9ecc91701b00dffcf4bbd77cb83720a1f9d867badd77ea227973135,2875
 - hlint-3.4

--- a/stack-lts19.yaml
+++ b/stack-lts19.yaml
@@ -48,11 +48,10 @@ extra-deps:
 - implicit-hie-0.1.2.7@sha256:82bbbb1a8c05f99c8af3c16ac53e80c8648d8bf047b25ed5ce45a135bd736907,3122
 - implicit-hie-cradle-0.5.0.0@sha256:4276f60f3a59bc22df03fd918f73bca9f777de9568f85e3a8be8bd7566234a59,2368
 - monad-dijkstra-0.1.1.3
-- ormolu-0.4.0.0
+- ormolu-0.5.0.0
 - refinery-0.4.0.0@sha256:fe3a43add8ff1db5cfffee7e7694c86128b1dfe62c541f26e25a8eadf9585610,1663
 - retrie-1.1.0.0
 - stylish-haskell-0.14.2.0@sha256:fffe1c13ad4c2678cf28a7470cac5d3bf20c71c36f09969e3e5f186787cceb7c,4321
-- SVGFonts-1.7.0.1  # for Chart-diagrams, https://github.com/timbod7/haskell-chart/issues/232
 
 configure-options:
   ghcide:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver: nightly-2022-05-31
-compiler: ghc-9.2.3
+resolver: nightly-2022-06-10
 
 packages:
 - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: nightly-2022-04-28
-compiler: ghc-9.2.2
+resolver: nightly-2022-05-29
+compiler: ghc-9.2.3
 
 packages:
 - .
@@ -34,8 +34,6 @@ packages:
 - ./plugins/hls-gadt-plugin
 
 extra-deps:
-- Chart-1.9.3@sha256:640a38463318b070d80a049577e4f0b3322df98290abb7afcf0cb74a4ad5b512,2948
-- Chart-diagrams-1.9.3@sha256:63668daff044a79827b7edb265265a4a8237424abb8f808ad1fcbdb3d47e753d,1801
 - direct-sqlite-2.3.26@sha256:04e835402f1508abca383182023e4e2b9b86297b8533afbd4e57d1a5652e0c23,3718
 - floskell-0.10.6@sha256:e77d194189e8540abe2ace2c7cb8efafc747ca35881a2fefcbd2d40a1292e036,3819
 - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
@@ -50,8 +48,6 @@ extra-deps:
 - retrie-1.2.0.1
 - rope-utf16-splay-0.3.2.0
 - sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
-- SVGFonts-1.7.0.1  # for Chart-diagrams, https://github.com/timbod7/haskell-chart/issues/232
-
 
 # currently needed for ghcide>extra, etc.
 allow-newer: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-05-29
+resolver: nightly-2022-05-31
 compiler: ghc-9.2.3
 
 packages:


### PR DESCRIPTION
Dropped ghc-8.10.6 and ghc-9.0.1, keep supporting ghc-9.2.2.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2936"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

