### PR TITLE
Two recompilation avoidance related bug fixes

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -55,6 +55,7 @@
     within:
     - Development.IDE.Core.Shake
     - Development.IDE.GHC.Util
+    - Development.IDE.Core.FileStore
     - Development.IDE.Plugin.CodeAction.Util
     - Development.IDE.Graph.Internal.Database
     - Development.IDE.Graph.Internal.Paths

--- a/ghcide/src/Development/IDE/GHC/Compat.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat.hs
@@ -43,6 +43,8 @@ module Development.IDE.GHC.Compat(
     myCoreToStgExpr,
 #endif
 
+    Usage(..),
+
     FastStringCompat,
     bytesFS,
     mkFastStringByteString,
@@ -167,9 +169,9 @@ import           GHC.Runtime.Context                   (icInteractiveModule)
 import           GHC.Unit.Home.ModInfo                 (HomePackageTable,
                                                         lookupHpt)
 #if MIN_VERSION_ghc(9,3,0)
-import GHC.Unit.Module.Deps (Dependencies(dep_direct_mods))
+import GHC.Unit.Module.Deps (Dependencies(dep_direct_mods), Usage(..))
 #else
-import GHC.Unit.Module.Deps (Dependencies(dep_mods))
+import GHC.Unit.Module.Deps (Dependencies(dep_mods), Usage(..))
 #endif
 #else
 import           GHC.CoreToByteCode                    (coreExprToBCOs)


### PR DESCRIPTION
1. Recompilation avoidance regresses in GHC 9.4 due to interactions between GHC and HLS's implementations.
   Avoid this by filtering out the information that causes the conflict
   See #3450.

2. The recompilation avoidance info GHC stores in interfaces can blow up to be
   extremely large when deserialised from disk. See https://gitlab.haskell.org/ghc/ghc/-/issues/22744
   Deduplicate these filepaths.
