### PR TITLE
Do not send Heap Stats to the LSP log

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -64,12 +64,12 @@ main = do
               liftIO $ (cb1 <> cb2) env
           }
 
-    let (minPriority, logFilePath, includeExamplePlugins) =
+    let (argsTesting, minPriority, logFilePath, includeExamplePlugins) =
           case args of
             Ghcide GhcideArguments{ argsTesting, argsDebugOn, argsLogFile, argsExamplePlugin } ->
               let minPriority = if argsDebugOn || argsTesting then Debug else Info
-              in (minPriority, argsLogFile, argsExamplePlugin)
-            _ -> (Info, Nothing, False)
+              in (argsTesting, minPriority, argsLogFile, argsExamplePlugin)
+            _ -> (False, Info, Nothing, False)
 
     withDefaultRecorder logFilePath Nothing minPriority $ \textWithPriorityRecorder -> do
       let
@@ -85,7 +85,7 @@ main = do
                 & cmapWithPrio (renderStrict . layoutPretty defaultLayoutOptions . fst)
                 -- do not log heap stats to the LSP log as they interfere with the
                 -- ability of lsp-test to detect a stuck server in tests and benchmarks
-                & cfilter (not . heapStats . snd . payload)
+                & if argsTesting then cfilter (not . heapStats . snd . payload) else id
             ]
         plugins = (Plugins.idePlugins (cmapWithPrio LogPlugins recorder) includeExamplePlugins)
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -5,11 +5,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main(main) where
 
-import           Control.Arrow ((&&&))
+import           Control.Arrow                ((&&&))
 import           Control.Monad.IO.Class       (liftIO)
 import           Data.Function                ((&))
 import           Data.Text                    (Text)
-import qualified Development.IDE.Main           as GhcideMain
+import qualified Development.IDE.Main         as GhcideMain
 import           Development.IDE.Types.Logger (Doc,
                                                Priority (Debug, Error, Info),
                                                WithPriority (WithPriority, priority),
@@ -17,8 +17,8 @@ import           Development.IDE.Types.Logger (Doc,
                                                defaultLayoutOptions,
                                                layoutPretty,
                                                makeDefaultStderrRecorder,
-                                               renderStrict,
-                                               withDefaultRecorder, payload)
+                                               payload, renderStrict,
+                                               withDefaultRecorder)
 import qualified Development.IDE.Types.Logger as Logger
 import           Ide.Arguments                (Arguments (..),
                                                GhcideArguments (..),
@@ -105,4 +105,4 @@ issueTrackerUrl = "https://github.com/haskell/haskell-language-server/issues"
 
 heapStats :: Log -> Bool
 heapStats (LogIdeMain (IdeMain.LogIDEMain (GhcideMain.LogHeapStats _))) = True
-heapStats _ = False
+heapStats _                                                             = False

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -5,11 +5,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main(main) where
 
+import           Control.Arrow ((&&&))
 import           Control.Monad.IO.Class       (liftIO)
 import           Data.Function                ((&))
 import           Data.Text                    (Text)
 import qualified Development.IDE.Main           as GhcideMain
-import qualified Development.IDE.Main.HeapStats as HeapStats
 import           Development.IDE.Types.Logger (Doc,
                                                Priority (Debug, Error, Info),
                                                WithPriority (WithPriority, priority),
@@ -34,7 +34,6 @@ import           Language.LSP.Types           as LSP
 import qualified Plugins
 #if MIN_VERSION_prettyprinter(1,7,0)
 import           Prettyprinter                (Pretty (pretty), vsep)
-import Control.Arrow ((&&&))
 #else
 import           Data.Text.Prettyprint.Doc    (Pretty (pretty), vsep)
 #endif


### PR DESCRIPTION
It interferes with the ability of lsp-test to detect timeouts in e.g. benchmarks

The assumption is that logging them to stderr serves the purpose they
were designed for.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3111"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

