### PR TITLE
configuration-ghc-94.nix: Fix references to lsp and lsp-types source

### DIFF
--- a/configuration-ghc-94.nix
+++ b/configuration-ghc-94.nix
@@ -41,8 +41,8 @@ let
       integer-logarithms = hsuper.callHackage "integer-logarithms" "1.0.3.1" {};
       hiedb = hsuper.callHackage "hiedb" "0.4.2.0" {};
       hie-bios = hsuper.callHackage "hie-bios" "0.11.0" {};
-      lsp = hsuper.callCabal2nix "lsp" "${inputs.lsp}/lsp" {};
-      lsp-types = hsuper.callCabal2nix "lsp-types" "${inputs.lsp}/lsp-types" {};
+      lsp = hsuper.callCabal2nix "lsp" inputs.lsp {};
+      lsp-types = hsuper.callCabal2nix "lsp-types" inputs.lsp-types {};
 
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =


### PR DESCRIPTION
Broken by: https://github.com/haskell/haskell-language-server/pull/3257

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3265"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

