### PR TITLE
Docs: Fix checkParents documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,8 +42,8 @@ Here is a list of the additional settings currently supported by `haskell-langua
 
 - Formatting provider (`haskell.formattingProvider`, default `ormolu`): what formatter to use; one of `floskell`, `ormolu`, `fourmolu`, `stylish-haskell`, or `brittany` (if compiled with the brittany plugin).
 - Max completions (`haskell.maxCompletions`, default 40): maximum number of completions sent to the LSP client.
-- Check project (`haskell.checkProject`, default true): whether to typecheck the entire project on load. As it is activated by default could drive to bad performance in large projects.
-- Check parents (`haskell.checkParents`, default `CheckOnSaveAndClose`): when to typecheck reverse dependencies of a file; one of `NeverCheck`, `CheckOnClose`, `CheckOnSaveAndClose`, or `AlwaysCheck`.
+- Check project (`haskell.checkProject`, default true): whether to typecheck the entire project on initial load. As it is activated by default could drive to bad performance in large projects.
+- Check parents (`haskell.checkParents`, default `CheckOnSave`): when to typecheck reverse dependencies of a file; one of `NeverCheck`, `CheckOnSave` (means dependent/parent modules will only be checked when you save), or `AlwaysCheck` (means re-typechecking them on every change).
 
 #### Generic plugin configuration
 

--- a/ghcide/README.md
+++ b/ghcide/README.md
@@ -100,24 +100,6 @@ If you can't get `ghcide` working outside the editor, see [this setup troublesho
 
 `ghcide` has been designed to handle projects with hundreds or thousands of modules. If `ghci` can handle it, then `ghcide` should be able to handle it. The only caveat is that this currently requires GHC >= 8.6, and that the first time a module is loaded in the editor will trigger generation of support files in the background if those do not already exist.
 
-### Configuration
-
-`ghcide` accepts the following lsp configuration options:
-
-```typescript
-{
-  // When to check the dependents of a module
-  // AlwaysCheck means retypechecking them on every change
-  // CheckOnSave means dependent/parent modules will only be checked when you save
-  // "CheckOnSaveAndClose" by default
-  checkParents : "NeverCheck" | "CheckOnClose" | "CheckOnSaveAndClose" | "AlwaysCheck" | ,
-  // Whether to check the entire project on initial load
-  // true by default
-  checkProject : boolean
-
-}
-```
-
 ### Using with VS Code
 
 The [Haskell](https://marketplace.visualstudio.com/items?itemName=haskell.haskell) extension has a setting for ghcide.


### PR DESCRIPTION
* Check on close modes were removed
* Moving docs to configuration and away from ghcide README

Solves #3156

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3184"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

