### PR TITLE
hls-fourmolu-plugin: add lower bound for process-extras

### DIFF
--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -36,7 +36,7 @@ library
     , hls-plugin-api  ^>=1.4
     , lens
     , lsp
-    , process-extras
+    , process-extras  >= 0.7.1
     , text
 
   default-language: Haskell2010


### PR DESCRIPTION
There is no `System.Process.Run` before `process-extras-0.7.1`

Matching revision:
https://hackage.haskell.org/package/hls-fourmolu-plugin-1.0.3.0/revisions/

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3028"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

