### PR TITLE
nix: fix nix environment for GHC 9.4

### DIFF
--- a/configuration-ghc-90.nix
+++ b/configuration-ghc-90.nix
@@ -23,7 +23,7 @@ let
       ghc-lib-parser-ex = hself.ghc-lib-parser-ex_9_2_0_4;
 
       Cabal = hself.Cabal_3_6_3_0;
-      ormolu = hself.ormolu_0_5_0_0;
+      ormolu = hself.ormolu_0_5_0_1;
       fourmolu = hself.fourmolu_0_6_0_0;
       # Hlint is still broken
       hlint = doJailbreak (hself.callCabal2nix "hlint" inputs.hlint-34 { });

--- a/configuration-ghc-94.nix
+++ b/configuration-ghc-94.nix
@@ -31,6 +31,19 @@ let
 
       stylish-haskell = appendConfigureFlag  hsuper.stylish-haskell "-fghc-lib";
 
+      cereal = hsuper.callHackage "cereal" "0.5.8.3" {};
+      base-compat = hsuper.callHackage "base-compat" "0.12.2" {};
+      base-compat-batteries = hsuper.callHackage "base-compat-batteries" "0.12.2" {};
+      hashable = hsuper.callHackage "hashable" "1.4.1.0" {};
+      primitive = hsuper.callHackage "primitive" "0.7.4.0" {};
+      ghc-check = hsuper.callHackage "ghc-check" "0.5.0.8" {};
+      lens = hsuper.callHackage "lens" "5.2" {};
+      integer-logarithms = hsuper.callHackage "integer-logarithms" "1.0.3.1" {};
+      hiedb = hsuper.callHackage "hiedb" "0.4.2.0" {};
+      hie-bios = hsuper.callHackage "hie-bios" "0.11.0" {};
+      lsp = hsuper.callCabal2nix "lsp" "${inputs.lsp}/lsp" {};
+      lsp-types = hsuper.callCabal2nix "lsp-types" "${inputs.lsp}/lsp-types" {};
+
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =
         hself.callCabal2nixWithOptions "haskell-language-server" ./.

--- a/flake.lock
+++ b/flake.lock
@@ -12,6 +12,23 @@
         "url": "https://hackage.haskell.org/package/aeson-1.5.2.0/aeson-1.5.2.0.tar.gz"
       }
     },
