### PR TITLE
ghcide needs prettyprinter 1.7

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -75,7 +75,7 @@ library
         optparse-applicative,
         parallel,
         prettyprinter-ansi-terminal,
-        prettyprinter >= 1.6,
+        prettyprinter >= 1.7,
         random,
         regex-tdfa >= 1.3.1.0,
         text-rope,


### PR DESCRIPTION
Since HLS 1.7, prettyprinter 1.7 is actually needed in order to build:

```
src/Development/IDE/Plugin/HLS.hs:44:1: error:
    Could not load module ‘Prettyprinter.Render.String’
    It is a member of the hidden package ‘prettyprinter-1.7.1’.
    Perhaps you need to add ‘prettyprinter’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘prettyprinter-1.7.1’.
    Perhaps you need to add ‘prettyprinter’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
44 | import           Prettyprinter.Render.String  (renderString)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: cabal: Failed to build ghcide-1.9.0.0 (which is required by
exe:haskell-language-server-wrapper from haskell-language-server-1.9.0.0 and
exe:haskell-language-server from haskell-language-server-1.9.0.0). See the
build log above for details.
```

(I have been carrying a patch for this in my Fedora [copr repo](https://github.com/fedora-haskell/haskell-language-server), though current Fedora releases are now all on 1.7.)