### PR TITLE
Update cabal.project to enable build with GHC-9.4.3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -50,7 +50,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-10-07T12:19:15Z
+index-state: 2022-11-20T20:19:15Z
 
 constraints:
   -- For GHC 9.4, older versions of entropy fail to build on Windows


### PR DESCRIPTION
Change `index-state` to today's date to make it possible to pull `ghc-exactprint-1.6.1` instead of 1.6.0, which breaks build with GHC-9.4.3.

In addition to above, may need to pass to Cabal something like `--constraint ghc-exactprint ==1.6.1`