### PR TITLE
Deduplicate HLS plugins

### DIFF
--- a/exe/Plugins.hs
+++ b/exe/Plugins.hs
@@ -211,12 +211,8 @@ idePlugins recorder includeExamples = pluginDescToIdePlugins allPlugins
 #if hls_gadt
       GADT.descriptor "gadt" :
 #endif
-    -- The ghcide descriptors should come last so that the notification handlers
-    -- (which restart the Shake build) run after everything else
       GhcIde.descriptors pluginRecorder
 #if explicitFixity
-    -- Make this plugin has a lower priority than ghcide's plugin to ensure
-    -- type info display first.
       ++ [ExplicitFixity.descriptor pluginRecorder]
 #endif
     examplePlugins =

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -192,6 +192,7 @@ library
         Development.IDE.Monitoring.EKG
         Development.IDE.LSP.HoverDefinition
         Development.IDE.LSP.LanguageServer
+        Development.IDE.LSP.Notifications
         Development.IDE.LSP.Outline
         Development.IDE.LSP.Server
         Development.IDE.Session
@@ -225,7 +226,6 @@ library
         Development.IDE.Core.FileExists
         Development.IDE.GHC.CPP
         Development.IDE.GHC.Warnings
-        Development.IDE.LSP.Notifications
         Development.IDE.Plugin.CodeAction.PositionIndexed
         Development.IDE.Plugin.CodeAction.Args
         Development.IDE.Plugin.Completions.Logic

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -10,6 +10,7 @@ module Development.IDE.LSP.Notifications
     ( whenUriFile
     , descriptor
     , Log(..)
+    , ghcideNotificationsPluginPriority
     ) where
 
 import           Language.LSP.Types
@@ -38,6 +39,7 @@ import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger
 import           Development.IDE.Types.Shake           (toKey)
 import           Ide.Types
+import           Numeric.Natural
 
 data Log
   = LogShake Shake.Log
@@ -138,5 +140,12 @@ descriptor recorder plId = (defaultPluginDescriptor plId) { pluginNotificationHa
       success <- registerFileWatches globs
       unless success $
         liftIO $ logDebug (ideLogger ide) "Warning: Client does not support watched files. Falling back to OS polling"
-  ]
+  ],
+
+    -- The ghcide descriptors should come last'ish so that the notification handlers
+    -- (which restart the Shake build) run after everything else
+        pluginPriority = ghcideNotificationsPluginPriority
     }
+
+ghcideNotificationsPluginPriority :: Natural
+ghcideNotificationsPluginPriority = defaultPluginPriority - 900

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -122,7 +122,7 @@ import           Ide.Types                                (IdeCommand (IdeComman
                                                            IdePlugins,
                                                            PluginDescriptor (PluginDescriptor, pluginCli),
                                                            PluginId (PluginId),
-                                                           ipMap)
+                                                           ipMap, pluginId)
 import qualified Language.LSP.Server                      as LSP
 import qualified "list-t" ListT
 import           Numeric.Natural                          (Natural)
@@ -224,7 +224,7 @@ commandP plugins =
 
     pluginCommands = mconcat
         [ command (T.unpack pId) (Custom <$> p)
-        | (PluginId pId, PluginDescriptor{pluginCli = Just p}) <- ipMap plugins
+        | PluginDescriptor{pluginCli = Just p, pluginId = PluginId pId} <- ipMap plugins
         ]
 
 

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -5,6 +5,7 @@
 module Development.IDE.Plugin.Completions
     ( descriptor
     , Log(..)
+    , ghcideCompletionsPluginPriority
     ) where
 
 import           Control.Concurrent.Async                     (concurrently)
@@ -49,6 +50,7 @@ import           Ide.Types
 import qualified Language.LSP.Server                          as LSP
 import           Language.LSP.Types
 import qualified Language.LSP.VFS                             as VFS
+import           Numeric.Natural
 import           Text.Fuzzy.Parallel                          (Scored (..))
 
 data Log = LogShake Shake.Log deriving Show
@@ -57,12 +59,16 @@ instance Pretty Log where
   pretty = \case
     LogShake log -> pretty log
 
+ghcideCompletionsPluginPriority :: Natural
+ghcideCompletionsPluginPriority = defaultPluginPriority
+
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId = (defaultPluginDescriptor plId)
   { pluginRules = produceCompletions recorder
   , pluginHandlers = mkPluginHandler STextDocumentCompletion getCompletionsLSP
   , pluginCommands = [extendImportCommand]
   , pluginConfigDescriptor = defaultConfigDescriptor {configCustomConfig = mkCustomConfig properties}
+  , pluginPriority = ghcideCompletionsPluginPriority
   }
 
 produceCompletions :: Recorder (WithPriority Log) -> Rules ()

