### PR TITLE
Remove redundant WARNING prefix

### DIFF
--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -184,7 +184,7 @@ instance Pretty Log where
       "SUCCEEDED LOADING HIE FILE FOR" <+> pretty path
     LogExactPrint log -> pretty log
     LogTypecheckedFOI path -> vcat
-      [ "WARNING: Typechecked a file which is not currently open in the editor:" <+> pretty (fromNormalizedFilePath path)
+      [ "Typechecked a file which is not currently open in the editor:" <+> pretty (fromNormalizedFilePath path)
       , "This can indicate a bug which results in excessive memory usage."
       , "This may be a spurious warning if you have recently closed the file."
       , "If you haven't opened this file recently, please file a report on the issue tracker mentioning"


### PR DESCRIPTION
It's logged as a warning, it shouldn't duplicate the severity in the
message.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3055"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

