### PR TITLE
flake.nix Add ghcide-bench to sourceDirs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,7 @@
           sourceDirs = {
             haskell-language-server = ./.;
             ghcide = ./ghcide;
+            ghcide-bench = ./ghcide-bench;
             hls-graph = ./hls-graph;
             shake-bench = ./shake-bench;
             hie-compat = ./hie-compat;


### PR DESCRIPTION
This is required for nix-based dev shells to work.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3125"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

