### PR TITLE
Pass package dependency information to Fourmolu

### DIFF
--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -34,6 +34,7 @@ library
   ghc-options:      -Wall
   build-depends:
     , base            >=4.12 && <5
+    , containers
     , filepath
     , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7 || ^>= 0.8
     , ghc

--- a/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
@@ -17,6 +17,7 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Bifunctor                  (bimap, first)
 import           Data.Maybe
+import qualified Data.Set                        as Set
 import           Data.Text                       (Text)
 import qualified Data.Text                       as T
 import           Development.IDE                 hiding (pluginHandlers)
@@ -24,6 +25,8 @@ import           Development.IDE.GHC.Compat      as Compat hiding (Cpp, Warning,
                                                             hang, vcat)
 import qualified Development.IDE.GHC.Compat.Util as S
 import           GHC.LanguageExtensions.Type     (Extension (Cpp))
+import           GHC.Unit                        (UnitId (UnitId))
+import           GHC.Unit.Env                    (UnitEnv (ue_units))
 import           Ide.Plugin.Fourmolu.Shim
 import           Ide.Plugin.Properties
 import           Ide.PluginUtils                 (makeDiffTextEdit,
@@ -55,16 +58,25 @@ properties =
 
 provider :: Recorder (WithPriority LogEvent) -> PluginId -> FormattingHandler IdeState
 provider recorder plId ideState typ contents fp fo = withIndefiniteProgress title Cancellable $ do
-    fileOpts <-
-        maybe [] (convertDynFlags . hsc_dflags . hscEnv)
-            <$> liftIO (runAction "Fourmolu" ideState $ use GhcSession fp)
+    maybeHscEnv <- liftIO (runAction "Fourmolu" ideState $ use GhcSession fp)
+    let fileOpts = maybe [] (convertDynFlags . hsc_dflags . hscEnv) maybeHscEnv
+        deps = case maybeHscEnv of
+            Nothing -> []
+            Just env -> flip mapMaybe (Compat.explicitUnits $ ue_units $ hsc_unit_env $ hscEnv env) $ \case
+                RealUnit (Definite (UnitId x)) -> pure . reverse <=< dropChunk <=< dropChunk . reverse $ S.unpackFS x
+                _ -> Nothing
+          where
+            dropChunk = tailSafe . dropWhile (/= '-')
+            tailSafe = \case
+                _ : xs -> Just xs
+                _      -> Nothing
     useCLI <- usePropertyLsp #external plId properties
     if useCLI
         then liftIO
             . fmap (join . first (mkError . show))
             . try @IOException
             $ do
-                CLIVersionInfo{noCabal} <- do -- check Fourmolu version so that we know which flags to use
+                CLIVersionInfo{noCabal, packages} <- do -- check Fourmolu version so that we know which flags to use
                     (exitCode, out, _err) <- readCreateProcessWithExitCode ( proc "fourmolu" ["-v"] ) ""
                     let version = do
                             guard $ exitCode == ExitSuccess
@@ -73,17 +85,20 @@ provider recorder plId ideState typ contents fp fo = withIndefiniteProgress titl
                     case version of
                         Just v -> pure CLIVersionInfo
                             { noCabal = v >= [0, 7]
+                            , packages = v >= [0, 7]
                             }
                         Nothing -> do
                             logWith recorder Warning $ NoVersion out
                             pure CLIVersionInfo
                                 { noCabal = True
+                                , packages = True
                                 }
                 (exitCode, out, err) <- -- run Fourmolu
                     readCreateProcessWithExitCode
                         ( proc "fourmolu" $
                             map ("-o" <>) fileOpts
                                 <> mwhen noCabal ["--no-cabal"]
+                                <> mwhen packages (deps >>= \d -> ["-p", d])
                                 <> catMaybes
                                     [ ("--start-line=" <>) . show <$> regionStartLine region
                                     , ("--end-line=" <>) . show <$> regionEndLine region
@@ -113,6 +128,7 @@ provider recorder plId ideState typ contents fp fo = withIndefiniteProgress titl
                                 fillMissingPrinterOpts
                                     (printerOpts <> lspPrinterOpts)
                                     defaultPrinterOpts
+                            , cfgDependencies = Set.fromList deps
                             }
              in liftIO (loadConfigFile fp') >>= \case
                     ConfigLoaded file opts -> liftIO $ do
@@ -167,8 +183,9 @@ convertDynFlags df =
             x   -> "-X" ++ show x
      in pp <> pm <> ex
 
-newtype CLIVersionInfo = CLIVersionInfo
+data CLIVersionInfo = CLIVersionInfo
     { noCabal :: Bool
+    , packages :: Bool
     }
 
 mwhen :: Monoid a => Bool -> a -> a


### PR DESCRIPTION
HLS 1.8 finally picks up Fourmolu > 0.7. In fact it ships with 0.8 on all GHC versions.

Unfortunately this causes a regression in recognising operator fixities for packages whose fixities were previously hardcoded. At least in environments with no Cabal file. I hit this with SBV, within seconds of installing the new HLS version.

This current implementation feels like a total hack. I could do with suggestions.


## TODO

- [ ] get fixities from env directly, rather than even having to read cabal file? this may be the key to doing this robustly
- [ ] implement this for Ormolu
- [ ] wrap version CPP around `cfgDependencies`, putting it in `Shim.hs`
- [ ] check compatiblity across GHC API versions - given this involves units, I'd expect the API used to have changed in 9.4
- [ ] regression test
- [ ] maybe combine `noCabal` and `packages` in to a single option, seeing as they're closely related and introduced in the same version of Fourmolu
