### PR TITLE
Add support for `.env` shells to `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -156,6 +156,18 @@
         "url": "https://hackage.haskell.org/package/ghc-exactprint-1.5.0/ghc-exactprint-1.5.0.tar.gz"
       }
     },
+    "ghc-exactprint-160": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-6fW4KSmDo7hi5i2C1lbI/rEyFWrowSGTNyaC+f73JaE=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.6.0/ghc-exactprint-1.6.0.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.6.0/ghc-exactprint-1.6.0.tar.gz"
+      }
+    },
     "gitignore": {
       "flake": false,
       "locked": {
@@ -322,6 +334,7 @@
         "ghc-check": "ghc-check",
         "ghc-exactprint": "ghc-exactprint",
         "ghc-exactprint-150": "ghc-exactprint-150",
+        "ghc-exactprint-160": "ghc-exactprint-160",
         "gitignore": "gitignore",
         "hie-bios": "hie-bios",
         "hiedb": "hiedb",

--- a/flake.nix
+++ b/flake.nix
@@ -356,6 +356,10 @@
 
             src = null;
           };
+
+        mkEnvShell = hpkgs:
+          pkgs.lib.mapAttrs (name: value: hpkgs.${name}.env) pkgs.hlsSources;
+
         # Create a hls executable
         # Copied from https://github.com/NixOS/nixpkgs/blob/210784b7c8f3d926b7db73bdad085f4dc5d79428/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix#L16
         mkExe = hpkgs:
@@ -388,6 +392,15 @@
           haskell-language-server-942-dev-nix = mkDevShellWithNixDeps ghc942 "cabal.project";
         };
 
+        # The default shell provided by Nixpkgs for a Haskell package (i.e. the
+        # one that comes in the `.env` attribute)
+        envShells = {
+          haskell-language-server-dev-env = mkEnvShell ghcDefault;
+          haskell-language-server-902-dev-env = mkEnvShell ghc902;
+          haskell-language-server-924-dev-env = mkEnvShell ghc924;
+          haskell-language-server-942-dev-env = mkEnvShell ghc942;
+        };
+
         allPackages = {
           haskell-language-server = mkExe ghcDefault;
           haskell-language-server-902 = mkExe ghc902;
@@ -395,7 +408,7 @@
           haskell-language-server-942 = mkExe ghc942;
         };
 
-        devShells = simpleDevShells // nixDevShells // {
+        devShells = simpleDevShells // nixDevShells // envShells // {
           default = simpleDevShells.haskell-language-server-dev;
         };
 


### PR DESCRIPTION
The main motivation for this change is to enable development of HLS plugins by generating a `.env` shell for every package in this repository.

Example usage:

```ShellSession
$ nix develop .#haskell-language-server-dev-env.hls-fourmolu-plugin
```

This is a plain shell, though, without any tooling installed, identical to the one that Nixpkgs provides by default.

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3322"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

