### PR TITLE
unify pre-commit hook & update Gitpod config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,6 @@ test/testdata/**/hie.yaml
 # shake build folder (used in benchmark suite)
 .shake/
 
-# pre-commit-hook.nix
-.pre-commit-config.yaml
-
 # direnv
 /.direnv/
 /.envrc

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -13,5 +13,5 @@ RUN sudo install-packages build-essential curl libffi-dev libffi7 libgmp-dev lib
     ghcup install cabal --set && \
     ghcup install stack --set && \
     cabal update && \
-    cabal install stylish-haskell hoogle && \
+    cabal install stylish-haskell hoogle implicit-hie && \
     pip install pre-commit

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,17 @@
+FROM gitpod/workspace-full
+
+RUN sudo install-packages build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 \
+        libncurses-dev libncurses5 libtinfo5 && \
+    BOOTSTRAP_HASKELL_NONINTERACTIVE=1 \
+    BOOTSTRAP_HASKELL_MINIMAL=1 \
+    curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh && \
+    echo 'source $HOME/.ghcup/env' >> $HOME/.bashrc && \
+    echo 'export PATH=$HOME/.cabal/bin:$HOME/.local/bin:$PATH' >> $HOME/.bashrc && \
+    . /home/gitpod/.ghcup/env && \
+    ghcup install ghc --set && \
+    ghcup install hls --set && \
+    ghcup install cabal --set && \
+    ghcup install stack --set && \
+    cabal update && \
+    cabal install stylish-haskell hoogle && \
+    pip install pre-commit

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -14,4 +14,5 @@ RUN sudo install-packages build-essential curl libffi-dev libffi7 libgmp-dev lib
     ghcup install stack --set && \
     cabal update && \
     cabal install stylish-haskell hoogle implicit-hie && \
-    pip install pre-commit
+    pip install pre-commit && \
+    npm install -g http-server

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,13 +29,13 @@ tasks:
       done
 
       # Install pre-commit hook
-      pre-commit
+      pre-commit install
 
       # Configure VSCode to use the locally built version of HLS
       mkdir -p .vscode
       if [ ! -f .vscode/settings.json ]; then
         # Only write to .vscode/settings.json if it doesn't exist.
