### PR TITLE
Hlint: CodeAction with isPreferred

### DIFF
--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -450,19 +450,19 @@ diagnosticToCodeActions dynFlags fileContents pluginId documentId diagnostic
            , let applyHintTitle = "Apply hint \"" <> hint <> "\""
                  applyHintArguments = [toJSON (AOP (documentId ^. LSP.uri) start hint)]
                  applyHintCommand = mkLspCommand pluginId "applyOne" applyHintTitle (Just applyHintArguments) ->
-               Just (mkCodeAction applyHintTitle diagnostic Nothing (Just applyHintCommand))
+               Just (mkCodeAction applyHintTitle diagnostic Nothing (Just applyHintCommand) True)
            | otherwise -> Nothing
-      , Just (mkCodeAction suppressHintTitle diagnostic (Just suppressHintWorkspaceEdit) Nothing)
+      , Just (mkCodeAction suppressHintTitle diagnostic (Just suppressHintWorkspaceEdit) Nothing False)
       ]
   | otherwise = []
 
-mkCodeAction :: T.Text -> LSP.Diagnostic -> Maybe LSP.WorkspaceEdit -> Maybe LSP.Command -> LSP.CodeAction
-mkCodeAction title diagnostic workspaceEdit command =
+mkCodeAction :: T.Text -> LSP.Diagnostic -> Maybe LSP.WorkspaceEdit -> Maybe LSP.Command -> Bool -> LSP.CodeAction
+mkCodeAction title diagnostic workspaceEdit command isPreferred =
   LSP.CodeAction
     { _title = title
     , _kind = Just LSP.CodeActionQuickFix
     , _diagnostics = Just (LSP.List [diagnostic])
-    , _isPreferred = Nothing
+    , _isPreferred = Just isPreferred
     , _disabled = Nothing
     , _edit = workspaceEdit
     , _command = command

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -446,6 +446,8 @@ diagnosticToCodeActions dynFlags fileContents pluginId documentId diagnostic
             Nothing
             Nothing
   = catMaybes
+      -- Applying the hint is marked preferred because it addresses the underlying error.
+      -- Disabling the rule isn't, because less often used and configuration can be adapted.
       [ if | isHintApplicable
            , let applyHintTitle = "Apply hint \"" <> hint <> "\""
                  applyHintArguments = [toJSON (AOP (documentId ^. LSP.uri) start hint)]


### PR DESCRIPTION
> A quick fix should be marked preferred if it properly addresses the underlying error. A refactoring should be marked preferred if it is the most reasonable choice of actions to take.

For hlint it is the likeliest choice to apply the fix. Ignore the rule
for the complete module is preferred less.

Related to https://github.com/haskell/haskell-language-server/issues/2057

## Demo

The client - in my case Vim/Coc - can respect `isPreferred`. In case of CoC it will be reflected in the sort order of code actions.

### Before

![screenshot-1657034414](https://user-images.githubusercontent.com/13085980/177363085-b937dba3-59fa-425d-8ca8-133945dbe862.png)


### After

![screenshot-1657034612](https://user-images.githubusercontent.com/13085980/177363107-2a7cdf17-cb02-4e4f-99a7-14c8100f940c.png)


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3018"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

