### PR TITLE
Fix Stack build with Nix on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -291,8 +291,11 @@
             # ormolu
             # stylish-haskell
             pre-commit
-            ];
-
+            ] ++ lib.optionals stdenv.isDarwin
+              (with darwin.apple_sdk.frameworks; [
+                Cocoa
+                CoreServices
+              ]);
 
           shellHook = ''
             # @guibou: I'm not sure theses lines are needed


### PR DESCRIPTION
Before the change the build was failing:

```
$ stack --nix build --keep-going
hfsevents          > Configuring hfsevents-0.1.6...
hfsevents          > build
hfsevents          > Preprocessing library for hfsevents-0.1.6..
hfsevents          > Building library for hfsevents-0.1.6..
hfsevents          > [1 of 1] Compiling System.OSX.FSEvents
hfsevents          > /private/tmp/stack-51fbae1892ce366f/hfsevents-0.1.6/In file included from cbits/c_fsevents.m:1:0: error:
hfsevents          >
hfsevents          > /private/tmp/stack-51fbae1892ce366f/hfsevents-0.1.6/In file included from /nix/store/yynq1crbdnd6fyaajv7d0zicf0bgb46y-apple-framework-CoreServices/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:19:0: error:
hfsevents          >
hfsevents          >
hfsevents          > /private/tmp/stack-51fbae1892ce366f/hfsevents-0.1.6/In file included from /nix/store/7ji012p4lxn30jql6l26dgnmsmqq8kxk-apple-framework-CoreFoundation/Library/Frameworks/CoreFoundation.framework/Headers/CoreFoundation.h:60:0: error:
hfsevents          >
hfsevents          >
hfsevents          > /private/tmp/stack-51fbae1892ce366f/hfsevents-0.1.6/In file included from /nix/store/7ji012p4lxn30jql6l26dgnmsmqq8kxk-apple-framework-CoreFoundation/Library/Frameworks/CoreFoundation.framework/Headers/CFPropertyList.h:13:0: error:
hfsevents          >
hfsevents          >
hfsevents          > /private/tmp/stack-51fbae1892ce366f/hfsevents-0.1.6/In file included from /nix/store/7ji012p4lxn30jql6l26dgnmsmqq8kxk-apple-framework-CoreFoundation/Library/Frameworks/CoreFoundation.framework/Headers/CFStream.h:15:0: error:
hfsevents          >
hfsevents          >
hfsevents          > /private/tmp/stack-51fbae1892ce366f/hfsevents-0.1.6/In file included from /nix/store/ni8221ym8df3iff8vn864pf4v7rm79ic-Libsystem-1238.60.2/include/dispatch/dispatch.h:48:0: error:
hfsevents          >
hfsevents          >
hfsevents          > /private/tmp/stack-51fbae1892ce366f/hfsevents-0.1.6//nix/store/ni8221ym8df3iff8vn864pf4v7rm79ic-Libsystem-1238.60.2/include/os/object.h:75:9: error:
hfsevents          >      fatal error: 'objc/NSObject.h' file not found
hfsevents          >    |
hfsevents          > 75 | #import <objc/NSObject.h>
hfsevents          >    |         ^
hfsevents          > #import <objc/NSObject.h>
hfsevents          >         ^~~~~~~~~~~~~~~~~
hfsevents          > 1 error generated.
hfsevents          > `cc' failed in phase `C Compiler'. (Exit code: 1)
```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3031"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

