### PR TITLE
hls-plugin-api: add lower bounds

### DIFF
--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -39,7 +39,7 @@ library
     , containers
     , data-default
     , dependent-map
-    , dependent-sum
+    , dependent-sum         >=0.7
     , Diff                  ^>=0.4.0
     , dlist
     , extra
@@ -50,7 +50,7 @@ library
     , lens
     , lens-aeson
     , lsp                   >=1.4.0.0 && < 1.6
-    , opentelemetry
+    , opentelemetry         >=0.4
     , optparse-applicative
     , process
     , regex-tdfa            >=1.3.1.0


### PR DESCRIPTION
Before `opentelemetry-0.4` `SpanInFlight` is not exported.
Before `dependent-sum-0.7` `GCompare` is not coming from `some`, but is defined elsewhere, which leads to incompatibility with `lsp`.

As a Hackage trustee, I made a matching revision:
https://hackage.haskell.org/package/hls-plugin-api-1.4.0.0/revisions/

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3022"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

