### PR TITLE
Add link to homepage and issues for `hie-compat`

### DIFF
--- a/hie-compat/hie-compat.cabal
+++ b/hie-compat/hie-compat.cabal
@@ -14,6 +14,8 @@ maintainer:          zubin.duggal@gmail.com
 build-type:          Simple
 extra-source-files:  CHANGELOG.md README.md
 category:            Development
+homepage:            https://github.com/haskell/haskell-language-server/tree/master/hie-compat#readme
+bug-reports:         https://github.com/haskell/haskell-language-server/issues
 
 flag ghc-lib
   description: build against ghc-lib instead of the ghc package


### PR DESCRIPTION
I had a build failure locally trying to get GHC 9.4 going with our project, and had a very odd error for `hie-compat`. Missing these links made it harder to figure out how to diagnose and report this.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

