### PR TITLE
Update ghc-version-support.md

### DIFF
--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -17,12 +17,13 @@ Support status (see the support policy below for more details):
 
 | GHC version  | Last supporting HLS version                                                        | Support status                                                              |
 |--------------|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| 9.4.3        | unreleased                                                                         | basic support                                                               |
-| 9.4.2        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | basic support                                                               |
-| 9.4.1        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | basic support                                                               |
-| 9.2.5        | unreleased                                                                         | full support                                                                |
-| 9.2.4        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
-| 9.2.3        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
+| 9.4.4        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | basic support                                                               |
+| 9.4.3        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | basic support                                                               |
+| 9.4.2        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | basic support                                                               |
+| 9.4.1        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | basic support                                                               |
+| 9.2.5        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
+| 9.2.4        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | full support                                                                |
+| 9.2.3        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | full support                                                                |
 | 9.2.(1,2)    | [1.7.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.7.0.0) | deprecated                                                                  |
 | 9.0.2        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
 | 9.0.1        | [1.6.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.6.1.0) | deprecated                                                                  |


### PR DESCRIPTION
I've updated these according to the release notes of 1.9.0.0. Although I don't know about the full vs basic support status.