### PR TITLE
 wrapper.in: Require runtime ghc-pkgs to be an abi compatible superset of bootpkgs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -106,6 +106,7 @@ bindist-ghc:
 	$(SED) \
 		-e "s/@@EXE_NAME@@/haskell-language-server-$(GHC_VERSION)/" \
 		-e "s/@@GHC_VERSION@@/$(GHC_VERSION)/" \
+		-e "s/@@BOOT_PKGS@@/$(shell ghc-pkg-$(GHC_VERSION) --global list --simple-output)/" \
 		-e "s/@@ABI_HASHES@@/$(shell for dep in `ghc-pkg-$(GHC_VERSION) --global list --simple-output` ; do printf "%s:" "$$dep" && ghc-pkg-$(GHC_VERSION) field $$dep abi --simple-output ; done | tr '\n' ' ' | xargs)/" \
 		bindist/wrapper.in > "$(BINDIST_OUT_DIR)/haskell-language-server-$(GHC_VERSION).in"
 	$(CHMOD_X) "$(BINDIST_OUT_DIR)/haskell-language-server-$(GHC_VERSION).in"

--- a/bindist/wrapper.in
+++ b/bindist/wrapper.in
@@ -3,6 +3,10 @@
 exedir="@@EXE_DIR@@"
 executablename="@@EXE_NAME@@"
 GHC_VERSION="@@GHC_VERSION@@"
+
+# This space separated list contains the names and versions of the boot libraries used to compile hls.
+BOOT_PKGS="@@BOOT_PKGS@@"
+# This space separated list contains the ABI hashes of the pkgs in BOOT_PKGS at compiletime.
 ABI_HASHES="@@ABI_HASHES@@"
 
 debug_msg() {
@@ -62,7 +66,7 @@ check_ghc() {
 
 	# check version
 	if [ "${check_ghc_ver}" = "${GHC_VERSION}" ] ; then
-		# check ABI
+		# check for all packages listed in BOOT_PKGS that they are present with the same ABI hash as at hls-compiletime to prevent linking issues.
 		if "${GHC_PKG}" --version >/dev/null ; then
 			:
 		elif "${GHC_PKG}-${GHC_VERSION}" --version >/dev/null ; then
@@ -73,7 +77,7 @@ check_ghc() {
 			return 1
 		fi
 		PKGCONF="${check_ghc_libdir}/package.conf.d"
-		MY_ABI_HASHES="$(for dep in $("${GHC_PKG}" --global --global-package-db "$PKGCONF" list --simple-output) ; do printf "%s:" "${dep}" && "${GHC_PKG}" --global --global-package-db "$PKGCONF" field "${dep}" abi --simple-output ; done | tr '\n' ' ' | xargs)"
+		MY_ABI_HASHES="$(for dep in ${BOOT_PKGS} ; do printf "%s:" "${dep}" && "${GHC_PKG}" --global --global-package-db "$PKGCONF" field "${dep}" abi --simple-output ; done | tr '\n' ' ' | xargs)"
 		if [ "${ABI_HASHES}" != "${MY_ABI_HASHES}" ] ; then
 			err_abi "${MY_ABI_HASHES}"
 			return 3

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -22,6 +22,7 @@ extra-source-files:
   test/testdata/**/*.cabal
   test/testdata/**/*.yaml
   test/testdata/**/*.hs
+  bindist/wrapper.in
 
 flag pedantic
   description: Enable -Werror


### PR DESCRIPTION
This still makes sure that ghc has been compiled with the same core
libraries as hls while it allows runtime environments where other
packages have been added to the ghc-pkg database.

This commit also adds that file to the sdist, so that distro
packagers can use it.

Compare: https://github.com/NixOS/nixpkgs/pull/192540 and
https://github.com/NixOS/nixpkgs/issues/175565 as motivations for this from
nixpkgs.


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3214"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

