### PR TITLE
fix lsp-types benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -140,24 +140,32 @@ jobs:
       run: |
         column -s, -t < ghcide/bench-results/unprofiled/${{ matrix.example }}/results.csv | tee ghcide/bench-results/unprofiled/${{ matrix.example }}/results.txt
 
+    - name: tar benchmarking artifacts
+      run: |
+        tar -czf benchmark-artifacts.tar.gz  \
+           ghcide/bench-results/results.*   \
+           ghcide/bench-results/**/*.csv    \
+           ghcide/bench-results/**/*.svg    \
+           ghcide/bench-results/**/*.eventlog.html
+
     - name: Archive benchmarking artifacts
       uses: actions/upload-artifact@v3
       with:
         name: bench-results-${{ runner.os }}-${{ matrix.ghc }}
-        path: |
-           ghcide/bench-results/results.*
-           ghcide/bench-results/**/*.csv
-           ghcide/bench-results/**/*.svg
-           ghcide/bench-results/**/*.eventlog.html
+        path: benchmark-artifacts.tar.gz
+
+    - name: tar benchmarking logs
+      run: |
+        tar -czf benchmark-logs.tar.gz \
+           ghcide/bench-results/**/*.log \
+           ghcide/bench-results/**/*.eventlog \
+           ghcide/bench-results/**/*.hp
 
     - name: Archive benchmark logs
       uses: actions/upload-artifact@v3
       with:
         name: bench-logs-${{ runner.os }}-${{ matrix.ghc }}
-        path: |
-           ghcide/bench-results/**/*.log
-           ghcide/bench-results/**/*.eventlog
-           ghcide/bench-results/**/*.hp
+        path: benchmark-logs.tar.gz
 
   bench_post_job:
     if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -141,12 +141,7 @@ jobs:
         column -s, -t < ghcide/bench-results/unprofiled/${{ matrix.example }}/results.csv | tee ghcide/bench-results/unprofiled/${{ matrix.example }}/results.txt
 
     - name: tar benchmarking artifacts
-      run: |
-        tar -czf benchmark-artifacts.tar.gz  \
-           ghcide/bench-results/results.*   \
-           ghcide/bench-results/**/*.csv    \
-           ghcide/bench-results/**/*.svg    \
-           ghcide/bench-results/**/*.eventlog.html
+      run:  find ghcide/bench-results -name "*.csv" -or -name "*.svg" -or -name "*.html" | xargs tar -czf benchmark-artifacts.tar.gz
 
     - name: Archive benchmarking artifacts
       uses: actions/upload-artifact@v3
@@ -155,11 +150,7 @@ jobs:
         path: benchmark-artifacts.tar.gz
 
     - name: tar benchmarking logs
-      run: |
-        tar -czf benchmark-logs.tar.gz \
-           ghcide/bench-results/**/*.log \
-           ghcide/bench-results/**/*.eventlog \
-           ghcide/bench-results/**/*.hp
+      run: find ghcide/bench-results -name "*.log" -or -name "*.eventlog" -or -name "*.hp" | xargs tar -czf benchmark-logs.tar.gz
 
     - name: Archive benchmark logs
       uses: actions/upload-artifact@v3

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -37,13 +37,13 @@ examples:
     package: lsp-types
     version: 1.5.0.0
     modules:
-        - src/Language/LSP/VFS.hs
+        - src/Language/LSP/Types/Uri.hs
         - src/Language/LSP/Types/Lens.hs
   - name: lsp-types-conservative
     package: lsp-types
     version: 1.5.0.0
     modules:
-        - src/Language/LSP/VFS.hs
+        - src/Language/LSP/Types/Uri.hs
         - src/Language/LSP/Types/Lens.hs
     extra-args:
       - --conservative-change-tracking

--- a/ghcide/bench/config.yaml
+++ b/ghcide/bench/config.yaml
@@ -37,14 +37,14 @@ examples:
     package: lsp-types
     version: 1.5.0.0
     modules:
