### PR TITLE
Fixes the flake deps to align with cabal bounds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,11 +21,11 @@
 
     # List of hackage dependencies
     lsp = {
-      url = "https://hackage.haskell.org/package/lsp-1.5.0.0/lsp-1.5.0.0.tar.gz";
+      url = "https://hackage.haskell.org/package/lsp-1.6.0.0/lsp-1.6.0.0.tar.gz";
       flake = false;
     };
     lsp-types = {
-      url = "https://hackage.haskell.org/package/lsp-types-1.5.0.0/lsp-types-1.5.0.0.tar.gz";
+      url = "https://hackage.haskell.org/package/lsp-types-1.6.0.0/lsp-types-1.6.0.0.tar.gz";
       flake = false;
     };
     lsp-test = {
@@ -85,7 +85,7 @@
       flake = false;
     };
     hie-bios = {
-      url = "https://hackage.haskell.org/package/hie-bios-0.9.1/hie-bios-0.9.1.tar.gz";
+      url = "https://hackage.haskell.org/package/hie-bios-0.11.0/hie-bios-0.11.0.tar.gz";
       flake = false;
     };
     myst-parser = {


### PR DESCRIPTION
Was trying to build HLS 1.8.0 with nix via the flake and noticed that the versions of the input deps were not in sync with the required cabal bounds. 

ghcide needs hie-bios-0.11.0 [here](https://github.com/haskell/haskell-language-server/blob/master/ghcide/ghcide.cabal#L108)

ghcide needs lsp-types-1.6.0.0 [here](https://github.com/haskell/haskell-language-server/blob/5a734dfb7f2ae12a1dc85a3bc0d0ef0a16125862/ghcide/ghcide.cabal#L72)

hls-plugin-api needs lsp-1.6.0.0 [here](https://github.com/haskell/haskell-language-server/blob/master/hls-plugin-api/hls-plugin-api.cabal#L52)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3163"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

