### PR TITLE
Bump gha versions in setup-build/action.yml

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -99,7 +99,7 @@ runs:
 
     - name: Compiled deps cache
       id: compiled-deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: compiled-deps
       with:

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       id: HaskEnvSetup
       with:
         ghc-version  : ${{ inputs.ghc   }}
@@ -74,7 +74,7 @@ runs:
     # We have to restore package sources before `cabal update`
     # because it overwrites the hackage index with the cached one
     - name: Hackage sources cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: hackage-sources
       with:

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -80,7 +80,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ "9.2.4"
+        # This list of GHC versions must fit to the list of GHC versions
+        # specified in 'test.yml'
+        ghc: [ "9.4.2"
+             , "9.4.1"
+             , "9.2.4"
              , "9.2.3"
              , "9.0.2"
              , "8.10.7"
@@ -89,6 +93,9 @@ jobs:
             , "macOS-latest"
             , "windows-latest"
             ]
+        exclude:
+          - os: windows-latest
+            ghc: '9.4.1'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,6 +26,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-build
       with:
+        # select a stable GHC version
+        ghc: 9.2.5
         os: ${{ runner.os }}
         shorten-hls: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
+      # when you edit this list of GHC versions,
+      # **don't forget**
+      # to update the ghc versions in 'caching.yml'.
       matrix:
         ghc: [ "9.4.2"
              , "9.4.1"
@@ -66,7 +69,15 @@ jobs:
              ]
         os: [ "ubuntu-latest"
             , "macOS-latest"
+            , "windows-latest"
             ]
+        # don't build these versions
+        # they are broken for good reasons, e.g. compiler is bugged
+        # on that platform.
+        exclude:
+           - os: windows-latest
+             ghc: '9.4.1'
+        # Mark which GHC versions on which platform we want to test.
         include:
            # only test supported ghc major versions
            - os: ubuntu-latest
@@ -93,9 +104,6 @@ jobs:
            - os: windows-latest
              ghc: '8.10.7'
              test: true
-           # only build rest of supported ghc versions for windows
-           - os: windows-latest
-             ghc: '9.2.3'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           echo "TEST_OPTS=-j1 --rerun-update --rerun-filter failures,exceptions" >> $GITHUB_ENV
 
-      - name: Cache test log bewteen attempts of the same run
+      - name: Cache test log between attempts of the same run
         uses: actions/cache@v3
         env:
           cache-name: cache-test-log


### PR DESCRIPTION
CI is insanely slow. Only *some* caching of build dependencies.
Caching should take care of it, why are the caches not hit in some cases?

This PR is meant to investigate #3318 

Moreover, dependabot seems not to work for our custom defined github action?

<a href="https://gitpod.io/#https://github.com/haskell/haskell-language-server/pull/3366"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