+    "all-cabal-hashes-unpacked": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1663164766,
+        "narHash": "sha256-7ypfdEzJwfaQMQx9HV8B+r9BV7bN6iIO0lWhDy+8+0k=",
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "ed701f5e64ece3e57efa4227243f9fb64f935253",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commercialhaskell",
+        "ref": "current-hackage",
+        "repo": "all-cabal-hashes",
+        "type": "github"
+      }
+    },
     "brittany-01312": {
       "flake": false,
       "locked": {
@@ -54,11 +71,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -69,11 +86,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -133,11 +150,11 @@
     "gitignore": {
       "flake": false,
       "locked": {
-        "lastModified": 1657706534,
-        "narHash": "sha256-5jIzNHKtDu06mA325K/5CshUVb5r7sSmnRiula6Gr7o=",
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "f840a659d57e53fa751a9248b17149fd0cf2a221",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
         "type": "github"
       },
       "original": {
@@ -149,13 +166,13 @@
     "hie-bios": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-5RqspT27rb/tMBwrKr4VfSSbq0+c0LMNuaKlTun0Kkk=",
+        "narHash": "sha256-KLAg++tO9lCOn7R/cSN2wLbrhpeBOOmeTEh7auIbUNk=",
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hie-bios-0.9.1/hie-bios-0.9.1.tar.gz"
+        "url": "https://hackage.haskell.org/package/hie-bios-0.11.0/hie-bios-0.11.0.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hie-bios-0.9.1/hie-bios-0.9.1.tar.gz"
+        "url": "https://hackage.haskell.org/package/hie-bios-0.11.0/hie-bios-0.11.0.tar.gz"
       }
     },
     "hlint": {
@@ -197,13 +214,18 @@
     "lsp": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-+rkFYvSAI1hyFxPkgWZReyM2P6irVDpGVUGK8mcfEJE=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-1.5.0.0/lsp-1.5.0.0.tar.gz"
+        "lastModified": 1662291729,
+        "narHash": "sha256-KlL38v/75G9zrW7+IiUeiCxFfLJGm/EdFeWQRUikab8=",
+        "owner": "haskell",
+        "repo": "lsp",
+        "rev": "b0f8596887088b8ab65fc1015c773f45b47234ae",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-1.5.0.0/lsp-1.5.0.0.tar.gz"
+        "owner": "haskell",
+        "repo": "lsp",
+        "rev": "b0f8596887088b8ab65fc1015c773f45b47234ae",
+        "type": "github"
       }
     },
     "lsp-test": {
@@ -216,18 +238,6 @@
       "original": {
         "type": "tarball",
         "url": "https://hackage.haskell.org/package/lsp-test-0.14.0.3/lsp-test-0.14.0.3.tar.gz"
-      }
-    },
-    "lsp-types": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-q4XTvIvsLvISjgedpRktJbWsWHSRIQbOx2Z/2u+3s50=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-types-1.5.0.0/lsp-types-1.5.0.0.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/lsp-types-1.5.0.0/lsp-types-1.5.0.0.tar.gz"
       }
     },
     "myst-parser": {
@@ -249,11 +259,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659782844,
-        "narHash": "sha256-tM/qhHFE61puBxh9ebP3BIG1fkRAT4rHqD3jCM0HXGY=",
+        "lastModified": 1663112159,
+        "narHash": "sha256-31rjPhB6Hj1QoqLvFSULFf9Z/6z05vR0KrLGYvr9w0M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c85e56bb060291eac3fb3c75d4e0e64f6836fcfe",
+        "rev": "78bce1608960b994405f3696ba086ba1d63654e9",
         "type": "github"
       },
       "original": {
@@ -265,11 +275,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1657888067,
-        "narHash": "sha256-GnwJoFBTPfW3+mz7QEeJEEQ9OMHZOiIJ/qDhZxrlKh8=",
+        "lastModified": 1663165252,
+        "narHash": "sha256-H9OiflDQy1vLu1w5yz46qWfGdcFBpS8VnPRLP0bsiZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "65fae659e31098ca4ac825a6fef26d890aaf3f4e",
+        "rev": "bde85b0815144b77763732e0f32918017480e6b5",
         "type": "github"
       },
       "original": {
@@ -284,11 +294,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1657626303,
-        "narHash": "sha256-O/JJ0hSBCmlx0oP8QGAlRrWn0BvlC5cj7/EZ0CCWHTU=",
+        "lastModified": 1662879385,
+        "narHash": "sha256-ZmiyHn0uPH4xHYcOhY0e0sPtfyM6jCF/shmVq2aTOLc=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "920ba682377d5c0d87945c5eb6141ab8447ca509",
+        "rev": "4f8d61cd936f853242a4ce1fd476f5488c288c26",
         "type": "github"
       },
       "original": {
@@ -325,6 +335,7 @@
     "root": {
       "inputs": {
         "aeson-1520": "aeson-1520",
+        "all-cabal-hashes-unpacked": "all-cabal-hashes-unpacked",
         "brittany-01312": "brittany-01312",
         "constraints-extras": "constraints-extras",
         "flake-compat": "flake-compat",
@@ -340,7 +351,6 @@
         "implicit-hie-cradle": "implicit-hie-cradle",
         "lsp": "lsp",
         "lsp-test": "lsp-test",
-        "lsp-types": "lsp-types",
         "myst-parser": "myst-parser",
         "nixpkgs": "nixpkgs",
         "poetry2nix": "poetry2nix",

--- a/flake.nix
+++ b/flake.nix
@@ -19,13 +19,16 @@
       flake = false;
     };
 
-    # List of hackage dependencies
-    lsp = {
-      url = "https://hackage.haskell.org/package/lsp-1.6.0.0/lsp-1.6.0.0.tar.gz";
+    # cabal hashes contains all the version for different haskell packages, to update:
+    # nix flake lock --update-input all-cabal-hashes-unpacked
+    all-cabal-hashes-unpacked = {
+      url = "github:commercialhaskell/all-cabal-hashes/current-hackage";
       flake = false;
     };
-    lsp-types = {
-      url = "https://hackage.haskell.org/package/lsp-types-1.6.0.0/lsp-types-1.6.0.0.tar.gz";
+
+    # List of hackage dependencies
+    lsp = {
+      url = "github:haskell/lsp/b0f8596887088b8ab65fc1015c773f45b47234ae";
       flake = false;
     };
     lsp-test = {
@@ -100,7 +103,7 @@
     poetry2nix.url = "github:nix-community/poetry2nix/master";
   };
   outputs =
-    inputs@{ self, nixpkgs, flake-compat, flake-utils, gitignore, ... }:
+    inputs@{ self, nixpkgs, flake-compat, flake-utils, gitignore, all-cabal-hashes-unpacked, ... }:
     {
       overlays.default = final: prev:
         with prev;
@@ -156,8 +159,8 @@
               # GHCIDE requires hie-bios ^>=0.9.1
               hie-bios = hself.callCabal2nix "hie-bios" inputs.hie-bios {};
 
-              lsp = hsuper.callCabal2nix "lsp" inputs.lsp {};
-              lsp-types = hsuper.callCabal2nix "lsp-types" inputs.lsp-types {};
+              lsp = hsuper.callCabal2nix "lsp" "${inputs.lsp}/lsp" {};
+              lsp-types = hsuper.callCabal2nix "lsp-types" "${inputs.lsp}/lsp-types" {};
               lsp-test = hsuper.callCabal2nix "lsp-test" inputs.lsp-test {};
 
               implicit-hie-cradle = hself.callCabal2nix "implicit-hie-cradle" inputs.implicit-hie-cradle {};
@@ -185,6 +188,14 @@
 
         in {
           inherit hlsSources;
+
+          all-cabal-hashes = prev.runCommand "all-cabal-hashes.tar.gz"
+            { }
+            ''
+              cd ${all-cabal-hashes-unpacked}
+              cd ..
+              tar czf $out $(basename ${all-cabal-hashes-unpacked})
+            '';
 
           # Haskell packages extended with our packages
           hlsHpkgs = compiler: extended haskell.packages.${compiler};
@@ -216,7 +227,7 @@
 
         ghc902Config = (import ./configuration-ghc-90.nix) { inherit pkgs inputs; };
         ghc924Config = (import ./configuration-ghc-92.nix) { inherit pkgs inputs; };
-        ghc941Config = (import ./configuration-ghc-94.nix) { inherit pkgs inputs; };
+        ghc942Config = (import ./configuration-ghc-94.nix) { inherit pkgs inputs; };
 
         # GHC versions
         # While HLS still works fine with 8.10 GHCs, we only support the versions that are cached
@@ -226,13 +237,13 @@
           cases = {
             ghc902 = ghc902Config.tweakHpkgs (pkgs.hlsHpkgs "ghc902");
             ghc924 = ghc924Config.tweakHpkgs (pkgs.hlsHpkgs "ghc924");
-            ghc941 = ghc941Config.tweakHpkgs (pkgs.hlsHpkgs "ghc941");
+            ghc942 = ghc942Config.tweakHpkgs (pkgs.hlsHpkgs "ghc942");
           };
           in { default = cases."${ghcVersion}"; } // cases;
 
         ghc902 = supportedGHCs.ghc902;
         ghc924 = supportedGHCs.ghc924;
-        ghc941 = supportedGHCs.ghc941;
+        ghc942 = supportedGHCs.ghc942;
         ghcDefault = supportedGHCs.default;
 
         # For markdown support
@@ -282,16 +293,16 @@
             hpkgs.ghc
             pkgs.cabal-install
             # @guibou: I'm not sure hie-bios is needed
-            ghcDefault.hie-bios
+            pkgs.haskellPackages.hie-bios
             # Dependencies needed to build some parts of hackage
             gmp zlib ncurses
             # Changelog tooling
-            (gen-hls-changelogs ghcDefault)
+            (gen-hls-changelogs pkgs.haskellPackages)
             # For the documentation
             pythonWithPackages
             # @guibou: I'm not sure this is needed.
             hlint
-            ghcDefault.opentelemetry-extra
+            pkgs.haskellPackages.opentelemetry-extra
             capstone tracy
             # ormolu
             # stylish-haskell
@@ -345,7 +356,7 @@
             src = null;
           };
         # Create a hls executable
-        # Copied from https://github.com/NixOS/nixpkgs/blob/210784b7c8f3d926b7db73bdad085f4dc5d79418/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix#L16
+        # Copied from https://github.com/NixOS/nixpkgs/blob/210784b7c8f3d926b7db73bdad085f4dc5d79428/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix#L16
         mkExe = hpkgs:
           with pkgs.haskell.lib;
           (enableSharedExecutables (overrideCabal hpkgs.haskell-language-server
@@ -365,7 +376,7 @@
           haskell-language-server-dev = mkDevShell ghcDefault "cabal.project";
           haskell-language-server-902-dev = mkDevShell ghc902 "cabal.project";
           haskell-language-server-924-dev = mkDevShell ghc924 "cabal.project";
-          haskell-language-server-941-dev = mkDevShell ghc941 "cabal.project";
+          haskell-language-server-942-dev = mkDevShell ghc942 "cabal.project";
         };
 
         # Developement shell, haskell packages are also provided by nix
@@ -373,14 +384,14 @@
           haskell-language-server-dev-nix = mkDevShellWithNixDeps ghcDefault "cabal.project";
           haskell-language-server-902-dev-nix = mkDevShellWithNixDeps ghc902 "cabal.project";
           haskell-language-server-924-dev-nix = mkDevShellWithNixDeps ghc924 "cabal.project";
-          haskell-language-server-941-dev-nix = mkDevShellWithNixDeps ghc941 "cabal.project";
+          haskell-language-server-942-dev-nix = mkDevShellWithNixDeps ghc942 "cabal.project";
         };
 
         allPackages = {
           haskell-language-server = mkExe ghcDefault;
           haskell-language-server-902 = mkExe ghc902;
           haskell-language-server-924 = mkExe ghc924;
-          haskell-language-server-941 = mkExe ghc941;
+          haskell-language-server-942 = mkExe ghc942;
         };
 
         devShells = simpleDevShells // nixDevShells // {


### PR DESCRIPTION
This is a work in progress, I'm trying to restore the build with nix.

- [X] restore `nix develop .\#haskell-language-server-941-dev` (light environment which provides cabal + ghc)
- [x] restore the build of all hackages dependencies with nix.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3133"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

