### PR TITLE
Update link to supported versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The official Haskell language server (LSP) implementation. Consult the [project 
 
 - [Features](https://haskell-language-server.readthedocs.io/en/latest/features.html)
 - [Installation](https://haskell-language-server.readthedocs.io/en/latest/installation.html)
-- [Supported GHC Versions](https://haskell-language-server.readthedocs.io/en/latest/supported-versions.html)
+- [Supported GHC Versions](https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html)
 - [Configuration](https://haskell-language-server.readthedocs.io/en/latest/configuration.html)
 - [Troubleshooting](https://haskell-language-server.readthedocs.io/en/latest/troubleshooting.html)
 - [Contributing](https://haskell-language-server.readthedocs.io/en/latest/contributing/index.html)


### PR DESCRIPTION
fix dead link on Read the Docs

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3242"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

