### PR TITLE
Change Type Signature Plugin buildable with 9.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,7 +252,7 @@ jobs:
         name: Test hls-code-range-plugin test suite
         run: cabal test hls-code-range-plugin --test-options="$TEST_OPTS" || cabal test hls-code-range-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-code-range-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test
         name: Test hls-change-type-signature test suite
         run: cabal test hls-change-type-signature-plugin --test-options="$TEST_OPTS" || cabal test hls-change-type-signature-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-change-type-signature-plugin --test-options="$TEST_OPTS"
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -324,7 +324,7 @@ common codeRange
     cpp-options: -Dhls_codeRange
 
 common changeTypeSignature
-  if flag(changeTypeSignature) && (impl(ghc < 9.4.1) || flag(ignore-plugins-ghc-bounds))
+  if flag(changeTypeSignature)
     build-depends: hls-change-type-signature-plugin ^>= 1.0
     cpp-options: -Dhls_changeTypeSignature
 

--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-change-type-signature-plugin
-version:            1.0.1.0
+version:            1.0.1.1
 synopsis:           Change a declarations type signature with a Code Action
 description:
   Please see the README on GitHub at <https://github.com/haskell/plugins/hls-change-type-signature-plugin/README.md>
@@ -19,10 +19,7 @@ extra-source-files:
   test/testdata/*.yaml
 
 library
-  if impl(ghc >= 9.3)
-    buildable: False
-  else
-    buildable: True
+  buildable: True
   exposed-modules:  Ide.Plugin.ChangeTypeSignature
   hs-source-dirs:   src
   build-depends:
@@ -50,10 +47,7 @@ library
 
 
 test-suite tests
-  if impl(ghc >= 9.3)
-    buildable: False
-  else
-    buildable: True
+  buildable: True
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test

--- a/plugins/hls-change-type-signature-plugin/test/Main.hs
+++ b/plugins/hls-change-type-signature-plugin/test/Main.hs
@@ -9,7 +9,7 @@ import           Ide.Plugin.ChangeTypeSignature (errorMessageRegexes)
 import qualified Ide.Plugin.ChangeTypeSignature as ChangeTypeSignature
 import           System.FilePath                ((<.>), (</>))
 import           Test.Hls                       (CodeAction (..), Command,
-                                                 GhcVersion (GHC92), IdeState,
+                                                 GhcVersion (..), IdeState,
                                                  PluginDescriptor,
                                                  Position (Position),
                                                  Range (Range), Session,
@@ -38,7 +38,8 @@ test :: TestTree
 test = testGroup "changeTypeSignature" [
         testRegexes
         , codeActionTest "TExpectedActual" 4 11
-        , knownBrokenForGhcVersions [GHC92] "Error Message in 9.2 does not provide enough info" $ codeActionTest "TRigidType" 4 14
+        , knownBrokenForGhcVersions [GHC92, GHC94] "Error Message in 9.2/9.4 does not provide enough info" $ codeActionTest "TRigidType" 4 14
+        , codeActionTest "TRigidType2" 4 6
         , codeActionTest "TLocalBinding" 7 22
         , codeActionTest "TLocalBindingShadow1" 11 8
         , codeActionTest "TLocalBindingShadow2" 7 22

--- a/plugins/hls-change-type-signature-plugin/test/testdata/TRigidType2.expected.hs
+++ b/plugins/hls-change-type-signature-plugin/test/testdata/TRigidType2.expected.hs
@@ -1,0 +1,4 @@
+module TRigidType2 where
+
+test :: [Int] -> Int
+test = head 

--- a/plugins/hls-change-type-signature-plugin/test/testdata/TRigidType2.hs
+++ b/plugins/hls-change-type-signature-plugin/test/testdata/TRigidType2.hs
@@ -1,0 +1,4 @@
+module TRigidType2 where
+
+test :: a -> Int
+test = head 


### PR DESCRIPTION
Change Type Signature compatible with GHC 9.4

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3139"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

