### PR TITLE
Record diagnostics source rule when testing

### DIFF
--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -1233,8 +1233,18 @@ updateFileDiagnostics recorder fp ver k ShakeExtras{diagnostics, hiddenDiagnosti
                  return action
     where
         diagsFromRule :: Diagnostic -> Diagnostic
-        diagsFromRule c
-            | coerce ideTesting = c{_code = Just $ InR $ T.pack(show k)}
+        diagsFromRule c@Diagnostic{_range}
+            | coerce ideTesting = c
+                {_relatedInformation =
+                    Just $ List [
+                        DiagnosticRelatedInformation
+                            (Location
+                                (filePathToUri $ fromNormalizedFilePath fp)
+                                _range
+                            )
+                            (T.pack $ show k)
+                            ]
+                }
             | otherwise = c
 
 

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -1232,8 +1232,9 @@ updateFileDiagnostics recorder fp ver k ShakeExtras{diagnostics, hiddenDiagnosti
                                 LSP.PublishDiagnosticsParams (fromNormalizedUri uri) (fmap fromIntegral ver) (List newDiags)
                  return action
     where
+        diagsFromRule :: Diagnostic -> Diagnostic
         diagsFromRule c
-            | coerce ideTesting = c{_source = ((T.pack(show k) <> ":") <>) <$> _source c}
+            | coerce ideTesting = c{_code = Just $ InR $ T.pack(show k)}
             | otherwise = c
 
 

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -1199,7 +1199,7 @@ updateFileDiagnostics :: MonadIO m
   -> ShakeExtras
   -> [(ShowDiagnostic,Diagnostic)] -- ^ current results
   -> m ()
-updateFileDiagnostics recorder fp ver k ShakeExtras{diagnostics, hiddenDiagnostics, publishedDiagnostics, debouncer, lspEnv} current =
+updateFileDiagnostics recorder fp ver k ShakeExtras{diagnostics, hiddenDiagnostics, publishedDiagnostics, debouncer, lspEnv, ideTesting} current0 =
   liftIO $ withTrace ("update diagnostics " <> fromString(fromNormalizedFilePath fp)) $ \ addTag -> do
     addTag "key" (show k)
     let (currentShown, currentHidden) = partition ((== ShowDiag) . fst) current
@@ -1208,6 +1208,7 @@ updateFileDiagnostics recorder fp ver k ShakeExtras{diagnostics, hiddenDiagnosti
         addTagUnsafe msg t x v = unsafePerformIO(addTag (msg <> t) x) `seq` v
         update :: (forall a. String -> String -> a -> a) -> [Diagnostic] -> STMDiagnosticStore -> STM [Diagnostic]
         update addTagUnsafe new store = addTagUnsafe "count" (show $ Prelude.length new) $ setStageDiagnostics addTagUnsafe uri ver (renderKey k) new store
+        current = second diagsFromRule <$> current0
     addTag "version" (show ver)
     mask_ $ do
         -- Mask async exceptions to ensure that updated diagnostics are always
@@ -1230,6 +1231,11 @@ updateFileDiagnostics recorder fp ver k ShakeExtras{diagnostics, hiddenDiagnosti
                             LSP.sendNotification LSP.STextDocumentPublishDiagnostics $
                                 LSP.PublishDiagnosticsParams (fromNormalizedUri uri) (fmap fromIntegral ver) (List newDiags)
                  return action
+    where
+        diagsFromRule c
+            | coerce ideTesting = c{_source = ((T.pack(show k) <> ":") <>) <$> _source c}
+            | otherwise = c
+
 
 newtype Priority = Priority Double
 


### PR DESCRIPTION
I have seen unexpected duplicate diagnostics leading to a failure in the ghcide testsuite: what seems to happen here is that both `Typecheck` and `GetModIfaceFromDisk` contribute the same diagnostics. But this should never happen, because we never run both these rules for the same file:
* `GetModIfaceFromDisk` is only run for non FOIs via `GetModIface`
* `Typecheck` is only run for FOIs, either via `GetModIface` or on demand by code actions 

This PR adds more testing-only logging to help diagnostics when this happens again next time

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3301"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

