### PR TITLE
hls-eval-plugin: add lower bound for parser-combinators

### DIFF
--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -75,7 +75,7 @@ library
     , lsp-types
     , megaparsec            >=9.0
     , mtl
-    , parser-combinators
+    , parser-combinators    >=1.2
     , pretty-simple
     , QuickCheck
     , safe-exceptions


### PR DESCRIPTION
`manyTill_` was introduced only in `parser-combinators-1.2`.

Matching revision:
https://hackage.haskell.org/package/hls-eval-plugin-1.2.2.0/revisions/

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3029"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

