### PR TITLE
various plugins: Add testdata to sdist

### DIFF
--- a/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
+++ b/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
@@ -12,7 +12,9 @@ copyright:          The Haskell IDE Team
 maintainer:         jana.chadt@nets.at
 category:           Development
 build-type:         Simple
-extra-source-files: LICENSE
+extra-source-files:
+  LICENSE
+  test/testdata/**/*.hs
 
 flag isolateTests
   description: Should tests search for 'cabal-fmt' on the $PATH or shall we install it via build-tool-depends?

--- a/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
+++ b/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
@@ -16,9 +16,7 @@ category:           Development
 build-type:         Simple
 extra-source-files:
   LICENSE
-  test/testdata/selection-range/*.hs
-  test/testdata/selection-range/*.yaml
-  test/testdata/selection-range/*.txt
+  test/testdata/**/*.hs
 
 source-repository head
     type:     git

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -12,7 +12,8 @@ maintainer:         berk.ozkutuk@tweag.io
 category:           Development
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
--- extra-source-files:
+extra-source-files:
+  test/testdata/**/*.hs
 
 source-repository head
   type:     git


### PR DESCRIPTION
Missing testdata breaks tests when running them from the hackage sdist. This affects nixpkgs because we run tests by default.