### PR TITLE
Fix build and tests with GHC-9.4.3.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: [ "9.4.2"
-             , "9.4.1"
+        ghc: [ "9.4.3"
+             , "9.4.2"
              , "9.2.4"
              , "9.2.3"
              , "9.0.2"
@@ -69,6 +69,9 @@ jobs:
             ]
         include:
            # only test supported ghc major versions
+           - os: ubuntu-latest
+             ghc: '9.4.3'
+             test: true
            - os: ubuntu-latest
              ghc: '9.4.2'
              test: true
@@ -150,15 +153,15 @@ jobs:
           HLS_WRAPPER_TEST_EXE: hls-wrapper
         run: cabal test wrapper-test --test-options="$TEST_OPTS --rerun-log-file .tasty-rerun-log-wrapper"
 
-      - if: matrix.test && matrix.ghc != '9.2.4' && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.2.4' && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-brittany-plugin
         run: cabal test hls-brittany-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-brittany-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-refactor-plugin
         run: cabal test hls-refactor-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-refactor-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-floskell-plugin
         run: cabal test hls-floskell-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-floskell-plugin --test-options="$TEST_OPTS"
 
@@ -170,31 +173,31 @@ jobs:
         name: Test hls-pragmas-plugin
         run: cabal test hls-pragmas-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-pragmas-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-eval-plugin
         run: cabal test hls-eval-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-eval-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.4' && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.2.4' && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-haddock-comments-plugin
         run: cabal test hls-haddock-comments-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-haddock-comments-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-splice-plugin
         run: cabal test hls-splice-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-splice-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-ormolu-plugin
         run: cabal test hls-ormolu-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-ormolu-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-fourmolu-plugin
         run: cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.2.4' && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.2.4' && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-tactics-plugin test suite
         run: cabal test hls-tactics-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-tactics-plugin --test-options="$TEST_OPTS"
 
@@ -210,15 +213,15 @@ jobs:
         name: Test hls-call-hierarchy-plugin test suite
         run: cabal test hls-call-hierarchy-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-call-hierarchy-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.os != 'windows-latest' && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.os != 'windows-latest' && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-rename-plugin test suite
         run: cabal test hls-rename-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-rename-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-hlint-plugin test suite
         run: cabal test hls-hlint-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-hlint-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.0.1' && matrix.ghc != '9.0.2' && matrix.ghc != '9.2.4' && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.0.1' && matrix.ghc != '9.0.2' && matrix.ghc != '9.2.4' && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-stan-plugin test suite
         run: cabal test hls-stan-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-stan-plugin --test-options="$TEST_OPTS"
 
@@ -242,7 +245,7 @@ jobs:
         name: Test hls-change-type-signature test suite
         run: cabal test hls-change-type-signature-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-change-type-signature-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2'
+      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
         name: Test hls-gadt-plugin test suit
         run: cabal test hls-gadt-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-gadt-plugin --test-options="$TEST_OPTS"
 

--- a/cabal.project
+++ b/cabal.project
@@ -51,7 +51,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-10-07T12:19:15Z
+index-state: 2022-11-20T20:19:15Z
 
 constraints:
   -- For GHC 9.4, older versions of entropy fail to build on Windows

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -66,6 +66,7 @@ library
         hashable,
         hie-compat ^>= 0.3.0.0,
         hls-plugin-api ^>= 1.5,
+        implicit-hie >= 0.1.2.7 && < 0.1.3,
         lens,
         list-t,
         hiedb == 0.4.2.*,

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -497,6 +497,9 @@ executable haskell-language-server
 
   default-language: Haskell2010
   default-extensions: DataKinds, TypeOperators
+  
+  if impl(ghc >= 9.4)
+    build-depends: ghc-exactprint >= 1.6.1
 
 executable haskell-language-server-wrapper
   import:           common-deps


### PR DESCRIPTION
Fixes build with GHC-9.4.3. 
Includes workaround for apparently-broken `implicit-hie` 0.1.3. 