### PR TITLE
haskell-language-server: add lower bound for githash

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -72,7 +72,7 @@ library
     , data-default
     , ghc
     , ghcide                ^>=1.7
-    , githash
+    , githash               >=0.1.6.1
     , lsp
     , hie-bios
     , hiedb

--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -90,6 +90,7 @@ extra-deps:
   - stm-hamt-1.2.0.6@sha256:fba86ccb4b45c5706c19b0e1315ba63dcac3b5d71de945ec001ba921fae80061,3972
   - primitive-extras-0.10.1
   - primitive-unlifted-0.1.3.1
+  - githash-0.1.6.2
 
 configure-options:
   ghcide:


### PR DESCRIPTION
The type of `tGitInfoCwdTry` has been different before `githash-0.1.6.1`.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3030"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

