### PR TITLE
Feat: basic record dot completions

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -48,7 +48,7 @@ import qualified Language.LSP.VFS                         as VFS
 import           Numeric.Natural
 import           Text.Fuzzy.Parallel                      (Scored (..))
 
-import qualified GHC.LanguageExtensions                       as LangExt
+import qualified GHC.LanguageExtensions                   as LangExt
 import           Language.LSP.Types
 
 data Log = LogShake Shake.Log deriving Show
@@ -167,8 +167,8 @@ getCompletionsLSP ide plId
                 let clientCaps = clientCapabilities $ shakeExtras ide
                     plugins = idePlugins $ shakeExtras ide
                 config <- getCompletionsConfig plId
-                
-                allCompletions <- liftIO $ getCompletions plId ideOpts cci' parsedMod astres bindMap pfix' clientCaps config moduleExports
+
+                allCompletions <- liftIO $ getCompletions plugins ideOpts cci' parsedMod astres bindMap pfix' clientCaps config moduleExports
                 pure $ InL (List $ orderedCompletions allCompletions)
               _ -> return (InL $ List [])
           _ -> return (InL $ List [])

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -144,7 +144,11 @@ getCompletionsLSP ide plId
             let compls = (fst <$> localCompls) <> (fst <$> nonLocalCompls) <> Just exportsCompls <> Just lModules
 
             -- get HieAst if OverloadedRecordDot is enabled
+#if MIN_VERSION_ghc(9,2,0)
             let uses_overloaded_record_dot (ms_hspp_opts . msrModSummary -> dflags) = xopt LangExt.OverloadedRecordDot dflags
+#else
+            let uses_overloaded_record_dot _ = False
+#endif
             ms <- fmap fst <$> useWithStaleFast GetModSummaryWithoutTimestamps npath
             astres <- case ms of
               Just ms' -> if uses_overloaded_record_dot ms'

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -69,9 +69,9 @@ import qualified Language.LSP.VFS                         as VFS
 import           Text.Fuzzy.Parallel                      (Scored (score),
                                                            original)
 
+import qualified Data.Text.Utf16.Rope                     as Rope
 import           Development.IDE
 
-import qualified Data.Rope.UTF16                          as Rope
 import           Development.IDE.Spans.AtPoint            (pointCommand)
 
 -- Chunk size used for parallelizing fuzzy matching

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -21,7 +21,8 @@ import           Data.List.Extra                          as List hiding
 import qualified Data.Map                                 as Map
 
 import           Data.Maybe                               (catMaybes, fromMaybe,
-                                                           isJust, mapMaybe, listToMaybe)
+                                                           isJust, listToMaybe,
+                                                           mapMaybe)
 import qualified Data.Text                                as T
 import qualified Text.Fuzzy.Parallel                      as Fuzzy
 
@@ -637,7 +638,7 @@ getCompletions plugins ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls,
               -- Completions can return more information that just the completion itself, but it will
               -- require more than what GHC currently gives us in the HieAST, since it only gives the Type
               -- of the fields, not where they are defined, etc. So for now the extra fields remain empty.
