### PR TITLE
Add hls-cabal-fmt-plugin to hackage release CI script and HLS library

### DIFF
--- a/.github/workflows/hackage.yml
+++ b/.github/workflows/hackage.yml
@@ -37,6 +37,7 @@ jobs:
                   "hls-splice-plugin", "hls-tactics-plugin",
                   "hls-call-hierarchy-plugin", "hls-alternate-number-format-plugin",
                   "hls-qualify-imported-names-plugin", "hls-code-range-plugin",
+                  "hls-cabal-fmt-plugin",
                   "haskell-language-server"]
         ghc: [ "9.0.2"
              , "8.10.7"

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -359,6 +359,7 @@ library
                   , pedantic
                   -- plugins
                   , callHierarchy
+                  , cabalfmt
                   , changeTypeSignature
                   , class
                   , haddockComments


### PR DESCRIPTION
This slipped through

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3335"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

