### PR TITLE
Disable flaky test on Windows

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4439,7 +4439,11 @@ findDefinitionAndHoverTests = let
   , test  no     yes    holeL65    hleInfo2      "hole with variable"
   , test  no     yes    cccL17     docLink       "Haddock html links"
   , testM yes    yes    imported   importedSig   "Imported symbol"
-  , testM yes    yes    reexported reexportedSig "Imported symbol (reexported)"
+  , if | isWindows ->
+        -- Flaky on Windows: https://github.com/haskell/haskell-language-server/issues/2997
+        testM no     yes    reexported reexportedSig "Imported symbol (reexported)"
+       | otherwise ->
+        testM yes    yes    reexported reexportedSig "Imported symbol (reexported)"
   , if | ghcVersion == GHC90 && isWindows ->
         test  no     broken    thLocL57   thLoc         "TH Splice Hover"
        | ghcVersion == GHC92 && (isWindows || isMac) ->


### PR DESCRIPTION
I don't think anyone is going to fix this soon, let's just disable it so
we can move on.

Fixes #2997.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3008"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

