### PR TITLE
Introduce common code for Recorders in Plugin Tests

### DIFF
--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -20,16 +20,18 @@ module Test.Hls
     goldenWithHaskellDocFormatter,
     goldenWithCabalDocFormatter,
     def,
-    pluginTestRecorder,
+    -- * Running HLS for integration tests
     runSessionWithServer,
-    runSessionWithServerAndRecorder,
+    runSessionWithServerAndCaps,
     runSessionWithServerFormatter,
     runSessionWithCabalServerFormatter,
     runSessionWithServer',
-    waitForProgressDone,
-    waitForAllProgressDone,
+    -- * Helpful re-exports
     PluginDescriptor,
     IdeState,
+    -- * Assertion helper functions
+    waitForProgressDone,
+    waitForAllProgressDone,
     waitForBuildQueue,
     waitForTypecheck,
     waitForAction,
@@ -37,6 +39,11 @@ module Test.Hls
     getLastBuildKeys,
     waitForKickDone,
     waitForKickStart,
+    -- * Plugin descriptor helper functions for tests
+    PluginTestDescriptor,
+    pluginTestRecorder,
+    mkPluginTestDescriptor,
+    mkPluginTestDescriptor',
     -- * Re-export logger types
     -- Avoids slightly annoying ghcide imports when they are unnecessary.
     WithPriority(..),
@@ -50,6 +57,7 @@ import           Control.Concurrent.Async        (async, cancel, wait)
 import           Control.Concurrent.Extra
 import           Control.Exception.Base
 import           Control.Monad                   (guard, unless, void)
