### PR TITLE
Prepare release 1.8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,10 +80,10 @@ workflow:
     - x86_64-linux
   image: "registry.gitlab.haskell.org/ghc/ci-images/x86_64-linux-centos7:$DOCKER_REV"
 
-.x86_64-linux-fedora27:
+.x86_64-linux-fedora33:
   tags:
     - x86_64-linux
-  image: "registry.gitlab.haskell.org/ghc/ci-images/x86_64-linux-fedora27:$DOCKER_REV"
+  image: "registry.gitlab.haskell.org/ghc/ci-images/x86_64-linux-fedora33:$DOCKER_REV"
 
 .x86_64-linux-alpine:
   tags:
@@ -268,35 +268,35 @@ test-x86_64-linux-centos7:
     - sudo yum install -y tree
 
 ######################
-# x86_64 linux fedora27
+# x86_64 linux fedora33
 ######################
 
-build-x86_64-linux-fedora27:
+build-x86_64-linux-fedora33:
   extends:
     - .build
-    - .x86_64-linux-fedora27
+    - .x86_64-linux-fedora33
   before_script:
     - sudo dnf install -y patchelf tree
   variables:
     ADD_CABAL_ARGS: "--enable-split-sections"
 
-tar-x86_64-linux-fedora27:
+tar-x86_64-linux-fedora33:
   extends:
     - .artifacts
-    - .x86_64-linux-fedora27
+    - .x86_64-linux-fedora33
   stage: tar
-  needs: ["build-x86_64-linux-fedora27"]
+  needs: ["build-x86_64-linux-fedora33"]
   script:
     - ./.gitlab/tar.sh
   variables:
-    TARBALL_ARCHIVE_SUFFIX: x86_64-fedora27-linux
+    TARBALL_ARCHIVE_SUFFIX: x86_64-fedora33-linux
     TARBALL_EXT: tar.xz
 
-test-x86_64-linux-fedora27:
+test-x86_64-linux-fedora33:
   extends:
     - .test
-    - .x86_64-linux-fedora27
-  needs: ["tar-x86_64-linux-fedora27"]
+    - .x86_64-linux-fedora33
+  needs: ["tar-x86_64-linux-fedora33"]
   before_script:
     - sudo dnf install -y tree
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
 # https://gitlab.haskell.org/haskell/haskell-language-server/-/pipelines
 variables:
   # Commit of ghc/ci-images repository from which to pull Docker images
-  DOCKER_REV: "4ed1a4f27828ba96a34662dc954335e29b470cd2"
+  DOCKER_REV: "9e4c540d9e4972a36291dfdf81f079f37d748890"
 
   CABAL_INSTALL_VERSION: 3.8.1.0
 

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -80,6 +80,7 @@ case "$(uname)" in
 		cp "$(cabal list-bin -v0 ${args[@]} exe:hls-wrapper)" "$CI_PROJECT_DIR/out/haskell-language-server-wrapper"$EXE_EXTENSION
         ;;
 	*)
+		sed -i.bak -e '/DELETE MARKER FOR CI/,/END DELETE/d' cabal.project # see comment in cabal.project
 		emake --version
 		emake GHCUP=ghcup hls
 		emake GHCUP=ghcup bindist

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -6,7 +6,7 @@ source "$CI_PROJECT_DIR/.gitlab/common.sh"
 
 export GHCUP_INSTALL_BASE_PREFIX="$CI_PROJECT_DIR/toolchain"
 export CABAL_DIR="$CI_PROJECT_DIR/cabal"
-EXE_EXTENSION = ""
+EXE_EXTENSION=""
 
 case "$(uname)" in
     MSYS_*|MINGW*)
@@ -50,10 +50,10 @@ esac
 case "$(uname)" in
     MSYS_*|MINGW*)
     # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/21196
-    export PATH="${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin:${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/usr/bin:$PATH"
-    ls ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin
-    cp ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin/libgcc_s_seh-1.dll ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/bin
-    cp ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin/libwinpthread-1.dll ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/bin
+    # export PATH="${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin:${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/usr/bin:$PATH"
+    # ls ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin
+    # cp ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin/libgcc_s_seh-1.dll ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/bin
+    # cp ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin/libwinpthread-1.dll ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/bin
     ghc --info
 		# Shorten binary names
 		sed -i.bak -e 's/haskell-language-server/hls/g' \
@@ -76,8 +76,8 @@ case "$(uname)" in
 
 		mkdir "$CI_PROJECT_DIR/out"
 
-		cp "$(cabal list-bin ${args[@]} exe:hls)" "$CI_PROJECT_DIR/out/haskell-language-server-${GHC_VERSION}"$EXE_EXTENSION
-		cp "$(cabal list-bin ${args[@]} exe:hls-wrapper)" "$CI_PROJECT_DIR/out/haskell-language-server-wrapper"$EXE_EXTENSION
+		cp "$(cabal list-bin -v0 ${args[@]} exe:hls)" "$CI_PROJECT_DIR/out/haskell-language-server-${GHC_VERSION}"$EXE_EXTENSION
+		cp "$(cabal list-bin -v0 ${args[@]} exe:hls-wrapper)" "$CI_PROJECT_DIR/out/haskell-language-server-wrapper"$EXE_EXTENSION
         ;;
 	*)
 		emake --version

--- a/.gitlab/test.sh
+++ b/.gitlab/test.sh
@@ -45,17 +45,17 @@ case "$(uname -s)" in
 		;;
 esac
 
-case "$(uname)" in
-    MSYS_*|MINGW*)
-        # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/21196
-        export PATH="${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin:${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/usr/bin:$PATH"
-        ls ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin
-        cp ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin/libgcc_s_seh-1.dll ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/bin
-        cp ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin/libwinpthread-1.dll ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/bin
-        ghc --info
-        ;;
-	*) ;;
-esac
+# case "$(uname)" in
+#     MSYS_*|MINGW*)
+#         # workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/21196
+#         export PATH="${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin:${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/usr/bin:$PATH"
+#         ls ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin
+#         cp ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin/libgcc_s_seh-1.dll ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/bin
+#         cp ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/mingw/bin/libwinpthread-1.dll ${GHCUP_INSTALL_BASE_PREFIX}/ghcup/ghc/${GHC_VERSION}/bin
+#         ghc --info
+#         ;;
+# 	*) ;;
+# esac
 
 # make sure out/ dir is gone, so build host rpaths don't
 # kick in (TODO: we should probably remove those)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,267 @@
 # Changelog for haskell-language-server
 
