### PR TITLE
Fix table in ghc-version-support.md

### DIFF
--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -20,7 +20,6 @@ Support status (see the support policy below for more details):
 | 9.4.2        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | basic support                                                               |
 | 9.4.1        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | basic support                                                               |
 | 9.2.5        | unreleased                                                                         | full support                                                                |
-
 | 9.2.4        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
 | 9.2.3        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
 | 9.2.(1,2)    | [1.7.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.7.0.0) | deprecated                                                                  |
@@ -36,6 +35,7 @@ Support status (see the support policy below for more details):
 | 8.8.2        | [1.2.0](https://github.com/haskell/haskell-language-server/releases/tag/1.2.0)     | deprecated                                                                  |
 | 8.6.5        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | deprecated                                                                  |
 | 8.6.4        | [1.4.0](https://github.com/haskell/haskell-language-server/releases/tag/1.4.0)     | deprecated                                                                  |
+
 
 GHC versions not in the list have never been supported by HLS.
 LTS stands for [Stackage](https://www.stackage.org/) Long Term Support.


### PR DESCRIPTION
The table is skewed after the change that adds 9.2.5.