### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,24 +1,24 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: Enhancement request
+about: I have an idea for how to make things better
 title: ''
 labels: 'status: needs triage, type: enhancement'
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your enhancement request related to a problem? Please describe.
 
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 
 <!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 
 <!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
+## Additional context
 
 <!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,18 +1,18 @@
 ---
-name: Bug report
-about: I've spotted something specific thats' going wrong
+name: Support request
+about: Help, something isn't working and I'm stuck!
 title: ''
-labels: 'status: needs triage, type: bug'
+labels: 'status: needs triage, type: support'
 assignees: ''
 
 ---
 
 <!--
-Before opening a bug, please take a look at the [troubleshooting guide](https://haskell-language-server.readthedocs.io/en/latest/troubleshooting.html).
+Before asking for support, please take a look at the [troubleshooting guide](https://haskell-language-server.readthedocs.io/en/latest/troubleshooting.html).
 This explains some common issues and will also help you to find the information that the issue template asks for.
 -->
 
-### Your environment
+## Your environment 
 
 <!--
 Everything in this section is optional, but it does help us to debug your issue!
@@ -30,17 +30,9 @@ Which version of HLS do you use and how did you install it?
 <!-- 1.7.0.1 from ghcup, etc. -->
 Have you configured HLS in any way (especially: a `hie.yaml` file)?
 
-### Steps to reproduce
+## What's wrong?
 
-<!-- Tell us how to reproduce this issue. -->
-
-### Expected behaviour
-
-<!-- Tell us what should happen. -->
-
-### Actual behaviour
-
-<!-- Tell us what happens instead. -->
+<!-- What's not working? What have you tried? -->
 
 ### Debug information
 


### PR DESCRIPTION
- Add a support issue template
- Ask questions about versions of GHC and HLS
- Add some heuristic details fields to help people pick an issue type

I thought it would be nice to have an issue template for support issues, to encourage people to distinguish those.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3044"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

