### PR TITLE
remove all usages of pre-commit-check in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -374,7 +374,6 @@
 
         devShells = simpleDevShells // nixDevShells // {
           default = simpleDevShells.haskell-language-server-dev;
-          inherit (self.checks.${system}.pre-commit-check) shellHook;
         };
 
         packages = allPackages // {
@@ -396,8 +395,6 @@
           all-simple-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues simpleDevShells)));
           docs = docs;
         };
-
-        checks = { pre-commit-check = pre-commit-check ghcDefault; };
 
         # The attributes for the default shell and package changed in recent versions of Nix,
         # these are here for backwards compatibility with the old versions.


### PR DESCRIPTION
In #2967, @teto points out `nix flake show` is broken due to some usages of `pre-commit-check` were not removed. As `pre-commit-check` is already removed from flake input, I believe we can remove the remaining usages of it safely.

However, `nix flake show` and `nix flake check` still fail due to our implicit use of IFD(import from derivation), see: https://github.com/NixOS/nix/issues/4265. With IFD, these commands are trying to build all systems listed in `flake-utils.lib.eachSystem`.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3024"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

