### PR TITLE
Fix #3095: disabling default flags in the cradle is not propagated to hlint properly

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat.hs
@@ -537,7 +537,7 @@ data GhcVersion
   | GHC810
   | GHC90
   | GHC92
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Enum, Bounded)
 
 ghcVersionStr :: String
 ghcVersionStr = VERSION_ghc

--- a/ghcide/src/Development/IDE/GHC/Compat/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Util.hs
@@ -38,6 +38,8 @@ module Development.IDE.GHC.Compat.Util (
     toList,
     fromList,
     difference,
+
+    allExtensions,
     -- * FastString exports
     FastString,
 #if MIN_VERSION_ghc(9,2,0)
@@ -84,6 +86,7 @@ import           GHC.Data.FastString
 import           GHC.Data.Maybe
 import           GHC.Data.Pair
 import           GHC.Data.StringBuffer
+import           GHC.LanguageExtensions  (Extension (..))
 import           GHC.Types.Unique
 import           GHC.Types.Unique.DFM
 import           GHC.Utils.Fingerprint
@@ -125,6 +128,15 @@ catch = Exception.gcatch
 try :: (Exception.ExceptionMonad m, Exception e) => m a -> m (Either e a)
 try = Exception.gtry
 #endif
+
+allExtensions :: EnumSet Extension
+#if MIN_VERSION_ghc(8,8,0)
+allExtensions = fromList $ enumFrom minBound
+#else
+-- GHC prior to 8.8 did not have an instance Bounded Extension :(
+allExtensions = fromList $ enumFrom Cpp
+#endif
+
 
 #if !MIN_VERSION_ghc(9,2,0)
 -- EnumSet doesn't have difference exported prior to ghc 9.2

--- a/ghcide/src/Development/IDE/GHC/Compat/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Util.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP             #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 -- | GHC Utils and Datastructures re-exports.
 --
 -- Mainly handles module hierarchy re-organisation of GHC
@@ -107,6 +108,11 @@ import           UniqDFM
 import           Unique
 import           Util
 #endif
+#if !MIN_VERSION_ghc(9,2,0)
+-- EnumSet doesn't have difference exported prior to ghc 9.2
+import           Data.Coerce             (coerce)
+import qualified Data.IntSet             as IntSe
+#endif
 
 #if !MIN_VERSION_ghc(9,0,0)
 type MonadCatch = Exception.ExceptionMonad
@@ -117,4 +123,12 @@ catch = Exception.gcatch
 
 try :: (Exception.ExceptionMonad m, Exception e) => m a -> m (Either e a)
 try = Exception.gtry
+#endif
+
+#if !MIN_VERSION_ghc(9,2,0)
+-- EnumSet doesn't have difference exported prior to ghc 9.2
+-- (also, the inside of the EnumSet newtype is not exported, so unsafeCoerce time)
+{-# HLINT ignore "Avoid restricted function" #-}
+difference :: EnumSet a -> EnumSet a -> EnumSet a
+difference a b = unsafeCoerce $ IntSet.difference (unsafeCoerce a :: IntSet) (unsafeCoerce b :: IntSet)
 #endif

--- a/ghcide/src/Development/IDE/GHC/Compat/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Util.hs
@@ -35,6 +35,8 @@ module Development.IDE.GHC.Compat.Util (
     -- * EnumSet
     EnumSet,
     toList,
+    fromList,
+    difference,
     -- * FastString exports
     FastString,
 #if MIN_VERSION_ghc(9,2,0)

--- a/ghcide/src/Development/IDE/GHC/Compat/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Util.hs
@@ -110,8 +110,9 @@ import           Util
 #endif
 #if !MIN_VERSION_ghc(9,2,0)
 -- EnumSet doesn't have difference exported prior to ghc 9.2
-import           Data.Coerce             (coerce)
-import qualified Data.IntSet             as IntSe
+import           Data.IntSet             (IntSet)
+import qualified Data.IntSet             as IntSet
+import           Unsafe.Coerce
 #endif
 
 #if !MIN_VERSION_ghc(9,0,0)

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -346,7 +346,7 @@ getExtensions nfp = do
     --      There is a MR to export it: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8817
     --      but it's not going to be in all our supported releases.
     let disabledExts = EnumSet.toList
-          $ EnumSet.difference (EnumSet.fromList (enumFrom minBound))
+          $ EnumSet.difference EnumSet.allExtensions
           (extensionFlags dflags)
     let hscExts = EnumSet.toList (extensionFlags dflags)
 

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -333,8 +333,18 @@ getIdeas recorder nfp = do
 getExtensions :: NormalizedFilePath -> Action ([Extension], [Extension])
 getExtensions nfp = do
     dflags <- getFlags
-    -- XXX: we just assume that all not-enabled flags are disabled. this is
-    --      Kinda Sketchy!
+    -- XXX: We just assume that all not-enabled flags are disabled. This is
+    --      Kinda Sketchy, but it is the only way to propagate extensions that
+    --      are enabled by default by the Language but are explicitly disabled
+    --      in the cradle. Problematically, HLint will reenable any such extensions
+    --      if they are in the default language set and are not in
+    --      disabledExtensions.
+    --
+    --      We can't get a set of only explicitly-disabled extensions due to
+    --      `OnOff` not being exported by ghc.
+    --
+    --      There is a MR to export it: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8817
+    --      but it's not going to be in all our supported releases.
     let disabledExts = EnumSet.toList
           $ EnumSet.difference (EnumSet.fromList (enumFrom minBound))
           (extensionFlags dflags)

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -333,11 +333,15 @@ getIdeas recorder nfp = do
 getExtensions :: NormalizedFilePath -> Action ([Extension], [Extension])
 getExtensions nfp = do
     dflags <- getFlags
-    let disabledExts = EnumSet.difference (EnumSet.fromList (enumFrom minBound)) (extensionFlags dflags)
+    -- XXX: we just assume that all not-enabled flags are disabled. this is
+    --      Kinda Sketchy!
+    let disabledExts = EnumSet.toList
+          $ EnumSet.difference (EnumSet.fromList (enumFrom minBound))
+          (extensionFlags dflags)
     let hscExts = EnumSet.toList (extensionFlags dflags)
-    let disabledExts' = EnumSet.toList disabledExts
+
     let hscExts' = toHlint hscExts
-    let notEnabled' = toHlint disabledExts'
+    let notEnabled' = toHlint disabledExts
     return (hscExts', notEnabled')
   where
     getFlags :: Action DynFlags

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -222,6 +222,12 @@ suggestionsTests =
         waitForAllProgressDone
         -- hlint will report a parse error if PatternSynonyms is enabled
         expectNoMoreDiagnostics 3 doc "hlint"
+    , testCase "hlint should not enable ForeignFunctionInterface if it is disabled" $ runHlintSession "labelkeyword" $ do
+        doc <- openDoc "LabelKeyword.hs" "haskell"
+
+        waitForAllProgressDone
+        -- hlint will report a parse error if ForeignFunctionInterface is enabled
+        expectNoMoreDiagnostics 3 doc "hlint"
     , testCase "hlint should not warn about redundant irrefutable pattern with LANGUAGE Strict" $ runHlintSession "" $ do
         doc <- openDoc "StrictData.hs" "haskell"
 

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -222,7 +222,9 @@ suggestionsTests =
         waitForAllProgressDone
         -- hlint will report a parse error if PatternSynonyms is enabled
         expectNoMoreDiagnostics 3 doc "hlint"
-    , testCase "hlint should not enable ForeignFunctionInterface if it is disabled" $ runHlintSession "labelkeyword" $ do
+    , onlyRunForGhcVersions (enumFrom GHC92) "uses OverloadedRecordDot" $
+            testCase "hlint should not enable ForeignFunctionInterface if it is disabled" $
+            runHlintSession "labelkeyword" $ do
         doc <- openDoc "LabelKeyword.hs" "haskell"
 
         waitForAllProgressDone

--- a/plugins/hls-hlint-plugin/test/testdata/labelkeyword/LabelKeyword.hs
+++ b/plugins/hls-hlint-plugin/test/testdata/labelkeyword/LabelKeyword.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+module Foo (Node(..)) where
+
+data Node = Node
+  {
+    label :: ()
+  }
+
+instance Semigroup Node where
+  n1 <> n2 = Node
+    { label = n1.label <> n2.label
+    }

--- a/plugins/hls-hlint-plugin/test/testdata/labelkeyword/LabelKeyword.hs
+++ b/plugins/hls-hlint-plugin/test/testdata/labelkeyword/LabelKeyword.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 module Foo (Node(..)) where
 
-data Node = Node
+newtype Node = Node
   {
     label :: ()
   }

--- a/plugins/hls-hlint-plugin/test/testdata/labelkeyword/hie.yaml
+++ b/plugins/hls-hlint-plugin/test/testdata/labelkeyword/hie.yaml
@@ -1,0 +1,5 @@
+cradle:
+  direct:
+    arguments:
+      - "-XNoForeignFunctionInterface"
+      - "LabelKeyword"


### PR DESCRIPTION
There is a lot of detail of the exact issue in #3095.

I assume that all the flags that are not enabled are disabled (the default flags have already been applied at this point; so this is probably actually true).

It seems to fix the issue but it is kind of a hack.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3096"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

