### PR TITLE
Stylish Haskell: CPP parse issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
       "hooks": [
         {
           "entry": "stylish-haskell --inplace",
-          "exclude": "(^Setup.hs$|test/testdata/.*$|test/data/.*$|test/manual/lhs/.*$|^hie-compat/.*$|^plugins/hls-tactics-plugin/.*$|^ghcide/src/Development/IDE/GHC/Compat.hs$|^ghcide/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs$|^ghcide/src/Development/IDE/GHC/Compat/Core.hs$|^ghcide/src/Development/IDE/Spans/Pragmas.hs$|^ghcide/src/Development/IDE/LSP/Outline.hs$|^plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs$|^ghcide/test/exe/Main.hs$|ghcide/src/Development/IDE/Core/Rules.hs|^hls-test-utils/src/Test/Hls/Util.hs$)",
+          "exclude": "(^Setup.hs$|test/testdata/.*$|test/data/.*$|test/manual/lhs/.*$|^hie-compat/.*$|^plugins/hls-tactics-plugin/.*$|^ghcide/src/Development/IDE/GHC/Compat.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/Compat/ExactPrint.hs$|^ghcide/src/Development/IDE/GHC/Compat/Core.hs$|^ghcide/src/Development/IDE/Spans/Pragmas.hs$|^ghcide/src/Development/IDE/LSP/Outline.hs$|^plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs$|^ghcide/test/exe/Main.hs$|^ghcide/src/Development/IDE/Core/Rules.hs$|^hls-test-utils/src/Test/Hls/Util.hs$|^ghcide/src/Development/IDE/Core/Compile.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs$)",
           "files": "\\.l?hs$",
           "id": "stylish-haskell",
           "language": "system",

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -57,6 +57,7 @@ newline: lf
 
 language_extensions:
   - BangPatterns
+  - CPP
   - DataKinds
   - DeriveFunctor
   - DeriveGeneric

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE TypeFamilies              #-}
-{-# LANGUAGE CPP                       #-}
 
 {-|
 The logic for setting up a ghcide session by tapping into hie-bios.
@@ -67,15 +67,16 @@ import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger         (Pretty (pretty),
                                                        Priority (Debug, Error, Info, Warning),
                                                        Recorder, WithPriority,
-                                                       logWith, nest, vcat,
-                                                       viaShow, (<+>),
-                                                       toCologActionWithPrio, cmapWithPrio)
+                                                       cmapWithPrio, logWith,
+                                                       nest,
+                                                       toCologActionWithPrio,
+                                                       vcat, viaShow, (<+>))
 import           Development.IDE.Types.Options
 import           GHC.Check
 import qualified HIE.Bios                             as HieBios
-import qualified HIE.Bios.Types                       as HieBios
 import           HIE.Bios.Environment                 hiding (getCacheDir)
 import           HIE.Bios.Types                       hiding (Log)
+import qualified HIE.Bios.Types                       as HieBios
 import           Hie.Implicit.Cradle                  (loadImplicitHieCradle)
 import           Language.LSP.Server
 import           Language.LSP.Types
@@ -90,6 +91,8 @@ import           Data.Void
 import           Control.Concurrent.STM.Stats         (atomically, modifyTVar',
                                                        readTVar, writeTVar)
 import           Control.Concurrent.STM.TQueue
+import           Control.DeepSeq
+import           Control.Exception                    (evaluate)
 import           Control.Monad.IO.Unlift              (MonadUnliftIO)
 import           Data.Foldable                        (for_)
 import           Data.HashMap.Strict                  (HashMap)
@@ -103,9 +106,6 @@ import           HieDb.Types
 import           HieDb.Utils
 import qualified System.Random                        as Random
 import           System.Random                        (RandomGen)
-import Control.Monad.IO.Unlift (MonadUnliftIO)
-import Control.Exception (evaluate)
-import Control.DeepSeq
 
 data Log
   = LogSettingInitialDynFlags

--- a/ghcide/src/Development/IDE/GHC/Compat/Iface.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Iface.hs
@@ -8,7 +8,7 @@ module Development.IDE.GHC.Compat.Iface (
 
 import           GHC
 #if MIN_VERSION_ghc(9,3,0)
-import           GHC.Driver.Session (targetProfile)
+import           GHC.Driver.Session                    (targetProfile)
 #endif
 #if MIN_VERSION_ghc(9,2,0)
 import qualified GHC.Iface.Load                        as Iface

--- a/ghcide/src/Development/IDE/Import/FindImports.hs
+++ b/ghcide/src/Development/IDE/Import/FindImports.hs
@@ -28,7 +28,7 @@ import           Data.List                         (isSuffixOf)
 import           Data.Maybe
 import           System.FilePath
 #if MIN_VERSION_ghc(9,3,0)
-import GHC.Types.PkgQual
+import           GHC.Types.PkgQual
 #endif
 
 data Import
@@ -123,11 +123,12 @@ locateModule env comp_info exts targetFor modName mbPkgName isSource = do
 #if MIN_VERSION_ghc(9,3,0)
     OtherPkg uid
       | Just dirs <- lookup uid import_paths
+          -> lookupLocal uid dirs
 #else
     Just pkgName
       | Just (uid, dirs) <- lookup (PackageName pkgName) import_paths
-#endif
           -> lookupLocal uid dirs
+#endif
       | otherwise -> lookupInPackageDB env
 #if MIN_VERSION_ghc(9,3,0)
     NoPkgQual -> do
@@ -148,7 +149,7 @@ locateModule env comp_info exts targetFor modName mbPkgName isSource = do
 
       mbFile <- locateModuleFile ((homeUnitId_ dflags, importPaths dflags) : import_paths') exts targetFor isSource $ unLoc modName
       case mbFile of
-        Nothing   -> lookupInPackageDB env
+        Nothing          -> lookupInPackageDB env
         Just (uid, file) -> toModLocation uid file
   where
     dflags = hsc_dflags env

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -59,7 +59,8 @@ import           GHC.Plugins                              (Depth (AllTheWay),
 #endif
 import           Ide.PluginUtils                          (mkLspCommand)
 import           Ide.Types                                (CommandId (..),
-                                                           IdePlugins(..), PluginId)
+                                                           IdePlugins (..),
+                                                           PluginId)
 import           Language.LSP.Types
 import           Language.LSP.Types.Capabilities
 import qualified Language.LSP.VFS                         as VFS
@@ -516,7 +517,6 @@ findRecordCompl uri pmod mn DataDecl {tcdLName, tcdDataDefn} = result
                              PrefixCon{} -> Just []
                              _           -> Nothing
 
-        extract ConDeclField{..}
             -- NOTE: 'cd_fld_names' is grouped so that the fields
             -- sharing the same type declaration to fit in the same group; e.g.
             --
@@ -527,8 +527,10 @@ findRecordCompl uri pmod mn DataDecl {tcdLName, tcdDataDefn} = result
             -- is encoded as @[[arg1, arg2], [arg3], [arg4]]@
             -- Hence, we must concat nested arguments into one to get all the fields.
 #if MIN_VERSION_ghc(9,3,0)
+        extract ConDeclField{..}
             = map (foLabel . unLoc) cd_fld_names
 #else
+        extract ConDeclField{..}
             = map (rdrNameFieldOcc . unLoc) cd_fld_names
 #endif
         -- XConDeclField

--- a/plugins/hls-haddock-comments-plugin/src/Ide/Plugin/HaddockComments.hs
+++ b/plugins/hls-haddock-comments-plugin/src/Ide/Plugin/HaddockComments.hs
@@ -15,10 +15,10 @@ import qualified Data.Map                              as Map
 import qualified Data.Text                             as T
 import           Development.IDE                       hiding (pluginHandlers)
 import           Development.IDE.GHC.Compat
-import           Development.IDE.Plugin.CodeAction
 import           Development.IDE.GHC.Compat.ExactPrint
 import           Development.IDE.GHC.ExactPrint        (GetAnnotatedParsedSource (..))
-import qualified Development.IDE.GHC.ExactPrint                   as E
+import qualified Development.IDE.GHC.ExactPrint        as E
+import           Development.IDE.Plugin.CodeAction
 import           Ide.Types
 import           Language.Haskell.GHC.ExactPrint
 import           Language.Haskell.GHC.ExactPrint.Types hiding (GhcPs)

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -19,9 +19,9 @@ import           Control.Arrow                                     (second,
                                                                     (&&&),
                                                                     (>>>))
 import           Control.Concurrent.STM.Stats                      (atomically)
+import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Maybe
-import           Control.Monad.Extra
 import           Data.Aeson
 import           Data.Char
 import qualified Data.DList                                        as DL
@@ -39,50 +39,52 @@ import qualified Data.Set                                          as S
 import qualified Data.Text                                         as T
 import qualified Data.Text.Utf16.Rope                              as Rope
 import           Data.Tuple.Extra                                  (fst3)
-import           Development.IDE.Types.Logger                      hiding (group)
 import           Development.IDE.Core.Rules
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Service
+import           Development.IDE.Core.Shake                        hiding (Log)
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Compat.ExactPrint
 import           Development.IDE.GHC.Compat.Util
 import           Development.IDE.GHC.Error
 import           Development.IDE.GHC.ExactPrint
-import qualified Development.IDE.GHC.ExactPrint                   as E
+import qualified Development.IDE.GHC.ExactPrint                    as E
 import           Development.IDE.GHC.Util                          (printOutputable,
                                                                     printRdrName)
-import           Development.IDE.Core.Shake                   hiding (Log)
 import           Development.IDE.Plugin.CodeAction.Args
 import           Development.IDE.Plugin.CodeAction.ExactPrint
-import           Development.IDE.Plugin.CodeAction.Util
 import           Development.IDE.Plugin.CodeAction.PositionIndexed
+import           Development.IDE.Plugin.CodeAction.Util
 import           Development.IDE.Plugin.Completions.Types
 import           Development.IDE.Plugin.TypeLenses                 (suggestSignature)
 import           Development.IDE.Types.Exports
 import           Development.IDE.Types.Location
+import           Development.IDE.Types.Logger                      hiding
+                                                                   (group)
 import           Development.IDE.Types.Options
+import           GHC.Exts                                          (fromList)
 import qualified GHC.LanguageExtensions                            as Lang
 import           Ide.PluginUtils                                   (subRange)
 import           Ide.Types
 import qualified Language.LSP.Server                               as LSP
-import           Language.LSP.Types                                (ApplyWorkspaceEditParams(..), CodeAction (..),
+import           Language.LSP.Types                                (ApplyWorkspaceEditParams (..),
+                                                                    CodeAction (..),
                                                                     CodeActionContext (CodeActionContext, _diagnostics),
                                                                     CodeActionKind (CodeActionQuickFix, CodeActionUnknown),
                                                                     CodeActionParams (CodeActionParams),
                                                                     Command,
                                                                     Diagnostic (..),
-                                                                    MessageType (..),
-                                                                    ShowMessageParams (..),
                                                                     List (..),
+                                                                    MessageType (..),
                                                                     ResponseError,
                                                                     SMethod (..),
+                                                                    ShowMessageParams (..),
                                                                     TextDocumentIdentifier (TextDocumentIdentifier),
                                                                     TextEdit (TextEdit, _range),
                                                                     UInt,
                                                                     WorkspaceEdit (WorkspaceEdit, _changeAnnotations, _changes, _documentChanges),
                                                                     type (|?) (InR),
                                                                     uriToFilePath)
-import           GHC.Exts                                           (fromList)
 import           Language.LSP.VFS                                  (VirtualFile,
                                                                     _file_text)
 import           Text.Regex.TDFA                                   (mrAfter,

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Util.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Util.hs
@@ -1,22 +1,23 @@
 module Development.IDE.Plugin.CodeAction.Util where
 
-import           Data.Data                         (Data)
-import qualified Data.Unique                       as U
+import           Data.Data                             (Data)
+import           Data.Time.Clock.POSIX                 (POSIXTime,
+                                                        getCurrentTime,
+                                                        utcTimeToPOSIXSeconds)
+import qualified Data.Unique                           as U
 import           Debug.Trace
 import           Development.IDE.GHC.Compat.ExactPrint as GHC
+import           Development.IDE.GHC.Dump              (showAstDataHtml)
 import           GHC.Stack
-import           System.Environment.Blank          (getEnvDefault)
+import           System.Environment.Blank              (getEnvDefault)
 import           System.IO.Unsafe
 import           Text.Printf
-import           Development.IDE.GHC.Dump          (showAstDataHtml)
-import           Data.Time.Clock.POSIX             (POSIXTime, getCurrentTime,
-                                                    utcTimeToPOSIXSeconds)
 #if MIN_VERSION_ghc(9,2,0)
 import           GHC.Utils.Outputable
 #else
-import           Development.IDE.GHC.Util
-import           Development.IDE.GHC.Compat.Util
 import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Compat.Util
+import           Development.IDE.GHC.Util
 #endif
 --------------------------------------------------------------------------------
 -- Tracing exactprint terms

--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -7,15 +7,15 @@ import           Control.Monad.Trans.Class      (lift)
 import           Control.Monad.Trans.Maybe      (MaybeT (MaybeT), runMaybeT)
 import           Data.Default
 import           Data.Foldable                  (toList)
-import qualified Data.HashMap.Strict            as HM
 import           Data.Hashable                  (Hashable)
+import qualified Data.HashMap.Strict            as HM
 import qualified Data.Map                       as Map
 import           Data.Maybe                     (fromJust, mapMaybe)
 import qualified Data.Text                      as T
 import           Development.IDE
-import           Development.IDE.Core.RuleTypes (HieAstResult (..))
 import           Development.IDE.Core.Rules     (getHieFile,
                                                  getSourceFileSource)
+import           Development.IDE.Core.RuleTypes (HieAstResult (..))
 import qualified Development.IDE.Core.Shake     as Shake
 import           Development.IDE.GHC.Compat     (HieASTs (HieASTs),
                                                  RealSrcSpan (..), mkHieFile',


### PR DESCRIPTION
## Change

* CPP language extension
* Manually fix some files with duplication
* Fixed ignored filepaths in pre-commit config (ExactPrint was moved)

## Result

### Without this change

```shell
pre-commit run --show-diff-on-failure --all-files

plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs: <string>:7:1: error: parse error on input `#'
plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Util.hs: <string>:14:1: error: parse error on input `#'
plugins/hls-refactor-plugin/src/Development/IDE/GHC/Compat/ExactPrint.hs: <string>:5:1: error: parse error on input `#'
plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs: <string>:90:1: error: parse error on input `#'
```

### With this change

![image](https://user-images.githubusercontent.com/13085980/191018938-7416171b-02e6-43c9-9693-f4f0f02f552a.png)

![image](https://user-images.githubusercontent.com/13085980/191019918-fc149bf8-1cbd-4fc6-a07c-e548316bdf49.png)


## System 

stylish-haskell 0.14.2.0

## Issue

* Related to #3170
* Followup of #3171
* If there would be a way to tell stylish-haskell to skip parts of a file, these kind of issues could easier be solved without mangling with the code. It's doesn't exist. See https://github.com/haskell/stylish-haskell/issues/409#issuecomment-1250887142

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3199"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

