### PR TITLE
Correct list of GHC versions in caching.yml to match test.yml

### DIFF
--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -80,8 +80,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # This list of GHC versions must fit to the list of GHC versions
-        # specified in 'test.yml'
+        # This list of GHC (including the "exclude" list) versions must match
+        # to the list of GHC versions specified in 'test.yml'
         ghc: [ "9.4.3"
              , "9.4.2"
              , "9.2.5"
@@ -94,12 +94,12 @@ jobs:
             , "windows-latest"
             ]
         exclude:
-          - os: windows-latest
-            ghc: '9.4.1'
-          # Exclude until https://github.com/haskell/actions/issues/129
-          # is resolved.
-          - os: windows-latest
-            ghc: '9.2.5'
+           # Exclude until https://github.com/haskell/actions/issues/129
+           # is resolved.
+           - os: windows-latest
+             ghc: '9.4.3' # Excluded because github action cannot install it
+           - os: windows-latest
+             ghc: '9.2.5'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,6 @@ jobs:
         # they are broken for good reasons, e.g. compiler is bugged
         # on that platform.
         exclude:
-           - os: windows-latest
-             ghc: '9.4.1'
            # Exclude until https://github.com/haskell/actions/issues/129
            # is resolved.
            - os: windows-latest


### PR DESCRIPTION
Small addition to #3396, exclude list wasn't completely up-to-date

Fixes Caching CI run https://github.com/haskell/haskell-language-server/actions/runs/3693755201/jobs/6254126700