### PR TITLE
Support stylish-haskell and ormolu in 9.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,7 +197,7 @@ jobs:
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
+      - if: matrix.test 
         name: Test hls-ormolu-plugin
         run: cabal test hls-ormolu-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-ormolu-plugin --test-options="$TEST_OPTS"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,7 +193,7 @@ jobs:
         name: Test hls-splice-plugin
         run: cabal test hls-splice-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-splice-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.4.2' && matrix.ghc != '9.4.3'
+      - if: matrix.test 
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS"
 

--- a/cabal.project
+++ b/cabal.project
@@ -50,7 +50,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2022-12-19T19:08:33Z
+index-state: 2023-01-10T00:00:00Z
 
 constraints:
   -- For GHC 9.4, older versions of entropy fail to build on Windows

--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -17,10 +17,10 @@ Support status (see the support policy below for more details):
 
 | GHC version  | Last supporting HLS version                                                        | Support status                                                              |
 |--------------|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| 9.4.4        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | basic support                                                               |
-| 9.4.3        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | basic support                                                               |
-| 9.4.2        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | basic support                                                               |
-| 9.4.1        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | basic support                                                               |
+| 9.4.4        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
+| 9.4.3        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
+| 9.4.2        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | full support                                                                |
+| 9.4.1        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | full support                                                                |
 | 9.2.5        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)       | full support                                                                |
 | 9.2.4        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | full support                                                                |
 | 9.2.3        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0) | full support                                                                |

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -58,7 +58,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-hlint-plugin`                  | 2    |                          |
 | `hls-module-name-plugin`            | 2    |                          |
 | `hls-qualify-imported-names-plugin` | 2    |                          |
-| `hls-ormolu-plugin`                 | 2    | 9.4                      |
+| `hls-ormolu-plugin`                 | 2    |                          |
 | `hls-rename-plugin`                 | 2    | 9.4                      |
 | `hls-refine-imports-plugin`         | 2    |                          |
 | `hls-stylish-haskell-plugin`        | 2    | 9.4                      |

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -61,7 +61,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-ormolu-plugin`                 | 2    |                          |
 | `hls-rename-plugin`                 | 2    | 9.4                      |
 | `hls-refine-imports-plugin`         | 2    |                          |
-| `hls-stylish-haskell-plugin`        | 2    | 9.4                      |
+| `hls-stylish-haskell-plugin`        | 2    |                          |
 | `hls-tactics-plugin`                | 2    | 9.2, 9.4                 |
 | `hls-haddock-comments-plugin`       | 3    | 9.2, 9.4                 |
 | `hls-stan-plugin`                   | 3    | 8.6, 9.0, 9.2, 9.4       |

--- a/flake.lock
+++ b/flake.lock
@@ -53,18 +53,6 @@
         "url": "https://hackage.haskell.org/package/apply-refact-0.9.3.0/apply-refact-0.9.3.0.tar.gz"
       }
     },
-    "brittany-01312": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-4rDE2bu4C8cv1D6lkTtLxMwLRyDfIK70BnptSrygK60=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/brittany-0.13.1.2/brittany-0.13.1.2.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/brittany-0.13.1.2/brittany-0.13.1.2.tar.gz"
-      }
-    },
     "constraints-extras": {
       "flake": false,
       "locked": {
@@ -302,7 +290,6 @@
         "all-cabal-hashes-unpacked": "all-cabal-hashes-unpacked",
         "apply-refact": "apply-refact",
         "apply-refact-0930": "apply-refact-0930",
-        "brittany-01312": "brittany-01312",
         "constraints-extras": "constraints-extras",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -339,7 +339,7 @@ common fourmolu
     cpp-options: -Dhls_fourmolu
 
 common ormolu
-  if flag(ormolu) && (impl(ghc < 9.4.1) || flag(ignore-plugins-ghc-bounds))
+  if flag(ormolu) 
     build-depends: hls-ormolu-plugin ^>= 1.0
     cpp-options: -Dhls_ormolu
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -344,7 +344,7 @@ common ormolu
     cpp-options: -Dhls_ormolu
 
 common stylishHaskell
-  if flag(stylishHaskell) && (impl(ghc < 9.4.1) || flag(ignore-plugins-ghc-bounds))
+  if flag(stylishHaskell) 
     build-depends: hls-stylish-haskell-plugin ^>= 1.0
     cpp-options: -Dhls_stylishHaskell
 

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -21,10 +21,6 @@ source-repository head
     location: https://github.com/haskell/haskell-language-server.git
 
 library
-  if impl(ghc >= 9.3)
-    buildable: False
-  else
-    buildable: True
   exposed-modules:  Ide.Plugin.Ormolu
   hs-source-dirs:   src
   build-depends:
@@ -42,10 +38,6 @@ library
   default-language: Haskell2010
 
 test-suite tests
-  if impl(ghc >= 9.3)
-    buildable: False
-  else
-    buildable: True
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -20,10 +20,6 @@ source-repository head
     location: https://github.com/haskell/haskell-language-server.git
 
 library
-  if impl(ghc >= 9.3)
-    buildable: False
-  else
-    buildable: True
   exposed-modules:  Ide.Plugin.StylishHaskell
   hs-source-dirs:   src
   build-depends:
@@ -41,10 +37,6 @@ library
   default-language: Haskell2010
 
 test-suite tests
-  if impl(ghc >= 9.3)
-    buildable: False
-  else
-    buildable: True
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test


### PR DESCRIPTION
Recent releases of both of these make them 9.4-compatible.

I think this qualifies 9.4 to be fully-supported by HLS, also.