--- a/ghcide/src/Development/IDE/Plugin/HLS.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS.hs
@@ -13,7 +13,6 @@ import           Control.Exception            (SomeException)
 import           Control.Lens                 ((^.))
 import           Control.Monad
 import qualified Data.Aeson                   as J
-import           Data.Bifunctor
 import           Data.Dependent.Map           (DMap)
 import qualified Data.Dependent.Map           as DMap
 import           Data.Dependent.Sum
@@ -96,7 +95,7 @@ asGhcIdePlugin recorder (IdePlugins ls) =
 
         mkPlugin :: ([(PluginId, b)] -> Plugin Config) -> (PluginDescriptor IdeState -> b) -> Plugin Config
         mkPlugin maker selector =
-          case map (second selector) ls of
+          case map (\p -> (pluginId p, selector p)) ls of
             -- If there are no plugins that provide a descriptor, use mempty to
             -- create the plugin – otherwise we we end up declaring handlers for
             -- capabilities that there are no plugins for

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -290,7 +290,8 @@ initializeResponseTests = withResource acquire release tests where
             doTest = do
                 ir <- getInitializeResponse
                 let Just ExecuteCommandOptions {_commands = List commands} = getActual $ innerCaps ir
-                zipWithM_ (\e o -> T.isSuffixOf e o @? show (e,o)) expected commands
+                    commandNames = (!! 2) . T.splitOn ":" <$> commands
+                zipWithM_ (\e o -> T.isSuffixOf e o @? show (e,o)) (sort expected) (sort commandNames)
 
   innerCaps :: ResponseMessage Initialize -> ServerCapabilities
   innerCaps (ResponseMessage _ _ (Right (InitializeResult c _))) = c

--- a/hls-plugin-api/src/Ide/Plugin/ConfigUtils.hs
+++ b/hls-plugin-api/src/Ide/Plugin/ConfigUtils.hs
@@ -34,7 +34,7 @@ pluginsToDefaultConfig IdePlugins {..} =
   A.toJSON defaultConfig & ix "haskell" . _Object . at "plugin" ?~ elems
   where
     defaultConfig@Config {} = def
-    elems = A.object $ mconcat $ singlePlugin <$> map snd ipMap
+    elems = A.object $ mconcat $ singlePlugin <$> ipMap
     -- Splice genericDefaultConfig and dedicatedDefaultConfig
     -- Example:
     --
@@ -96,7 +96,7 @@ pluginsToDefaultConfig IdePlugins {..} =
 -- | Generates json schema used in haskell vscode extension
 -- Similar to 'pluginsToDefaultConfig' but simpler, since schema has a flatten structure
 pluginsToVSCodeExtensionSchema :: IdePlugins a -> A.Value
-pluginsToVSCodeExtensionSchema IdePlugins {..} = A.object $ mconcat $ singlePlugin <$> map snd ipMap
+pluginsToVSCodeExtensionSchema IdePlugins {..} = A.object $ mconcat $ singlePlugin <$> ipMap
   where
     singlePlugin PluginDescriptor {pluginConfigDescriptor = ConfigDescriptor {..}, ..} = genericSchema <> dedicatedSchema
       where

--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -36,6 +36,7 @@ module Ide.PluginUtils
 where
 
 
+import           Control.Arrow                   ((&&&))
 import           Control.Monad.Extra             (maybeM)
 import           Control.Monad.Trans.Class       (lift)
 import           Control.Monad.Trans.Except      (ExceptT, runExceptT, throwE)
@@ -224,15 +225,8 @@ positionInRange p (Range sp ep) = sp <= p && p < ep -- Range's end position is e
 -- ---------------------------------------------------------------------
 
 allLspCmdIds' :: T.Text -> IdePlugins ideState -> [T.Text]
-allLspCmdIds' pid (IdePlugins ls) = mkPlugin (allLspCmdIds pid) (Just . pluginCommands)
-    where
-        justs (p, Just x)  = [(p, x)]
-        justs (_, Nothing) = []
-
-
-        mkPlugin maker selector
-            = maker $ concatMap (\p -> justs (pluginId p, selector p)) ls
-
+allLspCmdIds' pid (IdePlugins ls) =
+    allLspCmdIds pid $ map (pluginId &&& pluginCommands) ls
 
 allLspCmdIds :: T.Text -> [(PluginId, [PluginCommand ideState])] -> [T.Text]
 allLspCmdIds pid commands = concatMap go commands

--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -42,7 +42,6 @@ import           Control.Monad.Trans.Except      (ExceptT, runExceptT, throwE)
 import           Data.Algorithm.Diff
 import           Data.Algorithm.DiffOutput
 import           Data.Bifunctor                  (Bifunctor (first))
