### PR TITLE
Filter generated Core variable names from hovertip documentation

### DIFF
--- a/ghcide/src/Development/IDE/GHC/CoreFile.hs
+++ b/ghcide/src/Development/IDE/GHC/CoreFile.hs
@@ -10,7 +10,8 @@ module Development.IDE.GHC.CoreFile
   , typecheckCoreFile
   , readBinCoreFile
   , writeBinCoreFile
-  , getImplicitBinds) where
+  , getImplicitBinds
+  , occNamePrefixes) where
 
 import           Control.Monad
 import           Control.Monad.IO.Class
@@ -18,6 +19,7 @@ import           Data.Foldable
 import           Data.IORef
 import           Data.List                       (isPrefixOf)
 import           Data.Maybe
+import qualified Data.Text as T
 import           GHC.Fingerprint
 
 import           Development.IDE.GHC.Compat
@@ -228,3 +230,45 @@ tc_iface_bindings (TopIfaceNonRec v e) = do
 tc_iface_bindings (TopIfaceRec vs) = do
   vs' <- traverse (\(v, e) -> (,) <$> pure v <*> tcIfaceExpr e) vs
   pure $ Rec vs'
+
+-- | Prefixes that can occur in a GHC OccName
+occNamePrefixes :: [T.Text]
+occNamePrefixes =
+  [
+    -- long ones
+    "$con2tag_"
+  , "$tag2con_"
+  , "$maxtag_"
+
+  -- four chars
+  , "$sel:"
+  , "$tc'"
+
+  -- three chars
+  , "$dm"
+  , "$co"
+  , "$tc"
+  , "$cp"
+  , "$fx"
+
+  -- two chars
+  , "$W"
+  , "$w"
+  , "$m"
+  , "$b"
+  , "$c"
+  , "$d"
+  , "$i"
+  , "$s"
+  , "$f"
+  , "$r"
+  , "C:"
+  , "N:"
+  , "D:"
+  , "$p"
+  , "$L"
+  , "$f"
+  , "$t"
+  , "$c"
+  , "$m"
+  ]

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -770,17 +770,8 @@ stripPrefix :: T.Text -> T.Text
 stripPrefix name = T.takeWhile (/=':') $ fromMaybe name $
   getFirst $ foldMap (First . (`T.stripPrefix` name)) occNamePrefixes
 
