### PR TITLE
Don't use typecheck rule for non FOIs in refine imports plugin

### DIFF
--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -165,6 +165,7 @@ data Log
   | LogLoadingHieFileFail !FilePath !SomeException
   | LogLoadingHieFileSuccess !FilePath
   | LogExactPrint ExactPrint.Log
+  | LogTypecheckedFOI !NormalizedFilePath
   deriving Show
 
 instance Pretty Log where
@@ -182,6 +183,14 @@ instance Pretty Log where
     LogLoadingHieFileSuccess path ->
       "SUCCEEDED LOADING HIE FILE FOR" <+> pretty path
     LogExactPrint log -> pretty log
+    LogTypecheckedFOI path -> vcat
+      [ "WARNING: Typechecked a file which is not currently open in the editor:" <+> pretty (fromNormalizedFilePath path)
+      , "This can indicate a bug which results in excessive memory usage."
+      , "This may be a spurious warning if you have recently closed the file."
+      , "If you haven't opened this file recently, please file a report on the issue tracker mentioning"
+        <+> "the HLS version being used, the plugins enabled, and if possible the codebase and file which"
+        <+> "triggered this warning."
+      ]
 
 templateHaskellInstructions :: T.Text
 templateHaskellInstructions = "https://haskell-language-server.readthedocs.io/en/latest/troubleshooting.html#static-binaries"
@@ -650,6 +659,12 @@ typeCheckRule :: Recorder (WithPriority Log) -> Rules ()
 typeCheckRule recorder = define (cmapWithPrio LogShake recorder) $ \TypeCheck file -> do
     pm <- use_ GetParsedModule file
     hsc  <- hscEnv <$> use_ GhcSessionDeps file
+    foi <- use_ IsFileOfInterest file
+    -- We should only call the typecheck rule for files of interest.
+    -- Keeping typechecked modules in memory for other files is
+    -- very expensive.
+    when (foi == NotFOI) $
+      logWith recorder Logger.Warning $ LogTypecheckedFOI file
     typeCheckRuleDefinition hsc pm
 
 knownFilesRule :: Recorder (WithPriority Log) -> Rules ()

--- a/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
+++ b/plugins/hls-refine-imports-plugin/src/Ide/Plugin/RefineImports.hs
@@ -187,8 +187,8 @@ refineImportsRule recorder = define (cmapWithPrio LogShake recorder) $ \RefineIm
       -- second layer is from the imports of first layer to their imports
       ImportMap importIm <- use_ GetImportMap path
       forM importIm $ \imp_path -> do
-        imp_tmr <- use_ TypeCheck imp_path
-        return $ tcg_exports $ tmrTypechecked imp_tmr
+        imp_hir <- use_ GetModIface imp_path
+        return $ mi_exports $ hirModIface imp_hir
 
   -- Use the GHC api to extract the "minimal" imports
   -- We shouldn't blindly refine imports


### PR DESCRIPTION
Also add an assertion to check that we never use non-FOI rules

Fixes #2962


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/2995"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

