### PR TITLE
Stan: Respect plugin configuration globalOn

### DIFF
--- a/plugins/hls-stan-plugin/hls-stan-plugin.cabal
+++ b/plugins/hls-stan-plugin/hls-stan-plugin.cabal
@@ -32,6 +32,7 @@ library
   build-depends:
       base
     , containers
+    , data-default
     , deepseq
     , hashable
     , hls-plugin-api

--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -5,28 +5,17 @@ import           Control.Monad                  (void)
 import           Control.Monad.IO.Class         (liftIO)
 import           Control.Monad.Trans.Class      (lift)
 import           Control.Monad.Trans.Maybe      (MaybeT (MaybeT), runMaybeT)
+import           Data.Default
 import           Data.Foldable                  (toList)
-import           Data.Hashable                  (Hashable)
 import qualified Data.HashMap.Strict            as HM
+import           Data.Hashable                  (Hashable)
 import qualified Data.Map                       as Map
 import           Data.Maybe                     (fromJust, mapMaybe)
 import qualified Data.Text                      as T
-import           Development.IDE                (Action, FileDiagnostic,
-                                                 GetHieAst (..),
-                                                 GetModSummaryWithoutTimestamps (..),
-                                                 GhcSession (..), IdeState,
-                                                 NormalizedFilePath,
-                                                 Pretty (..), Recorder,
-                                                 RuleResult, Rules,
-                                                 ShowDiagnostic (..),
-                                                 TypeCheck (..), WithPriority,
-                                                 action, cmapWithPrio, define,
-                                                 getFilesOfInterestUntracked,
-                                                 hscEnv, msrModSummary,
-                                                 tmrTypechecked, use, uses)
+import           Development.IDE
+import           Development.IDE.Core.RuleTypes (HieAstResult (..))
 import           Development.IDE.Core.Rules     (getHieFile,
                                                  getSourceFileSource)
-import           Development.IDE.Core.RuleTypes (HieAstResult (..))
 import qualified Development.IDE.Core.Shake     as Shake
 import           Development.IDE.GHC.Compat     (HieASTs (HieASTs),
                                                  RealSrcSpan (..), mkHieFile',
@@ -38,9 +27,11 @@ import           Development.IDE.GHC.Compat     (HieASTs (HieASTs),
 import           Development.IDE.GHC.Error      (realSrcSpanToRange)
 import           GHC.Generics                   (Generic)
 import           HieTypes                       (HieASTs, HieFile)
+import           Ide.Plugin.Config
 import           Ide.Types                      (PluginDescriptor (..),
                                                  PluginId,
-                                                 defaultPluginDescriptor)
+                                                 defaultPluginDescriptor,
+                                                 pluginEnabledConfig)
 import qualified Language.LSP.Types             as LSP
 import           Stan.Analysis                  (Analysis (..), runAnalysis)
 import           Stan.Category                  (Category (..))
@@ -50,7 +41,8 @@ import           Stan.Inspection.All            (inspectionsIds, inspectionsMap)
 import           Stan.Observation               (Observation (..))
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder plId = (defaultPluginDescriptor plId) {pluginRules = rules recorder}
+descriptor recorder plId = (defaultPluginDescriptor plId)
+    {pluginRules = rules recorder plId}
 
 newtype Log = LogShake Shake.Log deriving (Show)
 
@@ -67,18 +59,21 @@ instance NFData GetStanDiagnostics
 
 type instance RuleResult GetStanDiagnostics = ()
 
-rules :: Recorder (WithPriority Log) -> Rules ()
-rules recorder = do
+rules :: Recorder (WithPriority Log) -> PluginId -> Rules ()
+rules recorder plId = do
   define (cmapWithPrio LogShake recorder) $
     \GetStanDiagnostics file -> do
-      maybeHie <- getHieFile file
-      case maybeHie of
-        Nothing -> return ([], Nothing)
-        Just hie -> do
-          let enabledInspections = HM.fromList [(LSP.fromNormalizedFilePath file, inspectionsIds)]
-          -- This should use Cabal config for extensions and Stan config for inspection preferences is the future
-          let analysis = runAnalysis Map.empty enabledInspections [] [hie]
-          return (analysisToDiagnostics file analysis, Just ())
+      config <- getClientConfigAction def
+      if pluginEnabledConfig plcDiagnosticsOn plId config then do
+          maybeHie <- getHieFile file
+          case maybeHie of
+            Nothing -> return ([], Nothing)
+            Just hie -> do
+              let enabledInspections = HM.fromList [(LSP.fromNormalizedFilePath file, inspectionsIds)]
+              -- This should use Cabal config for extensions and Stan config for inspection preferences is the future
+              let analysis = runAnalysis Map.empty enabledInspections [] [hie]
+              return (analysisToDiagnostics file analysis, Just ())
+      else return ([], Nothing)
 
   action $ do
     files <- getFilesOfInterestUntracked
@@ -87,7 +82,7 @@ rules recorder = do
     analysisToDiagnostics :: NormalizedFilePath -> Analysis -> [FileDiagnostic]
     analysisToDiagnostics file = mapMaybe (observationToDianostic file) . toList . analysisObservations
     observationToDianostic :: NormalizedFilePath -> Observation -> Maybe FileDiagnostic
-    observationToDianostic file (Observation {observationSrcSpan, observationInspectionId}) =
+    observationToDianostic file Observation {observationSrcSpan, observationInspectionId} =
       do
         inspection <- HM.lookup observationInspectionId inspectionsMap
         let
@@ -109,7 +104,7 @@ rules recorder = do
         return ( file,
           ShowDiag,
           LSP.Diagnostic
-            { _range = realSrcSpanToRange $ observationSrcSpan,
+            { _range = realSrcSpanToRange observationSrcSpan,
               _severity = Just LSP.DsHint,
               _code = Just (LSP.InR $ unId (inspectionId inspection)),
               _source = Just "stan",


### PR DESCRIPTION
Respects `globalOn` in stan plugin configuration and won't show hints anymore if the plugin is disabled. Solves #3157

## Tested

```json
"stan": { "globalOn": false }
```

Could verify the `globalOn` setting will be respected with a local project.

## About the change

Solves the issue (respecting if the plugin is disabled) the same way it is done [in the hlint plugin][hlint], as hinted to by @pepeiborra in [this comment][2]  thanks

[hlint]: https://github.com/haskell/haskell-language-server/blob/master/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs#L199-L205
[2]: https://github.com/haskell/haskell-language-server/issues/3157#issuecomment-1247766075

@uhbif19 Since you wanted to take a look - hope it's okay and I ddin't take it away from you - is this fine? Any doubts? Also feel free to take over. 


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3179"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