-        echo '{ "haskell.serverExecutablePath": "/home/gitpod/.cabal/bin/haskell-language-server" }' > .vscode/settings.json 
+        echo '{ "haskell.serverExecutablePath": "/home/gitpod/.cabal/bin/haskell-language-server" }' > .vscode/settings.json
       fi
     init: |
       cabal update

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,42 +1,47 @@
+image:
+  file: .gitpod.Dockerfile
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - before: |
-      # Only the /workspace folder is persistent
-      export XDG_DATA_HOME=/workspace/.local/share
-      export XDG_CONFIG_HOME=/workspace/.local/config
-      export XDG_STATE_HOME=/workspace/.local/state
-      export XDG_CACHE_HOME=/workspace/.cache
-      export CABAL_DIR=/workspace/.cabal
-      export STACK_ROOT=/workspace/.stack
+  - name: Setup
+    before: |
+      # Make sure some folders not in /workspace persist between worksapce restarts.
+      # You may add additional directories to this list.
+      declare -a CACHE_DIRS=(
+        $HOME/.local
+        $HOME/.cabal
+        $HOME/.stack
+        $HOME/.ghcup
+        /nix
+      )
+      for DIR in "${CACHE_DIRS[@]}"; do
+        mkdir -p $(dirname /workspace/cache$DIR)
+        mkdir -p $DIR # in case $DIR doesn't already exist
+        # On a fresh start with no prebuilds, we move existing directory
+        # to /workspace. 'sudo mv' fails with 'no permission', I don't know why
+        if [ ! -d /workspace/cache$DIR ]; then
+          sudo cp -rp $DIR /workspace/cache$DIR
+          sudo rm -rf $DIR/*
+        fi
+        mkdir -p /workspace/cache$DIR # make sure it exists even if cp fails
+        # Now /workspace/cache$DIR exists.
+        # Use bind mount to make $DIR backed by /workspace/cache$DIR
+        sudo mount --bind /workspace/cache$DIR $DIR
+      done
 
-      # install ghcup, ghc and cabal
-      export GHCUP_INSTALL_BASE_PREFIX=/workspace
-      export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
-      export BOOTSTRAP_HASKELL_MINIMAL=1
-      curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-      /workspace/.ghcup/bin/ghcup install ghc --set
-      /workspace/.ghcup/bin/ghcup install cabal
-
-      # Add ghcup binaries to the PATH since VSCode does not see 'source .ghcup/env'
-      pushd /usr/local/bin
-      sudo ln -s /workspace/.ghcup/bin/* /usr/local/bin
-      popd
-
-      # Fix the Cabal dir since VSCode does not see CABAL_DIR 
-      cabal update
-      echo "Symlinking /workspace/.cabal to ~/.cabal"
-      ln -s /workspace/.cabal ~
+      # Install pre-commit hook
+      pre-commit
 
       # Configure VSCode to use the locally built version of HLS
       mkdir -p .vscode
-      echo '{ "haskell.serverExecutablePath": "/workspace/.cabal/bin/haskell-language-server" }' > .vscode/settings.json 
-
-    init: | 
+      if [ ! -f .vscode/settings.json ]; then
+        # Only write to .vscode/settings.json if it doesn't exist.
+        echo '{ "haskell.serverExecutablePath": "/home/gitpod/.cabal/bin/haskell-language-server" }' > .vscode/settings.json 
+      fi
+    init: |
+      cabal update
       cabal configure --enable-executable-dynamic
-      cabal build --enable-tests
-      cabal install exe:haskell-language-server      
-    command: | 
-      cabal build --enable-tests
+      cabal build --enable-tests all
+      cabal install exe:haskell-language-server
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
 ports: []
@@ -62,4 +67,4 @@ vscode:
   extensions:
     - "haskell.haskell"
     - "justusadam.language-haskell"
-    - "usernamehw.errorlens"
+    - "EditorConfig.EditorConfig"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -37,6 +37,10 @@ tasks:
         # Only write to .vscode/settings.json if it doesn't exist.
         echo '{ "haskell.serverExecutablePath": "/home/gitpod/.cabal/bin/haskell-language-server" }' > .vscode/settings.json
       fi
+
+      pushd docs
+        pip install -r requirements.txt
+      popd
     init: |
       cabal update
       cabal configure --enable-executable-dynamic

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,3 +44,4 @@
 # Build
 *.nix @berberman @michaelpj @guibou
 *.project @jneira
+.gitpod.* @kokobd

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -172,12 +172,12 @@ Please, try to follow those basic settings to keep the codebase as uniform as po
 
 We are using [pre-commit](https://pre-commit.com/) to configure git pre-commit hook for formatting. Although it is possible to run formatting manually, we recommend you to use it to set pre-commit hook as our CI checks pre-commit hook is applied or not.
 
-Having installed [pre-commit](https://pre-commit.com/), you can install pre-commit hook by running:
-```sh
-pre-commit
-```
+If you are using Nix or Gitpod, pre-commit hook is automatically installed. Otherwise, follow instructions on
+[https://pre-commit.com/](https://pre-commit.com/) to install the `pre-commit` tool, then run the following command:
 
-If you are using Nix or Gitpod, pre-commit hook is automatically installed.
+```sh
+pre-commit install
+```
 
 #### Why some components are excluded from automatic formatting?
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -170,50 +170,14 @@ Please, try to follow those basic settings to keep the codebase as uniform as po
 
 ### Formatter pre-commit hook
 
-We are using [pre-commit-hook.nix](https://github.com/cachix/pre-commit-hooks.nix) to configure git pre-commit hook for formatting. Although it is possible to run formatting manually, we recommend you to use it to set pre-commit hook as our CI checks pre-commit hook is applied or not.
+We are using [pre-commit](https://pre-commit.com/) to configure git pre-commit hook for formatting. Although it is possible to run formatting manually, we recommend you to use it to set pre-commit hook as our CI checks pre-commit hook is applied or not.
 
-You can configure the pre-commit-hook by running
-
-``` bash
-nix-shell
+Having installed [pre-commit](https://pre-commit.com/), you can install pre-commit hook by running:
+```sh
+pre-commit
 ```
 
-If you don't want to use [nix](https://nixos.org/guides/install-nix.html), you can instead use [pre-commit](https://pre-commit.com) with the following config.
-
-```json
-{
-  "repos": [
-    {
-      "hooks": [
-        {
-          "entry": "stylish-haskell --inplace",
-          "exclude": "(^Setup.hs$|test/testdata/.*$|test/data/.*$|test/manual/lhs/.*$|^hie-compat/.*$|^plugins/hls-tactics-plugin/.*$|^ghcide/src/Development/IDE/GHC/Compat.hs$|^ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs$|^ghcide/src/Development/IDE/GHC/Compat/Core.hs$|^ghcide/src/Development/IDE/Spans/Pragmas.hs$|^ghcide/src/Development/IDE/LSP/Outline.hs$|^plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs$|^ghcide/test/exe/Main.hs$|ghcide/src/Development/IDE/Core/Rules.hs|^hls-test-utils/src/Test/Hls/Util.hs$)",
-          "files": "\\.l?hs$",
-          "id": "stylish-haskell",
-          "language": "system",
-          "name": "stylish-haskell",
-          "pass_filenames": true,
-          "types": [
-            "file"
-          ]
-        }
-      ],
-      "repo": "local"
-    },
-    {
-       "repo": "https://github.com/pre-commit/pre-commit-hooks",
-       "rev": "v4.1.0",
-       "hooks": [
-          {
-            "id": "mixed-line-ending",
-            "args": ["--fix", "lf"],
-            "exclude": "test/testdata/.*CRLF*.hs$"
-          }
-       ]
-    }
-  ]
-}
-```
+If you are using Nix or Gitpod, pre-commit hook is automatically installed.
 
 #### Why some components are excluded from automatic formatting?
 

--- a/flake.lock
+++ b/flake.lock
@@ -82,21 +82,6 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "fourmolu": {
       "flake": false,
       "locked": {
@@ -293,20 +278,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1645655918,
-        "narHash": "sha256-ZfbEFRW7o237+A1P7eTKhXje435FCAoe0blj2n20Was=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "77a7a4197740213879b9a1d2e1788c6c8ade4274",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
     "poetry2nix": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -324,25 +295,6 @@
         "owner": "nix-community",
         "ref": "master",
         "repo": "poetry2nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1652714503,
-        "narHash": "sha256-qQKVEfDe5FqvGgkZtg5Pc491foeiDPIOeycHMqnPDps=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "521a524771a8e93caddaa0ac1d67d03766a8b0b3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -392,7 +344,6 @@
         "myst-parser": "myst-parser",
         "nixpkgs": "nixpkgs",
         "poetry2nix": "poetry2nix",
-        "pre-commit-hooks": "pre-commit-hooks",
         "ptr-poker": "ptr-poker",
         "retrie": "retrie",
         "sphinx_rtd_theme": "sphinx_rtd_theme",

--- a/flake.nix
+++ b/flake.nix
@@ -301,7 +301,7 @@
             export PATH=$PATH:$HOME/.local/bin
 
             # Install pre-commit hook
-            pre-commit
+            pre-commit install
 
             # If the cabal project file is not the default one.
             # Print a warning and generate an alias.


### PR DESCRIPTION
This will close #2967.

Previously:
- `.pre-commit-config.yaml` is tracked by Git
- `flake.nix` contains an outdated pre-commit config
- `flake.nix` relies on the non-existence of `.pre-commit-config.yaml` to work, so its' broken now
- Documentation suggests using Nix to generate `.pre-commit-config.yaml`, which doesn't work now
- We have no `pre-commit` support in Gitpod.

In this PR, I unify pre-commit config, preserving `.pre-commit-config.yaml`
- Remove pre-commit config from flake.nix. Add pre-commit to shellHook directly (so that people using Nix still benefit from .pre-commit-config.yaml)
- Add pre-commit to Gitpod configuration
- Update docs about this. It's no longer required to copy .pre-commit-config.yaml from the docs.
- Remove `.pre-commit-config.yaml` from `.gitignore`

Meanwhile, I make some changes to the Gitpod config, making it easier to use (this PR is made on Gitpod):
- Cache `/nix` between workspace restarts. Cache `~/.local`, `~/.cabal`, `~/.stack` and `~/.ghcup` in the same way using mount binding. Tedious configuration of environment variables to point `cabal`, `stack` and `ghcup` to `/workspace` is no longer needed
- Move the installation of some global tools to `.gitpod.Dockerfile`. In this way, VSCode will be able to see them without any special configuration.
- Add EditorConfig extension to `.gitpod.yml`, as it is required according to our style guidelines.