### PR TITLE
Configuration: more advanced Vim / Coc example (suggestion)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,6 +271,8 @@ Coc is recommend since it is the only complete LSP implementation for Vim and Ne
 Follow Coc's [installation instructions](https://github.com/neoclide/coc.nvim).
 Then issue `:CocConfig` and add the following to your Coc config file.
 
+##### Minimal Example
+
 ```json
 {
   "languageserver": {
@@ -279,6 +281,32 @@ Then issue `:CocConfig` and add the following to your Coc config file.
       "args": ["--lsp"],
       "rootPatterns": ["*.cabal", "stack.yaml", "cabal.project", "package.yaml", "hie.yaml"],
       "filetypes": ["haskell", "lhaskell"]
+    }
+  }
+}
+```
+
+##### Example with Settings
+
+```json
+{
+  "languageserver": {
+    "haskell": {
+      "command": "haskell-language-server-wrapper",
+      "args": ["--lsp"],
+      "rootPatterns": [ "*.cabal", "stack.yaml", "cabal.project", "package.yaml", "hie.yaml" ],
+      "filetypes": ["haskell", "lhaskell"],
+      "settings": {
+        "haskell": {
+          "checkParents": "CheckOnSave",
+          "checkProject": true,
+          "maxCompletions": 40,
+          "formattingProvider": "ormolu",
+          "plugin": {
+            "stan": { "globalOn": true }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I wasn't aware how to properly configure CoC language servers so that they're recognized by haskell language server (see https://github.com/haskell/haskell-language-server/issues/3157#issuecomment-1247795588). Might be possible that the configuration changed. Therefore I'd suggest to add an example showing how to configure settings for plugins. I chose to add a second example in order to keep the default example minimal and avoid confusing people who want an easy way to start with.



This suggestion is open for discussion. I can see how this could somehow be redundant, or more than necessary for a minimal example. At the same time when I did want to look up how the configuration should be defined, [I didn't find any information](https://github.com/haskell/haskell-language-server/issues/3157#issuecomment-1247027434).

By the way, I also updated the [example in the CoC wiki](https://github.com/neoclide/coc.nvim/wiki/Language-servers/_compare/780ffbc2e76505e619de2e390d53106ba97b0c09...e68c01e38bd58dd09c0ee45d13369f755c8958c3)

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3181"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