+import           Control.Monad.Extra             (forM)
 import           Control.Monad.IO.Class
 import           Data.Aeson                      (Result (Success),
                                                   Value (Null), fromJSON,
@@ -69,7 +77,7 @@ import qualified Development.IDE.Main            as IDEMain
 import           Development.IDE.Plugin.Test     (TestRequest (GetBuildKeysBuilt, WaitForIdeRule, WaitForShakeQueue),
                                                   WaitForIdeRuleResult (ideResultSuccess))
 import qualified Development.IDE.Plugin.Test     as Test
-import           Development.IDE.Types.Logger    (Logger (Logger),
+import           Development.IDE.Types.Logger    (Doc, Logger (Logger),
                                                   Pretty (pretty),
                                                   Priority (Debug),
                                                   Recorder (Recorder, logger_),
@@ -106,8 +114,6 @@ import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
 import           Test.Tasty.Ingredients.Rerun
 import           Test.Tasty.Runners              (NumThreads (..))
-import Control.Monad.Extra (forM)
-import Development.IDE.Types.Logger (Doc)
 
 newtype Log = LogIDEMain IDEMain.Log
 
@@ -126,7 +132,8 @@ goldenGitDiff :: TestName -> FilePath -> IO ByteString -> TestTree
 goldenGitDiff name = goldenVsStringDiff name gitDiff
 
 goldenWithHaskellDoc
-  :: PluginDescriptor IdeState
+  :: Pretty b
+  => PluginTestDescriptor b
   -> TestName
   -> FilePath
   -> FilePath
@@ -137,7 +144,8 @@ goldenWithHaskellDoc
 goldenWithHaskellDoc = goldenWithDoc "haskell"
 
 goldenWithCabalDoc
-  :: PluginDescriptor IdeState
+  :: Pretty b
+  => PluginTestDescriptor b
   -> TestName
   -> FilePath
   -> FilePath
@@ -148,8 +156,9 @@ goldenWithCabalDoc
 goldenWithCabalDoc = goldenWithDoc "cabal"
 
 goldenWithDoc
-  :: T.Text
-  -> PluginDescriptor IdeState
+  :: Pretty b
+  => T.Text
+  -> PluginTestDescriptor b
   -> TestName
   -> FilePath
   -> FilePath
@@ -167,47 +176,119 @@ goldenWithDoc fileType plugin title testDataDir path desc ext act =
     act doc
     documentContents doc
 
-goldenWithHaskellDocAndRecorder
-  :: Pretty a
-  => (Recorder (WithPriority a) -> PluginDescriptor IdeState)
-  -> TestName
-  -> FilePath
-  -> FilePath
-  -> FilePath
-  -> FilePath
-  -> (TextDocumentIdentifier -> Session ())
-  -> TestTree
-goldenWithHaskellDocAndRecorder plugin title testDataDir path desc ext act =
-  goldenGitDiff title (testDataDir </> path <.> desc <.> ext)
-  $ runSessionWithServerAndRecorder plugin testDataDir
-  $ TL.encodeUtf8 . TL.fromStrict
-  <$> do
-    doc <- openDoc (path <.> ext) "haskell"
-    void waitForBuildQueue
-    act doc
-    documentContents doc
+-- ------------------------------------------------------------
+-- Helper function for initialising plugins under test
+-- ------------------------------------------------------------
 
-runSessionWithServer :: PluginDescriptor IdeState -> FilePath -> Session a -> IO a
-runSessionWithServer plugin = runSessionWithServer' [plugin] def def fullCaps
+-- | Plugin under test where a fitting recorder is injected.
+type PluginTestDescriptor b = Recorder (WithPriority b) -> PluginDescriptor IdeState
 
-runSessionWithServerAndRecorder :: Pretty b => (Recorder (WithPriority b) -> PluginDescriptor IdeState) -> FilePath -> Session a -> IO a
-runSessionWithServerAndRecorder pluginF fp act = do
+-- | Wrap a plugin you want to test, and inject a fitting recorder as required.
+--
+-- If you want to write the logs to stderr, run your tests with
+-- "HLS_TEST_PLUGIN_LOG_STDERR=1", e.g.
+--
+-- @
+--   HLS_TEST_PLUGIN_LOG_STDERR=1 cabal test <test-suite-of-plugin>
+-- @
+--
+--
+-- To write all logs to stderr, including logs of the server, use:
+--
+-- @
+--   HLS_TEST_LOG_STDERR=1 cabal test <test-suite-of-plugin>
+-- @
+mkPluginTestDescriptor
+  :: (Recorder (WithPriority b) -> PluginId -> PluginDescriptor IdeState)
+  -> PluginId
+  -> PluginTestDescriptor b
+mkPluginTestDescriptor pluginDesc plId recorder = pluginDesc recorder plId
+
+-- | Wrap a plugin you want to test.
+--
+-- Ideally, try to migrate this plugin to co-log logger style architecture.
+-- Therefore, you should prefer 'mkPluginTestDescriptor' to this if possible.
+mkPluginTestDescriptor'
+  :: (PluginId -> PluginDescriptor IdeState)
+  -> PluginId
+  -> PluginTestDescriptor b
+mkPluginTestDescriptor' pluginDesc plId _recorder = pluginDesc plId
+
+-- | Initialise a recorder that can be instructed to write to stderr by
+-- setting the environment variable "HLS_TEST_PLUGIN_LOG_STDERR=1" before
+-- running the tests.
+--
+-- On the cli, use for example:
+--
+-- @
+--   HLS_TEST_PLUGIN_LOG_STDERR=1 cabal test <test-suite-of-plugin>
+-- @
+--
+-- To write all logs to stderr, including logs of the server, use:
+--
+-- @
+--   HLS_TEST_LOG_STDERR=1 cabal test <test-suite-of-plugin>
+-- @
+pluginTestRecorder :: Pretty a => IO (Recorder (WithPriority a))
+pluginTestRecorder = do
+  (recorder, _) <- initialiseTestRecorder ["HLS_TEST_PLUGIN_LOG_STDERR", "HLS_TEST_LOG_STDERR"]
+  pure recorder
+
+-- | Generic recorder initialisation for plugins and the HLS server for test-cases.
+--
+-- The created recorder writes to stderr if any of the given environment variables
+-- have been set to a value different to @0@.
+-- We allow multiple values, to make it possible to define a single environment variable
+-- that instructs all recorders in the test-suite to write to stderr.
+--
+-- We have to return the base logger function for HLS server logging initialisation.
+-- See 'runSessionWithServer'' for details.
+initialiseTestRecorder :: Pretty a => [String] -> IO (Recorder (WithPriority a), WithPriority (Doc ann) -> IO ())
+initialiseTestRecorder envVars = do
+    docWithPriorityRecorder <- makeDefaultStderrRecorder Nothing Debug
+    -- There are potentially multiple environment variables that enable this logger
+    definedEnvVars <- forM envVars (\var -> fromMaybe "0" <$> lookupEnv var)
+    let logStdErr = any (/= "0") definedEnvVars
+
+        docWithFilteredPriorityRecorder =
+          if logStdErr then cfilter (\WithPriority{ priority } -> priority >= Debug) docWithPriorityRecorder
+          else mempty
+
+        Recorder {logger_} = docWithFilteredPriorityRecorder
+
+    pure (cmapWithPrio pretty docWithFilteredPriorityRecorder, logger_)
+
+-- ------------------------------------------------------------
+-- Run an HLS server testing a specific plugin
+-- ------------------------------------------------------------
+
+runSessionWithServer :: Pretty b => PluginTestDescriptor b -> FilePath -> Session a -> IO a
+runSessionWithServer plugin fp act = do
   recorder <- pluginTestRecorder
-  runSessionWithServer' [pluginF recorder] def def fullCaps fp act
+  runSessionWithServer' [plugin recorder] def def fullCaps fp act
 
-runSessionWithServerFormatter :: PluginDescriptor IdeState -> String -> PluginConfig -> FilePath -> Session a -> IO a
-runSessionWithServerFormatter plugin formatter conf =
+runSessionWithServerAndCaps :: Pretty b => PluginTestDescriptor b -> ClientCapabilities -> FilePath -> Session a -> IO a
+runSessionWithServerAndCaps plugin caps fp act = do
+  recorder <- pluginTestRecorder
+  runSessionWithServer' [plugin recorder] def def caps fp act
+
+runSessionWithServerFormatter :: Pretty b => PluginTestDescriptor b -> String -> PluginConfig -> FilePath -> Session a -> IO a
+runSessionWithServerFormatter plugin formatter conf fp act = do
+  recorder <- pluginTestRecorder
   runSessionWithServer'
-    [plugin]
+    [plugin recorder]
     def
       { formattingProvider = T.pack formatter
       , plugins = M.singleton (T.pack formatter) conf
       }
     def
     fullCaps
+    fp
+    act
 
 goldenWithHaskellDocFormatter
-  :: PluginDescriptor IdeState -- ^ Formatter plugin to be used
+  :: Pretty b
+  => PluginTestDescriptor b -- ^ Formatter plugin to be used
   -> String -- ^ Name of the formatter to be used
   -> PluginConfig
   -> TestName -- ^ Title of the test
@@ -228,7 +309,8 @@ goldenWithHaskellDocFormatter plugin formatter conf title testDataDir path desc 
     documentContents doc
 
 goldenWithCabalDocFormatter
-  :: PluginDescriptor IdeState -- ^ Formatter plugin to be used
+  :: Pretty b
+  => PluginTestDescriptor b -- ^ Formatter plugin to be used
   -> String -- ^ Name of the formatter to be used
   -> PluginConfig
   -> TestName -- ^ Title of the test
@@ -248,16 +330,18 @@ goldenWithCabalDocFormatter plugin formatter conf title testDataDir path desc ex
     act doc
     documentContents doc
 
-runSessionWithCabalServerFormatter :: PluginDescriptor IdeState -> String -> PluginConfig -> FilePath -> Session a -> IO a
-runSessionWithCabalServerFormatter plugin formatter conf =
+runSessionWithCabalServerFormatter :: Pretty b => PluginTestDescriptor b -> String -> PluginConfig -> FilePath -> Session a -> IO a
+runSessionWithCabalServerFormatter plugin formatter conf fp act = do
+  recorder <- pluginTestRecorder
   runSessionWithServer'
-    [plugin]
+    [plugin recorder]
     def
       { cabalFormattingProvider = T.pack formatter
       , plugins = M.singleton (T.pack formatter) conf
       }
     def
     fullCaps
+    fp act
 
 -- | Restore cwd after running an action
 keepCurrentDirectory :: IO a -> IO a
@@ -268,51 +352,13 @@ keepCurrentDirectory = bracket getCurrentDirectory setCurrentDirectory . const
 lock :: Lock
 lock = unsafePerformIO newLock
 
--- | Initialise a recorder that can be instructed to write to stderr by
--- setting the environment variable "HLS_TEST_PLUGIN_LOG_STDERR=1" before
--- running the tests.
---
--- On the cli, use for example:
---
--- @
---   HLS_TEST_PLUGIN_LOG_STDERR=1 cabal test <test-suite-of-plugin>
--- @
---
--- to write all logs to stderr.
-pluginTestRecorder :: Pretty a => IO (Recorder (WithPriority a))
-pluginTestRecorder = do
-  (recorder, _) <- initialiseTestRecorder ["HLS_TEST_PLUGIN_LOG_STDERR"]
-  pure recorder
-
--- | Generic recorder initialisation for plugins and the HLS server for test-cases.
---
--- The created recorder writes to stderr if any of the given environment variables
--- have been set to a value different to @0@.
--- We allow multiple values, to make it possible to define a single environment variable
--- that instructs all recorders in the test-suite to write to stderr.
---
--- We have to return the base logger function for HLS server logging initialisation.
--- See 'runSessionWithServer'' for details.
-initialiseTestRecorder :: Pretty a => [String] -> IO (Recorder (WithPriority a), WithPriority (Doc ann) -> IO ())
-initialiseTestRecorder envVars = do
-    docWithPriorityRecorder <- makeDefaultStderrRecorder Nothing Debug
-    -- There are potentially multiple environment variables that enable this logger
-    definedEnvVars <- forM envVars (\var -> fromMaybe "0" <$> lookupEnv var)
-    let logStdErr = any (/= "0") definedEnvVars
-
-        docWithFilteredPriorityRecorder =
-          if logStdErr then mempty
-          else cfilter (\WithPriority{ priority } -> priority >= Debug) docWithPriorityRecorder
-
-        Recorder {logger_} = docWithFilteredPriorityRecorder
-
-    pure (cmapWithPrio pretty docWithFilteredPriorityRecorder, logger_)
-
-
 -- | Host a server, and run a test session on it
 -- Note: cwd will be shifted into @root@ in @Session a@
 runSessionWithServer' ::
-  -- | plugins to load on the server
+  -- | Plugins to load on the server.
+  --
+  -- For improved logging, make sure these plugins have been initalised with
+  -- the recorder produced by @pluginTestRecorder@.
   [PluginDescriptor IdeState] ->
   -- | lsp config for the server
   Config ->
@@ -326,11 +372,14 @@ runSessionWithServer' plugins conf sconf caps root s = withLock lock $ keepCurre
     (inR, inW) <- createPipe
     (outR, outW) <- createPipe
 
-    -- Allow two environment variables, because "LSP_TEST_LOG_STDERR" has been used before,
+    -- Allow three environment variables, because "LSP_TEST_LOG_STDERR" has been used before,
     -- (thus, backwards compatibility) and "HLS_TEST_SERVER_LOG_STDERR" because it
     -- uses a more descriptive name.
-    -- It is also in better accordance with 'pluginTestRecorder' which uses "HLS_TEST_PLUGIN_LOG_STDERR"
-    (recorder, logger_) <- initialiseTestRecorder ["LSP_TEST_LOG_STDERR", "HLS_TEST_SERVER_LOG_STDERR"]
+    -- It is also in better accordance with 'pluginTestRecorder' which uses "HLS_TEST_PLUGIN_LOG_STDERR".
+    -- At last, "HLS_TEST_LOG_STDERR" is intended to enable all logging for the server and the plugins
+    -- under test.
+    (recorder, logger_) <- initialiseTestRecorder
+      ["LSP_TEST_LOG_STDERR", "HLS_TEST_SERVER_LOG_STDERR", "HLS_TEST_LOG_STDERR"]
 
     let
         -- exists until old logging style is phased out

--- a/plugins/hls-alternate-number-format-plugin/test/Main.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/Main.hs
@@ -19,8 +19,8 @@ import           Text.Regex.TDFA                  ((=~))
 main :: IO ()
 main = defaultTestRunner test
 
-alternateNumberFormatPlugin :: Recorder (WithPriority AlternateNumberFormat.Log) -> PluginDescriptor IdeState
-alternateNumberFormatPlugin recorder = AlternateNumberFormat.descriptor recorder  "alternateNumberFormat"
+alternateNumberFormatPlugin :: PluginTestDescriptor AlternateNumberFormat.Log
+alternateNumberFormatPlugin = mkPluginTestDescriptor AlternateNumberFormat.descriptor "alternateNumberFormat"
 
 -- NOTE: For whatever reason, this plugin does not play nice with creating Code Actions on time.
 -- As a result tests will mostly pass if `import Prelude` is added at the top. We (mostly fendor) surmise this has something
@@ -54,7 +54,7 @@ test = testGroup "alternateNumberFormat" [
 
 codeActionProperties :: TestName -> [(Int, Int)] -> ([CodeAction] -> Session ()) -> TestTree
 codeActionProperties fp locs assertions = testCase fp $ do
-    runSessionWithServerAndRecorder alternateNumberFormatPlugin testDataDir $ do
+    runSessionWithServer alternateNumberFormatPlugin testDataDir $ do
         openDoc (fp <.> ".hs") "haskell" >>= codeActionsFromLocs >>= findAlternateNumberActions >>= assertions
     where
         -- similar to codeActionTest
@@ -75,7 +75,7 @@ testDataDir :: FilePath
 testDataDir = "test" </> "testdata"
 
 goldenAlternateFormat :: FilePath -> (TextDocumentIdentifier -> Session ()) -> TestTree
-goldenAlternateFormat fp = goldenWithHaskellDoc (alternateNumberFormatPlugin mempty) (fp <> " (golden)") testDataDir fp "expected" "hs"
+goldenAlternateFormat fp = goldenWithHaskellDoc alternateNumberFormatPlugin (fp <> " (golden)") testDataDir fp "expected" "hs"
 
 codeActionTest :: (Maybe Text -> Bool) -> FilePath -> Int -> Int -> TestTree
 codeActionTest filter' fp line col = goldenAlternateFormat fp $ \doc -> do

--- a/plugins/hls-alternate-number-format-plugin/test/Main.hs
+++ b/plugins/hls-alternate-number-format-plugin/test/Main.hs
@@ -19,8 +19,8 @@ import           Text.Regex.TDFA                  ((=~))
 main :: IO ()
 main = defaultTestRunner test
 
-alternateNumberFormatPlugin :: PluginDescriptor IdeState
-alternateNumberFormatPlugin = AlternateNumberFormat.descriptor mempty  "alternateNumberFormat"
+alternateNumberFormatPlugin :: Recorder (WithPriority AlternateNumberFormat.Log) -> PluginDescriptor IdeState
+alternateNumberFormatPlugin recorder = AlternateNumberFormat.descriptor recorder  "alternateNumberFormat"
 
 -- NOTE: For whatever reason, this plugin does not play nice with creating Code Actions on time.
 -- As a result tests will mostly pass if `import Prelude` is added at the top. We (mostly fendor) surmise this has something
@@ -54,7 +54,7 @@ test = testGroup "alternateNumberFormat" [
 
 codeActionProperties :: TestName -> [(Int, Int)] -> ([CodeAction] -> Session ()) -> TestTree
 codeActionProperties fp locs assertions = testCase fp $ do
-    runSessionWithServer alternateNumberFormatPlugin testDataDir $ do
+    runSessionWithServerAndRecorder alternateNumberFormatPlugin testDataDir $ do
         openDoc (fp <.> ".hs") "haskell" >>= codeActionsFromLocs >>= findAlternateNumberActions >>= assertions
     where
         -- similar to codeActionTest
@@ -75,7 +75,7 @@ testDataDir :: FilePath
 testDataDir = "test" </> "testdata"
 
 goldenAlternateFormat :: FilePath -> (TextDocumentIdentifier -> Session ()) -> TestTree
-goldenAlternateFormat fp = goldenWithHaskellDoc alternateNumberFormatPlugin (fp <> " (golden)") testDataDir fp "expected" "hs"
+goldenAlternateFormat fp = goldenWithHaskellDoc (alternateNumberFormatPlugin mempty) (fp <> " (golden)") testDataDir fp "expected" "hs"
 
 codeActionTest :: (Maybe Text -> Bool) -> FilePath -> Int -> Int -> TestTree
 codeActionTest filter' fp line col = goldenAlternateFormat fp $ \doc -> do

--- a/plugins/hls-brittany-plugin/test/Main.hs
+++ b/plugins/hls-brittany-plugin/test/Main.hs
@@ -10,8 +10,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-brittanyPlugin :: PluginDescriptor IdeState
-brittanyPlugin = Brittany.descriptor "brittany"
+brittanyPlugin :: PluginTestDescriptor ()
+brittanyPlugin = mkPluginTestDescriptor' Brittany.descriptor "brittany"
 
 tests :: TestTree
 tests = testGroup "brittany"

--- a/plugins/hls-cabal-fmt-plugin/test/Main.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/Main.hs
@@ -30,8 +30,8 @@ main = do
   foundCabalFmt <- isCabalFmtFound
   defaultTestRunner (tests foundCabalFmt)
 
-cabalFmtPlugin :: Recorder (WithPriority CabalFmt.Log) -> PluginDescriptor IdeState
-cabalFmtPlugin recorder = CabalFmt.descriptor recorder "cabal-fmt"
+cabalFmtPlugin :: PluginTestDescriptor CabalFmt.Log
+cabalFmtPlugin = mkPluginTestDescriptor CabalFmt.descriptor "cabal-fmt"
 
 tests :: CabalFmtFound -> TestTree
 tests found = testGroup "cabal-fmt"
@@ -52,7 +52,7 @@ cabalFmtGolden NotFound title _ _ _ =
   testCase title $
     assertFailure $  "Couldn't find cabal-fmt on PATH or this is not an isolated run. "
                   <> "Use cabal flag 'isolateTests' to make it isolated or install cabal-fmt locally."
-cabalFmtGolden Found title path desc act = goldenWithCabalDocFormatter (cabalFmtPlugin mempty) "cabal-fmt" conf title testDataDir path desc "cabal" act
+cabalFmtGolden Found title path desc act = goldenWithCabalDocFormatter cabalFmtPlugin "cabal-fmt" conf title testDataDir path desc "cabal" act
   where
     conf = def
 

--- a/plugins/hls-cabal-fmt-plugin/test/Main.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/Main.hs
@@ -30,8 +30,8 @@ main = do
   foundCabalFmt <- isCabalFmtFound
   defaultTestRunner (tests foundCabalFmt)
 
-cabalFmtPlugin :: PluginDescriptor IdeState
-cabalFmtPlugin = CabalFmt.descriptor mempty "cabal-fmt"
+cabalFmtPlugin :: Recorder (WithPriority CabalFmt.Log) -> PluginDescriptor IdeState
+cabalFmtPlugin recorder = CabalFmt.descriptor recorder "cabal-fmt"
 
 tests :: CabalFmtFound -> TestTree
 tests found = testGroup "cabal-fmt"
@@ -52,7 +52,7 @@ cabalFmtGolden NotFound title _ _ _ =
   testCase title $
     assertFailure $  "Couldn't find cabal-fmt on PATH or this is not an isolated run. "
                   <> "Use cabal flag 'isolateTests' to make it isolated or install cabal-fmt locally."
-cabalFmtGolden Found title path desc act = goldenWithCabalDocFormatter cabalFmtPlugin "cabal-fmt" conf title testDataDir path desc "cabal" act
+cabalFmtGolden Found title path desc act = goldenWithCabalDocFormatter (cabalFmtPlugin mempty) "cabal-fmt" conf title testDataDir path desc "cabal" act
   where
     conf = def
 

--- a/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy.hs
+++ b/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy.hs
@@ -5,8 +5,8 @@ import qualified Ide.Plugin.CallHierarchy.Internal as X
 import           Ide.Types
 import           Language.LSP.Types
 
-descriptor :: PluginDescriptor IdeState
-descriptor = (defaultPluginDescriptor X.callHierarchyId)
+descriptor :: PluginId -> PluginDescriptor IdeState
+descriptor plId = (defaultPluginDescriptor plId)
     { Ide.Types.pluginHandlers =
         mkPluginHandler STextDocumentPrepareCallHierarchy X.prepareCallHierarchy
      <> mkPluginHandler SCallHierarchyIncomingCalls X.incomingCalls

--- a/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy/Internal.hs
+++ b/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy/Internal.hs
@@ -11,7 +11,6 @@ module Ide.Plugin.CallHierarchy.Internal (
   prepareCallHierarchy
 , incomingCalls
 , outgoingCalls
-, callHierarchyId
 ) where
 
 import           Control.Lens                   ((^.))
@@ -37,9 +36,6 @@ import           Ide.Types
 import           Language.LSP.Types
 import qualified Language.LSP.Types.Lens        as L
 import           Text.Read                      (readMaybe)
-
-callHierarchyId :: PluginId
-callHierarchyId = PluginId "callHierarchy"
 
 -- | Render prepare call hierarchy request.
 prepareCallHierarchy :: PluginMethodHandler IdeState TextDocumentPrepareCallHierarchy

--- a/plugins/hls-call-hierarchy-plugin/test/Main.hs
+++ b/plugins/hls-call-hierarchy-plugin/test/Main.hs
@@ -21,8 +21,8 @@ import qualified System.IO.Extra
 import           Test.Hls
 import           Test.Hls.Util            (withCanonicalTempDir)
 
-plugin :: PluginDescriptor IdeState
-plugin = descriptor
+plugin :: PluginTestDescriptor ()
+plugin = mkPluginTestDescriptor' descriptor "call-hierarchy"
 
 main :: IO ()
 main = defaultTestRunner $

--- a/plugins/hls-change-type-signature-plugin/test/Main.hs
+++ b/plugins/hls-change-type-signature-plugin/test/Main.hs
@@ -9,8 +9,8 @@ import           Ide.Plugin.ChangeTypeSignature (errorMessageRegexes)
 import qualified Ide.Plugin.ChangeTypeSignature as ChangeTypeSignature
 import           System.FilePath                ((<.>), (</>))
 import           Test.Hls                       (CodeAction (..), Command,
-                                                 GhcVersion (..), IdeState,
-                                                 PluginDescriptor,
+                                                 GhcVersion (..),
+                                                 PluginTestDescriptor,
                                                  Position (Position),
                                                  Range (Range), Session,
                                                  TestName, TestTree,
@@ -21,9 +21,11 @@ import           Test.Hls                       (CodeAction (..), Command,
                                                  getCodeActions,
                                                  goldenWithHaskellDoc,
                                                  knownBrokenForGhcVersions,
-                                                 liftIO, openDoc,
-                                                 runSessionWithServer, testCase,
-                                                 testGroup, toEither, type (|?),
+                                                 liftIO,
+                                                 mkPluginTestDescriptor',
+                                                 openDoc, runSessionWithServer,
+                                                 testCase, testGroup, toEither,
+                                                 type (|?),
                                                  waitForAllProgressDone,
                                                  waitForDiagnostics, (@?=))
 import           Text.Regex.TDFA                ((=~))
@@ -31,8 +33,8 @@ import           Text.Regex.TDFA                ((=~))
 main :: IO ()
 main = defaultTestRunner test
 
-changeTypeSignaturePlugin :: PluginDescriptor IdeState
-changeTypeSignaturePlugin = ChangeTypeSignature.descriptor
+changeTypeSignaturePlugin :: PluginTestDescriptor ()
+changeTypeSignaturePlugin = mkPluginTestDescriptor' ChangeTypeSignature.descriptor "changeTypeSignature"
 
 test :: TestTree
 test = testGroup "changeTypeSignature" [

--- a/plugins/hls-class-plugin/test/Main.hs
+++ b/plugins/hls-class-plugin/test/Main.hs
@@ -25,8 +25,8 @@ import           Test.Hls
 
 main :: IO ()
 main = do
-    recorder <- makeDefaultStderrRecorder Nothing Debug
-    defaultTestRunner . tests $ contramap (fmap pretty) recorder
+    recorder <- pluginTestRecorder
+    defaultTestRunner . tests $ recorder
 
 classPlugin :: Recorder (WithPriority Class.Log) -> PluginDescriptor IdeState
 classPlugin recorder = Class.descriptor recorder "class"

--- a/plugins/hls-class-plugin/test/Main.hs
+++ b/plugins/hls-class-plugin/test/Main.hs
@@ -9,38 +9,30 @@ module Main
   ( main
   ) where
 
-import           Control.Lens                 (Prism', prism', (^.), (^..),
-                                               (^?))
-import           Control.Monad                (void)
-import           Data.Aeson                   (toJSON, (.=))
-import           Data.Functor.Contravariant   (contramap)
+import           Control.Lens            (Prism', prism', (^.), (^..), (^?))
+import           Control.Monad           (void)
 import           Data.Maybe
-import           Development.IDE.Types.Logger
-import qualified Ide.Plugin.Class             as Class
-import           Ide.Plugin.Config            (PluginConfig (plcConfig))
-import qualified Ide.Plugin.Config            as Plugin
-import qualified Language.LSP.Types.Lens      as J
+import qualified Ide.Plugin.Class        as Class
+import qualified Language.LSP.Types.Lens as J
 import           System.FilePath
 import           Test.Hls
 
 main :: IO ()
-main = do
-    recorder <- pluginTestRecorder
-    defaultTestRunner . tests $ recorder
+main = defaultTestRunner tests
 
-classPlugin :: Recorder (WithPriority Class.Log) -> PluginDescriptor IdeState
-classPlugin recorder = Class.descriptor recorder "class"
+classPlugin :: PluginTestDescriptor Class.Log
+classPlugin = mkPluginTestDescriptor Class.descriptor "class"
 
-tests :: Recorder (WithPriority Class.Log) -> TestTree
-tests recorder = testGroup
+tests :: TestTree
+tests = testGroup
   "class"
-  [codeActionTests recorder , codeLensTests recorder]
+  [codeActionTests, codeLensTests]
 
-codeActionTests :: Recorder (WithPriority Class.Log) -> TestTree
-codeActionTests recorder = testGroup
+codeActionTests :: TestTree
+codeActionTests = testGroup
   "code actions"
   [ testCase "Produces addMinimalMethodPlaceholders code actions for one instance" $ do
-      runSessionWithServer (classPlugin recorder) testDataDir $ do
+      runSessionWithServer classPlugin testDataDir $ do
         doc <- openDoc "T1.hs" "haskell"
         _ <- waitForDiagnosticsFromSource doc "typecheck"
         caResults <- getAllCodeActions doc
@@ -51,40 +43,40 @@ codeActionTests recorder = testGroup
           , Just "Add placeholders for '/='"
           , Just "Add placeholders for '/=' with signature(s)"
           ]
-  , goldenWithClass recorder "Creates a placeholder for '=='" "T1" "eq" $ \(eqAction:_) -> do
+  , goldenWithClass "Creates a placeholder for '=='" "T1" "eq" $ \(eqAction:_) -> do
       executeCodeAction eqAction
-  , goldenWithClass recorder "Creates a placeholder for '/='" "T1" "ne" $ \(_:_:neAction:_) -> do
+  , goldenWithClass "Creates a placeholder for '/='" "T1" "ne" $ \(_:_:neAction:_) -> do
       executeCodeAction neAction
-  , goldenWithClass recorder "Creates a placeholder for 'fmap'" "T2" "fmap" $ \(_:_:_:_:fmapAction:_) -> do
+  , goldenWithClass "Creates a placeholder for 'fmap'" "T2" "fmap" $ \(_:_:_:_:fmapAction:_) -> do
       executeCodeAction fmapAction
-  , goldenWithClass recorder "Creates a placeholder for multiple methods 1" "T3" "1" $ \(mmAction:_) -> do
+  , goldenWithClass "Creates a placeholder for multiple methods 1" "T3" "1" $ \(mmAction:_) -> do
       executeCodeAction mmAction
-  , goldenWithClass recorder "Creates a placeholder for multiple methods 2" "T3" "2" $ \(_:_:mmAction:_) -> do
+  , goldenWithClass "Creates a placeholder for multiple methods 2" "T3" "2" $ \(_:_:mmAction:_) -> do
       executeCodeAction mmAction
-  , goldenWithClass recorder "Creates a placeholder for a method starting with '_'" "T4" "" $ \(_fAction:_) -> do
+  , goldenWithClass "Creates a placeholder for a method starting with '_'" "T4" "" $ \(_fAction:_) -> do
       executeCodeAction _fAction
-  , goldenWithClass recorder "Creates a placeholder for '==' with extra lines" "T5" "" $ \(eqAction:_) -> do
+  , goldenWithClass "Creates a placeholder for '==' with extra lines" "T5" "" $ \(eqAction:_) -> do
       executeCodeAction eqAction
-  , goldenWithClass recorder "Creates a placeholder for only the unimplemented methods of multiple methods" "T6" "1" $ \(gAction:_) -> do
+  , goldenWithClass "Creates a placeholder for only the unimplemented methods of multiple methods" "T6" "1" $ \(gAction:_) -> do
       executeCodeAction gAction
-  , goldenWithClass recorder "Creates a placeholder for other two methods" "T6" "2" $ \(_:_:ghAction:_) -> do
+  , goldenWithClass "Creates a placeholder for other two methods" "T6" "2" $ \(_:_:ghAction:_) -> do
       executeCodeAction ghAction
   , onlyRunForGhcVersions [GHC92, GHC94] "Only ghc-9.2+ enabled GHC2021 implicitly" $
-      goldenWithClass recorder "Don't insert pragma with GHC2021" "InsertWithGHC2021Enabled" "" $ \(_:eqWithSig:_) -> do
+      goldenWithClass "Don't insert pragma with GHC2021" "InsertWithGHC2021Enabled" "" $ \(_:eqWithSig:_) -> do
         executeCodeAction eqWithSig
-  , goldenWithClass recorder "Insert pragma if not exist" "InsertWithoutPragma" "" $ \(_:eqWithSig:_) -> do
+  , goldenWithClass "Insert pragma if not exist" "InsertWithoutPragma" "" $ \(_:eqWithSig:_) -> do
       executeCodeAction eqWithSig
-  , goldenWithClass recorder "Don't insert pragma if exist" "InsertWithPragma" "" $ \(_:eqWithSig:_) -> do
+  , goldenWithClass "Don't insert pragma if exist" "InsertWithPragma" "" $ \(_:eqWithSig:_) -> do
       executeCodeAction eqWithSig
-  , goldenWithClass recorder "Only insert pragma once" "InsertPragmaOnce" "" $ \(_:multi:_) -> do
+  , goldenWithClass "Only insert pragma once" "InsertPragmaOnce" "" $ \(_:multi:_) -> do
       executeCodeAction multi
   ]
 
-codeLensTests :: Recorder (WithPriority Class.Log) -> TestTree
-codeLensTests recorder = testGroup
+codeLensTests :: TestTree
+codeLensTests = testGroup
     "code lens"
     [ testCase "Has code lens" $ do
-        runSessionWithServer (classPlugin recorder) testDataDir $ do
+        runSessionWithServer classPlugin testDataDir $ do
             doc <- openDoc "CodeLensSimple.hs" "haskell"
             lens <- getCodeLenses doc
             let titles = map (^. J.title) $ mapMaybe (^. J.command) lens
@@ -92,14 +84,14 @@ codeLensTests recorder = testGroup
                 [ "(==) :: B -> B -> Bool"
                 , "(==) :: A -> A -> Bool"
                 ]
-    , goldenCodeLens recorder "Apply code lens" "CodeLensSimple" 1
-    , goldenCodeLens recorder "Apply code lens for local class" "LocalClassDefine" 0
-    , goldenCodeLens recorder "Apply code lens on the same line" "Inline" 0
-    , goldenCodeLens recorder "Don't insert pragma while existing" "CodeLensWithPragma" 0
+    , goldenCodeLens "Apply code lens" "CodeLensSimple" 1
+    , goldenCodeLens "Apply code lens for local class" "LocalClassDefine" 0
+    , goldenCodeLens "Apply code lens on the same line" "Inline" 0
+    , goldenCodeLens "Don't insert pragma while existing" "CodeLensWithPragma" 0
     , onlyRunForGhcVersions [GHC92, GHC94] "Only ghc-9.2+ enabled GHC2021 implicitly" $
-        goldenCodeLens recorder "Don't insert pragma while GHC2021 enabled" "CodeLensWithGHC2021" 0
-    , goldenCodeLens recorder "Qualified name" "Qualified" 0
-    , goldenCodeLens recorder "Type family" "TypeFamily" 0
+        goldenCodeLens "Don't insert pragma while GHC2021 enabled" "CodeLensWithGHC2021" 0
+    , goldenCodeLens "Qualified name" "Qualified" 0
+    , goldenCodeLens "Type family" "TypeFamily" 0
     ]
 
 _CACodeAction :: Prism' (Command |? CodeAction) CodeAction
@@ -108,16 +100,16 @@ _CACodeAction = prism' InR $ \case
   _          -> Nothing
 
 
-goldenCodeLens :: Recorder (WithPriority Class.Log) -> TestName -> FilePath -> Int -> TestTree
-goldenCodeLens recorder title path idx =
-    goldenWithHaskellDoc (classPlugin recorder) title testDataDir path "expected" "hs" $ \doc -> do
+goldenCodeLens :: TestName -> FilePath -> Int -> TestTree
+goldenCodeLens title path idx =
+    goldenWithHaskellDoc classPlugin title testDataDir path "expected" "hs" $ \doc -> do
         lens <- getCodeLenses doc
         executeCommand $ fromJust $ (lens !! idx) ^. J.command
         void $ skipManyTill anyMessage (message SWorkspaceApplyEdit)
 
-goldenWithClass :: Recorder (WithPriority Class.Log) -> TestName -> FilePath -> FilePath -> ([CodeAction] -> Session ()) -> TestTree
-goldenWithClass recorder title path desc act =
-  goldenWithHaskellDoc (classPlugin recorder) title testDataDir path (desc <.> "expected") "hs" $ \doc -> do
+goldenWithClass ::TestName -> FilePath -> FilePath -> ([CodeAction] -> Session ()) -> TestTree
+goldenWithClass title path desc act =
+  goldenWithHaskellDoc classPlugin title testDataDir path (desc <.> "expected") "hs" $ \doc -> do
     _ <- waitForDiagnosticsFromSource doc "typecheck"
     actions <- concatMap (^.. _CACodeAction) <$> getAllCodeActions doc
     act actions

--- a/plugins/hls-code-range-plugin/test/Main.hs
+++ b/plugins/hls-code-range-plugin/test/Main.hs
@@ -18,19 +18,18 @@ import           Language.LSP.Types.Lens
 import           System.FilePath                ((<.>), (</>))
 import           Test.Hls
 
-plugin :: Recorder (WithPriority Log) -> PluginDescriptor IdeState
-plugin recorder = descriptor recorder "codeRange"
+plugin :: PluginTestDescriptor Log
+plugin = mkPluginTestDescriptor descriptor "codeRange"
 
 main :: IO ()
 main = do
-    recorder <- pluginTestRecorder
     defaultTestRunner $
         testGroup "Code Range" [
             testGroup "Integration Tests" [
-                selectionRangeGoldenTest recorder "Import" [(4, 36), (1, 8)],
-                selectionRangeGoldenTest recorder "Function" [(5, 19), (5, 12), (4, 4), (3, 5)],
-                selectionRangeGoldenTest recorder "Empty" [(1, 5)],
-                foldingRangeGoldenTest recorder "Function"
+                selectionRangeGoldenTest "Import" [(4, 36), (1, 8)],
+                selectionRangeGoldenTest "Function" [(5, 19), (5, 12), (4, 4), (3, 5)],
+                selectionRangeGoldenTest "Empty" [(1, 5)],
+                foldingRangeGoldenTest "Function"
             ],
             testGroup "Unit Tests" [
                 Ide.Plugin.CodeRangeTest.testTree,
@@ -38,9 +37,9 @@ main = do
             ]
         ]
 
-selectionRangeGoldenTest :: Recorder (WithPriority Log) -> TestName -> [(UInt, UInt)] -> TestTree
-selectionRangeGoldenTest recorder testName positions = goldenGitDiff testName (testDataDir </> testName <.> "golden" <.> "txt") $ do
-    res <- runSessionWithServer (plugin recorder) testDataDir $ do
+selectionRangeGoldenTest :: TestName -> [(UInt, UInt)] -> TestTree
+selectionRangeGoldenTest testName positions = goldenGitDiff testName (testDataDir </> testName <.> "golden" <.> "txt") $ do
+    res <- runSessionWithServer plugin testDataDir $ do
         doc <- openDoc (testName <.> "hs") "haskell"
         resp <- request STextDocumentSelectionRange $ SelectionRangeParams Nothing Nothing doc
             (List $ fmap (uncurry Position . (\(x, y) -> (x-1, y-1))) positions)
@@ -67,9 +66,9 @@ selectionRangeGoldenTest recorder testName positions = goldenGitDiff testName (t
         showPosition (Position line col) = "(" <> showLBS (line + 1) <> "," <> showLBS (col + 1) <> ")"
         showLBS = fromString . show
 
-foldingRangeGoldenTest :: Recorder (WithPriority Log) -> TestName -> TestTree
-foldingRangeGoldenTest recorder testName = goldenGitDiff  testName (testDataDir </> testName <.> "golden" <.> "txt") $ do
-    res <- runSessionWithServer (plugin recorder) testDataDir $ do
+foldingRangeGoldenTest :: TestName -> TestTree
+foldingRangeGoldenTest testName = goldenGitDiff  testName (testDataDir </> testName <.> "golden" <.> "txt") $ do
+    res <- runSessionWithServer plugin testDataDir $ do
         doc <- openDoc (testName <.> "hs") "haskell"
         resp <- request STextDocumentFoldingRange $ FoldingRangeParams Nothing Nothing doc
         let res = resp ^. result

--- a/plugins/hls-code-range-plugin/test/Main.hs
+++ b/plugins/hls-code-range-plugin/test/Main.hs
@@ -23,7 +23,7 @@ plugin recorder = descriptor recorder "codeRange"
 
 main :: IO ()
 main = do
-    recorder <- contramap (fmap pretty) <$> makeDefaultStderrRecorder Nothing Debug
+    recorder <- pluginTestRecorder
     defaultTestRunner $
         testGroup "Code Range" [
             testGroup "Integration Tests" [

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -29,34 +29,34 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-evalPlugin :: Recorder (WithPriority Eval.Log) -> PluginDescriptor IdeState
-evalPlugin recorder = Eval.descriptor recorder "eval"
+evalPlugin :: PluginTestDescriptor Eval.Log
+evalPlugin = mkPluginTestDescriptor Eval.descriptor "eval"
 
 tests :: TestTree
 tests =
   testGroup "eval"
   [ testCase "Produces Evaluate code lenses" $
-      runSessionWithServerAndRecorder evalPlugin testDataDir $ do
+      runSessionWithServer evalPlugin testDataDir $ do
         doc <- openDoc "T1.hs" "haskell"
         lenses <- getCodeLenses doc
         liftIO $ map (preview $ command . _Just . title) lenses @?= [Just "Evaluate..."]
   , testCase "Produces Refresh code lenses" $
-      runSessionWithServerAndRecorder evalPlugin testDataDir $ do
+      runSessionWithServer evalPlugin testDataDir $ do
         doc <- openDoc "T2.hs" "haskell"
         lenses <- getCodeLenses doc
         liftIO $ map (preview $ command . _Just . title) lenses @?= [Just "Refresh..."]
   , testCase "Code lenses have ranges" $
-      runSessionWithServerAndRecorder evalPlugin testDataDir $ do
+      runSessionWithServer evalPlugin testDataDir $ do
         doc <- openDoc "T1.hs" "haskell"
         lenses <- getCodeLenses doc
         liftIO $ map (view range) lenses @?= [Range (Position 4 0) (Position 5 0)]
   , testCase "Multi-line expressions have a multi-line range" $ do
-      runSessionWithServerAndRecorder evalPlugin testDataDir $ do
+      runSessionWithServer evalPlugin testDataDir $ do
         doc <- openDoc "T3.hs" "haskell"
         lenses <- getCodeLenses doc
         liftIO $ map (view range) lenses @?= [Range (Position 3 0) (Position 5 0)]
   , testCase "Executed expressions range covers only the expression" $ do
-      runSessionWithServerAndRecorder evalPlugin testDataDir $ do
+      runSessionWithServer evalPlugin testDataDir $ do
         doc <- openDoc "T2.hs" "haskell"
         lenses <- getCodeLenses doc
         liftIO $ map (view range) lenses @?= [Range (Position 4 0) (Position 5 0)]
@@ -194,7 +194,7 @@ tests =
         not ("Baz Foo" `isInfixOf` output)          @? "Output includes instance Baz Foo"
     ]
   , testCase "Interfaces are reused after Eval" $ do
-      runSessionWithServerAndRecorder evalPlugin testDataDir $ do
+      runSessionWithServer evalPlugin testDataDir $ do
         doc <- openDoc "TLocalImport.hs" "haskell"
         waitForTypecheck doc
         lenses <- getCodeLenses doc
@@ -213,13 +213,13 @@ tests =
 
 goldenWithEval :: TestName -> FilePath -> FilePath -> TestTree
 goldenWithEval title path ext =
-  goldenWithHaskellDocAndRecorder evalPlugin title testDataDir path "expected" ext executeLensesBackwards
+  goldenWithHaskellDoc evalPlugin title testDataDir path "expected" ext executeLensesBackwards
 
 -- | Similar function as 'goldenWithEval' with an alternate reference file
 -- naming. Useful when reference file may change because of GHC version.
 goldenWithEval' :: TestName -> FilePath -> FilePath -> FilePath -> TestTree
 goldenWithEval' title path ext expected =
-  goldenWithHaskellDocAndRecorder evalPlugin title testDataDir path expected ext executeLensesBackwards
+  goldenWithHaskellDoc evalPlugin title testDataDir path expected ext executeLensesBackwards
 
 -- | Execute lenses backwards, to avoid affecting their position in the source file
 executeLensesBackwards :: TextDocumentIdentifier -> Session ()
@@ -246,7 +246,7 @@ executeCmd cmd = do
   pure ()
 
 evalLenses :: FilePath -> IO [CodeLens]
-evalLenses path = runSessionWithServerAndRecorder evalPlugin testDataDir $ do
+evalLenses path = runSessionWithServer evalPlugin testDataDir $ do
   doc <- openDoc path "haskell"
   executeLensesBackwards doc
   getCodeLenses doc
@@ -280,12 +280,12 @@ exceptionConfig exCfg = changeConfig ["exception" .= exCfg]
 
 goldenWithEvalConfig' :: TestName -> FilePath -> FilePath -> FilePath -> Config -> TestTree
 goldenWithEvalConfig' title path ext expected cfg =
-    goldenWithHaskellDocAndRecorder evalPlugin title testDataDir path expected ext $ \doc -> do
+    goldenWithHaskellDoc evalPlugin title testDataDir path expected ext $ \doc -> do
       sendConfigurationChanged (toJSON cfg)
       executeLensesBackwards doc
 
 evalInFile :: HasCallStack => FilePath -> T.Text -> T.Text -> IO ()
-evalInFile fp e expected = runSessionWithServerAndRecorder evalPlugin testDataDir $ do
+evalInFile fp e expected = runSessionWithServer evalPlugin testDataDir $ do
   doc <- openDoc fp "haskell"
   origin <- documentContents doc
   let withEval = origin <> e

--- a/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
+++ b/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
@@ -1,32 +1,32 @@
 {-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
-module Ide.Plugin.ExplicitFixity(descriptor) where
+module Ide.Plugin.ExplicitFixity(descriptor, Log) where
 
 import           Control.DeepSeq
-import           Control.Monad.Trans.Maybe
 import           Control.Monad.IO.Class               (MonadIO, liftIO)
+import           Control.Monad.Trans.Maybe
 import           Data.Either.Extra
 import           Data.Hashable
 import qualified Data.Map.Strict                      as M
-import qualified Data.Set                             as S
 import           Data.Maybe
+import qualified Data.Set                             as S
 import qualified Data.Text                            as T
 import           Development.IDE                      hiding (pluginHandlers,
                                                        pluginRules)
 import           Development.IDE.Core.PositionMapping (idDelta)
 import           Development.IDE.Core.Shake           (addPersistentRule)
 import qualified Development.IDE.Core.Shake           as Shake
-import           Development.IDE.Spans.AtPoint
 import           Development.IDE.GHC.Compat
 import qualified Development.IDE.GHC.Compat.Util      as Util
 import           Development.IDE.LSP.Notifications    (ghcideNotificationsPluginPriority)
+import           Development.IDE.Spans.AtPoint
 import           GHC.Generics                         (Generic)
 import           Ide.PluginUtils                      (getNormalizedFilePath,
                                                        handleMaybeM,
@@ -94,7 +94,7 @@ lookupFixities :: MonadIO m => HscEnv -> TcGblEnv -> S.Set Name -> m (M.Map Name
 lookupFixities hscEnv tcGblEnv names
     = liftIO
     $ fmap (fromMaybe M.empty . snd)
-    $ initTcWithGbl hscEnv tcGblEnv (realSrcLocSpan $ mkRealSrcLoc "<dummy>" 1 1) 
+    $ initTcWithGbl hscEnv tcGblEnv (realSrcLocSpan $ mkRealSrcLoc "<dummy>" 1 1)
     $ M.traverseMaybeWithKey (\_ v -> v)
     $ M.fromSet lookupFixity names
   where

--- a/plugins/hls-explicit-fixity-plugin/test/Main.hs
+++ b/plugins/hls-explicit-fixity-plugin/test/Main.hs
@@ -3,12 +3,12 @@
 module Main where
 
 import qualified Data.Text                 as T
-import           Ide.Plugin.ExplicitFixity (descriptor)
+import           Ide.Plugin.ExplicitFixity (Log, descriptor)
 import           System.FilePath
 import           Test.Hls
 
-plugin :: PluginDescriptor IdeState
-plugin = descriptor mempty "explicit-fixity"
+plugin :: PluginTestDescriptor Log
+plugin = mkPluginTestDescriptor descriptor "explicit-fixity"
 
 main :: IO ()
 main = defaultTestRunner tests

--- a/plugins/hls-explicit-imports-plugin/test/Main.hs
+++ b/plugins/hls-explicit-imports-plugin/test/Main.hs
@@ -15,8 +15,8 @@ import qualified Ide.Plugin.ExplicitImports as ExplicitImports
 import           System.FilePath            ((<.>), (</>))
 import           Test.Hls
 
-explicitImportsPlugin :: PluginDescriptor IdeState
-explicitImportsPlugin = ExplicitImports.descriptor mempty "explicitImports"
+explicitImportsPlugin :: PluginTestDescriptor ExplicitImports.Log
+explicitImportsPlugin = mkPluginTestDescriptor ExplicitImports.descriptor "explicitImports"
 
 longModule :: T.Text
 longModule = "F" <> T.replicate 80 "o"

--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -11,6 +11,7 @@
 
 module Ide.Plugin.ExplicitFields
   ( descriptor
+  , Log
   ) where
 
 import           Control.Lens                             ((^.))

--- a/plugins/hls-explicit-record-fields-plugin/test/Main.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/Main.hs
@@ -15,8 +15,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner test
 
-plugin :: PluginDescriptor IdeState
-plugin = ExplicitFields.descriptor mempty "explicit-fields"
+plugin :: PluginTestDescriptor ExplicitFields.Log
+plugin = mkPluginTestDescriptor ExplicitFields.descriptor "explicit-fields"
 
 test :: TestTree
 test = testGroup "explicit-fields"

--- a/plugins/hls-floskell-plugin/test/Main.hs
+++ b/plugins/hls-floskell-plugin/test/Main.hs
@@ -10,8 +10,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-floskellPlugin :: PluginDescriptor IdeState
-floskellPlugin = Floskell.descriptor "floskell"
+floskellPlugin :: PluginTestDescriptor ()
+floskellPlugin = mkPluginTestDescriptor' Floskell.descriptor "floskell"
 
 tests :: TestTree
 tests = testGroup "floskell"

--- a/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
@@ -9,6 +9,7 @@
 module Ide.Plugin.Fourmolu (
     descriptor,
     provider,
+    LogEvent,
 ) where
 
 import           Control.Exception               (IOException, try)

--- a/plugins/hls-fourmolu-plugin/test/Main.hs
+++ b/plugins/hls-fourmolu-plugin/test/Main.hs
@@ -15,8 +15,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-fourmoluPlugin :: PluginDescriptor IdeState
-fourmoluPlugin = Fourmolu.descriptor mempty "fourmolu"
+fourmoluPlugin :: PluginTestDescriptor Fourmolu.LogEvent
+fourmoluPlugin = mkPluginTestDescriptor Fourmolu.descriptor "fourmolu"
 
 tests :: TestTree
 tests =

--- a/plugins/hls-gadt-plugin/test/Main.hs
+++ b/plugins/hls-gadt-plugin/test/Main.hs
@@ -15,8 +15,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-gadtPlugin :: PluginDescriptor IdeState
-gadtPlugin = GADT.descriptor "GADT"
+gadtPlugin :: PluginTestDescriptor ()
+gadtPlugin = mkPluginTestDescriptor' GADT.descriptor "GADT"
 
 tests :: TestTree
 tests = testGroup "GADT"

--- a/plugins/hls-haddock-comments-plugin/src/Ide/Plugin/HaddockComments.hs
+++ b/plugins/hls-haddock-comments-plugin/src/Ide/Plugin/HaddockComments.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ViewPatterns              #-}
 
-module Ide.Plugin.HaddockComments (descriptor) where
+module Ide.Plugin.HaddockComments (descriptor, E.Log) where
 
 import           Control.Monad                         (join, when)
 import           Control.Monad.IO.Class

--- a/plugins/hls-haddock-comments-plugin/test/Main.hs
+++ b/plugins/hls-haddock-comments-plugin/test/Main.hs
@@ -18,8 +18,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-haddockCommentsPlugin :: PluginDescriptor IdeState
-haddockCommentsPlugin = HaddockComments.descriptor mempty "haddockComments"
+haddockCommentsPlugin :: PluginTestDescriptor HaddockComments.Log
+haddockCommentsPlugin = mkPluginTestDescriptor HaddockComments.descriptor "haddockComments"
 
 tests :: TestTree
 tests =

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -24,8 +24,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-hlintPlugin :: PluginDescriptor IdeState
-hlintPlugin = HLint.descriptor mempty "hlint"
+hlintPlugin :: PluginTestDescriptor HLint.Log
+hlintPlugin = mkPluginTestDescriptor HLint.descriptor "hlint"
 
 tests :: TestTree
 tests = testGroup "hlint" [
@@ -101,7 +101,7 @@ suggestionsTests =
         contents <- skipManyTill anyMessage $ getDocumentEdit doc
         liftIO $ contents @?= "main = undefined\nfoo x = x\n"
 
-    , testCase "falls back to pre 3.8 code actions" $ runSessionWithServer' [hlintPlugin] def def noLiteralCaps "test/testdata" $ do
+    , testCase "falls back to pre 3.8 code actions" $ runSessionWithServerAndCaps hlintPlugin noLiteralCaps "test/testdata" $ do
         doc <- openDoc "Base.hs" "haskell"
 
         _ <- waitForDiagnosticsFromSource doc "hlint"

--- a/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
+++ b/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
@@ -14,6 +14,7 @@ Provide CodeLenses to:
 -}
 module Ide.Plugin.ModuleName (
     descriptor,
+    Log,
 ) where
 
 import           Control.Monad                (forM_, void)

--- a/plugins/hls-module-name-plugin/test/Main.hs
+++ b/plugins/hls-module-name-plugin/test/Main.hs
@@ -12,8 +12,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-moduleNamePlugin :: PluginDescriptor IdeState
-moduleNamePlugin = ModuleName.descriptor mempty "moduleName"
+moduleNamePlugin :: PluginTestDescriptor ModuleName.Log
+moduleNamePlugin = mkPluginTestDescriptor ModuleName.descriptor "moduleName"
 
 tests :: TestTree
 tests =

--- a/plugins/hls-ormolu-plugin/test/Main.hs
+++ b/plugins/hls-ormolu-plugin/test/Main.hs
@@ -11,8 +11,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-ormoluPlugin :: PluginDescriptor IdeState
-ormoluPlugin = Ormolu.descriptor "ormolu"
+ormoluPlugin :: PluginTestDescriptor ()
+ormoluPlugin = mkPluginTestDescriptor' Ormolu.descriptor "ormolu"
 
 tests :: TestTree
 tests = testGroup "ormolu"

--- a/plugins/hls-pragmas-plugin/test/Main.hs
+++ b/plugins/hls-pragmas-plugin/test/Main.hs
@@ -15,8 +15,8 @@ import           Test.Hls.Util           (onlyWorkForGhcVersions)
 main :: IO ()
 main = defaultTestRunner tests
 
-pragmasPlugin :: PluginDescriptor IdeState
-pragmasPlugin = descriptor "pragmas"
+pragmasPlugin :: PluginTestDescriptor ()
+pragmasPlugin = mkPluginTestDescriptor' descriptor "pragmas"
 
 tests :: TestTree
 tests =

--- a/plugins/hls-qualify-imported-names-plugin/test/Main.hs
+++ b/plugins/hls-qualify-imported-names-plugin/test/Main.hs
@@ -15,6 +15,7 @@ import           Test.Hls                        (CodeAction (CodeAction, _title
                                                   Command (Command), IdeState,
                                                   MonadIO (liftIO),
                                                   PluginDescriptor,
+                                                  PluginTestDescriptor,
                                                   Position (Position),
                                                   Range (Range), Session,
                                                   TestName, TestTree,
@@ -23,8 +24,10 @@ import           Test.Hls                        (CodeAction (CodeAction, _title
                                                   defaultTestRunner,
                                                   executeCodeAction,
                                                   getCodeActions,
-                                                  goldenWithHaskellDoc, openDoc,
-                                                  rename, runSessionWithServer,
+                                                  goldenWithHaskellDoc,
+                                                  mkPluginTestDescriptor',
+                                                  openDoc, rename,
+                                                  runSessionWithServer,
                                                   testCase, testGroup,
                                                   type (|?) (InR), (@?=))
 
@@ -126,8 +129,8 @@ codeActionGoldenTest testCaseName goldenFilename point =
 testDataDir :: String
 testDataDir = "test" </> "data"
 
-pluginDescriptor :: PluginDescriptor IdeState
-pluginDescriptor = QualifyImportedNames.descriptor "qualifyImportedNames"
+pluginDescriptor :: PluginTestDescriptor ()
+pluginDescriptor = mkPluginTestDescriptor' QualifyImportedNames.descriptor "qualifyImportedNames"
 
 getCodeActionTitle :: (Command |? CodeAction) -> Maybe Text
 getCodeActionTitle commandOrCodeAction

--- a/plugins/hls-refactor-plugin/test/Test/AddArgument.hs
+++ b/plugins/hls-refactor-plugin/test/Test/AddArgument.hs
@@ -64,7 +64,7 @@ mkGoldenAddArgTest' testFileName range varName = do
           liftIO $ actionTitle @?= ("Add argument ‘" <> varName <> "’ to function")
           executeCodeAction action
     goldenWithHaskellDoc
-      (Refactor.bindingsPluginDescriptor mempty "ghcide-code-actions-bindings")
+      (mkPluginTestDescriptor Refactor.bindingsPluginDescriptor "ghcide-code-actions-bindings")
       (testFileName <> " (golden)")
       "test/data/golden/add-arg"
       testFileName

--- a/plugins/hls-refine-imports-plugin/test/Main.hs
+++ b/plugins/hls-refine-imports-plugin/test/Main.hs
@@ -23,8 +23,8 @@ main = defaultTestRunner $
     , codeLensGoldenTest "UsualCase" 1
     ]
 
-refineImportsPlugin :: PluginDescriptor IdeState
-refineImportsPlugin = RefineImports.descriptor mempty "refineImports"
+refineImportsPlugin :: PluginTestDescriptor RefineImports.Log
+refineImportsPlugin = mkPluginTestDescriptor RefineImports.descriptor "refineImports"
 
 -- code action tests
 

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Ide.Plugin.Rename (descriptor) where
+module Ide.Plugin.Rename (descriptor, E.Log) where
 
 #if MIN_VERSION_ghc(9,2,1)
 import           GHC.Parser.Annotation                 (AnnContext, AnnList,

--- a/plugins/hls-rename-plugin/test/Main.hs
+++ b/plugins/hls-rename-plugin/test/Main.hs
@@ -12,8 +12,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-renamePlugin :: PluginDescriptor IdeState
-renamePlugin = Rename.descriptor mempty "rename"
+renamePlugin :: PluginTestDescriptor Rename.Log
+renamePlugin = mkPluginTestDescriptor Rename.descriptor "rename"
 
 -- See https://github.com/wz1000/HieDb/issues/45
 recordConstructorIssue :: String

--- a/plugins/hls-splice-plugin/test/Main.hs
+++ b/plugins/hls-splice-plugin/test/Main.hs
@@ -21,8 +21,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-splicePlugin :: PluginDescriptor IdeState
-splicePlugin = Splice.descriptor "splice"
+splicePlugin :: PluginTestDescriptor ()
+splicePlugin = mkPluginTestDescriptor' Splice.descriptor "splice"
 
 tests :: TestTree
 tests = testGroup "splice"

--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -1,4 +1,4 @@
-module Ide.Plugin.Stan (descriptor) where
+module Ide.Plugin.Stan (descriptor, Log) where
 
 import           Control.DeepSeq                (NFData)
 import           Control.Monad                  (void)

--- a/plugins/hls-stan-plugin/test/Main.hs
+++ b/plugins/hls-stan-plugin/test/Main.hs
@@ -38,8 +38,8 @@ tests =
 testDir :: FilePath
 testDir = "test/testdata"
 
-stanPlugin :: PluginDescriptor IdeState
-stanPlugin = Stan.descriptor mempty "stan"
+stanPlugin :: PluginTestDescriptor Stan.Log
+stanPlugin = mkPluginTestDescriptor Stan.descriptor "stan"
 
 runStanSession :: FilePath -> Session a -> IO a
 runStanSession subdir =

--- a/plugins/hls-stylish-haskell-plugin/test/Main.hs
+++ b/plugins/hls-stylish-haskell-plugin/test/Main.hs
@@ -10,8 +10,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-stylishHaskellPlugin :: PluginDescriptor IdeState
-stylishHaskellPlugin = StylishHaskell.descriptor "stylishHaskell"
+stylishHaskellPlugin :: PluginTestDescriptor ()
+stylishHaskellPlugin = mkPluginTestDescriptor' StylishHaskell.descriptor "stylishHaskell"
 
 tests :: TestTree
 tests = testGroup "stylish-haskell"

--- a/plugins/hls-tactics-plugin/old/test/Utils.hs
+++ b/plugins/hls-tactics-plugin/old/test/Utils.hs
@@ -34,8 +34,8 @@ import           Wingman.LanguageServer (mkShowMessageParams)
 import           Wingman.Types
 
 
-plugin :: PluginDescriptor IdeState
-plugin = Tactic.descriptor mempty "tactics"
+plugin :: PluginTestDescriptor Log
+plugin = mkPluginTestDescriptor Tactic.descriptor "tactics"
 
 ------------------------------------------------------------------------------
 -- | Get a range at the given line and column corresponding to having nothing
@@ -61,13 +61,15 @@ resetGlobalHoleRef = writeIORef globalHoleRef 0
 
 
 runSessionForTactics :: Session a -> IO a
-runSessionForTactics =
+runSessionForTactics act = do
+  recorder <- pluginTestRecorder
   runSessionWithServer'
-    [plugin]
+    [plugin recorder]
     def
     (def { messageTimeout = 20 } )
     fullCaps
     tacticPath
+    act
 
 ------------------------------------------------------------------------------
 -- | Make a tactic unit test.

--- a/src/HlsPlugins.hs
+++ b/src/HlsPlugins.hs
@@ -182,7 +182,7 @@ idePlugins recorder = pluginDescToIdePlugins allPlugins
       Brittany.descriptor "brittany" :
 #endif
 #if hls_callHierarchy
-      CallHierarchy.descriptor :
+      CallHierarchy.descriptor "callHierarchy" :
 #endif
 #if hls_class
       let pId = "class" in Class.descriptor (pluginRecorder pId) pId:

--- a/src/HlsPlugins.hs
+++ b/src/HlsPlugins.hs
@@ -85,19 +85,19 @@ import qualified Ide.Plugin.CodeRange              as CodeRange
 #endif
 
 #if hls_changeTypeSignature
-import           Ide.Plugin.ChangeTypeSignature    as ChangeTypeSignature
+import qualified Ide.Plugin.ChangeTypeSignature    as ChangeTypeSignature
 #endif
 
 #if hls_gadt
-import           Ide.Plugin.GADT                   as GADT
+import qualified Ide.Plugin.GADT                   as GADT
 #endif
 
 #if explicitFixity
-import           Ide.Plugin.ExplicitFixity         as ExplicitFixity
+import qualified Ide.Plugin.ExplicitFixity         as ExplicitFixity
 #endif
 
 #if explicitFields
-import           Ide.Plugin.ExplicitFields         as ExplicitFields
+import qualified Ide.Plugin.ExplicitFields         as ExplicitFields
 #endif
 
 -- formatters

--- a/src/HlsPlugins.hs
+++ b/src/HlsPlugins.hs
@@ -221,7 +221,7 @@ idePlugins recorder = pluginDescToIdePlugins allPlugins
       let pId = "codeRange" in CodeRange.descriptor (pluginRecorder pId) pId:
 #endif
 #if hls_changeTypeSignature
-      ChangeTypeSignature.descriptor :
+      ChangeTypeSignature.descriptor "changeTypeSignature" :
 #endif
 #if hls_gadt
       GADT.descriptor "gadt" :


### PR DESCRIPTION
Plugin Tests need a recorder. Most plugin test-suite just set it to `mempty`, which, I think, will make it more difficult to debug test-failures.

Some plugin test-suites roll their own plugin initialisation code. This is fine, but makes the logging behaviour non-uniform.

Introduce the `PluginTestDescriptor` type definition.
Utility functions to create `PluginTestDescriptor`'s `mkPluginTestDescriptor`  and `mkPluginTestDescriptor'` which will help migrating plugins to the newer co-log style logger. 

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3347"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

