### PR TITLE
Fix the nix 9.4.2 devshell to build every dep with nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -214,17 +214,17 @@
     "lsp": {
       "flake": false,
       "locked": {
-        "lastModified": 1662291729,
-        "narHash": "sha256-KlL38v/75G9zrW7+IiUeiCxFfLJGm/EdFeWQRUikab8=",
+        "lastModified": 1663082924,
+        "narHash": "sha256-H2q53kVRJnxllZtnIN4JPETqCFVIM1WCJjj/iaSwYyk=",
         "owner": "haskell",
         "repo": "lsp",
-        "rev": "b0f8596887088b8ab65fc1015c773f45b47234ae",
+        "rev": "596376af3c9dff902797ef11f16ba6d177a22890",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
+        "ref": "1.6.0.0",
         "repo": "lsp",
-        "rev": "b0f8596887088b8ab65fc1015c773f45b47234ae",
         "type": "github"
       }
     },
@@ -259,16 +259,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663112159,
-        "narHash": "sha256-31rjPhB6Hj1QoqLvFSULFf9Z/6z05vR0KrLGYvr9w0M=",
-        "owner": "NixOS",
+        "lastModified": 1663470238,
+        "narHash": "sha256-gTTR4UOlv8RNGSUl7tpj/SHHKoxaTGwglOFwGUU4p+A=",
+        "owner": "lf-",
         "repo": "nixpkgs",
-        "rev": "78bce1608960b994405f3696ba086ba1d63654e9",
+        "rev": "bbc4757212d4dba415abcc573973a6ad038dd40f",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "owner": "lf-",
+        "ref": "ghc-942",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   description = "haskell language server flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:lf-/nixpkgs/ghc-942";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -28,7 +28,7 @@
 
     # List of hackage dependencies
     lsp = {
-      url = "github:haskell/lsp/b0f8596887088b8ab65fc1015c773f45b47234ae";
+      url = "github:haskell/lsp/1.6.0.0";
       flake = false;
     };
     lsp-test = {


### PR DESCRIPTION
Currently cabal tries to build HUnit and more with cabal instead of grabbing them from nix since nix provides old versions in the current ghc942 configuration. This is largely because nix simply does not have a usable package set for ghc942 (basically the configuration-ghc9.4.2.nix file was a stub).

I'm working on that upstream here: https://github.com/NixOS/nixpkgs/pull/191618

This PR fixes that today, but points to a nixpkgs fork, which is not necessarily desirable.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3196"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