-              -- Also: additionalTextEdits is a todo, since we may want to import the record. It requires a way 
+              -- Also: additionalTextEdits is a todo, since we may want to import the record. It requires a way
               -- to get the record's module, which isn't included in the type information used to get the fields.
               dotFieldSelectorToCompl :: T.Text -> T.Text -> (Bool, CompItem)
               dotFieldSelectorToCompl recname label = (True, CI
@@ -678,7 +679,7 @@ getCompletions plugins ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls,
               ty = showForSnippet <$> typ
               thisModName = Local $ nameSrcSpan name
 
-          -- When record-dot-syntax completions are available, we return them exclusively. 
+          -- When record-dot-syntax completions are available, we return them exclusively.
           -- They are only available when we write i.e. `myrecord.` with OverloadedRecordDot enabled.
           -- Anything that isn't a field is invalid, so those completion don't make sense.
           compls
@@ -741,6 +742,7 @@ getCompletions plugins ideOpts CC {allModNamesAsNS, anyQualCompls, unqualCompls,
             (isQual, CompletionItem{_label,_detail}) -> do
               let isLocal = maybe False (":" `T.isPrefixOf`) _detail
               (Down isQual, Down score, Down isLocal, _label, _detail)
+
 
 
 

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -26,6 +26,7 @@ import           Ide.PluginUtils              (getClientConfig, usePropertyLsp)
 import           Ide.Types                    (PluginId)
 import           Language.LSP.Server          (MonadLsp)
 import           Language.LSP.Types           (CompletionItemKind (..), Uri)
+import qualified Language.LSP.Types           as J
 
 -- | Produce completions info for a file
 type instance RuleResult LocalCompletions = CachedCompletions
@@ -136,3 +137,25 @@ instance Monoid CachedCompletions where
 instance Semigroup CachedCompletions where
     CC a b c d e <> CC a' b' c' d' e' =
         CC (a<>a') (b<>b') (c<>c') (d<>d') (e<>e')
+
+
+-- moved here from Language.LSP.VHS
+-- | Describes the line at the current cursor position
+data PosPrefixInfo = PosPrefixInfo
+  { fullLine :: !T.Text
+    -- ^ The full contents of the line the cursor is at
+
+  , prefixScope :: !T.Text
+    -- ^ If any, the module name that was typed right before the cursor position.
+    --  For example, if the user has typed "Data.Maybe.from", then this property
+    --  will be "Data.Maybe"
+    -- If OverloadedRecordDot is enabled, "Shape.rect.width" will be
+    -- "Shape.rect"
+
+  , prefixText :: !T.Text
+    -- ^ The word right before the cursor position, after removing the module part.
+    -- For example if the user has typed "Data.Maybe.from",
+    -- then this property will be "from"
+  , cursorPos :: !J.Position
+    -- ^ The cursor position
+  } deriving (Show,Eq)

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -139,7 +139,6 @@ instance Semigroup CachedCompletions where
         CC (a<>a') (b<>b') (c<>c') (d<>d') (e<>e')
 
 
--- moved here from Language.LSP.VFS
 -- | Describes the line at the current cursor position
 data PosPrefixInfo = PosPrefixInfo
   { fullLine    :: !T.Text

--- a/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Types.hs
@@ -139,10 +139,10 @@ instance Semigroup CachedCompletions where
         CC (a<>a') (b<>b') (c<>c') (d<>d') (e<>e')
 
 
--- moved here from Language.LSP.VHS
+-- moved here from Language.LSP.VFS
 -- | Describes the line at the current cursor position
 data PosPrefixInfo = PosPrefixInfo
-  { fullLine :: !T.Text
+  { fullLine    :: !T.Text
     -- ^ The full contents of the line the cursor is at
 
   , prefixScope :: !T.Text
@@ -152,10 +152,10 @@ data PosPrefixInfo = PosPrefixInfo
     -- If OverloadedRecordDot is enabled, "Shape.rect.width" will be
     -- "Shape.rect"
 
-  , prefixText :: !T.Text
+  , prefixText  :: !T.Text
     -- ^ The word right before the cursor position, after removing the module part.
     -- For example if the user has typed "Data.Maybe.from",
     -- then this property will be "from"
-  , cursorPos :: !J.Position
+  , cursorPos   :: !J.Position
     -- ^ The cursor position
   } deriving (Show,Eq)

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -94,11 +94,20 @@ tests = testGroup "completions" [
 
             compls <- getCompletions doc (Position 25 6)
             item <- getCompletionByLabel "a" compls
+
             liftIO $ do
                 item ^. label @?= "a"
-                --item ^. detail @?= Just "Data.List"  TODO
-                --item ^. kind @?= Just CiModule
-            liftIO $ length compls @?= 6
+        , testCase "shows field selectors for nested field" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+            doc <- openDoc "RecordDotSyntax.hs" "haskell"
+
+            let te = TextEdit (Range (Position 27 0) (Position 27 8)) "z2 = x.c.z"
+            _ <- applyEdit doc te
+
+            compls <- getCompletions doc (Position 27 9)
+            item <- getCompletionByLabel "z" compls
+
+            liftIO $ do
+                item ^. label @?= "z"
         ]
 
      -- See https://github.com/haskell/haskell-ide-engine/issues/903

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -376,4 +376,4 @@ compls `shouldNotContainCompl` lbl =
     @? "Should not contain completion: " ++ show lbl
 
 expectFailIfBeforeGhc92 :: String -> TestTree -> TestTree
-expectFailIfBeforeGhc92 = knownBrokenForGhcVersions [GHC810, GHC88, GHC86]
+expectFailIfBeforeGhc92 = knownBrokenForGhcVersions [GHC810, GHC88, GHC86, GHC90]

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -84,6 +84,22 @@ tests = testGroup "completions" [
          compls <- getCompletions doc (Position 5 7)
          liftIO $ assertBool "Expected completions" $ not $ null compls
 
+     , testGroup "recorddotsyntax"
+        [ testCase "shows field selectors" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
+            doc <- openDoc "RecordDotSyntax.hs" "haskell"
+
+            let te = TextEdit (Range (Position 25 0) (Position 25 5)) "z = x.a"
+            _ <- applyEdit doc te
+
+            compls <- getCompletions doc (Position 25 6)
+            item <- getCompletionByLabel "a" compls
+            liftIO $ do
+                item ^. label @?= "a"
+                --item ^. detail @?= Just "Data.List"  TODO
+                --item ^. kind @?= Just CiModule
+            liftIO $ length compls @?= 6
+        ]
+
      -- See https://github.com/haskell/haskell-ide-engine/issues/903
      , testCase "strips compiler generated stuff from completions" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
          doc <- openDoc "DupRecFields.hs" "haskell"

--- a/test/functional/Completion.hs
+++ b/test/functional/Completion.hs
@@ -84,7 +84,8 @@ tests = testGroup "completions" [
          compls <- getCompletions doc (Position 5 7)
          liftIO $ assertBool "Expected completions" $ not $ null compls
 
-     , testGroup "recorddotsyntax"
+     , expectFailIfBeforeGhc92 "record dot syntax is introduced in GHC 9.2"
+       $ testGroup "recorddotsyntax"
         [ testCase "shows field selectors" $ runSession hlsCommand fullCaps "test/testdata/completion" $ do
             doc <- openDoc "RecordDotSyntax.hs" "haskell"
 
@@ -364,3 +365,6 @@ shouldNotContainCompl :: [CompletionItem] -> T.Text -> Assertion
 compls `shouldNotContainCompl` lbl =
     all ((/= lbl) . (^. label)) compls
     @? "Should not contain completion: " ++ show lbl
+
+expectFailIfBeforeGhc92 :: String -> TestTree -> TestTree
+expectFailIfBeforeGhc92 = knownBrokenForGhcVersions [GHC810, GHC88, GHC86]

--- a/test/testdata/completion/RecordDotSyntax.hs
+++ b/test/testdata/completion/RecordDotSyntax.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Test where
+
+import qualified Data.Maybe as M
+
+data MyRecord = MyRecord1
+  { a :: String
+  , b :: Integer
+  , c :: MyChild
+  }
+  | MyRecord2 { a2 :: String
+  , b2 :: Integer
+  , c2 :: MyChild
+  } deriving (Eq, Show)
+
+newtype MyChild = MyChild
+  { z :: String
+  } deriving (Eq, Show)
+
+x = MyRecord1 { a = "Hello", b = 12, c = MyChild { z = "there" } }
+
+y = x.a ++ show x.b 
+
+

--- a/test/testdata/completion/RecordDotSyntax.hs
+++ b/test/testdata/completion/RecordDotSyntax.hs
@@ -24,4 +24,5 @@ x = MyRecord1 { a = "Hello", b = 12, c = MyChild { z = "there" } }
 
 y = x.a ++ show x.b 
 
+y2 = x.c.z 
 


### PR DESCRIPTION
When a user dots a record type with OverloadedRecordDot enabled, shows all possible record selectors for that type.

Todo:
* write test
* make completion items more complete

Notes
* Requires fresh HieAst to work, which shouldn't be a problem since we are dotting an actively worked on file
* Doesn't support HasField (virtual fields)
* Moves getCompletionPrefix, PosPrefixInfo in from LSP.Language.VFS (and patches them to support records in addition to modules)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3080"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

