### PR TITLE
Fix Nix CI, probably

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -57,8 +57,6 @@ jobs:
 
     - uses: cachix/install-nix-action@v18
       with:
-        install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
-        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
         extra_nix_config: |
           experimental-features = nix-command flakes
         nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
Seems that we have a weird nix version override from 2021 with the introduction
of flakes. No way that's load bearing, so let's delete it and see what happens.

Weird Nix version override added in https://github.com/haskell/haskell-language-server/pull/1827

Fixes #3387

Report here suggests that other people with overridden Nix versions are having
the same CI issues: https://github.com/cachix/install-nix-action/issues/148