-import           Data.Containers.ListUtils       (nubOrdOn)
 import qualified Data.HashMap.Strict             as H
 import           Data.String                     (IsString (fromString))
 import qualified Data.Text                       as T
@@ -159,11 +158,10 @@ clientSupportsDocumentChanges caps =
 -- ---------------------------------------------------------------------
 
 pluginDescToIdePlugins :: [PluginDescriptor ideState] -> IdePlugins ideState
-pluginDescToIdePlugins plugins =
-    IdePlugins $ map (\p -> (pluginId p, p)) $ nubOrdOn pluginId plugins
+pluginDescToIdePlugins = IdePlugins
 
 idePluginsToPluginDesc :: IdePlugins ideState -> [PluginDescriptor ideState]
-idePluginsToPluginDesc (IdePlugins pp) = map snd pp
+idePluginsToPluginDesc (IdePlugins pp) = pp
 
 -- ---------------------------------------------------------------------
 -- | Returns the current client configuration. It is not wise to permanently
@@ -233,7 +231,7 @@ allLspCmdIds' pid (IdePlugins ls) = mkPlugin (allLspCmdIds pid) (Just . pluginCo
 
 
         mkPlugin maker selector
-            = maker $ concatMap (\(pid, p) -> justs (pid, selector p)) ls
+            = maker $ concatMap (\p -> justs (pluginId p, selector p)) ls
 
 
 allLspCmdIds :: T.Text -> [(PluginId, [PluginCommand ideState])] -> [T.Text]

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -61,7 +61,7 @@ import           Data.Dependent.Map              (DMap)
 import qualified Data.Dependent.Map              as DMap
 import qualified Data.DList                      as DList
 import           Data.GADT.Compare
-import           Data.List.Extra (nubOrdOn)
+import           Data.List.Extra                 (nubOrdOn)
 import           Data.List.NonEmpty              (NonEmpty (..), toList)
 import qualified Data.Map                        as Map
 import           Data.Maybe

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -55,6 +55,7 @@ import           Control.Monad                   (void)
 import qualified System.Posix.Process            as P (getProcessID)
 import           System.Posix.Signals
 #endif
+import           Control.Arrow                   ((&&&))
 import           Control.Lens                    ((^.))
 import           Data.Aeson                      hiding (defaultOptions)
 import qualified Data.Default
