### PR TITLE
Prepare release 1.8.0.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,7 +200,7 @@ tar-x86_64-linux-ubuntu18.04:
     TARBALL_EXT: tar.xz
   before_script:
     - apt update
-    - apt install -y make tar xz-utils
+    - apt install -y make tar xz-utils curl
 
 test-x86_64-linux-ubuntu18.04:
   extends:
@@ -209,7 +209,7 @@ test-x86_64-linux-ubuntu18.04:
   needs: ["tar-x86_64-linux-ubuntu18.04"]
   before_script:
     - apt update
-    - apt install -y tree patchelf make
+    - apt install -y tree patchelf make curl build-essential
 
 
 ###########################
@@ -239,7 +239,7 @@ tar-x86_64-linux-ubuntu20.04:
     TARBALL_EXT: tar.xz
   before_script:
     - apt update
-    - apt install -y make tar xz-utils
+    - apt install -y make tar xz-utils curl
 
 test-x86_64-linux-ubuntu20.04:
   extends:
@@ -248,7 +248,7 @@ test-x86_64-linux-ubuntu20.04:
   needs: ["tar-x86_64-linux-ubuntu20.04"]
   before_script:
     - apt update
-    - apt install -y tree patchelf make
+    - apt install -y tree patchelf make curl build-essential
 
 
 ######################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,16 @@ workflow:
     - x86_64-linux
   image: "registry.gitlab.haskell.org/ghc/ci-images/x86_64-linux-deb9:$DOCKER_REV"
 
+.x86_64-linux-ubuntu18.04:
+  tags:
+    - x86_64-linux
+  image: "ubuntu:18.04"
+
+.x86_64-linux-ubuntu20.04:
+  tags:
+    - x86_64-linux
+  image: "ubuntu:20.04"
+
 .x86_64-linux-centos7:
   tags:
     - x86_64-linux
@@ -161,6 +171,84 @@ test-armv7-linux-deb10:
   before_script:
     - sudo apt update
     - sudo apt install -y tree
+
+
+###########################
+# x86_64 linux ubuntu18.04
+###########################
+
+build-x86_64-linux-ubuntu18.04:
+  extends:
+    - .build
+    - .x86_64-linux-ubuntu18.04
+  before_script:
+    - apt update
+    - apt install -y build-essential curl libffi-dev libffi6 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 zlib1g-dev patchelf tree
+  variables:
+    ADD_CABAL_ARGS: "--enable-split-sections"
+
+tar-x86_64-linux-ubuntu18.04:
+  extends:
+    - .artifacts
+    - .x86_64-linux-ubuntu18.04
+  stage: tar
+  needs: ["build-x86_64-linux-ubuntu18.04"]
+  script:
+    - ./.gitlab/tar.sh
+  variables:
+    TARBALL_ARCHIVE_SUFFIX: x86_64-ubuntu18.04-linux
+    TARBALL_EXT: tar.xz
+  before_script:
+    - apt update
+    - apt install -y make tar xz-utils
+
+test-x86_64-linux-ubuntu18.04:
+  extends:
+    - .test
+    - .x86_64-linux-ubuntu18.04
+  needs: ["tar-x86_64-linux-ubuntu18.04"]
+  before_script:
+    - apt update
+    - apt install -y tree patchelf make
+
+
+###########################
+# x86_64 linux ubuntu20.04
+###########################
+
+build-x86_64-linux-ubuntu20.04:
+  extends:
+    - .build
+    - .x86_64-linux-ubuntu20.04
+  before_script:
+    - apt update
+    - apt install -y build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 zlib1g-dev patchelf tree
+  variables:
+    ADD_CABAL_ARGS: "--enable-split-sections"
+
+tar-x86_64-linux-ubuntu20.04:
+  extends:
+    - .artifacts
+    - .x86_64-linux-ubuntu20.04
+  stage: tar
+  needs: ["build-x86_64-linux-ubuntu20.04"]
+  script:
+    - ./.gitlab/tar.sh
+  variables:
+    TARBALL_ARCHIVE_SUFFIX: x86_64-ubuntu20.04-linux
+    TARBALL_EXT: tar.xz
+  before_script:
+    - apt update
+    - apt install -y make tar xz-utils
+
+test-x86_64-linux-ubuntu20.04:
+  extends:
+    - .test
+    - .x86_64-linux-ubuntu20.04
+  needs: ["tar-x86_64-linux-ubuntu20.04"]
+  before_script:
+    - apt update
+    - apt install -y tree patchelf make
 
 
 ######################

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -36,6 +36,7 @@ case "$(uname -s)" in
 		case "$(/usr/bin/arch)" in
 			aarch64|arm64|armv8l)
 				curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | arch -arm64 /bin/bash
+				export C_INCLUDE_PATH="`xcrun --show-sdk-path`/usr/include/ffi"
 				;;
 			*)
 				curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for haskell-language-server
 
+## 1.8.0.1
+
+- Make stan plugin respect configuration and allow it to be disabled (#3157)
+- Include 9.0.2 binaries for aarch64-darwin
+- Generate bindists for ubuntu 18.04 and 20.04
+
 ## 1.8.0.0
 
 - Binaries for GHC 9.2.3 and GHC 9.2.4

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 category:           Development
 name:               haskell-language-server
-version:            1.8.0.0
+version:            1.8.0.1
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -252,7 +252,7 @@ common hlint
 
 common stan
   if flag(stan) && (impl(ghc >= 8.8) && impl(ghc < 9.0))
-    build-depends: hls-stan-plugin ^>= 1.0
+    build-depends: hls-stan-plugin ^>= 1.0.1
     cpp-options: -Dhls_stan
 
 common moduleName

--- a/plugins/hls-stan-plugin/hls-stan-plugin.cabal
+++ b/plugins/hls-stan-plugin/hls-stan-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-stan-plugin
-version:       1.0.0.0
+version:       1.0.1.0
 synopsis:      Stan integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>


### PR DESCRIPTION
- Make stan plugin respect configuration and allow it to be disabled (#3157)
- Include 9.0.2 binaries for aarch64-darwin
- Generate bindists for ubuntu 18.04 and 20.04

The release is only for critical bug fixes and will be made after backporting the commits in this PR to a branch based of 1.8.0.0


<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3236"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

