### PR TITLE
Probe-tools: Print stack ghc version

### DIFF
--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -14,7 +14,7 @@ module Main where
 import           Control.Monad.Extra
 import           Data.Char                          (isSpace)
 import           Data.Default
-import           Data.Either                        (fromRight)
+import           Data.Either.Extra                  (eitherToMaybe)
 import           Data.Foldable
 import           Data.List
 import           Data.Void
@@ -83,7 +83,7 @@ main = do
           putStrLn "Tool versions in your project"
           cradle <- findProjectCradle' False
           ghcVersion <- runExceptT $ getRuntimeGhcVersion' cradle
-          putStrLn $ "ghc:\t\t" ++ fromRight "Not found" ghcVersion
+          putStrLn $ showProgramVersion "ghc" $ mkVersion =<< eitherToMaybe ghcVersion
 
       VersionMode PrintVersion ->
           putStrLn hlsVer

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -80,7 +80,7 @@ main = do
           putStrLn hlsVer
           putStrLn "Tool versions found on the $PATH"
           putStrLn $ showProgramVersionOfInterest programsOfInterest
-          putStrLn "Tool versions found by cradle"
+          putStrLn "Tool versions in your project"
           cradle <- findProjectCradle' False
           ghcVersion <- runExceptT $ getRuntimeGhcVersion' cradle
           putStrLn $ "ghc:\t\t" ++ fromRight "Not found" ghcVersion

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -14,6 +14,7 @@ module Main where
 import           Control.Monad.Extra
 import           Data.Char                          (isSpace)
 import           Data.Default
+import           Data.Either                        (fromRight)
 import           Data.Foldable
 import           Data.List
 import           Data.Void
@@ -79,6 +80,10 @@ main = do
           putStrLn hlsVer
           putStrLn "Tool versions found on the $PATH"
           putStrLn $ showProgramVersionOfInterest programsOfInterest
+          putStrLn "Tool versions found by cradle"
+          cradle <- findProjectCradle' False
+          ghcVersion <- runExceptT $ getRuntimeGhcVersion' cradle
+          putStrLn $ "ghc:\t\t" ++ fromRight "Not found" ghcVersion
 
       VersionMode PrintVersion ->
           putStrLn hlsVer

--- a/src/Ide/Version.hs
+++ b/src/Ide/Version.hs
@@ -38,10 +38,9 @@ hlsVersion =
     hlsGhcDisplayVersion = compilerName ++ "-" ++ VERSION_ghc
 
 data ProgramsOfInterest = ProgramsOfInterest
-  { cabalVersion    :: Maybe Version
-  , stackVersion    :: Maybe Version
-  , ghcVersion      :: Maybe Version
-  , stackGhcVersion :: Maybe Version
+  { cabalVersion :: Maybe Version
+  , stackVersion :: Maybe Version
+  , ghcVersion   :: Maybe Version
   }
 
 showProgramVersionOfInterest :: ProgramsOfInterest -> String
@@ -50,7 +49,6 @@ showProgramVersionOfInterest ProgramsOfInterest {..} =
     [ "cabal:\t\t" ++ showVersionWithDefault cabalVersion
     , "stack:\t\t" ++ showVersionWithDefault stackVersion
     , "ghc:\t\t" ++ showVersionWithDefault ghcVersion
-    , "stack ghc:\t" ++ showVersionWithDefault stackGhcVersion
     ]
   where
     showVersionWithDefault :: Maybe Version -> String
@@ -58,19 +56,19 @@ showProgramVersionOfInterest ProgramsOfInterest {..} =
 
 findProgramVersions :: IO ProgramsOfInterest
 findProgramVersions = ProgramsOfInterest
-  <$> findVersionOf "cabal" ["--numeric-version"]
-  <*> findVersionOf "stack" ["--numeric-version"]
-  <*> findVersionOf "ghc" ["--numeric-version"]
-  <*> findVersionOf "stack" ["ghc", "--", "--numeric-version"]
+  <$> findVersionOf "cabal"
+  <*> findVersionOf "stack"
+  <*> findVersionOf "ghc"
 
 -- | Find the version of the given program.
+-- Assumes the program accepts the cli argument "--numeric-version".
 -- If the invocation has a non-zero exit-code, we return 'Nothing'
-findVersionOf :: FilePath -> [String] -> IO (Maybe Version)
-findVersionOf tool args =
+findVersionOf :: FilePath -> IO (Maybe Version)
+findVersionOf tool =
   findExecutable tool >>= \case
     Nothing -> pure Nothing
     Just path ->
-      readProcessWithExitCode path args "" >>= \case
+      readProcessWithExitCode path ["--numeric-version"] "" >>= \case
         (ExitSuccess, sout, _) -> pure $ consumeParser myVersionParser sout
         _                      -> pure Nothing
   where


### PR DESCRIPTION
The ghc version on the $PATH is often not relevant for stack projects. The ghc version stack is using is printed in addition.

## Example Output

```
haskell-language-server version: 1.7.0.0 (GHC: 9.2.4) (PATH: [...]/haskell-language-server-wrapper) (GIT hash: 0e74593e8df9665067174ca27543006c9a6ad230)
Tool versions found on the $PATH
cabal:          3.8.1.0
stack:          2.7.5
ghc:            9.2.4
stack ghc:      8.10.7
```

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3093"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>


## Discussion

@michaelpj Followup to [this comment](https://github.com/haskell/haskell-language-server/pull/3090#issuecomment-1212146888) to sketch the idea for a change. Do you have something like this change in mind?