### PR TITLE
unescape printable characters

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -78,9 +78,9 @@ import qualified Outputable                      as Out
 import           SrcLoc
 #endif
 #if MIN_VERSION_ghc(9,3,0)
-import GHC.Utils.Logger
-import GHC.Driver.Config.Diagnostic
-import Data.Maybe
+import           Data.Maybe
+import           GHC.Driver.Config.Diagnostic
+import           GHC.Utils.Logger
 #endif
 
 -- | A compatible function to print `Outputable` instances

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -81,6 +81,7 @@ import           GHC.IO.Exception
 import           GHC.IO.Handle.Internals
 import           GHC.IO.Handle.Types
 import           GHC.Stack
+import           Ide.PluginUtils                   (unescape)
 import           System.Environment.Blank          (getEnvDefault)
 import           System.FilePath
 import           System.IO.Unsafe
@@ -292,5 +293,5 @@ instance Outputable SDoc where
 --
 -- It internal using `showSDocUnsafe` with `unsafeGlobalDynFlags`.
 printOutputable :: Outputable a => a -> T.Text
-printOutputable = T.pack . printWithoutUniques
+printOutputable = unescape . T.pack . printWithoutUniques
 {-# INLINE printOutputable #-}

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -289,9 +289,13 @@ instance Outputable SDoc where
 
 -- | Print a GHC value in `defaultUserStyle` without unique symbols.
 --
--- This is the most common print utility, will print with a user-friendly style like: `a_a4ME` as `a`.
+-- This is the most common print utility, and it will print with a user-friendly style like: `a_a4ME` as `a`.
 --
--- It internal using `showSDocUnsafe` with `unsafeGlobalDynFlags`.
+-- It uses `showSDocUnsafe` with `unsafeGlobalDynFlags` internally.
 printOutputable :: Outputable a => a -> T.Text
-printOutputable = unescape . T.pack . printWithoutUniques
+printOutputable =
+    -- IfaceTyLit from GHC.Iface.Type implements Outputable with 'show'.
+    -- Showing a String escapes non-ascii printable characters. We unescape it here.
+    -- More discussion at https://github.com/haskell/haskell-language-server/issues/3115.
+    unescape . T.pack . printWithoutUniques
 {-# INLINE printOutputable #-}

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -288,10 +288,13 @@ instance Outputable SDoc where
 #endif
 
 -- | Print a GHC value in `defaultUserStyle` without unique symbols.
---
--- This is the most common print utility, and it will print with a user-friendly style like: `a_a4ME` as `a`.
---
 -- It uses `showSDocUnsafe` with `unsafeGlobalDynFlags` internally.
+--
+-- This is the most common print utility.
+-- It will do something additionally compared to what the 'Outputable' instance does.
+--
+--   1. print with a user-friendly style: `a_a4ME` as `a`.
+--   2. unescape escape sequences of printable unicode characters within a pair of double quotes
 printOutputable :: Outputable a => a -> T.Text
 printOutputable =
     -- IfaceTyLit from GHC.Iface.Type implements Outputable with 'show'.

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -91,4 +91,5 @@ test-suite tests
     , tasty
     , tasty-hunit
     , tasty-rerun
+    , text
     , lsp-types

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -57,6 +57,7 @@ library
     , text
     , transformers
     , unordered-containers
+    , megaparsec > 9
 
   if os(windows)
     build-depends: Win32

--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -277,9 +277,7 @@ unescape input =
 
 -- | Parser for a string that contains double quotes. Returns unescaped string.
 escapedTextParser :: TextParser String
-escapedTextParser = do
-    xs <- P.many (outsideStringLiteral P.<|> stringLiteral)
-    pure $ concat xs
+escapedTextParser = concat <$> P.many (outsideStringLiteral P.<|> stringLiteral)
   where
     outsideStringLiteral :: TextParser String
     outsideStringLiteral = P.someTill (P.anySingleBut '"') (P.lookAhead (void (P.char '"') P.<|> P.eof))

--- a/hls-plugin-api/test/Ide/PluginUtilsTest.hs
+++ b/hls-plugin-api/test/Ide/PluginUtilsTest.hs
@@ -29,7 +29,7 @@ unescapeTest = testGroup "unescape"
     , testCase "many pairs of quote" $
         unescape "oo\"hello\\19990\\30028\"abc\"\1087\1088\1080\1074\1077\1090\"hh" @?= "oo\"hello世界\"abc\"привет\"hh"
     , testCase "double quote itself should not be unescaped" $
-        unescape "\"\\\"o\"" @?= "\"\\\"o\""
+        unescape "\"\\\"\\19990o\"" @?= "\"\\\"世o\""
     , testCase "control characters should not be escaped" $
         unescape "\"\\n\\t\"" @?= "\"\\n\\t\""
     ]

--- a/hls-plugin-api/test/Ide/PluginUtilsTest.hs
+++ b/hls-plugin-api/test/Ide/PluginUtilsTest.hs
@@ -1,29 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Ide.PluginUtilsTest
     ( tests
     ) where
 
-import           Ide.PluginUtils    (positionInRange)
+import           Data.Char          (isPrint)
+import qualified Data.Text          as T
+import           Ide.PluginUtils    (positionInRange, unescape)
 import           Language.LSP.Types (Position (Position), Range (Range))
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "PluginUtils"
-    [ positionInRangeTest
+    [ unescapeTest
     ]
 
-positionInRangeTest :: TestTree
-positionInRangeTest = testGroup "positionInRange"
-    [ testCase "single line, after the end" $
-        positionInRange (Position 1 10) (Range (Position 1 1) (Position 1 3)) @?= False
-    , testCase "single line, before the begining" $
-        positionInRange (Position 1 0) (Range (Position 1 1) (Position 1 6)) @?= False
-    , testCase "single line, in range" $
-        positionInRange (Position 1 5) (Range (Position 1 1) (Position 1 6)) @?= True
-    , testCase "single line, at the end" $
-        positionInRange (Position 1 5) (Range (Position 1 1) (Position 1 5)) @?= False
-    , testCase "multiline, in range" $
-        positionInRange (Position 3 5) (Range (Position 1 1) (Position 5 6)) @?= True
-    , testCase "multiline, out of range" $
-        positionInRange (Position 3 5) (Range (Position 3 6) (Position 4 10)) @?= False
+unescapeTest :: TestTree
+unescapeTest = testGroup "unescape"
+    [ testCase "no double quote" $
+        unescape "hello世界" @?= "hello世界"
+    , testCase "whole string quoted" $
+        unescape "\"hello\\19990\\30028\"" @?= "\"hello世界\""
+    , testCase "text before quotes should not be unescaped" $
+        unescape "\\19990a\"hello\\30028\"" @?= "\\19990a\"hello界\""
+    , testCase "some text after quotes" $
+        unescape "\"hello\\19990\\30028\"abc" @?= "\"hello世界\"abc"
+    , testCase "many pairs of quote" $
+        unescape "oo\"hello\\19990\\30028\"abc\"\1087\1088\1080\1074\1077\1090\"hh" @?= "oo\"hello世界\"abc\"привет\"hh"
+    , testCase "double quote itself should not be unescaped" $
+        unescape "\"\\\"o\"" @?= "\"\\\"o\""
+    , testCase "control characters should not be escaped" $
+        unescape "\"\\n\\t\"" @?= "\"\\n\\t\""
     ]


### PR DESCRIPTION
This should fix #3115. It works. I will add tests later if the idea is okay.
Maybe a more proper fix is to modify the `Outputable` instance for `IfaceTyLit` in GHC?

Demo:
<img width="313" alt="image" src="https://user-images.githubusercontent.com/16440269/188503193-5b4ab283-5c7c-46a8-8687-11f4e9ff0785.png">

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3140"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

