### PR TITLE
Revert back to Warning not Error in Logging `ResponseErrors`

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/HLS.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS.hs
@@ -202,7 +202,7 @@ extensiblePlugins recorder xs = mempty { P.pluginHandlers = handlers }
                 handlers = fmap (\(plid,_,handler) -> (plid,handler)) fs
             es <- runConcurrently msg (show m) handlers ide params
             let (errs,succs) = partitionEithers $ toList es
-            unless (null errs) $ forM_ errs $ \err -> logWith recorder Error $ LogPluginError err
+            unless (null errs) $ forM_ errs $ \err -> logWith recorder Warning $ LogPluginError err
             case nonEmpty succs of
               Nothing -> pure $ Left $ combineErrors errs
               Just xs -> do


### PR DESCRIPTION
I made a boo-boo and changed only one instance of `Error` to `Warning` when it should have been changed here as well...

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3009"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

