### PR TITLE
Fixed none cradle files shown as failed

### DIFF
--- a/ghcide/test/data/none/a/A.hs
+++ b/ghcide/test/data/none/a/A.hs
@@ -1,0 +1,3 @@
+module A(foo) where
+import Control.Concurrent.Async
+foo = ()

--- a/ghcide/test/data/none/a/a.cabal
+++ b/ghcide/test/data/none/a/a.cabal
@@ -1,0 +1,9 @@
+name: a
+version: 1.0.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  build-depends: base, async
+  exposed-modules: A
+  hs-source-dirs: .

--- a/ghcide/test/data/none/b/B.hs
+++ b/ghcide/test/data/none/b/B.hs
@@ -1,0 +1,3 @@
+module B(module B) where
+import A
+qux = foo

--- a/ghcide/test/data/none/b/b.cabal
+++ b/ghcide/test/data/none/b/b.cabal
@@ -1,0 +1,9 @@
+name: b
+version: 1.0.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  build-depends: base, a
+  exposed-modules: B
+  hs-source-dirs: .

--- a/ghcide/test/data/none/c/C.hs
+++ b/ghcide/test/data/none/c/C.hs
@@ -1,0 +1,3 @@
+module C(module C) where
+import A
+cux = foo

--- a/ghcide/test/data/none/c/c.cabal
+++ b/ghcide/test/data/none/c/c.cabal
@@ -1,0 +1,9 @@
+name: c
+version: 1.0.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  build-depends: base, a
+  exposed-modules: C
+  hs-source-dirs: .

--- a/ghcide/test/data/none/cabal.project
+++ b/ghcide/test/data/none/cabal.project
@@ -1,0 +1,1 @@
+packages: a b c

--- a/ghcide/test/data/none/hie.yaml
+++ b/ghcide/test/data/none/hie.yaml
@@ -1,0 +1,16 @@
+cradle:
+  multi:
+    - path: "./a"
+      config:
+        cradle:
+          cabal:
+            component: "lib:a"
+    - path: "./c"
+      config:
+        cradle:
+          cabal:
+            component: "lib:c"
+    - path: "./b"
+      config:
+        cradle:
+          none:

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -2812,6 +2812,16 @@ nonLspCommandLine = testGroup "ghcide command line"
         (ec, _, _) <- readCreateProcessWithExitCode cmd ""
 
         ec @?= ExitSuccess
+  , testCase "none cradle does not fail" $ withTempDir $ \dir -> do
+        ghcide <- locateGhcideExecutable
+        copyTestDataFiles dir "none"
+        let cmd = (proc ghcide ["c/C.hs"]){cwd = Just dir}
+
+        setEnv "HOME" "/homeless-shelter" False
+
+        (ec, _, _) <- readCreateProcessWithExitCode cmd ""
+
+        ec @?= ExitSuccess
   ]
 
 -- | checks if we use InitializeParams.rootUri for loading session


### PR DESCRIPTION
This PR introduces a hacky fix to filter out the ignored files when printing out the failed files.

closes #2692

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3270"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

