### PR TITLE
Add diagnostics to Stan descriptor

### DIFF
--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -29,7 +29,8 @@ import           GHC.Generics                   (Generic)
 import           HieTypes                       (HieASTs, HieFile)
 import           Ide.Plugin.Config
 import           Ide.Types                      (PluginDescriptor (..),
-                                                 PluginId,
+                                                 PluginId, configHasDiagnostics,
+                                                 defaultConfigDescriptor,
                                                  defaultPluginDescriptor,
                                                  pluginEnabledConfig)
 import qualified Language.LSP.Types             as LSP
@@ -42,7 +43,11 @@ import           Stan.Observation               (Observation (..))
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId = (defaultPluginDescriptor plId)
-    {pluginRules = rules recorder plId}
+  { pluginRules = rules recorder plId
+  , pluginConfigDescriptor = defaultConfigDescriptor
+      { configHasDiagnostics = True
+      }
+    }
 
 newtype Log = LogShake Shake.Log deriving (Show)
 


### PR DESCRIPTION
This has effect only when generating the config schema and won't change anything for the Stan plugin schema at all

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3213"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

