### PR TITLE
New plugin: Explicit record fields

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -33,6 +33,7 @@ packages:
          ./plugins/hls-stan-plugin
          ./plugins/hls-gadt-plugin
          ./plugins/hls-explicit-fixity-plugin
+         ./plugins/hls-explicit-record-fields-plugin
          ./plugins/hls-refactor-plugin
 
 -- Standard location for temporary packages needed for particular environments

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -163,6 +163,11 @@ flag explicitFixity
   default:     True
   manual:      True
 
+flag explicitFields
+  description: Enable explicitFields plugin
+  default:     True
+  manual:      True
+
 -- formatters
 
 flag floskell
@@ -300,6 +305,11 @@ common explicitFixity
     build-depends: hls-explicit-fixity-plugin ^>= 1.0
     cpp-options: -DexplicitFixity
 
+common explicitFields
+  if flag(explicitFields)
+    build-depends: hls-explicit-record-fields-plugin ^>= 1.0
+    cpp-options: -DexplicitFields
+
 -- formatters
 
 common floskell
@@ -358,6 +368,7 @@ library
                   , codeRange
                   , gadt
                   , explicitFixity
+                  , explicitFields
                   , floskell
                   , fourmolu
                   , ormolu

--- a/plugins/hls-explicit-record-fields-plugin/CHANGELOG.md
+++ b/plugins/hls-explicit-record-fields-plugin/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for hls-explicit-record-fields-plugin
+
+## 1.0.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/plugins/hls-explicit-record-fields-plugin/LICENSE
+++ b/plugins/hls-explicit-record-fields-plugin/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2022, Berk Ozkutuk
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Berk Ozkutuk nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -36,7 +36,6 @@ library
       , text
       , syb
       , transformers
-      , ghc
       , ghc-boot-th
       , unordered-containers
     hs-source-dirs:   src

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -1,0 +1,54 @@
+cabal-version:      3.0
+name:               hls-explicit-record-fields-plugin
+version:            1.0.0.0
+synopsis:           Explicit record fields plugin for Haskell Language Server
+description:
+  Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Berk Ozkutuk
+maintainer:         berk.ozkutuk@tweag.io
+-- copyright:
+category:           Development
+build-type:         Simple
+extra-doc-files:    CHANGELOG.md
+-- extra-source-files:
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell/haskell-language-server
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  Ide.Plugin.ExplicitFields
+    -- other-modules:
+    -- other-extensions:
+    build-depends:
+      , base                  ^>=4.15.1.0
+      , ghcide                ^>=1.7 || ^>=1.8
+      , hls-plugin-api        ^>=1.4 || ^>=1.5
+      , lsp
+      , lens
+      , hls-graph
+      , text
+      , syb
+      , transformers
+      , ghc
+      , unordered-containers
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite hls-explicit-record-fields-plugin-test
+    import:           warnings
+    default-language: Haskell2010
+    -- other-modules:
+    -- other-extensions:
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Main.hs
+    build-depends:
+        base ^>=4.15.1.0,
+        hls-explicit-record-fields-plugin

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -50,5 +50,9 @@ test-suite hls-explicit-record-fields-plugin-test
     hs-source-dirs:   test
     main-is:          Main.hs
     build-depends:
-        base ^>=4.15.1.0,
-        hls-explicit-record-fields-plugin
+      , base ^>=4.15.1.0
+      , filepath
+      , text
+      , hls-explicit-record-fields-plugin
+      , lsp-test
+      , hls-test-utils

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -37,6 +37,7 @@ library
       , syb
       , transformers
       , ghc
+      , ghc-boot-th
       , unordered-containers
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -13,7 +13,7 @@ module Ide.Plugin.ExplicitFields
   ) where
 
 import           Control.Arrow                   ((&&&))
-import           Control.Lens                    ((^.))
+import           Control.Lens                    ((%~), (^.))
 import           Control.Monad.IO.Class          (MonadIO, liftIO)
 import           Control.Monad.Trans.Except      (ExceptT)
 import           Data.Data                       (Data)
@@ -276,7 +276,9 @@ codeActionProvider recorder ideState pId (CodeActionParams _ _ docId range _) = 
         pragmaEdit :: Maybe TextEdit
         pragmaEdit = if RecordPuns `elem` exts
                        then Nothing
-                       else Just $ insertNewPragma pragma RecordPuns
+                       else Just $ patchExtName $ insertNewPragma pragma RecordPuns
+          where
+            patchExtName = L.newText %~ T.replace "Record" "NamedField"
 
     mkWorkspaceEdit :: NormalizedFilePath -> [TextEdit] -> WorkspaceEdit
     mkWorkspaceEdit nfp edits = WorkspaceEdit changes Nothing Nothing
@@ -287,7 +289,7 @@ mkCodeActionTitle :: [Extension] -> Text
 mkCodeActionTitle exts =
   if RecordPuns `elem` exts
     then title
