### PR TITLE
Add a mergify action to update PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,3 +13,15 @@ pull_request_rules:
       queue:
         method: squash
         name: default
+  # The queue action automatically updates PRs that
+  # have entered the queue, but in order to do that
+  # they must have passed CI. Since our CI is a bit
+  # flaky, PRs can fail to get in, which then means
+  # they don't get updated, which is extra annoying.
+  # This just adds the updating as an independent 
+  # step.
+  - name: Automatically update pull requests
+    conditions:
+      - label=merge me
+    actions:
+      update:


### PR DESCRIPTION
After a bit of digging I've worked out what's up with mergify. It's
still working fine, but it's not updating PRs very often now. The reason
for that is that it updates PRs that are in the queue, but to get
_into_ the queue you have to pass CI, which is hard ATM because of our
flaky CI. So we can add a separate update rule that just updates the
labelled PRs, so that they are at least kept up-to-date with master.
