### PR TITLE
Fix ghc source plugins for GHC 9.2

### DIFF
--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -1187,7 +1187,6 @@ checkFileCompiles fp diag =
 pluginSimpleTests :: TestTree
 pluginSimpleTests =
   ignoreInWindowsForGHC810 $
-  ignoreForGHC92Plus "blocked on ghc-typelits-natnormalise" $
   testSessionWithExtraFiles "plugin-knownnat" "simple plugin" $ \dir -> do
     _ <- openDoc (dir </> "KnownNat.hs") "haskell"
     liftIO $ writeFile (dir</>"hie.yaml")


### PR DESCRIPTION
This is supposed to fix ghc source plugins for GHC 9.4 as well, but I couldn't prove that locally.

After GHC 9.0, plugins no longer live in DynFlags, but in HscEnv. Thus, we need to make sure to pass the modified HscEnv to the subsequent typechecking phase.

Supposed to fix #2989, let's see whether it works out.

This is likely to have been introduced by #2128 (my bad!)

EDIT: ~~I am going to write a regression test for this~~ Just needed to enable the test.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3311"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

