### PR TITLE
Remove Cabal dependency from hls-cabal-plugin

### DIFF
--- a/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
+++ b/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
     , base                  >=4.12     && <5
     , bytestring
-    , Cabal-syntax          ^>= 3.6 || ^>= 3.8
+    , Cabal-syntax          ^>= 3.8
     , deepseq
     , directory
     , extra                 >=1.7.4

--- a/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
+++ b/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
@@ -33,19 +33,7 @@ library
   build-depends:
     , base                  >=4.12     && <5
     , bytestring
-    -- Ideally, we only want to support a single Cabal version, supporting
-    -- older versions is completely pointless since Cabal is backwards compatible,
-    -- the latest Cabal version can parse all versions of the Cabal file format.
-    --
-    -- However, stack is making this difficult, if we change the version of Cabal,
-    -- we essentially need to make sure all other packages in the snapshot have their
-    -- Cabal dependency version relaxed.
-    -- Most packages have a Hackage revision, but stack won't pick these up (for sensible reasons)
-    -- automatically, forcing us to manually update the packages revision id.
-    -- This is a lot of work for almost zero benefit, so we just allow more versions here
-    -- and we eventually completely drop support for building HLS with stack.
-    , Cabal                 ^>=3.2 || ^>=3.4 || ^>=3.6 || ^>= 3.8
-    , Cabal-syntax          ^>= 3.6
+    , Cabal-syntax          ^>= 3.6 || ^>= 3.8
     , deepseq
     , directory
     , extra                 >=1.7.4

--- a/stack-lts19.yaml
+++ b/stack-lts19.yaml
@@ -42,7 +42,7 @@ ghc-options:
   "$everything": -haddock
 
 extra-deps:
-- Cabal-3.6.0.0
+- Cabal-syntax-3.8.1.0
 # needed for tests of hls-cabal-fmt-plugin
 - cabal-fmt-0.1.6@sha256:54041d50c8148c32d1e0a67aef7edeebac50ae33571bef22312f6815908eac19,3626
 - floskell-0.10.6@sha256:e77d194189e8540abe2ace2c7cb8efafc747ca35881a2fefcbd2d40a1292e036,3819

--- a/stack.yaml
+++ b/stack.yaml
@@ -52,6 +52,7 @@ extra-deps:
 - lsp-types-1.6.0.0
 - lsp-test-0.14.1.0
 - hie-bios-0.11.0
+- Cabal-syntax-3.8.1.0
 
 # currently needed for ghcide>extra, etc.
 allow-newer: true


### PR DESCRIPTION
Only Cabal-syntax is needed. I was unable to build using Nix without this change due to errors like the following:

```
src/Ide/Plugin/Cabal/Diagnostics.hs:17:1: error:
    Ambiguous module name ‘Distribution.Fields’:
      it was found in multiple packages:
      Cabal-3.6.3.0 Cabal-syntax-3.8.1.0
```