### PR TITLE
Expose `makeDefaultHandleRecorder`

### DIFF
--- a/ghcide/src/Development/IDE/Types/Logger.hs
+++ b/ghcide/src/Development/IDE/Types/Logger.hs
@@ -19,6 +19,7 @@ module Development.IDE.Types.Logger
   , cfilter
   , withDefaultRecorder
   , makeDefaultStderrRecorder
+  , makeDefaultHandleRecorder
   , priorityToHsLoggerPriority
   , LoggingColumn(..)
   , cmapWithPrio


### PR DESCRIPTION
I am trying to run HLS/Ghcide without giving it stdin/stdout/stderr. We can currently redirect stdout and stderr by passing appropriate values in `Arguments.argsHandleIn` and `argsHandleOut`, but we can't redirect the recorder anywhere but stderr.