### PR TITLE
re-enable haddock

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -38,8 +38,7 @@ optional-packages: vendored/*/*.cabal
 tests: true
 
 package *
-  -- ghc 8.10 cannot build ghc-lib 9.2 with --haddock
-  -- ghc-options: -haddock
+  ghc-options: -haddock
   test-show-details: direct
 
 write-ghc-environment-files: never

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -25,11 +25,6 @@ flag pedantic
   default:     False
   manual:      True
 
-flag ghc-lib
-   default:     True
-   manual:      True
-   description: Use ghc-lib types (requires hlint to be built with ghc-lib)
-
 library
   exposed-modules:    Ide.Plugin.Hlint
   hs-source-dirs:     src
@@ -61,7 +56,6 @@ library
     , transformers
     , unordered-containers
     , apply-refact          >=0.9.0.0
-    , ghc-lib
     , ghc-lib-parser
     , ghc-lib-parser-ex
 

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -67,8 +67,16 @@ import           Development.IDE.GHC.Compat                         (DynFlags,
                                                                      topDir,
                                                                      wopt)
 import qualified Development.IDE.GHC.Compat.Util                    as EnumSet
-import           "ghc-lib-parser" GHC.Types.SrcLoc                  hiding (RealSrcSpan)
+
+#if MIN_GHC_API_VERSION(9,0,0)
+import           "ghc-lib-parser" GHC.Types.SrcLoc                  hiding
+                                                                    (RealSrcSpan)
 import qualified "ghc-lib-parser" GHC.Types.SrcLoc                  as GHC
+#else
+import           "ghc-lib-parser" SrcLoc                            hiding
+                                                                    (RealSrcSpan)
+import qualified "ghc-lib-parser" SrcLoc                            as GHC
+#endif
 import           "ghc-lib-parser" GHC.LanguageExtensions            (Extension)
 import           Language.Haskell.GhclibParserEx.GHC.Driver.Session as GhclibParserEx (readExtension)
 import           System.FilePath                                    (takeFileName)

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -4,24 +4,24 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiWayIf            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedLabels      #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ViewPatterns          #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiWayIf            #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE StrictData            #-}
 
 {-# OPTIONS_GHC -Wno-orphans   #-}
 
 #ifdef HLINT_ON_GHC_LIB
-#define MIN_GHC_API_VERSION(x,y,z) MIN_VERSION_ghc_lib(x,y,z)
+#define MIN_GHC_API_VERSION(x,y,z) MIN_VERSION_ghc_lib_parser(x,y,z)
 #else
 #define MIN_GHC_API_VERSION(x,y,z) MIN_VERSION_ghc(x,y,z)
 #endif
@@ -44,8 +44,8 @@ import           Data.Aeson.Types                                   (FromJSON (.
                                                                      Value (..))
 import qualified Data.ByteString                                    as BS
 import           Data.Default
-import qualified Data.HashMap.Strict                                as Map
 import           Data.Hashable
+import qualified Data.HashMap.Strict                                as Map
 import           Data.Maybe
 import qualified Data.Text                                          as T
 import qualified Data.Text.Encoding                                 as T
@@ -67,14 +67,8 @@ import           Development.IDE.GHC.Compat                         (DynFlags,
                                                                      topDir,
                                                                      wopt)
 import qualified Development.IDE.GHC.Compat.Util                    as EnumSet
-import           "ghc-lib" GHC                                      hiding
-                                                                    (DynFlags (..),
-                                                                     RealSrcSpan,
-                                                                     ms_hspp_opts)
-import qualified "ghc-lib" GHC
-#if MIN_GHC_API_VERSION(9,0,0)
-import           "ghc-lib-parser" GHC.Types.SrcLoc                  (BufSpan)
-#endif
+import           "ghc-lib-parser" GHC.Types.SrcLoc                  hiding (RealSrcSpan)
+import qualified "ghc-lib-parser" GHC.Types.SrcLoc                  as GHC
 import           "ghc-lib-parser" GHC.LanguageExtensions            (Extension)
 import           Language.Haskell.GhclibParserEx.GHC.Driver.Session as GhclibParserEx (readExtension)
 import           System.FilePath                                    (takeFileName)
@@ -89,7 +83,8 @@ import           System.IO                                          (IOMode (Wri
 import           System.IO.Temp
 #else
 import           Development.IDE.GHC.Compat                         hiding
-                                                                    (setEnv, (<+>))
+                                                                    (setEnv,
+                                                                     (<+>))
 import           GHC.Generics                                       (Associativity (LeftAssociative, NotAssociative, RightAssociative))
 #if MIN_GHC_API_VERSION(9,2,0)
 import           Language.Haskell.GHC.ExactPrint.ExactPrint         (deltaOptions)


### PR DESCRIPTION
Currently, we disable `-haddock` option in `cabal.project` because `ghc-lib` 9.2 doesn't build on GHC 8.10.
For now, we can remove the dependency on `ghc-lib` in `hls-hlint-plugin`, using `ghc-lib-parser` instead. (actually `hlint` itself doesn't depend on `ghc-lib`) Meanwhile, I've opened an issue in `ghc-lib`, see: https://github.com/digital-asset/ghc-lib/issues/391

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3015"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

