### PR TITLE
Enable support for 9.4 on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,9 @@ jobs:
              ghc: '8.6.5'
              test: true
            - os: windows-latest
+             ghc: '9.4.2'
+             test: true
+           - os: windows-latest
              ghc: '9.2.4'
              test: true
            - os: windows-latest

--- a/cabal.project
+++ b/cabal.project
@@ -51,6 +51,7 @@ write-ghc-environment-files: never
 index-state: 2022-08-15T06:53:13Z
 
 constraints:
+  entropy == 0.4.1.10,
   hyphenation +embed,
   -- remove this when hlint sets ghc-lib to true by default
   -- https://github.com/ndmitchell/hlint/issues/1376

--- a/cabal.project
+++ b/cabal.project
@@ -51,7 +51,9 @@ write-ghc-environment-files: never
 index-state: 2022-08-29T06:53:13Z
 
 constraints:
+  -- For GHC 9.4, older versions of entropy fail to build on Windows
   entropy >= 0.4.1.10,
+  -- For GHC 9.4
   basement >= 0.0.15,
   hyphenation +embed,
   -- remove this when hlint sets ghc-lib to true by default

--- a/cabal.project
+++ b/cabal.project
@@ -48,10 +48,11 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-08-15T06:53:13Z
+index-state: 2022-08-29T06:53:13Z
 
 constraints:
-  entropy == 0.4.1.10,
+  entropy >= 0.4.1.10,
+  basement >= 0.0.15,
   hyphenation +embed,
   -- remove this when hlint sets ghc-lib to true by default
   -- https://github.com/ndmitchell/hlint/issues/1376
@@ -87,8 +88,28 @@ source-repository-package
   -- https://github.com/haskell/lsp/pull/450
 
 allow-newer:
-  base, ghc-prim, ghc-bignum, ghc, Cabal, binary, bytestring, unix, time, template-haskell,
+  -- ghc-9.4
+  Chart-diagrams:lens,
+  Chart:lens,
+  co-log-core:base,
+  constraints-extras:base,
+  constraints-extras:template-haskell,
+  dependent-sum:some,
+  diagrams-contrib:base,
+  diagrams-contrib:lens,
+  diagrams-postscript:base,
+  diagrams-postscript:lens,
+  diagrams-svg:base,
+  diagrams-svg:lens,
   ghc-paths:Cabal,
+  haddock-library:base,
+  hie-bios:aeson,
+  hie-bios:ghc,
+  monoid-extras:base,
+  monoid-subclasses:vector,
+  svg-builder:base,
+  uuid:time,
+  vector-space:base,
 
   -- ghc-9.2
   ----------

--- a/cabal.project
+++ b/cabal.project
@@ -101,6 +101,7 @@ allow-newer:
   diagrams-postscript:lens,
   diagrams-svg:base,
   diagrams-svg:lens,
+  ekg-json:base,
   ghc-paths:Cabal,
   haddock-library:base,
   hie-bios:aeson,

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -349,7 +349,6 @@ test-suite ghcide-tests
         ghc,
         --------------------------------------------------------------
         ghcide,
-        ghcide-test-utils-internal,
         lsp,
         lsp-types,
         hls-plugin-api,
@@ -379,7 +378,7 @@ test-suite ghcide-tests
           record-hasfield
     if impl(ghc < 9.3)
        build-depends:  ghc-typelits-knownnat
-    hs-source-dirs: test/cabal test/exe bench/lib
+    hs-source-dirs: test/cabal test/exe test/src bench/lib
     ghc-options: -threaded -Wall -Wno-name-shadowing -O0 -Wno-unticked-promoted-constructors
     main-is: Main.hs
     other-modules:
@@ -387,42 +386,6 @@ test-suite ghcide-tests
         FuzzySearch
         Progress
         HieDbRetry
-    default-extensions:
-        BangPatterns
-        DeriveFunctor
-        DeriveGeneric
-        FlexibleContexts
-        GeneralizedNewtypeDeriving
-        LambdaCase
-        NamedFieldPuns
-        OverloadedStrings
-        RecordWildCards
-        ScopedTypeVariables
-        StandaloneDeriving
-        TupleSections
-        TypeApplications
-        ViewPatterns
-
-library ghcide-test-utils-internal
-    default-language: Haskell2010
-    build-depends:
-        aeson,
-        base,
-        containers,
-        data-default,
-        directory,
-        extra,
-        filepath,
-        ghcide,
-        lsp-types,
-        hls-plugin-api,
-        lens,
-        lsp-test ^>= 0.14,
-        tasty-hunit >= 0.10,
-        text,
-    hs-source-dirs: test/src
-    ghc-options: -Wunused-packages
-    exposed-modules:
         Development.IDE.Test
         Development.IDE.Test.Diagnostic
     default-extensions:

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -2002,7 +2002,7 @@ completionDocTests =
   ]
   where
     brokenForGhc9 = knownBrokenFor (BrokenForGHC [GHC90, GHC92, GHC94]) "Completion doc doesn't support ghc9"
-    brokenForWinGhc9 = knownBrokenFor (BrokenSpecific Windows [GHC90, GHC92, GHC94]) "Extern doc doesn't support Windows for ghc9.2"
+    brokenForWinGhc9 = knownBrokenFor (BrokenSpecific Windows [GHC90, GHC92]) "Extern doc doesn't support Windows for ghc9.2"
     -- https://gitlab.haskell.org/ghc/ghc/-/issues/20903
     brokenForMacGhc9 = knownBrokenFor (BrokenSpecific MacOS [GHC90, GHC92, GHC94]) "Extern doc doesn't support MacOS for ghc9"
     test doc pos label mn expected = do

--- a/hie-compat/hie-compat.cabal
+++ b/hie-compat/hie-compat.cabal
@@ -25,7 +25,7 @@ flag ghc-lib
 library
   default-language:    Haskell2010
   build-depends:
-     base < 4.17, array, bytestring, containers, directory, filepath, transformers
+     base < 4.18, array, bytestring, containers, directory, filepath, transformers
   if flag(ghc-lib) && impl(ghc < 9)
     build-depends: ghc-lib < 9.0
   else


### PR DESCRIPTION
- Revert "drop windows for 9.4.2"
- Fix entropy to 0.4.1.10 to fix build on windows


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3132"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

