### PR TITLE
Support `fourmolu ^>= 0.7`

### DIFF
--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -9,12 +9,18 @@ license:            Apache-2.0
 license-file:       LICENSE
 author:             The Haskell IDE Team
 copyright:          The Haskell IDE Team
+homepage:           https://github.com/haskell/haskell-language-server
+bug-reports:        https://github.com/haskell/haskell-language-server/issues
 maintainer:         alan.zimm@gmail.com
 category:           Development
 build-type:         Simple
 extra-source-files:
   LICENSE
   test/testdata/**/*.hs
+
+source-repository head
+  type:     git
+  location: git://github.com/haskell/haskell-language-server.git
 
 library
   exposed-modules:  Ide.Plugin.Fourmolu
@@ -23,7 +29,7 @@ library
   build-depends:
     , base            >=4.12 && <5
     , filepath
-    , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6
+    , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7
     , ghc
     , ghc-boot-th
     , ghcide          ^>=1.7

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -29,7 +29,8 @@ library
   build-depends:
     , base            >=4.12 && <5
     , filepath
-    , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7
+    -- , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7
+    , fourmolu        == 0.7.0.1
     , ghc
     , ghc-boot-th
     , ghcide          ^>=1.7

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -29,8 +29,7 @@ library
   build-depends:
     , base            >=4.12 && <5
     , filepath
-    -- , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7
-    , fourmolu        == 0.7.0.1
+    , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7
     , ghc
     , ghc-boot-th
     , ghcide          ^>=1.7

--- a/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
@@ -1,10 +1,10 @@
+{-# LANGUAGE CPP                      #-}
+{-# LANGUAGE DataKinds                #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE OverloadedLabels         #-}
 {-# LANGUAGE OverloadedStrings        #-}
 {-# LANGUAGE TypeApplications         #-}
-{-# LANGUAGE DataKinds                #-}
-{-# LANGUAGE OverloadedLabels         #-}
-{-# LANGUAGE CPP                      #-}
 
 module Ide.Plugin.Fourmolu (
     descriptor,
@@ -24,18 +24,19 @@ import           Development.IDE.GHC.Compat      as Compat hiding (Cpp)
 import qualified Development.IDE.GHC.Compat.Util as S
 import           GHC.LanguageExtensions.Type     (Extension (Cpp))
 import           Ide.Plugin.Properties
-import           Ide.PluginUtils                 (makeDiffTextEdit, usePropertyLsp)
+import           Ide.PluginUtils                 (makeDiffTextEdit,
+                                                  usePropertyLsp)
 import           Ide.Types
 import           Language.LSP.Server             hiding (defaultConfig)
 import           Language.LSP.Types
 import           Language.LSP.Types.Lens         (HasTabSize (tabSize))
 import           Ormolu
+import           Ormolu.Config
 import           System.Exit
 import           System.FilePath
 import           System.IO                       (stderr)
-import           System.Process.Run              (proc, cwd)
+import           System.Process.Run              (cwd, proc)
 import           System.Process.Text             (readCreateProcessWithExitCode)
-import Ormolu.Config
 
 descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId =

--- a/stack.yaml
+++ b/stack.yaml
@@ -51,7 +51,6 @@ extra-deps:
 - rope-utf16-splay-0.3.2.0
 - sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
 - SVGFonts-1.7.0.1  # for Chart-diagrams, https://github.com/timbod7/haskell-chart/issues/232
-- fourmolu-0.7.0.1
 
 
 # currently needed for ghcide>extra, etc.

--- a/stack.yaml
+++ b/stack.yaml
@@ -51,6 +51,7 @@ extra-deps:
 - rope-utf16-splay-0.3.2.0
 - sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
 - SVGFonts-1.7.0.1  # for Chart-diagrams, https://github.com/timbod7/haskell-chart/issues/232
+- fourmolu-0.7.0.1
 
 
 # currently needed for ghcide>extra, etc.


### PR DESCRIPTION
This PR adds support for `fourmolu-0.7`

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2944"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