-    else title <> " (needs extension: " <> (T.pack $ show RecordPuns) <> ")"
+    else title <> " (needs extension: NamedFieldPuns)"
     where
       title = "Expand record wildcard"
 

--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+module Ide.Plugin.ExplicitFields
+  ( descriptor
+  ) where
+
+import           Control.Arrow                   ((&&&))
+import           Control.Lens                    ((^.))
+import           Control.Monad.IO.Class          (MonadIO, liftIO)
+import           Control.Monad.Trans.Except      (ExceptT)
+import           Data.Data                       (Data)
+import           Data.Generics                   (GenericQ, everything, mkQ)
+import qualified Data.HashMap.Strict             as HashMap
+import           Data.Maybe                      (catMaybes, isJust,
+                                                  maybeToList)
+import           Data.Text                       (Text)
+import qualified Data.Text                       as T
+import           Development.IDE                 (IdeState, NormalizedFilePath,
+                                                  Pretty (..), Priority (..),
+                                                  Range (..), Recorder (..),
+                                                  Rules, WithPriority (..),
+                                                  logWith, realSrcSpanToRange,
+                                                  srcSpanToRange)
+import           Development.IDE.Core.Rules      (runAction)
+import           Development.IDE.Core.RuleTypes  (GhcSessionDeps (..),
+                                                  TcModuleResult (..),
+                                                  TypeCheck (..))
+import           Development.IDE.Core.Shake      (define, use)
+import qualified Development.IDE.Core.Shake      as Shake
+import           Development.IDE.GHC.Compat      (HasSrcSpan (..),
+                                                  HsConDetails (RecCon),
+                                                  HsRecFields (..), LPat,
+                                                  Outputable, RealSrcSpan, SDoc,
+                                                  SrcSpan, getLocA, locA, unLoc,
+                                                  unLocA)
+import           Development.IDE.GHC.Compat.Core (GenLocated (..), GhcPass (..),
+                                                  HsBindLR (..),
+                                                  HsValBindsLR (..),
+                                                  NHsValBindsLR (..), Pass (..),
+                                                  Pat (..), hs_valds)
+import           Development.IDE.GHC.Compat.Util (bagToList)
+import           Development.IDE.GHC.Util        (printOutputable)
+import           Development.IDE.Graph           (RuleResult)
+import           Development.IDE.Graph.Classes   (Hashable, NFData)
+import           Development.IDE.Types.Logger    (cmapWithPrio)
+import           GHC.Data.Maybe                  (fromMaybe)
+import           GHC.Generics                    (Generic)
+import           GHC.Hs.Dump                     (BlankSrcSpan (..),
+                                                  showAstData)
+import           Ide.PluginUtils                 (getNormalizedFilePath,
+                                                  handleMaybeM, pluginResponse,
+                                                  subRange)
+import           Ide.Types                       (PluginDescriptor (..),
+                                                  PluginId, PluginMethodHandler,
+                                                  defaultPluginDescriptor,
+                                                  mkPluginHandler)
+import           Language.LSP.Types              (CodeAction (..),
+                                                  CodeActionKind (CodeActionRefactorRewrite),
+                                                  CodeActionParams (..),
+                                                  Command, List (..),
+                                                  Method (..), SMethod (..),
+                                                  TextEdit (..),
+                                                  WorkspaceEdit (WorkspaceEdit),
+                                                  fromNormalizedUri,
+                                                  isSubrangeOf,
+                                                  normalizedFilePathToUri,
+                                                  type (|?) (InR))
+import qualified Language.LSP.Types.Lens         as L
+
+showAstDataFull :: Data a => a -> SDoc
+showAstDataFull = showAstData NoBlankSrcSpan
+--
+-- showAstDataFull' :: Data a => a -> SDoc
+-- showAstDataFull' = showAstData BlankSrcSpan
+
+-- `Outputable` instance of `HsRecFields` does smart things to print
+-- the records that originally had wildcards with dots, even after they
+-- are removed by the renamer pass. Here `rec_dotdot` is set to
+-- `Nothing` so that fields are printed without such post-processing.
+showRecord :: Outputable arg => HsRecFields p arg -> Text
+showRecord rec = printOutputable (rec { rec_dotdot = Nothing })
+
+-- Same as `showRecord` but works with `Pat` types. This is a partial function
+-- but it is only ever called with record patterns, so it should be okay.
+showRecordPat :: Outputable (Pat p) => Pat p -> Maybe Text
+showRecordPat pat@(ConPat _ _ (RecCon flds)) =
+  Just $ printOutputable $ pat { pat_args = RecCon (flds { rec_dotdot = Nothing }) }
+showRecordPat _ = Nothing
+
+data Log
+  = LogShake Shake.Log
+  | LogTxts [Text]
+  deriving Show
+
+instance Pretty Log where
+  pretty = \case
+    LogShake shakeLog -> pretty shakeLog
+    LogTxts txts      -> pretty (length txts) <> " - " <> pretty txts
+
+descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
+descriptor recorder plId = (defaultPluginDescriptor plId)
+  { pluginHandlers = mkPluginHandler STextDocumentCodeAction (codeActionProvider recorder)
+  -- , pluginRules = collectRecordsRule recorder
+  }
+
+-- data CollectRecords = CollectRecords
+--                     deriving (Eq, Show, Generic)
+--
+-- instance Hashable CollectRecords
+-- instance NFData CollectRecords
+--
+-- type instance RuleResult CollectRecords = CollectRecordsResult
+--
+-- -- TODO(ozkutuk)
+-- data CollectRecordsResult = CRR -- [RecordInfo]
+--                           deriving (Show, Generic)
+-- instance NFData CollectRecordsResult
+
+-- newtype RecordPattern = RecordPattern [Pat (GhcPass 'Renamed)]
+--                       deriving (Generic)
+
+-- instance Show RecordPattern where
+--   show (RecordPattern l) = T.unpack (printOutputable l)
+
+data RecordInfo = RecordInfo !SrcSpan !(Pat (GhcPass 'Renamed))
+                -- deriving (Show, Generic)
+
+getSrcSpan :: RecordInfo -> SrcSpan
+getSrcSpan (RecordInfo ss _) = ss
+
+getEdit :: RecordInfo -> Maybe Text
+getEdit (RecordInfo _ pat) = showRecordPat pat
+
+collectRecords :: GenericQ [LPat (GhcPass 'Renamed)]
+collectRecords = everything (<>) (maybeToList . (Nothing `mkQ` getRecPatterns))
+
+getRecPatterns :: LPat (GhcPass 'Renamed) -> Maybe (LPat (GhcPass 'Renamed))
+getRecPatterns conPat@(unLoc -> ConPat _ _ (RecCon flds))
+  | isJust (rec_dotdot flds) = Just conPat
+getRecPatterns _ = Nothing
+
+collectRecordsInRange :: MonadIO m => IdeState -> Range -> NormalizedFilePath -> ExceptT String m [RecordInfo]
+collectRecordsInRange ideState range nfp = do
+  recs <- collectRecords' ideState range nfp
+  let recsInRange = filter inRange recs
+  pure recsInRange
+
+  where
+    inRange :: RecordInfo -> Bool
+    inRange (RecordInfo (srcSpanToRange -> recRange) _) =
+      maybe False (subRange range) recRange
+
+collectRecords' :: MonadIO m => IdeState -> Range -> NormalizedFilePath -> ExceptT String m [RecordInfo]
+collectRecords' ideState range nfp = do
+  tmr <- handleMaybeM "Unable to TypeCheck"
+    $ liftIO
+    $ runAction "ExplicitFields" ideState
+    $ use TypeCheck nfp
+  let (hsGroup,_,_,_) = tmrRenamed tmr
+      valBinds = hs_valds hsGroup
+      recs = collectRecords valBinds
+      (srcs, recs') = unzip $ map (getLoc &&& unLoc) recs
+      -- recs' = map unLoc recs
+      -- srcs = map (locA . (\(L l _) -> l) . pat_con) recs
+      -- recsPrinted = map (showRecord . (\(RecCon x) -> x) . pat_args) recs
+      recInfos = zipWith RecordInfo srcs recs'
+  pure recInfos
+      -- logTxts xs = logWith recorder Info (LogTxts xs)
+  -- logTxts recsPrinted
+  --   *> logTxts (map printOutputable srcs)
+  --   *> logTxts (map (printOutputable . showAstDataFull) recs)
+  --   *> pure ([], Nothing)
+
+-- collectRecordsRule :: Recorder (WithPriority Log) -> Rules ()
+-- collectRecordsRule recorder = define (cmapWithPrio LogShake recorder) $ \CollectRecords nfp -> do
+--   tmr <- use TypeCheck nfp
+--   -- hsc <- use GhcSessionDeps nfp
+--   case tmr of
+--     Nothing -> undefined
+--     Just tmr' ->
+--       let (hsGroup,_,_,_) = tmrRenamed tmr'
+--           valBinds = hs_valds hsGroup
+--           recs = collectRecords valBinds
+--           srcs = map (locA . (\(L l _) -> l) . pat_con) recs
+--           recsPrinted = map (showRecord . (\(RecCon x) -> x) . pat_args) recs
+--           logTxts xs = logWith recorder Info (LogTxts xs)
+--       in logTxts recsPrinted
+--            *> logTxts (map printOutputable srcs)
+--            *> logTxts (map (printOutputable . showAstDataFull) recs)
+--            *> pure ([], Nothing)
+-- -- *> logWith recorder Info (LogTxts $ map printOutputable bindsList') *> pure ([], Nothing)
+
+codeActionProvider :: Recorder (WithPriority Log)
+                   -> PluginMethodHandler IdeState 'TextDocumentCodeAction
+codeActionProvider recorder ideState _ (CodeActionParams _ _ docId range _) = pluginResponse $ do
+  nfp <- getNormalizedFilePath (docId ^. L.uri)
+  recs <- collectRecordsInRange ideState range nfp
+  logWith recorder Info $ LogTxts $ map (T.pack . show . srcSpanToRange . getSrcSpan) recs
+  let actions = map (mkCodeAction nfp) recs
+  -- liftIO $ runAction "ExplicitFields" ideState $ use CollectRecords nfp
+  pure $ List actions
+
+  where
+    mkCodeAction :: NormalizedFilePath -> RecordInfo -> Command |? CodeAction
+    mkCodeAction nfp rec = InR CodeAction
+      { _title = "Expand the record wildcard"
+      , _kind = Just CodeActionRefactorRewrite
+      , _diagnostics = Nothing
+      , _isPreferred = Nothing
+      , _disabled = Nothing
+      , _edit = Just $ mkWorkspaceEdit nfp edits
+      , _command = Nothing
+      , _xdata = Nothing
+      }
+      where
+        edits = catMaybes [TextEdit <$> (srcSpanToRange $ getSrcSpan rec) <*> getEdit rec]
+
+    mkWorkspaceEdit :: NormalizedFilePath -> [TextEdit] -> WorkspaceEdit
+    mkWorkspaceEdit nfp edits = WorkspaceEdit changes Nothing Nothing
+      where
+        changes = Just $ HashMap.singleton (fromNormalizedUri (normalizedFilePathToUri nfp)) (List edits)

--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -75,35 +75,6 @@ import           Language.LSP.Types              (CodeAction (..),
 import qualified Language.LSP.Types.Lens         as L
 
 
--- `Outputable` instance of `HsRecFields` does smart things to print
--- the records that originally had wildcards with dots, even after they
--- are removed by the renamer pass. Here `rec_dotdot` is set to
--- `Nothing` so that fields are printed without such post-processing.
-preprocessRecord :: HsRecFields (GhcPass c) arg -> HsRecFields (GhcPass c) arg
-preprocessRecord flds = flds { rec_dotdot = Nothing , rec_flds = rec_flds' }
-  where
-    no_pun_count = maybe (length (rec_flds flds)) unLoc (rec_dotdot flds)
-    -- Field binds of the explicit form (e.g. `{ a = a' }`) should be
-    -- left as is, hence the split.
-    (no_puns, puns) = splitAt no_pun_count (rec_flds flds)
-    -- `hsRecPun` is set to `True` in order to pretty-print the fields as field
-    -- puns (since there is similar mechanism in the `Outputable` instance as
-    -- explained above).
-    puns' = map (mapLoc (\fld -> fld { hfbPun = True })) puns
-    rec_flds' = no_puns <> puns'
-
-showRecordPat :: Outputable (Pat (GhcPass c)) => Pat (GhcPass c) -> Maybe Text
-showRecordPat pat@(ConPat _ _ (RecCon flds)) =
-  Just $ printOutputable $
-    pat { pat_args = RecCon (preprocessRecord flds) }
-showRecordPat _ = Nothing
-
-showRecordCon :: Outputable (HsExpr (GhcPass c)) => HsExpr (GhcPass c) -> Maybe Text
-showRecordCon expr@(RecordCon _ _ flds) =
-  Just $ printOutputable $
-    expr { rcon_flds = preprocessRecord flds }
-showRecordCon _ = Nothing
-
 data Log = LogShake Shake.Log
 
 instance Pretty Log where
@@ -115,98 +86,6 @@ descriptor recorder plId = (defaultPluginDescriptor plId)
   { pluginHandlers = mkPluginHandler STextDocumentCodeAction codeActionProvider
   , pluginRules = collectRecordsRule recorder
   }
-
-data CollectRecords = CollectRecords
-                    deriving (Eq, Show, Generic)
-
-instance Hashable CollectRecords
-instance NFData CollectRecords
-
-data CollectRecordsResult = CRR
-  { recordInfos       :: ![RenderedRecordInfo]
-  , enabledExtensions :: ![GhcExtension]
-  }
-  deriving (Generic)
-
-instance NFData CollectRecordsResult
-
-instance Show CollectRecordsResult where
-  show _ = "<CollectRecordsResult>"
-
-type instance RuleResult CollectRecords = CollectRecordsResult
-
-newtype GhcExtension = GhcExtension { unExt :: Extension }
-
-instance NFData GhcExtension where
-  rnf x = x `seq` ()
-
-data RecordInfo
-  = RecordInfoPat !SrcSpan !(Pat (GhcPass 'Renamed))
-  | RecordInfoCon !SrcSpan !(HsExpr (GhcPass 'Renamed))
-
-data RenderedRecordInfo = RenderedRecordInfo
-  { renderedSrcSpan :: !SrcSpan
-  , renderedRecord  :: !Text
-  }
-  deriving (Generic)
-
-instance NFData RenderedRecordInfo
-
-renderRecordInfo :: RecordInfo -> Maybe RenderedRecordInfo
-renderRecordInfo (RecordInfoPat ss pat) = RenderedRecordInfo ss <$> showRecordPat pat
-renderRecordInfo (RecordInfoCon ss expr) = RenderedRecordInfo ss <$> showRecordCon expr
-
--- collectRecords :: GenericQ [LPat (GhcPass 'Renamed)]
-collectRecords :: GenericQ [RecordInfo]
-collectRecords = everything (<>) (maybeToList . (Nothing `mkQ` getRecPatterns `extQ` getRecCons))
-
-getRecCons :: LHsExpr (GhcPass 'Renamed) -> Maybe RecordInfo
-getRecCons e@(unLoc -> RecordCon _ _ flds)
-  | isJust (rec_dotdot flds) = Just $ mkRecInfo e
-  where
-    mkRecInfo :: LHsExpr (GhcPass 'Renamed) -> RecordInfo
-    mkRecInfo expr = RecordInfoCon (getLoc expr) (unLoc expr)
-getRecCons _ = Nothing
-
-getRecPatterns :: LPat (GhcPass 'Renamed) -> Maybe RecordInfo
-getRecPatterns conPat@(unLoc -> ConPat _ _ (RecCon flds))
-  | isJust (rec_dotdot flds) = Just $ mkRecInfo conPat
-  where
-    mkRecInfo :: LPat (GhcPass 'Renamed) -> RecordInfo
-    mkRecInfo pat = RecordInfoPat (getLoc pat) (unLoc pat)
-getRecPatterns _ = Nothing
-
-getEnabledExtensions :: TcModuleResult -> [GhcExtension]
-getEnabledExtensions = map GhcExtension . toList . extensionFlags . ms_hspp_opts . pm_mod_summary . tmrParsed
-
-getRecords :: TcModuleResult -> [RecordInfo]
-getRecords (tmrRenamed -> (hs_valds -> valBinds,_,_,_)) =
-  collectRecords valBinds
-
-collectRecordsRule :: Recorder (WithPriority Log) -> Rules ()
-collectRecordsRule recorder = define (cmapWithPrio LogShake recorder) $ \CollectRecords nfp -> do
-  tmr <- use TypeCheck nfp
-  let exts = getEnabledExtensions <$> tmr
-      recs = getRecords <$> tmr
-      renderedRecs = mapMaybe renderRecordInfo <$> recs
-  pure ([], CRR <$> renderedRecs <*> exts)
-
-collectRecords' :: MonadIO m => IdeState -> NormalizedFilePath -> ExceptT String m CollectRecordsResult
-collectRecords' ideState =
-  handleMaybeM "Unable to TypeCheck"
-    . liftIO
-    . runAction "ExplicitFields" ideState
-    . use CollectRecords
-
-collectRecordsInRange :: MonadIO m => Range -> IdeState -> NormalizedFilePath -> ExceptT String m CollectRecordsResult
-collectRecordsInRange range ideState nfp = do
-  CRR renderedRecs exts <- collectRecords' ideState nfp
-  pure $ CRR (filter inRange renderedRecs) exts
-
-  where
-    inRange :: RenderedRecordInfo -> Bool
-    inRange (RenderedRecordInfo ss _) = maybe False (subRange range) (srcSpanToRange ss)
-
 
 codeActionProvider :: PluginMethodHandler IdeState 'TextDocumentCodeAction
 codeActionProvider ideState pId (CodeActionParams _ _ docId range _) = pluginResponse $ do
@@ -250,13 +129,132 @@ codeActionProvider ideState pId (CodeActionParams _ _ docId range _) = pluginRes
       where
         changes = Just $ HashMap.singleton (fromNormalizedUri (normalizedFilePathToUri nfp)) (List edits)
 
-mkCodeActionTitle :: [Extension] -> Text
-mkCodeActionTitle exts =
-  if NamedFieldPuns `elem` exts
-    then title
-    else title <> " (needs extension: NamedFieldPuns)"
-    where
-      title = "Expand record wildcard"
+    mkCodeActionTitle :: [Extension] -> Text
+    mkCodeActionTitle exts =
+      if NamedFieldPuns `elem` exts
+        then title
+        else title <> " (needs extension: NamedFieldPuns)"
+        where
+          title = "Expand record wildcard"
+
+collectRecordsRule :: Recorder (WithPriority Log) -> Rules ()
+collectRecordsRule recorder = define (cmapWithPrio LogShake recorder) $ \CollectRecords nfp -> do
+  tmr <- use TypeCheck nfp
+  let exts = getEnabledExtensions <$> tmr
+      recs = getRecords <$> tmr
+      renderedRecs = mapMaybe renderRecordInfo <$> recs
+  pure ([], CRR <$> renderedRecs <*> exts)
+
+getEnabledExtensions :: TcModuleResult -> [GhcExtension]
+getEnabledExtensions = map GhcExtension . toList . extensionFlags . ms_hspp_opts . pm_mod_summary . tmrParsed
+
+getRecords :: TcModuleResult -> [RecordInfo]
+getRecords (tmrRenamed -> (hs_valds -> valBinds,_,_,_)) =
+  collectRecords valBinds
+
+data CollectRecords = CollectRecords
+                    deriving (Eq, Show, Generic)
+
+instance Hashable CollectRecords
+instance NFData CollectRecords
+
+data CollectRecordsResult = CRR
+  { recordInfos       :: ![RenderedRecordInfo]
+  , enabledExtensions :: ![GhcExtension]
+  }
+  deriving (Generic)
+
+instance NFData CollectRecordsResult
+
+instance Show CollectRecordsResult where
+  show _ = "<CollectRecordsResult>"
+
+type instance RuleResult CollectRecords = CollectRecordsResult
+
+newtype GhcExtension = GhcExtension { unExt :: Extension }
+
+instance NFData GhcExtension where
+  rnf x = x `seq` ()
+
+data RecordInfo
+  = RecordInfoPat !SrcSpan !(Pat (GhcPass 'Renamed))
+  | RecordInfoCon !SrcSpan !(HsExpr (GhcPass 'Renamed))
+
+data RenderedRecordInfo = RenderedRecordInfo
+  { renderedSrcSpan :: !SrcSpan
+  , renderedRecord  :: !Text
+  }
+  deriving (Generic)
+
+instance NFData RenderedRecordInfo
+
+renderRecordInfo :: RecordInfo -> Maybe RenderedRecordInfo
+renderRecordInfo (RecordInfoPat ss pat) = RenderedRecordInfo ss <$> showRecordPat pat
+renderRecordInfo (RecordInfoCon ss expr) = RenderedRecordInfo ss <$> showRecordCon expr
+
+-- `Outputable` instance of `HsRecFields` does smart things to print
+-- the records that originally had wildcards with dots, even after they
+-- are removed by the renamer pass. Here `rec_dotdot` is set to
+-- `Nothing` so that fields are printed without such post-processing.
+preprocessRecord :: HsRecFields (GhcPass c) arg -> HsRecFields (GhcPass c) arg
+preprocessRecord flds = flds { rec_dotdot = Nothing , rec_flds = rec_flds' }
+  where
+    no_pun_count = maybe (length (rec_flds flds)) unLoc (rec_dotdot flds)
+    -- Field binds of the explicit form (e.g. `{ a = a' }`) should be
+    -- left as is, hence the split.
+    (no_puns, puns) = splitAt no_pun_count (rec_flds flds)
+    -- `hsRecPun` is set to `True` in order to pretty-print the fields as field
+    -- puns (since there is similar mechanism in the `Outputable` instance as
+    -- explained above).
+    puns' = map (mapLoc (\fld -> fld { hfbPun = True })) puns
+    rec_flds' = no_puns <> puns'
+
+showRecordPat :: Outputable (Pat (GhcPass c)) => Pat (GhcPass c) -> Maybe Text
+showRecordPat pat@(ConPat _ _ (RecCon flds)) =
+  Just $ printOutputable $
+    pat { pat_args = RecCon (preprocessRecord flds) }
+showRecordPat _ = Nothing
+
+showRecordCon :: Outputable (HsExpr (GhcPass c)) => HsExpr (GhcPass c) -> Maybe Text
+showRecordCon expr@(RecordCon _ _ flds) =
+  Just $ printOutputable $
+    expr { rcon_flds = preprocessRecord flds }
+showRecordCon _ = Nothing
+
+collectRecords :: GenericQ [RecordInfo]
+collectRecords = everything (<>) (maybeToList . (Nothing `mkQ` getRecPatterns `extQ` getRecCons))
+
+getRecCons :: LHsExpr (GhcPass 'Renamed) -> Maybe RecordInfo
+getRecCons e@(unLoc -> RecordCon _ _ flds)
+  | isJust (rec_dotdot flds) = Just $ mkRecInfo e
+  where
+    mkRecInfo :: LHsExpr (GhcPass 'Renamed) -> RecordInfo
+    mkRecInfo expr = RecordInfoCon (getLoc expr) (unLoc expr)
+getRecCons _ = Nothing
+
+getRecPatterns :: LPat (GhcPass 'Renamed) -> Maybe RecordInfo
+getRecPatterns conPat@(unLoc -> ConPat _ _ (RecCon flds))
+  | isJust (rec_dotdot flds) = Just $ mkRecInfo conPat
+  where
+    mkRecInfo :: LPat (GhcPass 'Renamed) -> RecordInfo
+    mkRecInfo pat = RecordInfoPat (getLoc pat) (unLoc pat)
+getRecPatterns _ = Nothing
+
+collectRecords' :: MonadIO m => IdeState -> NormalizedFilePath -> ExceptT String m CollectRecordsResult
+collectRecords' ideState =
+  handleMaybeM "Unable to TypeCheck"
+    . liftIO
+    . runAction "ExplicitFields" ideState
+    . use CollectRecords
+
+collectRecordsInRange :: MonadIO m => Range -> IdeState -> NormalizedFilePath -> ExceptT String m CollectRecordsResult
+collectRecordsInRange range ideState nfp = do
+  CRR renderedRecs exts <- collectRecords' ideState nfp
+  pure $ CRR (filter inRange renderedRecs) exts
+
+  where
+    inRange :: RenderedRecordInfo -> Bool
+    inRange (RenderedRecordInfo ss _) = maybe False (subRange range) (srcSpanToRange ss)
 
 -- Copied from hls-alternate-number-format-plugin
 getFirstPragma :: MonadIO m => PluginId -> IdeState -> NormalizedFilePath -> ExceptT String m NextPragmaInfo

--- a/plugins/hls-explicit-record-fields-plugin/test/Main.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented."

--- a/plugins/hls-explicit-record-fields-plugin/test/Main.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/Main.hs
@@ -1,4 +1,65 @@
-module Main (main) where
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeOperators         #-}
+
+module Main ( main ) where
+
+import           Data.Either               (rights)
+import qualified Data.Text                 as T
+import qualified Ide.Plugin.ExplicitFields as ExplicitFields
+import           System.FilePath           ((<.>), (</>))
+import           Test.Hls
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented."
+main = defaultTestRunner test
+
+plugin :: PluginDescriptor IdeState
+plugin = ExplicitFields.descriptor mempty "explicit-fields"
+
+test :: TestTree
+test = testGroup "explicit-fields"
+  [ mkTest "WildcardOnly" "WildcardOnly" 12 10 12 20
+  , mkTest "WithPun" "WithPun" 13 10 13 25
+  , mkTest "WithExplicitBind" "WithExplicitBind" 12 10 12 32
+  , mkTest "Mixed" "Mixed" 13 10 13 37
+  , mkTest "Construction" "Construction" 16 5 16 15
+  , mkTestNoAction "ExplicitBinds" "ExplicitBinds" 11 10 11 52
+  , mkTestNoAction "Puns" "Puns" 12 10 12 31
+  , mkTestNoAction "Infix" "Infix" 11 11 11 31
+  , mkTestNoAction "Prefix" "Prefix" 10 11 10 28
+  ]
+
+mkTestNoAction :: TestName -> FilePath -> UInt -> UInt -> UInt -> UInt -> TestTree
+mkTestNoAction title fp x1 y1 x2 y2 =
+  testCase title $
+    runSessionWithServer plugin (testDataDir </> "noop") $ do
+      doc <- openDoc (fp <.> "hs") "haskell"
+      actions <- getExplicitFieldsActions doc x1 y1 x2 y2
+      liftIO $ actions @?= []
+
+mkTest :: TestName -> FilePath -> UInt -> UInt -> UInt -> UInt -> TestTree
+mkTest title fp x1 y1 x2 y2 =
+  goldenWithHaskellDoc plugin title testDataDir fp "expected" "hs" $ \doc -> do
+    (act:_) <- getExplicitFieldsActions doc x1 y1 x2 y2
+    executeCodeAction act
+
+getExplicitFieldsActions
+  :: TextDocumentIdentifier
+  -> UInt -> UInt -> UInt -> UInt
+  -> Session [CodeAction]
+getExplicitFieldsActions doc x1 y1 x2 y2 =
+  findExplicitFieldsAction <$> getCodeActions doc range
+  where
+    range = Range (Position x1 y1) (Position x2 y2)
+
+findExplicitFieldsAction :: [a |? CodeAction] -> [CodeAction]
+findExplicitFieldsAction = filter isExplicitFieldsCodeAction . rights . map toEither
+
+isExplicitFieldsCodeAction :: CodeAction -> Bool
+isExplicitFieldsCodeAction CodeAction {_title} =
+  "Expand record wildcard" `T.isPrefixOf` _title
+
+testDataDir :: FilePath
+testDataDir = "test" </> "testdata"

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/Construction.expected.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/Construction.expected.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Construction where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: () -> MyRec
+convertMe _ =
+  let foo = 3
+      bar = 5
+      baz = 'a'
+  in MyRec {foo, bar, baz}

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/Construction.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/Construction.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Construction where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: () -> MyRec
+convertMe _ =
+  let foo = 3
+      bar = 5
+      baz = 'a'
+  in MyRec {..}

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/Mixed.expected.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/Mixed.expected.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Mixed where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo, bar = bar', baz} = show foo ++ show bar' ++ show baz

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/Mixed.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/Mixed.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Mixed where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo, bar = bar', ..} = show foo ++ show bar' ++ show baz

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/WildcardOnly.expected.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/WildcardOnly.expected.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module WildcardOnly where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo, bar, baz} = show foo ++ show bar ++ show baz

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/WildcardOnly.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/WildcardOnly.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module WildcardOnly where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {..} = show foo ++ show bar ++ show baz

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/WithExplicitBind.expected.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/WithExplicitBind.expected.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module WithExplicitBind where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo = foo', bar, baz} = show foo' ++ show bar ++ show baz

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/WithExplicitBind.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/WithExplicitBind.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module WithExplicitBind where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo = foo', ..} = show foo' ++ show bar ++ show baz

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/WithPun.expected.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/WithPun.expected.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module WithPun where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo, bar, baz} = show foo ++ show bar ++ show baz

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/WithPun.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/WithPun.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module WithPun where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo, ..} = show foo ++ show bar ++ show baz

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/ExplicitBinds.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/ExplicitBinds.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE Haskell2010 #-}
+
+module ExplicitBinds where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo = foo', bar = bar', baz = baz'} = show foo' ++ show bar' ++ show baz'

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/Infix.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/Infix.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE Haskell2010 #-}
+
+module Infix where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  }
+
+convertMe :: MyRec -> String
+convertMe (foo' `MyRec` bar') = show foo' ++ show bar'

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/Prefix.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/Prefix.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE Haskell2010 #-}
+
+module Prefix where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  }
+
+convertMe :: MyRec -> String
+convertMe (foo' `MyRec` bar') = show foo' ++ show bar'

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/Puns.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/Puns.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE Haskell2010 #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Puns where
+
+data MyRec = MyRec
+  { foo :: Int
+  , bar :: Int
+  , baz :: Char
+  }
+
+convertMe :: MyRec -> String
+convertMe MyRec {foo, bar, baz} = show foo ++ show bar ++ show baz

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -42,7 +42,8 @@ import           Development.IDE.Core.Rules
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Service
 import           Development.IDE.Core.Shake                        hiding (Log)
-import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Compat                        hiding
+                                                                   (ImplicitPrelude)
 import           Development.IDE.GHC.Compat.ExactPrint
 import           Development.IDE.GHC.Compat.Util
 import           Development.IDE.GHC.Error

--- a/plugins/hls-tactics-plugin/src/Wingman/EmptyCase.hs
+++ b/plugins/hls-tactics-plugin/src/Wingman/EmptyCase.hs
@@ -21,7 +21,7 @@ import           Development.IDE (hscEnv, realSrcSpanToRange)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake (IdeState (..))
 import           Development.IDE.Core.UseStale
-import           Development.IDE.GHC.Compat hiding (empty)
+import           Development.IDE.GHC.Compat hiding (empty, EmptyCase)
 import           Development.IDE.GHC.ExactPrint
 import           Development.IDE.Spans.LocalBindings (getLocalScope)
 import           Ide.Types

--- a/src/HlsPlugins.hs
+++ b/src/HlsPlugins.hs
@@ -94,6 +94,10 @@ import           Ide.Plugin.GADT                   as GADT
 import           Ide.Plugin.ExplicitFixity         as ExplicitFixity
 #endif
 
+#if explicitFields
+import           Ide.Plugin.ExplicitFields         as ExplicitFields
+#endif
+
 -- formatters
 
 #if hls_floskell
@@ -220,5 +224,8 @@ idePlugins recorder = pluginDescToIdePlugins allPlugins
       GhcIde.descriptors (pluginRecorder "ghcide")
 #if explicitFixity
       ++ [let pId = "explicit-fixity" in ExplicitFixity.descriptor (pluginRecorder pId) pId]
+#endif
+#if explicitFields
+      ++ [let pId = "explicit-fields" in ExplicitFields.descriptor (pluginRecorder pId) pId]
 #endif
 


### PR DESCRIPTION
#### What?
This is a plugin to expand record wildcards, explicitly listing all fields as field puns. [Here](https://asciinema.org/a/gQJW6rlqeEmbQnJ4ASvBw6KNL) is a little demo. It works in both record construction and pattern binding scenarios, and it works as you would expect regardless of whether there are explicitly provided fields or puns in addition to the wildcard.

#### Known issues
One of the shortcomings of the current approach is that all fields of the record are expanded, whether they are actually used or not. This results in warnings of unused bindings, if the corresponding warning flag is enabled. I am looking for ways to expand only used fields, but I still think this is useful as it is, hence the PR :slightly_smiling_face:

