### PR TITLE
Register Fourmolu plugin properties

### DIFF
--- a/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
@@ -43,6 +43,7 @@ descriptor :: Recorder (WithPriority LogEvent) -> PluginId -> PluginDescriptor I
 descriptor recorder plId =
     (defaultPluginDescriptor plId)
         { pluginHandlers = mkFormattingHandlers $ provider recorder plId
+        , pluginConfigDescriptor = defaultConfigDescriptor{configCustomConfig = mkCustomConfig properties}
         }
 
 properties :: Properties '[ 'PropertyKey "external" 'TBoolean]


### PR DESCRIPTION
One effect of this is that `haskell-language-server vscode-extension-schema` now generates the schema for this plugin. I'm unsure if it has any other effect, as this is all quite under-documented (see #2827).