### PR TITLE
fix record-dot-syntax test

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -4359,7 +4359,7 @@ findDefinitionAndHoverTests = let
                         , tst (getTypeDefinitions, checkDefs) aL20 sourceFilePath (pure [ExpectNoDefinitions]) "Polymorphic variable"]
   
   recordDotSyntaxTests 
-    | ghcVersion == GHC92 =
+    | ghcVersion >= GHC92 =
         [ tst (getHover, checkHover) (Position 19 24) (T.unpack "RecordDotSyntax.hs") (pure [ExpectHoverText ["x :: MyRecord"]]) "hover over parent" 
         , tst (getHover, checkHover) (Position 19 25) (T.unpack "RecordDotSyntax.hs") (pure [ExpectHoverText ["_ :: MyChild"]]) "hover over dot shows child" 
         , tst (getHover, checkHover) (Position 19 26) (T.unpack "RecordDotSyntax.hs") (pure [ExpectHoverText ["_ :: MyChild"]]) "hover over child" 


### PR DESCRIPTION
Makes the record-dot-syntax tests to apply to future versions of GHC

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3051"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