-safeTyThingForRecord :: TyThing -> Maybe (T.Text, [T.Text])
-safeTyThingForRecord (AnId _) = Nothing
-safeTyThingForRecord (AConLike dc) =
-    let ctxStr = printOutputable . occName . conLikeName $ dc
-        field_names = T.pack . unpackFS . flLabel <$> conLikeFieldLabels dc
-    in
-        Just (ctxStr, field_names)
-safeTyThingForRecord _ = Nothing
-
-mkRecordSnippetCompItem :: Uri -> Maybe T.Text -> T.Text -> [T.Text] -> Provenance -> SpanDoc -> Maybe (LImportDecl GhcPs) -> CompItem
-mkRecordSnippetCompItem uri parent ctxStr compl importedFrom docs imp = r
+mkRecordSnippetCompItem :: Uri -> Maybe T.Text -> T.Text -> [T.Text] -> Provenance -> Maybe (LImportDecl GhcPs) -> CompItem
+mkRecordSnippetCompItem uri parent ctxStr compl importedFrom imp = r
   where
       r  = CI {
             compKind = CiSnippet

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -41,6 +41,7 @@ import           Development.IDE.Core.PositionMapping
 import           Development.IDE.GHC.Compat               hiding (ppr)
 import qualified Development.IDE.GHC.Compat               as GHC
 import           Development.IDE.GHC.Compat.Util
+import           Development.IDE.GHC.CoreFile            (occNamePrefixes)
 import           Development.IDE.GHC.Error
 import           Development.IDE.GHC.Util
 import           Development.IDE.Plugin.Completions.Types
@@ -767,50 +768,7 @@ openingBacktick line prefixModule prefixText Position { _character=(fromIntegral
 -- TODO: Turn this into an alex lexer that discards prefixes as if they were whitespace.
 stripPrefix :: T.Text -> T.Text
 stripPrefix name = T.takeWhile (/=':') $ fromMaybe name $
-  getFirst $ foldMap (First . (`T.stripPrefix` name)) prefixes
-
--- | Prefixes that can occur in a GHC OccName
-prefixes :: [T.Text]
-prefixes =
-  [
-    -- long ones
-    "$con2tag_"
-  , "$tag2con_"
-  , "$maxtag_"
-
-  -- four chars
-  , "$sel:"
-  , "$tc'"
-
-  -- three chars
-  , "$dm"
-  , "$co"
-  , "$tc"
-  , "$cp"
-  , "$fx"
-
-  -- two chars
-  , "$W"
-  , "$w"
-  , "$m"
-  , "$b"
-  , "$c"
-  , "$d"
-  , "$i"
-  , "$s"
-  , "$f"
-  , "$r"
-  , "C:"
-  , "N:"
-  , "D:"
-  , "$p"
-  , "$L"
-  , "$f"
-  , "$t"
-  , "$c"
-  , "$m"
-  ]
-
+  getFirst $ foldMap (First . (`T.stripPrefix` name)) occNamePrefixes
 
 mkRecordSnippetCompItem :: Uri -> Maybe T.Text -> T.Text -> [T.Text] -> Provenance -> Maybe (LImportDecl GhcPs) -> CompItem
 mkRecordSnippetCompItem uri parent ctxStr compl importedFrom imp = r

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -770,8 +770,17 @@ stripPrefix :: T.Text -> T.Text
 stripPrefix name = T.takeWhile (/=':') $ fromMaybe name $
   getFirst $ foldMap (First . (`T.stripPrefix` name)) occNamePrefixes
 
-mkRecordSnippetCompItem :: Uri -> Maybe T.Text -> T.Text -> [T.Text] -> Provenance -> Maybe (LImportDecl GhcPs) -> CompItem
-mkRecordSnippetCompItem uri parent ctxStr compl importedFrom imp = r
+safeTyThingForRecord :: TyThing -> Maybe (T.Text, [T.Text])
+safeTyThingForRecord (AnId _) = Nothing
+safeTyThingForRecord (AConLike dc) =
+    let ctxStr = printOutputable . occName . conLikeName $ dc
+        field_names = T.pack . unpackFS . flLabel <$> conLikeFieldLabels dc
+    in
+        Just (ctxStr, field_names)
+safeTyThingForRecord _ = Nothing
+
+mkRecordSnippetCompItem :: Uri -> Maybe T.Text -> T.Text -> [T.Text] -> Provenance -> SpanDoc -> Maybe (LImportDecl GhcPs) -> CompItem
+mkRecordSnippetCompItem uri parent ctxStr compl importedFrom docs imp = r
   where
       r  = CI {
             compKind = CiSnippet

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -227,10 +227,17 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
         wrapHaskell x = "\n```haskell\n"<>x<>"\n```\n"
         info = nodeInfoH kind ast
         names = M.assocs $ nodeIdentifiers info
+        isInternal :: (Identifier, IdentifierDetails a) -> Bool
+        isInternal (Right n, _) =
+          let name = printOutputable n
+              prefix = T.take 2 name
+          in elem prefix ["$d", "$c"]
+        isInternal (Left _, _) = False
+        filteredNames = filter (not . isInternal) names
         types = nodeType info
 
         prettyNames :: [T.Text]
-        prettyNames = map prettyName names
+        prettyNames = map prettyName filteredNames
         prettyName (Right n, dets) = T.unlines $
           wrapHaskell (printOutputable n <> maybe "" (" :: " <>) ((prettyType <$> identType dets) <|> maybeKind))
           : maybeToList (pretty (definedAt n) (prettyPackageName n))

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -227,10 +227,14 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
         wrapHaskell x = "\n```haskell\n"<>x<>"\n```\n"
         info = nodeInfoH kind ast
         names = M.assocs $ nodeIdentifiers info
-        -- Check if a name matches a pattern for a generated Core variable.
+        -- Check for evidence bindings
         isInternal :: (Identifier, IdentifierDetails a) -> Bool
         isInternal (Right _, dets) =
+#if MIN_VERSION_ghc(9,0,1)
           any isEvidenceContext $ identInfo dets
+#else
+          False
+#endif
         isInternal (Left _, _) = False
         filteredNames = filter (not . isInternal) names
         types = nodeType info

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -34,6 +34,7 @@ import           Development.IDE.Core.PositionMapping
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import qualified Development.IDE.GHC.Compat.Util      as Util
+import           Development.IDE.GHC.CoreFile         (occNamePrefixes)
 import           Development.IDE.GHC.Util             (printOutputable)
 import           Development.IDE.Spans.Common
 import           Development.IDE.Types.Options

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -34,7 +34,6 @@ import           Development.IDE.Core.PositionMapping
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import qualified Development.IDE.GHC.Compat.Util      as Util
-import           Development.IDE.GHC.CoreFile         (occNamePrefixes)
 import           Development.IDE.GHC.Util             (printOutputable)
 import           Development.IDE.Spans.Common
 import           Development.IDE.Types.Options
@@ -230,9 +229,8 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
         names = M.assocs $ nodeIdentifiers info
         -- Check if a name matches a pattern for a generated Core variable.
         isInternal :: (Identifier, IdentifierDetails a) -> Bool
-        isInternal (Right n, _) =
-          let name = printOutputable n
-          in any (`T.isPrefixOf` name) occNamePrefixes
+        isInternal (Right _, dets) =
+          any isEvidenceContext $ identInfo dets
         isInternal (Left _, _) = False
         filteredNames = filter (not . isInternal) names
         types = nodeType info

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -34,6 +34,7 @@ import           Development.IDE.Core.PositionMapping
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import qualified Development.IDE.GHC.Compat.Util      as Util
+import           Development.IDE.GHC.CoreFile         (occNamePrefixes)
 import           Development.IDE.GHC.Util             (printOutputable)
 import           Development.IDE.Spans.Common
 import           Development.IDE.Types.Options
@@ -231,12 +232,10 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
         isInternal :: (Identifier, IdentifierDetails a) -> Bool
         isInternal (Right n, _) =
           let name = printOutputable n
-              prefix = T.take 2 name
-          in elem prefix ["$d", "$c"]
+          in any (`T.isPrefixOf` name) occNamePrefixes
         isInternal (Left _, _) = False
         filteredNames = filter (not . isInternal) names
         types = nodeType info
-
         prettyNames :: [T.Text]
         prettyNames = map prettyName filteredNames
         prettyName (Right n, dets) = T.unlines $

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -227,6 +227,7 @@ atPoint IdeOptions{} (HAR _ hf _ _ kind) (DKMap dm km) env pos = listToMaybe $ p
         wrapHaskell x = "\n```haskell\n"<>x<>"\n```\n"
         info = nodeInfoH kind ast
         names = M.assocs $ nodeIdentifiers info
+        -- Check if a name matches a pattern for a generated Core variable.
         isInternal :: (Identifier, IdentifierDetails a) -> Bool
         isInternal (Right n, _) =
           let name = printOutputable n

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -34,7 +34,6 @@ import           Development.IDE.Core.PositionMapping
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import qualified Development.IDE.GHC.Compat.Util      as Util
-import           Development.IDE.GHC.CoreFile         (occNamePrefixes)
 import           Development.IDE.GHC.Util             (printOutputable)
 import           Development.IDE.Spans.Common
 import           Development.IDE.Types.Options

--- a/ghcide/test/data/hover/GotoHover.hs
+++ b/ghcide/test/data/hover/GotoHover.hs
@@ -64,3 +64,7 @@ hole = _
 
 hole2 :: a -> Maybe a
 hole2 = _
+
+-- A comment above a type defnition with a deriving clause
+data Example = Example
+  deriving (Eq)


### PR DESCRIPTION
This addresses https://github.com/haskell/haskell-language-server/issues/3280 by checking if names associated with a Haskell source file location follow particular prefix patterns used by generated Core variables. The two prefixes used are: `$d` and `$c`. If a name is prefixed with either of those strings then it is removed from the list of names used to generate the hovertip documentation content.

This change has been tested with the cases mentioned in the associated issue.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3316"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

