### PR TITLE
Do not collect Hlint diagnostics when plugin is disabled

### DIFF
--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -209,8 +209,11 @@ rules recorder plugin = do
     liftIO $ argsSettings flags
 
   action $ do
-    files <- getFilesOfInterestUntracked
-    void $ uses GetHlintDiagnostics $ Map.keys files
+    config <- getClientConfigAction def
+    let hlintOn = pluginEnabledConfig plcDiagnosticsOn plugin config
+    when hlintOn $ do
+        files <- getFilesOfInterestUntracked
+        void $ uses GetHlintDiagnostics $ Map.keys files
 
   where
 


### PR DESCRIPTION
Fixes an oversight since actions in build rules are not implicitly gated in the same way that plugin handlers are.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3116"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

