### PR TITLE
Document the `stack` requirement in wrapper tests

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -71,6 +71,7 @@ GHC 8.6.5 is not supported here because `nixpkgs-unstable` no longer maintains t
 The tests make use of the [Tasty](https://github.com/feuerbach/tasty) test framework.
 
 There are two test suites in the main haskell-language-server package, functional tests, and wrapper tests.
+Some of the wrapper tests expect `stack` to be present on the system, or else they fail.
 Other project packages, like the core library or plugins, can have their own test suite.
 
 ### Testing with Cabal


### PR DESCRIPTION
Some wrapper tests fail in the absence of `stack` on the system. This PR adds a small note in the _testing_ section of the _contributing_ page regarding that.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

