### PR TITLE
Add associated type families to local completions

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -462,11 +462,13 @@ localCompletionsForParsedModule uri pm@ParsedModule{pm_parsed_source = L _ HsMod
             ValD _ PatBind{pat_lhs} ->
                 [mkComp id CiVariable Nothing
                 | VarPat _ id <- listify (\(_ :: Pat GhcPs) -> True) pat_lhs]
-            TyClD _ ClassDecl{tcdLName, tcdSigs} ->
+            TyClD _ ClassDecl{tcdLName, tcdSigs, tcdATs} ->
                 mkComp tcdLName CiInterface (Just $ showForSnippet tcdLName) :
                 [ mkComp id CiFunction (Just $ showForSnippet typ)
                 | L _ (ClassOpSig _ _ ids typ) <- tcdSigs
-                , id <- ids]
+                , id <- ids] ++
+                [ mkComp fdLName CiStruct (Just $ showForSnippet fdLName)
+                | L _ (FamilyDecl{fdLName}) <- tcdATs]
             TyClD _ x ->
                 let generalCompls = [mkComp id cl (Just $ showForSnippet $ tyClDeclLName x)
                         | id <- listify (\(_ :: LIdP GhcPs) -> True) x

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -147,6 +147,16 @@ tests = testGroup "completions" [
              item ^. label @?= "liftA"
              item ^. kind @?= Just CiFunction
              item ^. detail @?= Just "Control.Applicative"
+
+     , testCase "completes locally defined associated type family" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+         doc <- openDoc "AssociatedTypeFamily.hs" "haskell"
+
+         compls <- getCompletions doc (Position 5 20)
+         item <- getCompletionByLabel "Fam" compls
+         liftIO $ do
+             item ^. label @?= "Fam"
+             item ^. kind @?= Just CiStruct
+
      , contextTests
      , snippetTests
     ]

--- a/test/testdata/completion/AssociatedTypeFamily.hs
+++ b/test/testdata/completion/AssociatedTypeFamily.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeFamilies #-}
+module AssociatedTypeFamily () where
+
+class C a where
+    type Fam a
+
+x :: C a => a -> Fam a
+x = undefined


### PR DESCRIPTION
Currently, completing exported associated type families defined in the current module incorrectly adds an import, while non-exported ones do not show up at all. This PR fixes both of these issues.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2987"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