@@ -112,10 +113,10 @@ newtype IdePlugins ideState = IdePlugins_ { ipMap_ :: HashMap PluginId (PluginDe
   deriving newtype (Semigroup, Monoid)
 
 -- | Smart constructor that deduplicates plugins
-pattern IdePlugins :: [(PluginId, PluginDescriptor ideState)] -> IdePlugins ideState
-pattern IdePlugins{ipMap} <- IdePlugins_ (sortOn (Down . pluginPriority . snd) . HashMap.toList -> ipMap)
+pattern IdePlugins :: [PluginDescriptor ideState] -> IdePlugins ideState
+pattern IdePlugins{ipMap} <- IdePlugins_ (sortOn (Down . pluginPriority) . HashMap.elems -> ipMap)
   where
-    IdePlugins ipMap = IdePlugins_{ipMap_ = HashMap.fromList ipMap}
+    IdePlugins ipMap = IdePlugins_{ipMap_ = HashMap.fromList $ (pluginId &&& id) <$> ipMap}
 {-# COMPLETE IdePlugins #-}
 
 -- | Hooks for modifying the 'DynFlags' at different times of the compilation

--- a/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
+++ b/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
@@ -28,6 +28,7 @@ import qualified Development.IDE.Core.Shake           as Shake
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.Util      (FastString)
 import qualified Development.IDE.GHC.Compat.Util      as Util
+import           Development.IDE.LSP.Notifications    (ghcideNotificationsPluginPriority)
 import           GHC.Generics                         (Generic)
 import           Ide.PluginUtils                      (getNormalizedFilePath,
                                                        handleMaybeM,
@@ -42,6 +43,9 @@ descriptor :: Recorder (WithPriority Log) -> PluginDescriptor IdeState
 descriptor recorder = (defaultPluginDescriptor pluginId)
     { pluginRules = fixityRule recorder
     , pluginHandlers = mkPluginHandler STextDocumentHover hover
+    -- Make this plugin has a lower priority than ghcide's plugin to ensure
+    -- type info display first.
+    , pluginPriority = ghcideNotificationsPluginPriority - 1
     }
 
 hover :: PluginMethodHandler IdeState TextDocumentHover

--- a/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
@@ -14,21 +14,22 @@ module Ide.Plugin.Pragmas
   , validPragmas
   ) where
 
-import           Control.Lens                  hiding (List)
-import           Control.Monad.IO.Class        (MonadIO (liftIO))
-import qualified Data.HashMap.Strict           as H
-import           Data.List.Extra               (nubOrdOn)
-import           Data.Maybe                    (catMaybes)
-import qualified Data.Text                     as T
+import           Control.Lens                       hiding (List)
+import           Control.Monad.IO.Class             (MonadIO (liftIO))
+import qualified Data.HashMap.Strict                as H
+import           Data.List.Extra                    (nubOrdOn)
+import           Data.Maybe                         (catMaybes)
+import qualified Data.Text                          as T
 import           Development.IDE
 import           Development.IDE.GHC.Compat
-import qualified Development.IDE.Spans.Pragmas as Pragmas
+import           Development.IDE.Plugin.Completions (ghcideCompletionsPluginPriority)
+import qualified Development.IDE.Spans.Pragmas      as Pragmas
 import           Ide.Types
-import qualified Language.LSP.Server           as LSP
-import qualified Language.LSP.Types            as J
-import qualified Language.LSP.Types.Lens       as J
-import qualified Language.LSP.VFS              as VFS
-import qualified Text.Fuzzy                    as Fuzzy
+import qualified Language.LSP.Server                as LSP
+import qualified Language.LSP.Types                 as J
+import qualified Language.LSP.Types.Lens            as J
+import qualified Language.LSP.VFS                   as VFS
+import qualified Text.Fuzzy                         as Fuzzy
 
 -- ---------------------------------------------------------------------
 
@@ -36,6 +37,7 @@ descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId = (defaultPluginDescriptor plId)
   { pluginHandlers = mkPluginHandler J.STextDocumentCodeAction codeActionProvider
                   <> mkPluginHandler J.STextDocumentCompletion completion
+  , pluginPriority = ghcideCompletionsPluginPriority + 1
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -32,7 +32,7 @@ import           Ide.Arguments
 import           Ide.Plugin.ConfigUtils        (pluginsToDefaultConfig,
                                                 pluginsToVSCodeExtensionSchema)
 import           Ide.Types                     (IdePlugins, PluginId (PluginId),
-                                                ipMap)
+                                                ipMap, pluginId)
 import           Ide.Version
 import           System.Directory
 import qualified System.Directory.Extra        as IO
@@ -80,7 +80,7 @@ defaultMain recorder args idePlugins = do
 
         ListPluginsMode -> do
             let pluginNames = sort
-                    $ map ((\(PluginId t) -> T.unpack t) . fst)
+                    $ map ((\(PluginId t) -> T.unpack t) . pluginId)
                     $ ipMap idePlugins
             mapM_ putStrLn pluginNames
 
@@ -118,7 +118,7 @@ runLspMode recorder ghcideArgs@GhcideArguments{..} idePlugins = withTelemetryLog
     log Info $ LogDirectory dir
 
     when (isLSP argsCommand) $ do
-        log Info $ LogLspStart ghcideArgs (map fst $ ipMap idePlugins)
+        log Info $ LogLspStart ghcideArgs (map pluginId $ ipMap idePlugins)
 
     -- exists so old-style logging works. intended to be phased out
     let logger = Logger $ \p m -> logger_ recorder (WithPriority p emptyCallStack $ LogOther m)

--- a/test/functional/Format.hs
+++ b/test/functional/Format.hs
@@ -47,7 +47,10 @@ providerTests = testGroup "formatting provider" [
     testCase "respects none" $ runSessionWithConfig (formatConfig "none") hlsCommand fullCaps "test/testdata/format" $ do
         doc <- openDoc "Format.hs" "haskell"
         resp <- request STextDocumentFormatting $ DocumentFormattingParams Nothing doc (FormattingOptions 2 True Nothing Nothing Nothing)
-        liftIO $ resp ^. LSP.result @?= Left (ResponseError InvalidRequest "No plugin enabled for STextDocumentFormatting, available:\nPluginId \"floskell\"\nPluginId \"fourmolu\"\nPluginId \"ormolu\"\nPluginId \"stylish-haskell\"\nPluginId \"brittany\"\n" Nothing)
+        liftIO $ resp ^. LSP.result @?= Left (ResponseError InvalidRequest
+            ("No plugin enabled for STextDocumentFormatting, available:\n"
+            <> "PluginId \"floskell\"\nPluginId \"fourmolu\"\nPluginId \"stylish-haskell\"\nPluginId \"brittany\"\nPluginId \"ormolu\"\n")
+            Nothing)
 
     , requiresOrmoluPlugin . requiresFloskellPlugin $ testCase "can change on the fly" $ runSession hlsCommand fullCaps "test/testdata/format" $ do
         formattedOrmolu <- liftIO $ T.readFile "test/testdata/format/Format.ormolu.formatted.hs"


### PR DESCRIPTION
Use a smart constructor to prevent duplicated plugins. We cannot use a
set since order matters for plugin execution.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3112"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

