### PR TITLE
Bump hlint version CI flow

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: 'Installing'
       uses: rwe/actions-hlint-setup@v1
       with:
-        version: '3.4'
+        version: '3.5'
 
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2


### PR DESCRIPTION
Running HLint is failing, likely due to https://github.com/haskell/actions/issues/133#issue-1477449436, the ubuntu-latest version points to ubuntu-22.04. Probably breaks the pre-packaged hlint binary.

If this doesn't work, we will follow the suggestions from https://github.com/haskell/unix/pull/266#discussion_r1040654412