### PR TITLE
Change default cabal install target name on docs/installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ More information here: <https://www.haskell.org/ghcup/guide/#hls>
 
 ## Installation from source
 
-Direct installation from source, while possible via `cabal install haskell-language-server`
+Direct installation from source, while possible via `cabal install exe:haskell-language-server`
 and `stack install --stack-yaml stack-<GHCVER>.yaml`, is not recommended for most people.
 Said command builds the `haskell-language-server` binary and installs it in the default `cabal` binaries folder,
 but the binary will only work with projects that use the same GHC version that built it.


### PR DESCRIPTION
The command `cabal install haskell-language-server`, present in `docs/installation#instalation-from-source` fails with the following error:

```
Error: cabal: Ambiguous target 'haskell-language-server'. It could be:
exe:haskell-language-server (component)
lib:haskell-language-server (component)
```

This PR only changes the documentation so that it points to `exe:haskell-language-server`

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3298"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

