### PR TITLE
Fix fourmolu with -f-fixity-th in nix env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,10 @@
                 then overrideCabal hsuper.ormolu (_: { enableSeparateBinOutput = false; })
                 else hsuper.ormolu;
 
-              fourmolu = hself.callCabal2nix "fourmolu" inputs.fourmolu {};
+              fourmolu =
+                addBuildDepend
+                  (appendConfigureFlag (hself.callCabal2nix "fourmolu" inputs.fourmolu {}) "-f-fixity-th")
+                  hself.file-embed;
             };
 
           hlsSources =

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,8 @@
                 then overrideCabal hsuper.ormolu (_: { enableSeparateBinOutput = false; })
                 else hsuper.ormolu;
 
+              # Due to the following issue, fixity-th should be disabled, especially for darwin.
+              # https://github.com/fourmolu/fourmolu/issues/238
               fourmolu =
                 addBuildDepend
                   (appendConfigureFlag (hself.callCabal2nix "fourmolu" inputs.fourmolu {}) "-f-fixity-th")


### PR DESCRIPTION
on current master, `.#haskell-language-server-925-dev-nix` shell is broken. 
```
% nix develop .#haskell-language-server-925-dev-nix
warning: Using saved setting for 'extra-substituters = https://haskell-language-server.cachix.org' from ~/.local/share/nix/trusted-settings.json.
warning: Using saved setting for 'extra-trusted-public-keys = haskell-language-server.cachix.org-1:juFfHrwkOxqIOZShtC4YC1uT1bBcq2RSvC7OMKx0Nz8=' from ~/.local/share/nix/trusted-settings.json.
[1/44/249 built, 3 copied (1489.5 MiB), 127.6 MiB DL] building HsYAML-0.2.1.1 (buildPhase): [ 4 of 14] Compiling Data.YAML.Token  ( src/Derror: interrupted by the user
ianwookim@IANWOOs-MacBook-Pro haskell-language-server % nix develop -j auto .#haskell-language-server-925-dev-nix
warning: Using saved setting for 'extra-substituters = https://haskell-language-server.cachix.org' from ~/.local/share/nix/trusted-settings.json.
warning: Using saved setting for 'extra-trusted-public-keys = haskell-language-server.cachix.org-1:juFfHrwkOxqIOZShtC4YC1uT1bBcq2RSvC7OMKx0Nz8=' from ~/.local/share/nix/trusted-settings.json.
[5/191/205 built] building ghc-lib-parser-9.2.4.20220729 (buildPhase): [330 of 333] Compiling GHC.Tc.Erro[1/202/205 built] building fourmolu-0.9.0.0 (buildPhase): [ 5 of 55] Compiling Ormolu.Fixity    ( serror: builder for '/nix/store/36r7hcfph5f8xn2vcs0sn5s2rba5vjly-fourmolu-0.9.0.0.drv' failed with exit code 1;
       last 10 log lines:
       > [54 of 55] Compiling Ormolu.Utils.Fixity ( src/Ormolu/Utils/Fixity.hs, dist/build/Ormolu/Utils/Fixity.o, dist/build/Ormolu/Utils/Fixity.dyn_o )
       > [55 of 55] Compiling Ormolu           ( src/Ormolu.hs, dist/build/Ormolu.o, dist/build/Ormolu.dyn_o )
       > Preprocessing executable 'fourmolu' for fourmolu-0.9.0.0..
       > Building executable 'fourmolu' for fourmolu-0.9.0.0..
       > [1 of 2] Compiling Paths_fourmolu   ( dist/build/fourmolu/autogen/Paths_fourmolu.hs, dist/build/fourmolu/fourmolu-tmp/Paths_fourmolu.o, dist/build/fourmolu/fourmolu-tmp/Paths_fourmolu.dyn_o )
       > [2 of 2] Compiling Main             ( app/Main.hs, dist/build/fourmolu/fourmolu-tmp/Main.o, dist/build/fourmolu/fourmolu-tmp/Main.dyn_o )
       > Linking dist/build/fourmolu/fourmolu ...
       > /nix/store/v069wkyb6y6qw2bhpzag5kka19j7clgg-clang-wrapper-11.1.0/bin/ld: line 256: 74868 Segmentation fault: 11  /nix/store/lyjnk6a0hi0d6favfz7vvj1dg8f1sqgq-cctools-binutils-darwin-973.0.1/bin/ld ${extraBefore+"${extraBefore[@]}"} ${params+"${params[@]}"} ${extraAfter+"${extraAfter[@]}"}
       > clang-11: error: linker command failed with exit code 139 (use -v to see invocation)
       > `cc' failed in phase `Linker'. (Exit code: 139)
       For full logs, run 'nix log /nix/store/36r7hcfph5f8xn2vcs0sn5s2rba5vjly-fourmolu-0.9.0.0.drv'.
error: 1 dependencies of derivation '/nix/store/51jz1h324rkrdgwa9siim1p8vlqiq4y3-ghc-9.2.5-with-packages.drv' failed to build
error: 1 dependencies of derivation '/nix/store/51f5mynbnc9sz7knrlr6qz1rz7vqlrmw-haskell-language-server-dev-nix-ghc9.2.5-env.drv' failed to build
```
This fixes the issue.