### PR TITLE
Fix lower ghcide bounds of rename and fourmolu plugins

### DIFF
--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -34,7 +34,7 @@ library
     , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7 || ^>= 0.8 || ^>= 0.9 || ^>= 0.10
     , ghc
     , ghc-boot-th
-    , ghcide          ^>=1.8.0.2 || ^>= 1.9
+    , ghcide          ^>= 1.9
     , hls-plugin-api  ^>=1.5 || ^>= 1.6
     , lens
     , lsp

--- a/plugins/hls-rename-plugin/hls-rename-plugin.cabal
+++ b/plugins/hls-rename-plugin/hls-rename-plugin.cabal
@@ -29,7 +29,7 @@ library
     , extra
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.8 || ^>= 1.9
+    , ghcide                ^>= 1.9
     , hashable
     , hiedb
     , hie-compat


### PR DESCRIPTION
These plugins depend on the `usePropertyAction` api that was introduced first in ghcide 1.9