### PR TITLE
Add `source-repository` to all cabal files

### DIFF
--- a/ghcide-bench/ghcide-bench.cabal
+++ b/ghcide-bench/ghcide-bench.cabal
@@ -14,6 +14,10 @@ homepage:           https://github.com/haskell/haskell-language-server/tree/mast
 bug-reports:        https://github.com/haskell/haskell-language-server/issues
 tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.3 || == 9.2.4
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 executable ghcide-bench
     default-language: Haskell2010
     build-depends:

--- a/hie-compat/hie-compat.cabal
+++ b/hie-compat/hie-compat.cabal
@@ -17,6 +17,10 @@ category:            Development
 homepage:            https://github.com/haskell/haskell-language-server/tree/master/hie-compat#readme
 bug-reports:         https://github.com/haskell/haskell-language-server/issues
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 flag ghc-lib
   description: build against ghc-lib instead of the ghc package
   default: False

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -17,6 +17,10 @@ extra-source-files:
   test/testdata/*.hs
   test/testdata/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   buildable: True
   exposed-modules:  Ide.Plugin.AlternateNumberFormat, Ide.Plugin.Conversion

--- a/plugins/hls-brittany-plugin/hls-brittany-plugin.cabal
+++ b/plugins/hls-brittany-plugin/hls-brittany-plugin.cabal
@@ -16,6 +16,10 @@ extra-source-files:
   LICENSE
   test/testdata/**/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.2)
     buildable: False

--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -15,6 +15,10 @@ extra-source-files:
   LICENSE
   test/testdata/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   buildable: True
   exposed-modules:    Ide.Plugin.CallHierarchy

--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -18,6 +18,10 @@ extra-source-files:
   test/testdata/*.txt
   test/testdata/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   buildable: True
   exposed-modules:  Ide.Plugin.ChangeTypeSignature

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -20,6 +20,10 @@ extra-source-files:
   LICENSE
   test/testdata/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
+++ b/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
@@ -20,6 +20,10 @@ extra-source-files:
   test/testdata/selection-range/*.yaml
   test/testdata/selection-range/*.txt
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   exposed-modules:
     Ide.Plugin.CodeRange

--- a/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
+++ b/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
@@ -15,6 +15,10 @@ extra-source-files:
   LICENSE
   test/testdata/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   buildable: True
   exposed-modules:    Ide.Plugin.ExplicitFixity

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -15,6 +15,10 @@ extra-source-files:
   test/testdata/*.hs
   test/testdata/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   buildable: True
   exposed-modules:    Ide.Plugin.ExplicitImports

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -16,6 +16,10 @@ extra-source-files:
   LICENSE
   test/testdata/**/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
+++ b/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
@@ -15,6 +15,10 @@ extra-source-files:
   LICENSE
   test/testdata/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
+++ b/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
@@ -17,6 +17,10 @@ extra-source-files:
   LICENSE
   test/testdata/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.2)
     buildable: False

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -20,6 +20,10 @@ extra-source-files:
   test/testdata/**/*.hs
   test/testdata/**/*.h
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 flag pedantic
   description: Enable -Werror
   default:     False

--- a/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
+++ b/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
@@ -19,6 +19,10 @@ extra-source-files:
   test/testdata/**/*.cabal
   test/testdata/**/*.project
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   buildable: True
   exposed-modules:  Ide.Plugin.ModuleName

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -16,6 +16,10 @@ extra-source-files:
   LICENSE
   test/testdata/**/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
+++ b/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
@@ -17,6 +17,10 @@ extra-source-files:
   test/testdata/*.hs
   test/testdata/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   buildable: True
   exposed-modules:  Ide.Plugin.Pragmas

--- a/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
+++ b/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
@@ -17,6 +17,10 @@ extra-source-files:
   test/data/*.hs
   test/data/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   exposed-modules:    Ide.Plugin.QualifyImportedNames
   hs-source-dirs:     src

--- a/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
+++ b/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
@@ -17,6 +17,10 @@ extra-source-files:
   test/data/**/*.hs
   test/data/**/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
+++ b/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
@@ -15,6 +15,10 @@ extra-source-files:
   test/testdata/*.hs
   test/testdata/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   buildable: True
   exposed-modules:    Ide.Plugin.RefineImports

--- a/plugins/hls-rename-plugin/hls-rename-plugin.cabal
+++ b/plugins/hls-rename-plugin/hls-rename-plugin.cabal
@@ -16,6 +16,10 @@ extra-source-files:
   test/testdata/*.hs
   test/testdata/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -12,6 +12,10 @@ category:           Development
 build-type:         Simple
 extra-source-files: LICENSE
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -22,6 +22,10 @@ extra-source-files:
   test/testdata/*.hs
   test/testdata/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-stan-plugin/hls-stan-plugin.cabal
+++ b/plugins/hls-stan-plugin/hls-stan-plugin.cabal
@@ -16,11 +16,14 @@ extra-source-files:
   LICENSE
   test/testdata/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 flag pedantic
   description: Enable -Werror
   default:     False
   manual:      True
-
 
 library
   if impl(ghc < 8.8) || impl(ghc >= 9.0)

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -15,6 +15,10 @@ extra-source-files:
   LICENSE
   test/testdata/*.hs
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   if impl(ghc >= 9.3)
     buildable: False

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -19,6 +19,10 @@ extra-source-files:
   test/golden/*.hs
   test/golden/*.yaml
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 flag pedantic
   description: Enable -Werror
   default:     False

--- a/shake-bench/shake-bench.cabal
+++ b/shake-bench/shake-bench.cabal
@@ -11,6 +11,10 @@ build-type:    Simple
 -- description is a single line so that implicit-hie can parse it
 description:   A library Shake rules to build and run benchmarks for multiple revisions of a project.  An example of usage can be found in the ghcide benchmark suite
 
+source-repository head
+    type:     git
+    location: https://github.com/haskell/haskell-language-server.git
+
 library
   exposed-modules:  Development.Benchmark.Rules
   hs-source-dirs:   src


### PR DESCRIPTION
Add a `source-repository` stanza to any `.cabal` files in the project that are missing it.

This metadata can be useful for package maintainers.

See: https://cabal.readthedocs.io/en/stable/cabal-package.html#source-repositories

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3219"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