-        - src/Language/LSP/Types/Uri.hs
-        - src/Language/LSP/Types/Lens.hs
+        - src/Language/LSP/Types/WatchedFiles.hs
+        - src/Language/LSP/Types/CallHierarchy.hs
   - name: lsp-types-conservative
     package: lsp-types
     version: 1.5.0.0
     modules:
-        - src/Language/LSP/Types/Uri.hs
-        - src/Language/LSP/Types/Lens.hs
+        - src/Language/LSP/Types/WatchedFiles.hs
+        - src/Language/LSP/Types/CallHierarchy.hs
     extra-args:
       - --conservative-change-tracking
   # Small-sized project with TH

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -24,8 +24,9 @@ module Experiments
 ) where
 import           Control.Applicative.Combinators (skipManyTill)
 import           Control.Exception.Safe          (IOException, handleAny, try)
-import           Control.Monad.Extra
-import           Control.Monad.Fail
+import Control.Monad.Extra
+    ( forM_, void, unless, forM, (&&^), allM, whenJust )
+import           Control.Monad.Fail              (MonadFail)
 import           Control.Monad.IO.Class
 import           Data.Aeson                      (Value (Null), toJSON)
 import           Data.Either                     (fromRight)

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -24,8 +24,8 @@ module Experiments
 ) where
 import           Control.Applicative.Combinators (skipManyTill)
 import           Control.Exception.Safe          (IOException, handleAny, try)
-import Control.Monad.Extra
-    ( forM_, void, unless, forM, (&&^), allM, whenJust )
+import           Control.Monad.Extra             (allM, forM, forM_, unless,
+                                                  void, whenJust, (&&^))
 import           Control.Monad.Fail              (MonadFail)
 import           Control.Monad.IO.Class
 import           Data.Aeson                      (Value (Null), toJSON)
@@ -77,7 +77,7 @@ data DocumentPositions = DocumentPositions {
 allWithIdentifierPos :: MonadFail m => (DocumentPositions -> m Bool) -> [DocumentPositions] -> m Bool
 allWithIdentifierPos f docs = case applicableDocs of
     -- fail if there are no documents to benchmark
-    [] -> fail "None of the example modules have identifier positions"
+    []    -> fail "None of the example modules have identifier positions"
     docs' -> allM f docs'
   where
     applicableDocs = filter (isJust . identifierP) docs

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -25,6 +25,7 @@ module Experiments
 import           Control.Applicative.Combinators (skipManyTill)
 import           Control.Exception.Safe          (IOException, handleAny, try)
 import           Control.Monad.Extra
+import           Control.Monad.Fail
 import           Control.Monad.IO.Class
 import           Data.Aeson                      (Value (Null), toJSON)
 import           Data.Either                     (fromRight)

--- a/ghcide/bench/lib/Experiments.hs
+++ b/ghcide/bench/lib/Experiments.hs
@@ -72,8 +72,13 @@ data DocumentPositions = DocumentPositions {
     doc            :: !TextDocumentIdentifier
 }
 
-allWithIdentifierPos :: Monad m => (DocumentPositions -> m Bool) -> [DocumentPositions] -> m Bool
-allWithIdentifierPos f docs = allM f (filter (isJust . identifierP) docs)
+allWithIdentifierPos :: MonadFail m => (DocumentPositions -> m Bool) -> [DocumentPositions] -> m Bool
+allWithIdentifierPos f docs = case applicableDocs of
+    -- fail if there are no documents to benchmark
+    [] -> fail "None of the example modules have identifier positions"
+    docs' -> allM f docs'
+  where
+    applicableDocs = filter (isJust . identifierP) docs
 
 experiments :: [Bench]
 experiments =


### PR DESCRIPTION
The lsp-types benchmark definition needs some fixes in ghc 9.2

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3079"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Also fixes #3102 by tar'ing the benchmark artefacts before upload