### PR TITLE
hls-graph: add lower bound for async

### DIFF
--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -61,7 +61,7 @@ library
   hs-source-dirs:     src
   build-depends:
     , aeson
-    , async
+    , async >= 2.0
     , base >=4.12 && <5
     , bytestring
     , containers


### PR DESCRIPTION
`Control.Concurrent.Async` is not available before `async-2.0`.

As a Hackage trustee, I made a matching revision:
https://hackage.haskell.org/package/hls-graph-1.7.0.0/revisions/

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3021"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

