### PR TITLE
Run the benchmark suite on GHC 9.2.3

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.7']
+        ghc: ['8.10.7','9.0.2', '9.2.3']
         os: [ubuntu-latest]
 
     # This code is fitted to the strategy: assumes Linux is used ... etc,

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.7','9.0.2', '9.2.3']
+        ghc: ['8.10.7', '9.2.3']
         os: [ubuntu-latest]
 
     # This code is fitted to the strategy: assumes Linux is used ... etc,

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.7']
+        ghc: ['8.10.7', '9.2.3']
         os: [ubuntu-latest]
         cabal: ['3.6']
         example: ['cabal', 'lsp-types']

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -14,22 +14,22 @@ examples:
   # Medium-sized project without TH
   - name: cabal
     package: Cabal
-    version: 3.0.0.0
+    version: 3.6.3.0
     modules:
-        - Distribution/Simple.hs
-        - Distribution/Types/Module.hs
+        - src/Distribution/Simple.hs
+        - src/Distribution/Types/Module.hs
     extra-args: [] # extra ghcide command line args
   - name: cabal-1module
     package: Cabal
-    version: 3.0.0.0
+    version: 3.6.3.0
     modules:
-        - Distribution/Simple.hs
+        - src/Distribution/Simple.hs
   - name: cabal-conservative
     package: Cabal
-    version: 3.0.0.0
+    version: 3.6.3.0
     modules:
-        - Distribution/Simple.hs
-        - Distribution/Types/Module.hs
+        - src/Distribution/Simple.hs
+        - src/Distribution/Types/Module.hs
     extra-args:  # extra ghcide command line args
       - --conservative-change-tracking
   # Small-sized project with TH

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -35,13 +35,13 @@ examples:
   # Small-sized project with TH
   - name: lsp-types
     package: lsp-types
-    version: 1.0.0.1
+    version: 1.5.0.0
     modules:
         - src/Language/LSP/VFS.hs
         - src/Language/LSP/Types/Lens.hs
   - name: lsp-types-conservative
     package: lsp-types
-    version: 1.0.0.1
+    version: 1.5.0.0
     modules:
         - src/Language/LSP/VFS.hs
         - src/Language/LSP/Types/Lens.hs


### PR DESCRIPTION
As @kokobd noticed in #3046 the benchmark suite is not running in 9.x

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3069"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