+## 1.8.0.0
+
+- Binaries for GHC 9.2.3 and GHC 9.2.4
+- Initial support for GHC 9.4 with binaries for GHC 9.4.1 and GHC 9.4.2
+- Startup time and performance improvements on projects using Template Haskell by serializing intermediate core (#2813)
+- Memory usage improvements due to using a packed representation for filepaths (#3067, @kokobd)
+- Improvements for hls-class-plugin (#2920, @July541) 
+- The new hls-gadt-plugin (#2899, @July541)
+- Moving code actions from ghcide to the new hls-refactor-plugin (#3091, @wz1000)
+- Many more improvements and bug fixes thanks to our contributors!
+
+### Pull requests merged for 1.8.0.0
+
+- Alternate Number Format Plugin buildable with GHC 9.4
+([#3138](https://github.com/haskell/haskell-language-server/pull/3138)) by @drsooch
+- Enable a bunch of plugins that build with ghc 9.4
+([#3136](https://github.com/haskell/haskell-language-server/pull/3136)) by @pepeiborra
+- Enable support for 9.4 on windows
+([#3132](https://github.com/haskell/haskell-language-server/pull/3132)) by @wz1000
+- flake.nix Add ghcide-bench to sourceDirs
+([#3125](https://github.com/haskell/haskell-language-server/pull/3125)) by @akshaymankar
+- Update hls-retrie-plugin to be usable with 9.2.4.
+([#3120](https://github.com/haskell/haskell-language-server/pull/3120)) by @drsooch
+- Add link to homepage and issues for `hie-compat`
+([#3119](https://github.com/haskell/haskell-language-server/pull/3119)) by @parsonsmatt
+- Remove pluginId from getNormalizedFilePath error message
+([#3118](https://github.com/haskell/haskell-language-server/pull/3118)) by @drsooch
+- HLS benchmarks
+([#3117](https://github.com/haskell/haskell-language-server/pull/3117)) by @pepeiborra
+- Fix --testing
+([#3113](https://github.com/haskell/haskell-language-server/pull/3113)) by @pepeiborra
+- Deduplicate HLS plugins
+([#3112](https://github.com/haskell/haskell-language-server/pull/3112)) by @pepeiborra
+- Do not send Heap Stats to the LSP log
+([#3111](https://github.com/haskell/haskell-language-server/pull/3111)) by @pepeiborra
+- Send begin progress message synchronously
+([#3110](https://github.com/haskell/haskell-language-server/pull/3110)) by @pepeiborra
+- Remove unused config in hls-class-plugin
+([#3107](https://github.com/haskell/haskell-language-server/pull/3107)) by @July541
+- Support fourmolu-0.8.1.0
+([#3103](https://github.com/haskell/haskell-language-server/pull/3103)) by @brandonchinn178
+- Probe-tools: Print stack ghc version
+([#3093](https://github.com/haskell/haskell-language-server/pull/3093)) by @andys8
+- Fix #3047
+([#3092](https://github.com/haskell/haskell-language-server/pull/3092)) by @July541
+- Remove exactprint dependencies from ghcide by introducing hls-refactor-plugin.
+([#3091](https://github.com/haskell/haskell-language-server/pull/3091)) by @wz1000
+- Stan: Avoid terminal colors in messages
+([#3090](https://github.com/haskell/haskell-language-server/pull/3090)) by @andys8
+- Support ghc-9.2.4
+([#3085](https://github.com/haskell/haskell-language-server/pull/3085)) by @July541
+- Bump Nix flake GHC 9.2.3 to 9.2.4
+([#3081](https://github.com/haskell/haskell-language-server/pull/3081)) by @cydparser
+- fix lsp-types benchmark
+([#3079](https://github.com/haskell/haskell-language-server/pull/3079)) by @pepeiborra
+- Add support for Fourmolu 0.8
+([#3078](https://github.com/haskell/haskell-language-server/pull/3078)) by @brandonchinn178
+- upgrade lsp to 1.5
+([#3072](https://github.com/haskell/haskell-language-server/pull/3072)) by @kokobd
+- Bump actions/cache from 2 to 3
+([#3071](https://github.com/haskell/haskell-language-server/pull/3071)) by @dependabot[bot]
+- Bump actions/setup-python from 3 to 4
+([#3070](https://github.com/haskell/haskell-language-server/pull/3070)) by @dependabot[bot]
+- Run the benchmark suite on GHC 9.2.3
+([#3069](https://github.com/haskell/haskell-language-server/pull/3069)) by @pepeiborra
+- Simplify instructions about 'ghcup compile hls'
+([#3068](https://github.com/haskell/haskell-language-server/pull/3068)) by @hasufell
+- Improve performance of NormalizedFilePath
+([#3067](https://github.com/haskell/haskell-language-server/pull/3067)) by @kokobd
+- add a prefix to plugin CPP definitions
+([#3065](https://github.com/haskell/haskell-language-server/pull/3065)) by @kokobd
+- Add Github precommit workflow
+([#3060](https://github.com/haskell/haskell-language-server/pull/3060)) by @lunaticare
+- Run pre-commit hooks
+([#3059](https://github.com/haskell/haskell-language-server/pull/3059)) by @lunaticare
+- Fix grammar and spelling errors in configuration.md
+([#3056](https://github.com/haskell/haskell-language-server/pull/3056)) by @arsenkhy
+- Remove redundant WARNING prefix
+([#3055](https://github.com/haskell/haskell-language-server/pull/3055)) by @michaelpj
+- fix a typo in src/Ide/Plugin/Class/CodeLens.hs
+([#3053](https://github.com/haskell/haskell-language-server/pull/3053)) by @tensorknower69
+- fix record-dot-syntax test
+([#3051](https://github.com/haskell/haskell-language-server/pull/3051)) by @coltenwebb
+- build(nix): ghc922 -> ghc923
+([#3049](https://github.com/haskell/haskell-language-server/pull/3049)) by @teto
+- build(nix): bumped gitignore dependency
+([#3048](https://github.com/haskell/haskell-language-server/pull/3048)) by @teto
+- Update issue templates
+([#3044](https://github.com/haskell/haskell-language-server/pull/3044)) by @michaelpj
+- Simplify hlint config
+([#3038](https://github.com/haskell/haskell-language-server/pull/3038)) by @michaelpj
+- handle trailing comma in import list properly
+([#3035](https://github.com/haskell/haskell-language-server/pull/3035)) by @kokobd
+- upgrade ghc-check to fix #3002
+([#3034](https://github.com/haskell/haskell-language-server/pull/3034)) by @kokobd
+- Fix Stack build with Nix on macOS
+([#3031](https://github.com/haskell/haskell-language-server/pull/3031)) by @lunaticare
+- haskell-language-server: add lower bound for githash
+([#3030](https://github.com/haskell/haskell-language-server/pull/3030)) by @Bodigrim
+- hls-eval-plugin: add lower bound for parser-combinators
+([#3029](https://github.com/haskell/haskell-language-server/pull/3029)) by @Bodigrim
+- hls-fourmolu-plugin: add lower bound for process-extras
+([#3028](https://github.com/haskell/haskell-language-server/pull/3028)) by @Bodigrim
+- ghcide: lower bounds
+([#3025](https://github.com/haskell/haskell-language-server/pull/3025)) by @Bodigrim
+- remove all usages of pre-commit-check in nix
+([#3024](https://github.com/haskell/haskell-language-server/pull/3024)) by @kokobd
+- hls-plugin-api: add lower bounds
+([#3022](https://github.com/haskell/haskell-language-server/pull/3022)) by @Bodigrim
+- hls-graph: add lower bound for async
+([#3021](https://github.com/haskell/haskell-language-server/pull/3021)) by @Bodigrim
+- Hlint: CodeAction with isPreferred
+([#3018](https://github.com/haskell/haskell-language-server/pull/3018)) by @andys8
+- Record Dot Hover Types
+([#3016](https://github.com/haskell/haskell-language-server/pull/3016)) by @coltenwebb
+- re-enable haddock
+([#3015](https://github.com/haskell/haskell-language-server/pull/3015)) by @kokobd
+- add Helix to configuration.md
+([#3014](https://github.com/haskell/haskell-language-server/pull/3014)) by @0rphee
+- Renaming of indirect references (RecordFieldPuns)
+([#3013](https://github.com/haskell/haskell-language-server/pull/3013)) by @OliverMadine
+- Revert back to Warning not Error in Logging `ResponseErrors`
+([#3009](https://github.com/haskell/haskell-language-server/pull/3009)) by @drsooch
+- Disable flaky test on Windows
+([#3008](https://github.com/haskell/haskell-language-server/pull/3008)) by @michaelpj
+- Improve troubleshooting and installation docs a bit
+([#3004](https://github.com/haskell/haskell-language-server/pull/3004)) by @michaelpj
+- refactor selection range plugin
+([#3003](https://github.com/haskell/haskell-language-server/pull/3003)) by @kokobd
+- Hlint more partial functions, and Debug.Trace
+([#3000](https://github.com/haskell/haskell-language-server/pull/3000)) by @michaelpj
+- Don't use typecheck rule for non FOIs in refine imports plugin
+([#2995](https://github.com/haskell/haskell-language-server/pull/2995)) by @wz1000
+- GHC 9.4 compatibility + Multiple Home Units
+([#2994](https://github.com/haskell/haskell-language-server/pull/2994)) by @wz1000
+- unify pre-commit hook & update Gitpod config
+([#2991](https://github.com/haskell/haskell-language-server/pull/2991)) by @kokobd
+- Log response errors returned from Plugins
+([#2988](https://github.com/haskell/haskell-language-server/pull/2988)) by @drsooch
+- Add associated type families to local completions
+([#2987](https://github.com/haskell/haskell-language-server/pull/2987)) by @gasparattila
+- Remove some partial functions from Shake.hs
+([#2986](https://github.com/haskell/haskell-language-server/pull/2986)) by @michaelpj
+- Clean up ghc-9.0 partial support contents
+([#2983](https://github.com/haskell/haskell-language-server/pull/2983)) by @July541
+- fix new import position
+([#2981](https://github.com/haskell/haskell-language-server/pull/2981)) by @kokobd
+- Implement PluginMethod for hard-wired in handlers
+([#2977](https://github.com/haskell/haskell-language-server/pull/2977)) by @fendor
+- Set up partial functions ratchet
+([#2974](https://github.com/haskell/haskell-language-server/pull/2974)) by @michaelpj
+- Turn HLS-wrapper into an LSP Server
+([#2960](https://github.com/haskell/haskell-language-server/pull/2960)) by @smatting
+- More Fourmolu improvements
+([#2959](https://github.com/haskell/haskell-language-server/pull/2959)) by @georgefst
+- hls-class-plugin: Only create placeholders for unimplemented methods
+([#2956](https://github.com/haskell/haskell-language-server/pull/2956)) by @akshaymankar
+- Fix Fourmolu 0.7 support
+([#2950](https://github.com/haskell/haskell-language-server/pull/2950)) by @georgefst
+- Teach HLS about different file extensions
+([#2945](https://github.com/haskell/haskell-language-server/pull/2945)) by @fendor
+- Support `fourmolu ^>= 0.7`
+([#2944](https://github.com/haskell/haskell-language-server/pull/2944)) by @parsonsmatt
+- hls-explicit-fixity-plugin
+([#2941](https://github.com/haskell/haskell-language-server/pull/2941)) by @July541
+- chore(nix): bump nixpkgs to prevent glibc issues
+([#2937](https://github.com/haskell/haskell-language-server/pull/2937)) by @teto
+- Support ghc-9.2.3
+([#2936](https://github.com/haskell/haskell-language-server/pull/2936)) by @July541
+- Typo fix, dependecies -> dependencies
+([#2934](https://github.com/haskell/haskell-language-server/pull/2934)) by @vikrem
+- Update Archlinux installation section
+([#2933](https://github.com/haskell/haskell-language-server/pull/2933)) by @marcin-rzeznicki
+- docs/installation: Remove unused clone with submodule command
+([#2930](https://github.com/haskell/haskell-language-server/pull/2930)) by @sloorush
+- Omit more parens for wildcard type signature
+([#2929](https://github.com/haskell/haskell-language-server/pull/2929)) by @sergv
+- Add `throwPluginError` to Plugin Utilities
+([#2924](https://github.com/haskell/haskell-language-server/pull/2924)) by @drsooch
+- hls-class-plugin enhancement
+([#2920](https://github.com/haskell/haskell-language-server/pull/2920)) by @July541
+- Bump documentation requirements
+([#2918](https://github.com/haskell/haskell-language-server/pull/2918)) by @xsebek
+- Document eval plugin limitations
+([#2917](https://github.com/haskell/haskell-language-server/pull/2917)) by @xsebek
+- Replace TextDocumentIdentifier with Uri in getNormalizedFilePath
+([#2912](https://github.com/haskell/haskell-language-server/pull/2912)) by @July541
+- Fix hover format
+([#2911](https://github.com/haskell/haskell-language-server/pull/2911)) by @July541
+- Fix multiline eval plugin padding
+([#2910](https://github.com/haskell/haskell-language-server/pull/2910)) by @xsebek
+- Stan integration #258
+([#2908](https://github.com/haskell/haskell-language-server/pull/2908)) by @uhbif19
+- A plugin for GADT syntax converter
+([#2899](https://github.com/haskell/haskell-language-server/pull/2899)) by @July541
+- Fix DisplayTHWarning error
+([#2895](https://github.com/haskell/haskell-language-server/pull/2895)) by @pepeiborra
+- Enable hls-eval-plugin test on ghc-9.2.2
+([#2893](https://github.com/haskell/haskell-language-server/pull/2893)) by @July541
+- nix update
+([#2892](https://github.com/haskell/haskell-language-server/pull/2892)) by @michaelpj
+- Build hls-alternate-number-format-plugin with stack.yaml
+([#2891](https://github.com/haskell/haskell-language-server/pull/2891)) by @July541
+- Modify ghcide requirements of hls-change-type-signature-plugin
+([#2889](https://github.com/haskell/haskell-language-server/pull/2889)) by @July541
+- Fix hls-call-hierarchy-plugin tests
+([#2888](https://github.com/haskell/haskell-language-server/pull/2888)) by @July541
+- Add .txt files as extra-source-files for hls-change-type-signature-plugin
+([#2887](https://github.com/haskell/haskell-language-server/pull/2887)) by @cdepillabout
+- Prefer Data.HashSet.member to Data.Foldable.elem
+([#2886](https://github.com/haskell/haskell-language-server/pull/2886)) by @sergv
+- no longer disable -dynamic in CI
+([#2885](https://github.com/haskell/haskell-language-server/pull/2885)) by @pepeiborra
+- hls-pragmas-plugin requires ghcide >= 1.7
+([#2884](https://github.com/haskell/haskell-language-server/pull/2884)) by @Bodigrim
+- Make iface-error-test-1 less flaky
+([#2882](https://github.com/haskell/haskell-language-server/pull/2882)) by @pepeiborra
+- hls-haddock-comments does not support ghc-exactprint >= 1.0
+([#2878](https://github.com/haskell/haskell-language-server/pull/2878)) by @Bodigrim
+- Restore compat. with prettyprinter 1.6
+([#2877](https://github.com/haskell/haskell-language-server/pull/2877)) by @pepeiborra
+- ghcide requires ghc-exactprint >= 1.4
+([#2876](https://github.com/haskell/haskell-language-server/pull/2876)) by @Bodigrim
+- ghcide needs prettyprinter-1.7 to build
+([#2875](https://github.com/haskell/haskell-language-server/pull/2875)) by @juhp
+- Review project stack descriptors according to #2533
+([#2874](https://github.com/haskell/haskell-language-server/pull/2874)) by @pepeiborra
+- hls-call-hierarchy-plugin Patch release
+([#2873](https://github.com/haskell/haskell-language-server/pull/2873)) by @pepeiborra
+- Expand input to pragma if available
+([#2871](https://github.com/haskell/haskell-language-server/pull/2871)) by @July541
+- Fix hanging redundant import on Unicode function 
+([#2870](https://github.com/haskell/haskell-language-server/pull/2870)) by @drsooch
+- Compatibility with older aeson releases
+([#2868](https://github.com/haskell/haskell-language-server/pull/2868)) by @pepeiborra
+- simplify hlint plugin Cabal descriptor
+([#2867](https://github.com/haskell/haskell-language-server/pull/2867)) by @pepeiborra
+- Consolidate all cabal.project files
+([#2866](https://github.com/haskell/haskell-language-server/pull/2866)) by @pepeiborra
+- release script fixes
+([#2861](https://github.com/haskell/haskell-language-server/pull/2861)) by @wz1000
+- Support hls-hlint-plugin and hls-stylish-plugin for ghc9.0 and ghc9.2
+([#2854](https://github.com/haskell/haskell-language-server/pull/2854)) by @July541
+- Bump haskell/actions from 1 to 2
+([#2852](https://github.com/haskell/haskell-language-server/pull/2852)) by @dependabot[bot]
+- Add scripts for releases and final 1.7 tweaks
+([#2850](https://github.com/haskell/haskell-language-server/pull/2850)) by @wz1000
+- Fix Completion document format
+([#2848](https://github.com/haskell/haskell-language-server/pull/2848)) by @July541
+- Improve name export code action
+([#2847](https://github.com/haskell/haskell-language-server/pull/2847)) by @sergv
+- Update plugin support table
+([#2840](https://github.com/haskell/haskell-language-server/pull/2840)) by @michaelpj
+- Unify showSDocUnsafe
+([#2830](https://github.com/haskell/haskell-language-server/pull/2830)) by @July541
+- ghcide: remove redundant env NIX_GHC_LIBDIR
+([#2819](https://github.com/haskell/haskell-language-server/pull/2819)) by @sloorush
+- Serialize Core
+([#2813](https://github.com/haskell/haskell-language-server/pull/2813)) by @wz1000
+- Expose runtime metrics via EKG
+([#2267](https://github.com/haskell/haskell-language-server/pull/2267)) by @pepeiborra
+
 ## 1.7.0.0
 
 - Distribute dynamically linked binaries for HLS to avoid statically linking against GLIBC

--- a/cabal.project
+++ b/cabal.project
@@ -65,11 +65,16 @@ constraints:
 -- This is benign and won't affect our ability to release to Hackage,
 -- because we only depend on `ekg-json` when a non-default flag
 -- is turned on.
+-- DELETE MARKER FOR CI
+-- centos7 has an old version of git which cabal doesn't
+-- support. We delete these lines in gitlab ci to workaround
+-- this issue, as this is not necessary to build our binaries.
 source-repository-package
   type:git
   location: https://github.com/pepeiborra/ekg-json
   tag: 7a0af7a8fd38045fd15fb13445bdcc7085325460
   -- https://github.com/tibbe/ekg-json/pull/12
+-- END DELETE
 
 allow-newer:
   -- ghc-9.4

--- a/cabal.project
+++ b/cabal.project
@@ -48,7 +48,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-08-29T06:53:13Z
+index-state: 2022-09-14T16:53:13Z
 
 constraints:
   -- For GHC 9.4, older versions of entropy fail to build on Windows
@@ -71,35 +71,6 @@ source-repository-package
   tag: 7a0af7a8fd38045fd15fb13445bdcc7085325460
   -- https://github.com/tibbe/ekg-json/pull/12
 
-source-repository-package
-  type:git
-  location: https://github.com/wz1000/hiedb
-  tag: 67b92df2359558091df9102db5b701327308b930
-
-source-repository-package
-  type:git
-  location: https://github.com/wz1000/hie-bios
-  tag: aa73d3d2eb89df0003d2468a105e326d71b62cc7
-
--- Remove me when a new version of lsp is released
-source-repository-package
-  type:git
-  location: https://github.com/haskell/lsp
-  subdir: lsp
-  tag: b0f8596887088b8ab65fc1015c773f45b47234ae
-
-source-repository-package
-  type:git
-  location: https://github.com/haskell/lsp
-  subdir: lsp-types
-  tag: b0f8596887088b8ab65fc1015c773f45b47234ae
-
-source-repository-package
-  type:git
-  location: https://github.com/haskell/lsp
-  subdir: lsp-test
-  tag: b0f8596887088b8ab65fc1015c773f45b47234ae
-
 allow-newer:
   -- ghc-9.4
   Chart-diagrams:lens,
@@ -117,16 +88,9 @@ allow-newer:
   ekg-json:base,
   ghc-paths:Cabal,
   haddock-library:base,
-  hie-bios:aeson,
-  hie-bios:ghc,
   monoid-extras:base,
   monoid-subclasses:vector,
   svg-builder:base,
   uuid:time,
   vector-space:base,
-
-  -- ghc-9.2
-  ----------
-  hiedb:base,
-
-  ekg-wai:time
+  ekg-wai:time,

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -47,13 +47,12 @@ import           Development.IDE.LSP.LanguageServer (runLanguageServer)
 import qualified Development.IDE.Main               as Main
 import           Development.IDE.Types.Logger       (Logger (Logger),
                                                      Pretty (pretty),
-                                                     Priority (Debug, Error, Info, Warning),
+                                                     Priority (Info),
                                                      Recorder (logger_),
                                                      WithPriority (WithPriority),
                                                      cmapWithPrio,
                                                      makeDefaultStderrRecorder)
 import           GHC.Stack.Types                    (emptyCallStack)
-import           HIE.Bios.Internal.Log
 import           Ide.Plugin.Config                  (Config)
 import           Language.LSP.Server                (LspM)
 import qualified Language.LSP.Server                as LSP
@@ -316,11 +315,3 @@ launchErrorLSP errorMsg = do
 
 exitHandler :: IO () -> LSP.Handlers (ErrorLSPM c)
 exitHandler exit = LSP.notificationHandler SExit $ const $ liftIO exit
-
-hlsWrapperLogger :: Logger
-hlsWrapperLogger = Logger $ \pri txt ->
-    case pri of
-      Debug   -> debugm   (T.unpack txt)
-      Info    -> logm     (T.unpack txt)
-      Warning -> warningm (T.unpack txt)
-      Error   -> errorm   (T.unpack txt)

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.7.0.1
+version:            1.8.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -64,13 +64,13 @@ library
         Glob,
         haddock-library >= 1.8 && < 1.11,
         hashable,
-        hie-compat ^>= 0.2.0.0,
-        hls-plugin-api ^>= 1.4,
+        hie-compat ^>= 0.3.0.0,
+        hls-plugin-api ^>= 1.5,
         lens,
         list-t,
-        hiedb == 0.4.1.*,
-        lsp-types ^>= 1.5.0.0,
-        lsp ^>= 1.5.0.0 ,
+        hiedb == 0.4.2.*,
+        lsp-types ^>= 1.6.0.0,
+        lsp ^>= 1.6.0.0 ,
         monoid-subclasses,
         mtl,
         optparse-applicative,
@@ -81,7 +81,7 @@ library
         regex-tdfa >= 1.3.1.0,
         text-rope,
         safe-exceptions,
-        hls-graph ^>= 1.7,
+        hls-graph ^>= 1.8,
         sorted-list,
         sqlite-simple,
         stm,
@@ -105,7 +105,7 @@ library
         ghc-check >=0.5.0.8,
         ghc-paths,
         cryptohash-sha1 >=0.11.100 && <0.12,
-        hie-bios ^>= 0.9.1,
+        hie-bios ^>= 0.11.0,
         implicit-hie-cradle ^>= 0.3.0.5 || ^>= 0.5,
         base16-bytestring >=0.1.1 && <1.1
     if os(windows)

--- a/ghcide/test/ghcide-test-utils.cabal
+++ b/ghcide/test/ghcide-test-utils.cabal
@@ -3,7 +3,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide-test-utils
-version:            1.7.0.1
+version:            1.8.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 category:           Development
 name:               haskell-language-server
-version:            1.7.0.0
+version:            1.8.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -71,12 +71,12 @@ library
     , cryptohash-sha1
     , data-default
     , ghc
-    , ghcide                ^>=1.7
+    , ghcide                ^>=1.8
     , githash               >=0.1.6.1
     , lsp
     , hie-bios
     , hiedb
-    , hls-plugin-api        ^>=1.4
+    , hls-plugin-api        ^>=1.5
     , optparse-applicative
     , optparse-simple
     , process
@@ -240,22 +240,22 @@ flag dynamic
 
 common class
   if flag(class) && (impl(ghc < 9.4.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-class-plugin ^>= 1.0
+    build-depends: hls-class-plugin ^>= 1.1
     cpp-options: -Dhls_class
 
 common callHierarchy
   if flag(callHierarchy)
-    build-depends: hls-call-hierarchy-plugin ^>= 1.0
+    build-depends: hls-call-hierarchy-plugin ^>= 1.1
     cpp-options: -Dhls_callHierarchy
 
 common haddockComments
   if flag(haddockComments) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-haddock-comments-plugin ^>= 1.0
+    build-depends: hls-haddock-comments-plugin ^>= 1.1
     cpp-options: -Dhls_haddockComments
 
 common eval
   if flag(eval) && (impl(ghc < 9.4.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-eval-plugin ^>= 1.2
+    build-depends: hls-eval-plugin ^>= 1.3
     cpp-options: -Dhls_eval
 
 common importLens
@@ -280,12 +280,12 @@ common retrie
 
 common tactic
   if flag(tactic) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-tactics-plugin >=1.2.0.0 && <1.7
+    build-depends: hls-tactics-plugin ^>= 1.7
     cpp-options: -Dhls_tactic
 
 common hlint
   if flag(hlint) && (impl(ghc < 9.4.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-hlint-plugin ^>= 1.0
+    build-depends: hls-hlint-plugin ^>= 1.1
     cpp-options: -Dhls_hlint
 
 common stan
@@ -295,7 +295,7 @@ common stan
 
 common moduleName
   if flag(moduleName)
-    build-depends: hls-module-name-plugin ^>= 1.0
+    build-depends: hls-module-name-plugin ^>= 1.1
     cpp-options: -Dhls_moduleName
 
 common pragmas
@@ -310,7 +310,7 @@ common splice
 
 common alternateNumberFormat
   if flag(alternateNumberFormat) 
-    build-depends: hls-alternate-number-format-plugin ^>= 1.1
+    build-depends: hls-alternate-number-format-plugin ^>= 1.2
     cpp-options: -Dhls_alternateNumberFormat
 
 common qualifyImportedNames
@@ -347,7 +347,7 @@ common floskell
 
 common fourmolu
   if flag(fourmolu) && (impl(ghc < 9.4.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-fourmolu-plugin ^>= 1.0
+    build-depends: hls-fourmolu-plugin ^>= 1.1
     cpp-options: -Dhls_fourmolu
 
 common ormolu
@@ -534,7 +534,7 @@ test-suite func-test
     , lens
     , lens-aeson
     , ghcide
-    , hls-test-utils ^>=1.3
+    , hls-test-utils ^>=1.4
     , lsp-types
     , aeson
     , hls-plugin-api

--- a/hie-compat/hie-compat.cabal
+++ b/hie-compat/hie-compat.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.22
 name:                hie-compat
-version:             0.2.1.1
+version:             0.3.0.0
 synopsis:            HIE files for GHC 8.6 and other HIE file backports
 license:             Apache-2.0
 description:

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-graph
-version:       1.7.0.0
+version:       1.8.0.0
 synopsis:      Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       1.4.0.0
+version:       1.5.0.0
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -46,10 +46,10 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             ^>= 1.7
+    , hls-graph             ^>= 1.8
     , lens
     , lens-aeson
-    , lsp                   ^>=1.5.0.0
+    , lsp                   ^>=1.6.0.0
     , opentelemetry         >=0.4
     , optparse-applicative
     , process

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       1.3.0.0
+version:       1.4.0.0
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -41,13 +41,13 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  ^>=1.6 || ^>=1.7
+    , ghcide                  ^>=1.8
     , hls-graph
-    , hls-plugin-api          ^>=1.3 || ^>=1.4
+    , hls-plugin-api          ^>=1.5
     , lens
-    , lsp                     ^>=1.5.0.0
+    , lsp                     ^>=1.6.0.0
     , lsp-test                ^>=0.14
-    , lsp-types               ^>=1.5.0.0
+    , lsp-types               ^>=1.6.0.0
     , tasty
     , tasty-expected-failure
     , tasty-golden

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-alternate-number-format-plugin
-version:            1.1.0.1
+version:            1.2.0.0
 synopsis:           Provide Alternate Number Formats plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -27,13 +27,13 @@ library
       aeson
     , base                 >=4.12 && < 5
     , containers
-    , ghcide               ^>=1.6 || ^>=1.7
+    , ghcide               ^>= 1.8
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       ^>=1.4
+    , hls-plugin-api       ^>= 1.5
     , hie-compat
     , lens
-    , lsp
+    , lsp                  ^>=1.6
     , mtl
     , regex-tdfa
     , syb
@@ -59,7 +59,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-alternate-number-format-plugin
-    , hls-test-utils       ^>=1.3
+    , hls-test-utils       ^>=1.3 || ^>= 1.4
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-brittany-plugin/hls-brittany-plugin.cabal
+++ b/plugins/hls-brittany-plugin/hls-brittany-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-brittany-plugin
-version:            1.0.2.1
+version:            1.0.2.2
 synopsis:           Integration with the Brittany code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,8 +29,8 @@ library
     , brittany        >=0.13.1.0 && < 0.14.0.1 || > 0.14.0.1
     , filepath
     , ghc-boot-th
-    , ghcide          ^>= 1.6 || ^>= 1.7
-    , hls-plugin-api  ^>= 1.3 || ^>= 1.4
+    , ghcide          ^>= 1.6 || ^>= 1.7 || ^>= 1.8
+    , hls-plugin-api  ^>= 1.3 || ^>= 1.4 || ^>= 1.5
     , lens
     , lsp-types
     , text
@@ -56,4 +56,4 @@ test-suite tests
     , base
     , filepath
     , hls-brittany-plugin
-    , hls-test-utils        ^>=1.3
+    , hls-test-utils        ^>=1.3 || ^>= 1.4

--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-call-hierarchy-plugin
-version:            1.0.3.1
+version:            1.1.0.0
 synopsis:           Call hierarchy plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-call-hierarchy-plugin#readme>
@@ -31,9 +31,9 @@ library
     , containers
     , extra
     , ghc
-    , ghcide                ^>= 1.6 || ^>= 1.7
+    , ghcide                ^>= 1.8
     , hiedb
-    , hls-plugin-api        ^>= 1.2 || ^>= 1.3 || ^>= 1.4
+    , hls-plugin-api        ^>= 1.5
     , lens
     , lsp                    >=1.2.0.1
     , sqlite-simple
@@ -57,7 +57,7 @@ test-suite tests
     , extra
     , filepath
     , hls-call-hierarchy-plugin
-    , hls-test-utils              ^>=1.3
+    , hls-test-utils              ^>=1.4
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -24,8 +24,8 @@ library
   hs-source-dirs:   src
   build-depends:
     , base             >=4.12 && < 5
-    , ghcide          ^>=1.7
-    , hls-plugin-api  ^>=1.4
+    , ghcide          ^>=1.8
+    , hls-plugin-api  ^>=1.5
     , lsp-types
     , regex-tdfa
     , syb
@@ -57,7 +57,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-change-type-signature-plugin
-    , hls-test-utils       ^>=1.3
+    , hls-test-utils       ^>=1.4
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-class-plugin
-version:            1.0.3.0
+version:            1.1.0.0
 synopsis:
   Class/instance management plugin for Haskell Language Server
 
@@ -39,10 +39,10 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide          ^>=1.7
+    , ghcide          ^>=1.8
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api  ^>=1.4
+    , hls-plugin-api  ^>=1.5
     , lens
     , lsp
     , text
@@ -78,6 +78,6 @@ test-suite tests
     , ghcide
     , hls-class-plugin
     , hls-plugin-api
-    , hls-test-utils     ^>=1.3
+    , hls-test-utils     ^>=1.4
     , lens
     , lsp-types

--- a/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
+++ b/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
@@ -35,9 +35,9 @@ library
     , containers
     , deepseq
     , extra
-    , ghcide           ^>=1.6 || ^>=1.7
+    , ghcide           ^>=1.8
     , hashable
-    , hls-plugin-api   ^>=1.3 || ^>=1.4
+    , hls-plugin-api   ^>=1.5
     , lens
     , lsp
     , mtl
@@ -60,9 +60,9 @@ test-suite tests
     , bytestring
     , containers
     , filepath
-    , ghcide                     ^>=1.6 || ^>=1.7
+    , ghcide                     ^>=1.8
     , hls-code-range-plugin
-    , hls-test-utils             ^>=1.2 || ^>=1.3
+    , hls-test-utils             ^>=1.4
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-eval-plugin
-version:            1.2.2.0
+version:            1.3.0.0
 synopsis:           Eval plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -70,10 +70,10 @@ library
     , ghc
     , ghc-boot-th
     , ghc-paths
-    , ghcide                ^>=1.7
+    , ghcide                ^>=1.8
     , hashable
     , hls-graph
-    , hls-plugin-api        ^>=1.4
+    , hls-plugin-api        ^>=1.5
     , lens
     , lsp
     , lsp-types
@@ -119,7 +119,7 @@ test-suite tests
     , filepath
     , hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   ^>=1.3
+    , hls-test-utils   ^>=1.4
     , lens
     , lsp-types
     , text

--- a/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
+++ b/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
@@ -26,9 +26,9 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide               ^>=1.7
+    , ghcide               ^>=1.8
     , hashable
-    , hls-plugin-api       ^>=1.4
+    , hls-plugin-api       ^>=1.5
     , lsp                   >=1.2.0.1
     , text
 
@@ -50,5 +50,5 @@ test-suite tests
     , base
     , filepath
     , hls-explicit-fixity-plugin
-    , hls-test-utils              ^>=1.3
+    , hls-test-utils              ^>=1.4
     , text

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-explicit-imports-plugin
-version:            1.1.0.0
+version:            1.1.0.1
 synopsis:           Explicit imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -25,9 +25,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                ^>=1.7
+    , ghcide                ^>=1.7 || ^>=1.8
     , hls-graph
-    , hls-plugin-api        ^>=1.4
+    , hls-plugin-api        ^>=1.4 || ^>=1.5
     , lsp
     , text
     , unordered-containers

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-floskell-plugin
-version:            1.0.1.1
+version:            1.0.1.2
 synopsis:           Integration with the Floskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -26,9 +26,9 @@ library
   build-depends:
     , base            >=4.12 && <5
     , floskell        ^>=0.10
-    , ghcide          ^>=1.6 || ^>=1.7
-    , hls-plugin-api  ^>=1.3 || ^>=1.4
-    , lsp-types
+    , ghcide          ^>=1.6 || ^>=1.7 || ^>= 1.8
+    , hls-plugin-api  ^>=1.3 || ^>=1.4 || ^>= 1.5
+    , lsp-types       ^>=1.6
     , text
     , transformers
 
@@ -48,4 +48,4 @@ test-suite tests
     , base
     , filepath
     , hls-floskell-plugin
-    , hls-test-utils       ^>=1.3
+    , hls-test-utils       ^>=1.3 || ^>= 1.4

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-fourmolu-plugin
-version:            1.0.3.0
+version:            1.1.0.0
 synopsis:           Integration with the Fourmolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -38,8 +38,8 @@ library
     , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7 || ^>= 0.8
     , ghc
     , ghc-boot-th
-    , ghcide          ^>=1.7
-    , hls-plugin-api  ^>=1.4
+    , ghcide          ^>=1.8
+    , hls-plugin-api  ^>=1.5
     , lens
     , lsp
     , process-extras  >= 0.7.1
@@ -66,5 +66,5 @@ test-suite tests
     , filepath
     , hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       ^>=1.3
+    , hls-test-utils       ^>=1.4
     , lsp-test

--- a/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
+++ b/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
@@ -30,10 +30,10 @@ library
     , containers
     , extra
     , ghc
-    , ghcide                ^>= 1.7
+    , ghcide                ^>= 1.8
     , ghc-boot-th
     , ghc-exactprint
-    , hls-plugin-api        ^>= 1.4
+    , hls-plugin-api        ^>= 1.5
     , hls-refactor-plugin
     , lens
     , lsp                    >=1.2.0.1
@@ -63,7 +63,7 @@ test-suite tests
     , base
     , filepath
     , hls-gadt-plugin
-    , hls-test-utils              ^>=1.3
+    , hls-test-utils              ^>=1.4
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
+++ b/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-haddock-comments-plugin
-version:            1.0.1.0
+version:            1.1.0.0
 synopsis:           Haddock comments plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server>
@@ -33,8 +33,8 @@ library
     , containers
     , ghc
     , ghc-exactprint        < 1
-    , ghcide                ^>=1.6 || ^>=1.7
-    , hls-plugin-api        ^>=1.3 || ^>=1.4
+    , ghcide                ^>=1.8
+    , hls-plugin-api        ^>=1.5
     , hls-refactor-plugin
     , lsp-types
     , text
@@ -59,5 +59,5 @@ test-suite tests
     , base
     , filepath
     , hls-haddock-comments-plugin
-    , hls-test-utils               ^>=1.2 || ^>=1.3
+    , hls-test-utils               ^>=1.2 || ^>=1.3 || ^>= 1.4
     , text

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-hlint-plugin
-version:       1.0.4.0
+version:       1.1.0.0
 synopsis:      Hlint integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -45,10 +45,10 @@ library
     , extra
     , filepath
     , ghc-exactprint        >=0.6.3.4
-    , ghcide                ^>=1.7
+    , ghcide                ^>=1.8
     , hashable
     , hlint                 < 3.5
-    , hls-plugin-api        ^>=1.4
+    , hls-plugin-api        ^>=1.5
     , hslogger
     , lens
     , lsp
@@ -93,7 +93,7 @@ test-suite tests
     , filepath
     , hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      ^>=1.3
+    , hls-test-utils      ^>=1.4
     , lens
     , lsp-types
     , text

--- a/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
+++ b/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-module-name-plugin
-version:            1.0.2.0
+version:            1.1.0.0
 synopsis:           Module name plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,8 +28,8 @@ library
     , base                  >=4.12 && <5
     , directory
     , filepath
-    , ghcide                ^>=1.7
-    , hls-plugin-api        ^>=1.4
+    , ghcide                ^>=1.8
+    , hls-plugin-api        ^>=1.5
     , lsp
     , text
     , transformers
@@ -48,4 +48,4 @@ test-suite tests
     , base
     , filepath
     , hls-module-name-plugin
-    , hls-test-utils          ^>=1.3
+    , hls-test-utils          ^>=1.4

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-ormolu-plugin
-version:            1.0.2.1
+version:            1.0.2.2
 synopsis:           Integration with the Ormolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,8 +28,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          ^>=1.6 || ^>=1.7
-    , hls-plugin-api  ^>=1.3 || ^>=1.4
+    , ghcide          ^>=1.6 || ^>=1.7 || ^>= 1.8
+    , hls-plugin-api  ^>=1.3 || ^>=1.4 || ^>= 1.5
     , lens
     , lsp
     , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || ^>= 0.5
@@ -51,5 +51,5 @@ test-suite tests
     , base
     , filepath
     , hls-ormolu-plugin
-    , hls-test-utils     ^>=1.3
+    , hls-test-utils     ^>=1.3 || ^>=1.4
     , lsp-types

--- a/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
+++ b/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-pragmas-plugin
-version:            1.0.2.1
+version:            1.0.3.0
 synopsis:           Pragmas plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -26,8 +26,8 @@ library
     , extra
     , fuzzy
     , ghc
-    , ghcide                ^>=1.7
-    , hls-plugin-api        ^>=1.3 || ^>=1.4
+    , ghcide                ^>=1.8
+    , hls-plugin-api        ^>=1.5
     , lens
     , lsp
     , text
@@ -48,7 +48,7 @@ test-suite tests
     , base
     , filepath
     , hls-pragmas-plugin
-    , hls-test-utils      ^>=1.3
+    , hls-test-utils      ^>=1.4
     , lens
     , lsp-types
     , text

--- a/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
+++ b/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
@@ -18,7 +18,6 @@ extra-source-files:
   test/data/*.yaml
 
 library
-  buildable: True
   exposed-modules:    Ide.Plugin.QualifyImportedNames
   hs-source-dirs:     src
   build-depends:
@@ -27,9 +26,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                ^>=1.6 || ^>=1.7
+    , ghcide                ^>=1.6 || ^>=1.7 || ^>= 1.8
     , hls-graph
-    , hls-plugin-api        ^>=1.3 || ^>=1.4
+    , hls-plugin-api        ^>=1.3 || ^>=1.4 || ^>= 1.5
     , lsp
     , text
     , unordered-containers
@@ -42,7 +41,6 @@ library
     TypeOperators
 
 test-suite tests
-  buildable: True
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test
@@ -53,4 +51,4 @@ test-suite tests
     , text
     , filepath
     , hls-qualify-imported-names-plugin
-    , hls-test-utils             ^>= 1.2 || ^>=1.3
+    , hls-test-utils             ^>= 1.2 || ^>=1.3 || ^>= 1.4

--- a/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
+++ b/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
@@ -63,8 +63,8 @@ library
     , ghc-boot
     , regex-tdfa
     , text-rope
-    , ghcide                ^>=1.7
-    , hls-plugin-api        ^>=1.3 || ^>=1.4
+    , ghcide                ^>=1.8
+    , hls-plugin-api        ^>=1.3 || ^>=1.4 || ^>= 1.5
     , lsp
     , text
     , transformers
@@ -98,7 +98,7 @@ test-suite tests
     , base
     , filepath
     , hls-refactor-plugin
-    , hls-test-utils      ^>=1.3
+    , hls-test-utils      ^>=1.4
     , lens
     , lsp-types
     , text

--- a/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
+++ b/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-refine-imports-plugin
-version:            1.0.2.0
+version:            1.0.3.0
 synopsis:           Refine imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -25,10 +25,10 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                       ^>=1.7
+    , ghcide                       ^>=1.8
     , hls-explicit-imports-plugin  ^>=1.1
     , hls-graph
-    , hls-plugin-api               ^>=1.4
+    , hls-plugin-api               ^>=1.5
     , lsp
     , text
     , unordered-containers

--- a/plugins/hls-rename-plugin/hls-rename-plugin.cabal
+++ b/plugins/hls-rename-plugin/hls-rename-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-rename-plugin
-version:            1.0.0.2
+version:            1.0.1.0
 synopsis:           Rename plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,10 +29,10 @@ library
     , extra
     , ghc
     , ghc-exactprint
-    , ghcide                ^>= 1.6 || ^>=1.7
+    , ghcide                ^>=1.8
     , hashable
     , hiedb
-    , hls-plugin-api        ^>= 1.3 || ^>=1.4
+    , hls-plugin-api        ^>= 1.3 || ^>=1.4 || ^>= 1.5
     , hls-refactor-plugin
     , lsp
     , lsp-types
@@ -61,4 +61,4 @@ test-suite tests
     , filepath
     , hls-plugin-api
     , hls-rename-plugin
-    , hls-test-utils             ^>=1.3
+    , hls-test-utils             ^>=1.4

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -28,9 +28,9 @@ library
     , directory
     , extra
     , ghc
-    , ghcide                ^>=1.7
+    , ghcide                ^>=1.8
     , hashable
-    , hls-plugin-api        ^>=1.4
+    , hls-plugin-api        ^>=1.5
     , lsp
     , lsp-types
     , retrie                >=0.1.1.0

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-splice-plugin
-version:            1.0.1.0
+version:            1.0.2.0
 synopsis:
   HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 
@@ -42,8 +42,8 @@ library
     , foldl
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.6 || ^>=1.7
-    , hls-plugin-api        ^>=1.3 || ^>=1.4
+    , ghcide                ^>=1.8
+    , hls-plugin-api        ^>= 1.5
     , hls-refactor-plugin
     , lens
     , lsp
@@ -73,5 +73,5 @@ test-suite tests
     , base
     , filepath
     , hls-splice-plugin
-    , hls-test-utils     ^>=1.2 || ^>=1.3
+    , hls-test-utils ^>= 1.4
     , text

--- a/plugins/hls-stan-plugin/hls-stan-plugin.cabal
+++ b/plugins/hls-stan-plugin/hls-stan-plugin.cabal
@@ -70,7 +70,7 @@ test-suite test
     , filepath
     , hls-stan-plugin
     , hls-plugin-api
-    , hls-test-utils      ^>=1.3
+    , hls-test-utils      ^>=1.3 || ^>= 1.4
     , lens
     , lsp-types
     , text

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -28,8 +28,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide           ^>=1.7
-    , hls-plugin-api   ^>=1.4
+    , ghcide           ^>=1.7 || ^>= 1.8
+    , hls-plugin-api   ^>=1.4 || ^>= 1.5
     , lsp-types
     , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14.2
     , text
@@ -50,4 +50,4 @@ test-suite tests
     , base
     , filepath
     , hls-stylish-haskell-plugin
-    , hls-test-utils              ^>=1.3
+    , hls-test-utils              ^>=1.3 || ^>=1.4

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 category:           Development
 name:               hls-tactics-plugin
-version:            1.6.2.0
+version:            1.7.0.0
 synopsis:           Wingman plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -86,9 +86,9 @@ library
     , ghc-boot-th
     , ghc-exactprint
     , ghc-source-gen        ^>=0.4.1
-    , ghcide                ^>=1.7
+    , ghcide                ^>= 1.8
     , hls-graph
-    , hls-plugin-api        ^>=1.4
+    , hls-plugin-api        ^>=1.5
     , hls-refactor-plugin
     , hyphenation
     , lens
@@ -169,7 +169,7 @@ test-suite tests
     , ghcide
     , hls-plugin-api
     , hls-tactics-plugin
-    , hls-test-utils      ^>=1.3
+    , hls-test-utils      ^>=1.4
     , hspec
     , hspec-expectations
     , lens

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -27,7 +27,7 @@ import           Development.IDE.Types.Logger  as G
 import qualified Development.IDE.Types.Options as Ghcide
 import           GHC.Stack                     (emptyCallStack)
 import qualified HIE.Bios.Environment          as HieBios
-import           HIE.Bios.Types
+import           HIE.Bios.Types                hiding (Log)
 import           Ide.Arguments
 import           Ide.Plugin.ConfigUtils        (pluginsToDefaultConfig,
                                                 pluginsToVSCodeExtensionSchema)

--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -58,7 +58,6 @@ extra-deps:
   - ghc-trace-events-0.1.2.1
   - haskell-src-exts-1.21.1
   - heapsize-0.3.0
-  - hie-bios-0.9.1
   - hlint-3.2.8
   - HsYAML-aeson-0.2.0.0@rev:2
   - hoogle-5.0.17.11
@@ -78,7 +77,7 @@ extra-deps:
   - temporary-1.2.1.1
   - th-compat-0.1.2@sha256:3d55de1adc542c1a870c9ada90da2fbbe5f4e8bcd3eed545a55c3df9311b32a8,2854
   - bytestring-encoding-0.1.0.0@sha256:460b49779fbf0112e8e2f1753c1ed9131eb18827600c298f4d6bb51c4e8c1c0d,1727
-  - hiedb-0.4.1.0
+  - hiedb-0.4.2.0
   - sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
   - direct-sqlite-2.3.26@sha256:04e835402f1508abca383182023e4e2b9b86297b8533afbd4e57d1a5652e0c23,3718
   - dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
@@ -87,12 +86,6 @@ extra-deps:
   - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-  - git: git@github.com:haskell/lsp
-    commit: b0f8596887088b8ab65fc1015c773f45b47234ae
-    subdirs:
-    - lsp
-    - lsp-types
-    - lsp-test
   - stm-containers-1.1.0.4
   - stm-hamt-1.2.0.6@sha256:fba86ccb4b45c5706c19b0e1315ba63dcac3b5d71de945ec001ba921fae80061,3972
   - primitive-extras-0.10.1
@@ -107,6 +100,11 @@ extra-deps:
   - trial-tomland-0.0.0.0@sha256:743a9baaa36891ed3a44618fdfd5bc4ed9afc39cf9b9fa23ea1b96f3787f5ec0,2526
   - text-rope-0.2
   - co-log-core-0.3.1.0
+  - lsp-1.6.0.0
+  - lsp-types-1.6.0.0
+  - lsp-test-0.14.1.0
+  - hie-bios-0.11.0
+  - prettyprinter-1.7.1@sha256:9c43c9d8c3cd9f445596e5a2379574bba87f935a4d1fa41b5407ee3cf4edc743,6987
 
 configure-options:
   ghcide:

--- a/stack-lts19.yaml
+++ b/stack-lts19.yaml
@@ -46,7 +46,7 @@ extra-deps:
 - ghc-lib-parser-9.2.4.20220729
 - ghc-lib-parser-ex-9.2.0.4
 - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
-- hiedb-0.4.1.0@sha256:fb20c657d9ecc91701b00dffcf4bbd77cb83720a1f9d867badd77ea227973135,2875
+- hiedb-0.4.2.0
 - hlint-3.4
 - implicit-hie-0.1.2.7@sha256:82bbbb1a8c05f99c8af3c16ac53e80c8648d8bf047b25ed5ce45a135bd736907,3122
 - implicit-hie-cradle-0.5.0.0@sha256:4276f60f3a59bc22df03fd918f73bca9f777de9568f85e3a8be8bd7566234a59,2368
@@ -55,13 +55,11 @@ extra-deps:
 - refinery-0.4.0.0@sha256:fe3a43add8ff1db5cfffee7e7694c86128b1dfe62c541f26e25a8eadf9585610,1663
 - retrie-1.1.0.0
 - stylish-haskell-0.14.2.0@sha256:fffe1c13ad4c2678cf28a7470cac5d3bf20c71c36f09969e3e5f186787cceb7c,4321
-- git: git@github.com:haskell/lsp
-  commit: b0f8596887088b8ab65fc1015c773f45b47234ae
-  subdirs:
-  - lsp
-  - lsp-types
-  - lsp-test
 - co-log-core-0.3.1.0
+- lsp-1.6.0.0
+- lsp-types-1.6.0.0
+- lsp-test-0.14.1.0
+- hie-bios-0.11.0
 
 configure-options:
   ghcide:

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,18 +38,16 @@ packages:
 extra-deps:
 - floskell-0.10.6@sha256:e77d194189e8540abe2ace2c7cb8efafc747ca35881a2fefcbd2d40a1292e036,3819
 - heapsize-0.3.0.1@sha256:0b69aa97a46d819b700ac7b145f3b5493c3565cf2c5b8298682238d405d0326e,1417
-- hiedb-0.4.1.0@sha256:fb20c657d9ecc91701b00dffcf4bbd77cb83720a1f9d867badd77ea227973135,2875
+- hiedb-0.4.2.0
 - implicit-hie-0.1.2.7@sha256:82bbbb1a8c05f99c8af3c16ac53e80c8648d8bf047b25ed5ce45a135bd736907,3122
 - implicit-hie-cradle-0.5.0.0@sha256:4276f60f3a59bc22df03fd918f73bca9f777de9568f85e3a8be8bd7566234a59,2368
-- git: git@github.com:haskell/lsp
-  commit: b0f8596887088b8ab65fc1015c773f45b47234ae
-  subdirs:
-  - lsp
-  - lsp-types
-  - lsp-test
 - monad-dijkstra-0.1.1.3@sha256:d2fc098d7c122555e726830a12ae0423ac187f89de9228f32e56e2f6fc2238e1,1900
 - retrie-1.2.0.1
 - co-log-core-0.3.1.0
+- lsp-1.6.0.0
+- lsp-types-1.6.0.0
+- lsp-test-0.14.1.0
+- hie-bios-0.11.0
 
 # currently needed for ghcide>extra, etc.
 allow-newer: true

--- a/test/functional/HieBios.hs
+++ b/test/functional/HieBios.hs
@@ -24,7 +24,7 @@ tests = testGroup "hie-bios" [
                             @? "found hover text for main"
                  _ -> error $ "Unexpected hover contents: " ++ show hoverContents
 
-    , testCase "reports errors in hie.yaml" $ do
+    , expectFailBecause "hie-bios 0.11 has poor error messages" $ testCase "reports errors in hie.yaml" $ do
         writeFile (hieBiosErrorPath </> "hie.yaml") ""
         runSession hlsCommand fullCaps hieBiosErrorPath $ do
             _ <- openDoc "Foo.hs" "haskell"


### PR DESCRIPTION
- Prepare 1.8.0.0
- fix ci
- Bump hie-compat
- Use hiedb from hackage


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3150"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

