### PR TITLE
Update list of unsupported plugins

### DIFF
--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -44,7 +44,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-code-range-plugin`             | 1    |                          |
 | `hls-explicit-imports-plugin`       | 1    |                          |
 | `hls-pragmas-plugin`                | 1    |                          |
-| `hls-refactor-plugin`               | 1    | 9.4                      |
+| `hls-refactor-plugin`               | 1    |                          |
 | `hls-alternate-number-plugin`       | 2    |                          |
 | `hls-cabal-fmt-plugin`              | 2    |                          |
 | `hls-class-plugin`                  | 2    |                          |
@@ -53,9 +53,9 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-explicit-fixity-plugin`        | 2    |                          |
 | `hls-explicit-record-fields-plugin` | 2    |                          |
 | `hls-floskell-plugin`               | 2    | 9.4                      |
-| `hls-fourmolu-plugin`               | 2    | 9.4                      |
-| `hls-gadt-plugin`                   | 2    | 9.4                      |
-| `hls-hlint-plugin`                  | 2    | 9.4                      |
+| `hls-fourmolu-plugin`               | 2    |                          |
+| `hls-gadt-plugin`                   | 2    |                          |
+| `hls-hlint-plugin`                  | 2    |                          |
 | `hls-module-name-plugin`            | 2    |                          |
 | `hls-qualify-imported-names-plugin` | 2    |                          |
 | `hls-ormolu-plugin`                 | 2    | 9.4                      |
@@ -66,5 +66,5 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-brittany-plugin`               | 3    | 9.2, 9.4                 |
 | `hls-haddock-comments-plugin`       | 3    | 9.2, 9.4                 |
 | `hls-stan-plugin`                   | 3    | 8.6, 9.0, 9.2, 9.4       |
-| `hls-retrie-plugin`                 | 3    | 9.2, 9.4                 |
-| `hls-splice-plugin`                 | 3    | 9.4                      |
+| `hls-retrie-plugin`                 | 3    | 9.2                      |
+| `hls-splice-plugin`                 | 3    |                          |

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -66,5 +66,5 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-brittany-plugin`               | 3    | 9.2, 9.4                 |
 | `hls-haddock-comments-plugin`       | 3    | 9.2, 9.4                 |
 | `hls-stan-plugin`                   | 3    | 8.6, 9.0, 9.2, 9.4       |
-| `hls-retrie-plugin`                 | 3    | 9.2                      |
+| `hls-retrie-plugin`                 | 3    |                          |
 | `hls-splice-plugin`                 | 3    |                          |


### PR DESCRIPTION
I checked fourmolu and hlint work fine with HLS 1.9, ghc 9.4. Other plugins are updated according to the following issues and release notes: 

ghc 9.2: https://github.com/haskell/haskell-language-server/issues/2982, [release note of HLS 1.8](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0)
ghc 9.4: https://github.com/haskell/haskell-language-server/issues/3190, [release note of HLS 1.9](https://github.com/haskell/haskell-language-server/releases/tag/1.9.0.0)
