### PR TITLE
 Update flake to GHC 9.2.6 and 9.4.4

### DIFF
--- a/configuration-ghc-90.nix
+++ b/configuration-ghc-90.nix
@@ -18,27 +18,31 @@ let
       # https://github.com/nikita-volkov/ptr-poker/issues/11
       ptr-poker = hself.callCabal2nix "ptr-poker" inputs.ptr-poker { };
 
-      ghc-lib = hself.ghc-lib_9_2_5_20221107;
-      ghc-lib-parser = hself.ghc-lib-parser_9_2_5_20221107;
-      ghc-lib-parser-ex = hself.ghc-lib-parser-ex_9_2_1_1;
-
       Cabal = hself.Cabal_3_6_3_0;
-      ormolu = hself.ormolu_0_5_0_1;
-      fourmolu = hself.fourmolu_0_9_0_0;
-      hlint = appendConfigureFlag (hself.callCabal2nix "hlint" inputs.hlint-341 {}) "-fghc-lib";
+
+      Cabal-syntax = hself.Cabal-syntax_3_8_1_0;
+
+      ghc-lib-parser = hself.callCabal2nix "ghc-lib-parser" inputs.ghc-lib-parser-94 {};
+
+      hlint = appendConfigureFlag (hself.callCabal2nix "hlint" inputs.hlint-35 {}) "-fghc-lib";
 
       hls-hlint-plugin = hself.callCabal2nixWithOptions "hls-hlint-plugin"
         ./plugins/hls-hlint-plugin
         (pkgs.lib.concatStringsSep " " [ "-fhlint34" "-fghc-lib" ]) { };
+
+      OneTuple = overrideCabal hsuper.OneTuple (drv: {
+        libraryHaskellDepends = drv.libraryHaskellDepends or [] ++ [
+          hself.base-orphans
+        ];
+      });
+
+      ormolu = hself.callCabal2nix "ormolu" inputs.ormolu-052 {};
 
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =
         hself.callCabal2nixWithOptions "haskell-language-server" ./.
         (pkgs.lib.concatStringsSep " " [ "-f-stylishhaskell" ])
         { };
-
-      retrie = hself.retrie_1_1_0_0;
-      apply-refact = hself.apply-refact_0_9_3_0;
 
     });
 in {

--- a/configuration-ghc-92.nix
+++ b/configuration-ghc-92.nix
@@ -19,14 +19,19 @@ let
           doCheck = false;
         });
     } // (builtins.mapAttrs (_: drv: disableLibraryProfiling drv) {
+      apply-refact = hsuper.apply-refact_0_12_0_0;
+
       # ptr-poker breaks on MacOS without SSE2 optimizations
       # https://github.com/nikita-volkov/ptr-poker/issues/11
       ptr-poker = hself.callCabal2nix "ptr-poker" inputs.ptr-poker { };
 
-      ghc-exactprint =
-        hself.callCabal2nix "ghc-exactprint" inputs.ghc-exactprint-150 { };
-      fourmolu = hself.fourmolu_0_9_0_0;
-      hlint = appendConfigureFlag (hself.callCabal2nix "hlint" inputs.hlint-341 {}) "-fghc-lib";
+      Cabal-syntax = hself.Cabal-syntax_3_8_1_0;
+
+      ghc-lib-parser = hself.callCabal2nix "ghc-lib-parser" inputs.ghc-lib-parser-94 {};
+
+      hlint = appendConfigureFlag (hself.callCabal2nix "hlint" inputs.hlint-35 {}) "-fghc-lib";
+
+      ormolu = hself.callCabal2nix "ormolu" inputs.ormolu-052 {};
 
       stylish-haskell = appendConfigureFlag  hsuper.stylish-haskell "-fghc-lib";
 

--- a/configuration-ghc-94.nix
+++ b/configuration-ghc-94.nix
@@ -17,8 +17,9 @@ let
       # https://github.com/nikita-volkov/ptr-poker/issues/11
       ptr-poker = hself.callCabal2nix "ptr-poker" inputs.ptr-poker { };
 
+      # Freezes in test for some reason.
       ghc-exactprint =
-        hself.callCabal2nix "ghc-exactprint" inputs.ghc-exactprint-160 { };
+        dontCheck (hself.callCabal2nix "ghc-exactprint" inputs.ghc-exactprint-160 { });
       hlint = hsuper.callCabal2nix "hlint" inputs.hlint-35 {};
 
       stylish-haskell = appendConfigureFlag  hsuper.stylish-haskell "-fghc-lib";
@@ -26,8 +27,9 @@ let
       # Re-generate HLS drv excluding some plugins
       haskell-language-server =
         hself.callCabal2nixWithOptions "haskell-language-server" ./.
-        (pkgs.lib.concatStringsSep " " [ "-fpedantic" "-f-hlint" ]) { };
-
+        # Pedantic cannot be used due to -Werror=unused-top-binds
+        # Check must be disabled due to some missing required files
+        (pkgs.lib.concatStringsSep " " [ "--no-check" "-f-pedantic" "-f-hlint" ]) { };
     });
 in {
   inherit disabledPlugins;

--- a/configuration-ghc-94.nix
+++ b/configuration-ghc-94.nix
@@ -12,12 +12,6 @@ let
     with pkgs.haskell.lib;
     {
       hlsDisabledPlugins = disabledPlugins;
-      # YOLO
-      mkDerivation = args:
-        hsuper.mkDerivation (args // {
-          jailbreak = true;
-          doCheck = false;
-        });
     } // (builtins.mapAttrs (_: drv: disableLibraryProfiling drv) {
       # ptr-poker breaks on MacOS without SSE2 optimizations
       # https://github.com/nikita-volkov/ptr-poker/issues/11

--- a/configuration-ghc-94.nix
+++ b/configuration-ghc-94.nix
@@ -13,14 +13,13 @@ let
     {
       hlsDisabledPlugins = disabledPlugins;
     } // (builtins.mapAttrs (_: drv: disableLibraryProfiling drv) {
+      apply-refact = hsuper.apply-refact_0_12_0_0;
+
       # ptr-poker breaks on MacOS without SSE2 optimizations
       # https://github.com/nikita-volkov/ptr-poker/issues/11
       ptr-poker = hself.callCabal2nix "ptr-poker" inputs.ptr-poker { };
 
-      # Freezes in test for some reason.
-      ghc-exactprint =
-        dontCheck (hself.callCabal2nix "ghc-exactprint" inputs.ghc-exactprint-160 { });
-      hlint = hsuper.callCabal2nix "hlint" inputs.hlint-35 {};
+      ormolu = hself.ormolu_0_5_3_0;
 
       stylish-haskell = appendConfigureFlag  hsuper.stylish-haskell "-fghc-lib";
 

--- a/flake.lock
+++ b/flake.lock
@@ -12,23 +12,6 @@
         "url": "https://hackage.haskell.org/package/aeson-1.5.2.0/aeson-1.5.2.0.tar.gz"
       }
     },
-    "all-cabal-hashes-unpacked": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1670865018,
-        "narHash": "sha256-ygmGi0Y2So/DS74PEtBw+ozUoSiN2NM8D8OpjJxwNLc=",
-        "owner": "commercialhaskell",
-        "repo": "all-cabal-hashes",
-        "rev": "dbe1f3f215709c53df234197497cf9a5cc1d95a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "commercialhaskell",
-        "ref": "current-hackage",
-        "repo": "all-cabal-hashes",
-        "type": "github"
-      }
-    },
     "apply-refact": {
       "flake": false,
       "locked": {
@@ -287,7 +270,6 @@
     "root": {
       "inputs": {
         "aeson-1520": "aeson-1520",
-        "all-cabal-hashes-unpacked": "all-cabal-hashes-unpacked",
         "apply-refact": "apply-refact",
         "apply-refact-0930": "apply-refact-0930",
         "constraints-extras": "constraints-extras",

--- a/flake.lock
+++ b/flake.lock
@@ -1,53 +1,5 @@
 {
   "nodes": {
-    "aeson-1520": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-btKp7CTOgC0wT33lROffARW9qr1jx9oKE5EWydaR52c=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/aeson-1.5.2.0/aeson-1.5.2.0.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/aeson-1.5.2.0/aeson-1.5.2.0.tar.gz"
-      }
-    },
-    "apply-refact": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-cK+rsko/aydlvr7di9XS9XEP9tq3SwFWTRrwYrhfCLs=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/apply-refact-0.11.0.0/apply-refact-0.11.0.0.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/apply-refact-0.11.0.0/apply-refact-0.11.0.0.tar.gz"
-      }
-    },
-    "apply-refact-0930": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-EosZM++NRncMEr1KM+UIEjGivknqWFvwpTa6kLgK2Mk=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/apply-refact-0.9.3.0/apply-refact-0.9.3.0.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/apply-refact-0.9.3.0/apply-refact-0.9.3.0.tar.gz"
-      }
-    },
-    "constraints-extras": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-WGDSpT37RrHwpQtExGkL5eEmBk/s9b0rxtT9DYqSGg4=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/constraints-extras-0.3.2.1/constraints-extras-0.3.2.1.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/constraints-extras-0.3.2.1/constraints-extras-0.3.2.1.tar.gz"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -79,64 +31,16 @@
         "type": "github"
       }
     },
-    "fourmolu": {
+    "ghc-lib-parser-94": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-nmMz6kgI9cRljNSH9lbuozKJ7nd5pM4EKfUs0+x5N4U=",
+        "narHash": "sha256-WElfrJexd0VciSYe0T23s/5pxpOQzKhMn0z5zxa0Ax0=",
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/fourmolu-0.10.1.0/fourmolu-0.10.1.0.tar.gz"
+        "url": "https://hackage.haskell.org/package/ghc-lib-parser-9.4.4.20221225/ghc-lib-parser-9.4.4.20221225.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://hackage.haskell.org/package/fourmolu-0.10.1.0/fourmolu-0.10.1.0.tar.gz"
-      }
-    },
-    "ghc-check": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-pmmQMrk6X00+zbsstV49w/Es9+V9gssrXzJoub2ReEs=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-check-0.5.0.8/ghc-check-0.5.0.8.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-check-0.5.0.8/ghc-check-0.5.0.8.tar.gz"
-      }
-    },
-    "ghc-exactprint": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-8OWLBQj0WYi1f91EE3d5Pq+lTjY+FQei37NEedDtKeo=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.4.1/ghc-exactprint-1.4.1.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.4.1/ghc-exactprint-1.4.1.tar.gz"
-      }
-    },
-    "ghc-exactprint-150": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-f+WmS86c7B0dx2SMABIMm66z6sbRVWdqSZ1QBBEpUMw=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.5.0/ghc-exactprint-1.5.0.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.5.0/ghc-exactprint-1.5.0.tar.gz"
-      }
-    },
-    "ghc-exactprint-160": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-TiFybKVP3JIuUfnyESrKXInW9o0C8FLnsMjO4PEJ3I0=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.6.1/ghc-exactprint-1.6.1.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-exactprint-1.6.1/ghc-exactprint-1.6.1.tar.gz"
+        "url": "https://hackage.haskell.org/package/ghc-lib-parser-9.4.4.20221225/ghc-lib-parser-9.4.4.20221225.tar.gz"
       }
     },
     "gitignore": {
@@ -155,30 +59,6 @@
         "type": "github"
       }
     },
-    "hiedb": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-Ny9Ya7Y8GGdBh8r2cryQfK4XZj2dIrYQpaB8dTNQ3KI=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hiedb-0.4.2.0/hiedb-0.4.2.0.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hiedb-0.4.2.0/hiedb-0.4.2.0.tar.gz"
-      }
-    },
-    "hlint-341": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-qJF5mDe4N5MG7C1x62Aumo2b49tIUvQE3wQe8nBUx4U=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hlint-3.4.1/hlint-3.4.1.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hlint-3.4.1/hlint-3.4.1.tar.gz"
-      }
-    },
     "hlint-35": {
       "flake": false,
       "locked": {
@@ -191,37 +71,13 @@
         "url": "https://hackage.haskell.org/package/hlint-3.5/hlint-3.5.tar.gz"
       }
     },
-    "hw-prim": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-++rg/bx4TjWUDyHSWKm/8ITwQLonPRLXHPLlnhJy8ik=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hw-prim-0.6.3.2/hw-prim-0.6.3.2.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/hw-prim-0.6.3.2/hw-prim-0.6.3.2.tar.gz"
-      }
-    },
-    "implicit-hie": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-bFPhAuQe5IjKYQIz1OEC/j/imDESAv3H1nLNVM3lZF4=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/implicit-hie-0.1.2.7/implicit-hie-0.1.2.7.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/implicit-hie-0.1.2.7/implicit-hie-0.1.2.7.tar.gz"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670827406,
-        "narHash": "sha256-nLNk7uiLbhbvb4TVz67XK7+Ezr1zcWYDWmNrWGmEUqA=",
+        "lastModified": 1676928847,
+        "narHash": "sha256-FIqk+DHRICsWozlOdRxOXO/g9hCqjPYpmr8wQGrpUCA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffca9ffaaafb38c8979068cee98b2644bd3f14cb",
+        "rev": "5ab8b5ae26e6a4b781bdebdfd131c054f0b96e70",
         "type": "github"
       },
       "original": {
@@ -229,6 +85,18 @@
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
+      }
+    },
+    "ormolu-052": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-H7eqId488RBRxcf7flgJefAZmRgFJASJva+Oy7GG4q4=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/ormolu-0.5.2.0/ormolu-0.5.2.0.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/ormolu-0.5.2.0/ormolu-0.5.2.0.tar.gz"
       }
     },
     "ptr-poker": {
@@ -243,53 +111,29 @@
         "url": "https://hackage.haskell.org/package/ptr-poker-0.1.2.8/ptr-poker-0.1.2.8.tar.gz"
       }
     },
-    "retrie": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-yokMPa3T7gO3YGwaE0CwCO+vG4IVvObSo+q8fzGbAvc=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/retrie-1.2.1/retrie-1.2.1.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/retrie-1.2.1/retrie-1.2.1.tar.gz"
-      }
-    },
-    "retrie-1100": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-yn8gguMdBtrB3fCa+4Rq6GHtPSyxYlriENPTgOvjeHE=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/retrie-1.1.0.0/retrie-1.1.0.0.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/retrie-1.1.0.0/retrie-1.1.0.0.tar.gz"
-      }
-    },
     "root": {
       "inputs": {
-        "aeson-1520": "aeson-1520",
-        "apply-refact": "apply-refact",
-        "apply-refact-0930": "apply-refact-0930",
-        "constraints-extras": "constraints-extras",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "fourmolu": "fourmolu",
-        "ghc-check": "ghc-check",
-        "ghc-exactprint": "ghc-exactprint",
-        "ghc-exactprint-150": "ghc-exactprint-150",
-        "ghc-exactprint-160": "ghc-exactprint-160",
+        "ghc-lib-parser-94": "ghc-lib-parser-94",
         "gitignore": "gitignore",
-        "hiedb": "hiedb",
-        "hlint-341": "hlint-341",
         "hlint-35": "hlint-35",
-        "hw-prim": "hw-prim",
-        "implicit-hie": "implicit-hie",
         "nixpkgs": "nixpkgs",
+        "ormolu-052": "ormolu-052",
         "ptr-poker": "ptr-poker",
-        "retrie": "retrie",
-        "retrie-1100": "retrie-1100"
+        "stylish-haskell": "stylish-haskell"
+      }
+    },
+    "stylish-haskell": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-493M/S38dad82mA04l98xK50WPfue618TIln+7hE7VM=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/stylish-haskell-0.14.4.0/stylish-haskell-0.14.4.0.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/stylish-haskell-0.14.4.0/stylish-haskell-0.14.4.0.tar.gz"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -19,13 +19,6 @@
       flake = false;
     };
 
-    # cabal hashes contains all the version for different haskell packages, to update:
-    # nix flake lock --update-input all-cabal-hashes-unpacked
-    all-cabal-hashes-unpacked = {
-      url = "github:commercialhaskell/all-cabal-hashes/current-hackage";
-      flake = false;
-    };
-
     # List of hackage dependencies
     ghc-exactprint-160 = {
       url = "https://hackage.haskell.org/package/ghc-exactprint-1.6.1/ghc-exactprint-1.6.1.tar.gz";
@@ -97,7 +90,7 @@
     };
   };
   outputs =
-    inputs@{ self, nixpkgs, flake-compat, flake-utils, gitignore, all-cabal-hashes-unpacked, ... }:
+    inputs@{ self, nixpkgs, flake-compat, flake-utils, gitignore, ... }:
     {
       overlays.default = final: prev:
         with prev;
@@ -201,14 +194,6 @@
           });
         in {
           inherit hlsSources;
-
-          all-cabal-hashes = prev.runCommand "all-cabal-hashes.tar.gz"
-            { }
-            ''
-              cd ${all-cabal-hashes-unpacked}
-              cd ..
-              tar czf $out $(basename ${all-cabal-hashes-unpacked})
-            '';
 
           # Haskell packages extended with our packages
           hlsHpkgs = compiler: extended haskell.packages.${compiler};

--- a/flake.nix
+++ b/flake.nix
@@ -20,44 +20,8 @@
     };
 
     # List of hackage dependencies
-    ghc-exactprint-160 = {
-      url = "https://hackage.haskell.org/package/ghc-exactprint-1.6.1/ghc-exactprint-1.6.1.tar.gz";
-      flake = false;
-    };
-    ghc-exactprint-150 = {
-      url = "https://hackage.haskell.org/package/ghc-exactprint-1.5.0/ghc-exactprint-1.5.0.tar.gz";
-      flake = false;
-    };
-    ghc-exactprint = {
-      url = "https://hackage.haskell.org/package/ghc-exactprint-1.4.1/ghc-exactprint-1.4.1.tar.gz";
-      flake = false;
-    };
-    ghc-check = {
-      url = "https://hackage.haskell.org/package/ghc-check-0.5.0.8/ghc-check-0.5.0.8.tar.gz";
-      flake = false;
-    };
-    constraints-extras = {
-      url = "https://hackage.haskell.org/package/constraints-extras-0.3.2.1/constraints-extras-0.3.2.1.tar.gz";
-      flake = false;
-    };
-    retrie-1100 = {
-      url = "https://hackage.haskell.org/package/retrie-1.1.0.0/retrie-1.1.0.0.tar.gz";
-      flake = false;
-    };
-    retrie = {
-      url = "https://hackage.haskell.org/package/retrie-1.2.1/retrie-1.2.1.tar.gz";
-      flake = false;
-    };
-    aeson-1520= {
-      url = "https://hackage.haskell.org/package/aeson-1.5.2.0/aeson-1.5.2.0.tar.gz";
-      flake = false;
-    };
-    fourmolu = {
-      url = "https://hackage.haskell.org/package/fourmolu-0.10.1.0/fourmolu-0.10.1.0.tar.gz";
-      flake = false;
-    };
-    hlint-341 = {
-      url = "https://hackage.haskell.org/package/hlint-3.4.1/hlint-3.4.1.tar.gz";
+    ghc-lib-parser-94 = {
+      url = "https://hackage.haskell.org/package/ghc-lib-parser-9.4.4.20221225/ghc-lib-parser-9.4.4.20221225.tar.gz";
       flake = false;
     };
     hlint-35 = {
@@ -68,24 +32,12 @@
       url = "https://hackage.haskell.org/package/ptr-poker-0.1.2.8/ptr-poker-0.1.2.8.tar.gz";
       flake = false;
     };
-    hiedb = {
-      url = "https://hackage.haskell.org/package/hiedb-0.4.2.0/hiedb-0.4.2.0.tar.gz";
+    ormolu-052 = {
+      url = "https://hackage.haskell.org/package/ormolu-0.5.2.0/ormolu-0.5.2.0.tar.gz";
       flake = false;
     };
-    hw-prim = {
-      url = "https://hackage.haskell.org/package/hw-prim-0.6.3.2/hw-prim-0.6.3.2.tar.gz";
-      flake = false;
-    };
-    apply-refact = {
-      url = "https://hackage.haskell.org/package/apply-refact-0.11.0.0/apply-refact-0.11.0.0.tar.gz";
-      flake = false;
-    };
-    apply-refact-0930 = {
-      url = "https://hackage.haskell.org/package/apply-refact-0.9.3.0/apply-refact-0.9.3.0.tar.gz";
-      flake = false;
-    };
-    implicit-hie = {
-      url = "https://hackage.haskell.org/package/implicit-hie-0.1.2.7/implicit-hie-0.1.2.7.tar.gz";
+    stylish-haskell = {
+      url = "https://hackage.haskell.org/package/stylish-haskell-0.14.4.0/stylish-haskell-0.14.4.0.tar.gz";
       flake = false;
     };
   };
@@ -135,13 +87,6 @@
             hls-plugin-api = ./hls-plugin-api;
             hls-test-utils = ./hls-test-utils;
             ghcide-test-utils = ./ghcide/test;
-            # hiedb depends on hie-compact, which is part of this repository. If
-            # cabal inside the nix development shell tries to use the hiedb
-            # compiled inside nix, it thinks that this package is broken and
-            # does nothing. Adding this here ensures that hiedb compiled in nix
-            # is not available to cabal and then cabal downloads hiedb from
-            # hackage and compiles it.
-            hiedb = inputs.hiedb;
           } // pluginSourceDirs;
 
           # Tweak our packages
@@ -150,16 +95,6 @@
             with haskell.lib; {
               # Patches don't apply
               github = overrideCabal hsuper.github (drv: { patches = []; });
-              # Tests are broken on 9.2 and 9.4, and we wind up bypassing the
-              # nixpkgs fixes to the test suite by doing this override. So just
-              # turn it off.
-              hiedb = haskell.lib.dontCheck (hsuper.callCabal2nix "hiedb" inputs.hiedb {});
-              hw-prim = hsuper.callCabal2nix "hw-prim" inputs.hw-prim {};
-              retrie = hsuper.callCabal2nix "retrie" inputs.retrie {};
-              retrie_1_1_0_0 = hsuper.callCabal2nix "retrie" inputs.retrie-1100 {};
-              apply-refact = hsuper.callCabal2nix "apply-refact" inputs.apply-refact {};
-              apply-refact_0_9_3_0 = hsuper.callCabal2nix "apply-refact" inputs.apply-refact-0930 {};
-              implicit-hie = hsuper.callCabal2nix "implicit-hie" inputs.implicit-hie {};
 
               # https://github.com/NixOS/nixpkgs/issues/140774
               ormolu =
@@ -169,10 +104,13 @@
 
               # Due to the following issue, fixity-th should be disabled, especially for darwin.
               # https://github.com/fourmolu/fourmolu/issues/238
+              # nixpkgs now disables fixity-th for ghc944.
               fourmolu =
                 addBuildDepend
-                  (appendConfigureFlag (hself.callCabal2nix "fourmolu" inputs.fourmolu {}) "-f-fixity-th")
+                  (appendConfigureFlag hself.fourmolu_0_10_1_0 "-f-fixity-th")
                   hself.file-embed;
+
+              stylish-haskell = hself.callCabal2nix "stylish-haskell" inputs.stylish-haskell {};
             };
 
           hlsSources =
@@ -234,8 +172,8 @@
         };
 
         ghc902Config = (import ./configuration-ghc-90.nix) { inherit pkgs inputs; };
-        ghc925Config = (import ./configuration-ghc-92.nix) { inherit pkgs inputs; };
-        ghc943Config = (import ./configuration-ghc-94.nix) { inherit pkgs inputs; };
+        ghc926Config = (import ./configuration-ghc-92.nix) { inherit pkgs inputs; };
+        ghc944Config = (import ./configuration-ghc-94.nix) { inherit pkgs inputs; };
 
         # GHC versions
         # While HLS still works fine with 8.10 GHCs, we only support the versions that are cached
@@ -244,14 +182,14 @@
           ghcVersion = "ghc" + (pkgs.lib.replaceStrings ["."] [""] pkgs.haskellPackages.ghc.version);
           cases = {
             ghc902 = ghc902Config.tweakHpkgs (pkgs.hlsHpkgs "ghc902");
-            ghc925 = ghc925Config.tweakHpkgs (pkgs.hlsHpkgs "ghc925");
-            ghc943 = ghc943Config.tweakHpkgs (pkgs.hlsHpkgs "ghc943");
+            ghc926 = ghc926Config.tweakHpkgs (pkgs.hlsHpkgs "ghc926");
+            ghc944 = ghc944Config.tweakHpkgs (pkgs.hlsHpkgs "ghc944");
           };
           in { default = cases."${ghcVersion}"; } // cases;
 
         ghc902 = supportedGHCs.ghc902;
-        ghc925 = supportedGHCs.ghc925;
-        ghc943 = supportedGHCs.ghc943;
+        ghc926 = supportedGHCs.ghc926;
+        ghc944 = supportedGHCs.ghc944;
         ghcDefault = supportedGHCs.default;
 
         pythonWithPackages = pkgs.python3.withPackages (ps: [ps.sphinx ps.myst-parser ps.sphinx_rtd_theme ps.pip]);
@@ -291,7 +229,7 @@
             pythonWithPackages
             # @guibou: I'm not sure this is needed.
             hlint
-            pkgs.haskellPackages.opentelemetry-extra
+            (pkgs.haskell.lib.justStaticExecutables (pkgs.haskell.lib.dontCheck pkgs.haskellPackages.opentelemetry-extra))
             capstone
             # ormolu
             # stylish-haskell
@@ -372,16 +310,16 @@
         simpleDevShells = {
           haskell-language-server-dev = mkDevShell ghcDefault "cabal.project";
           haskell-language-server-902-dev = mkDevShell ghc902 "cabal.project";
-          haskell-language-server-925-dev = mkDevShell ghc925 "cabal.project";
-          haskell-language-server-943-dev = mkDevShell ghc943 "cabal.project";
+          haskell-language-server-926-dev = mkDevShell ghc926 "cabal.project";
+          haskell-language-server-944-dev = mkDevShell ghc944 "cabal.project";
         };
 
         # Developement shell, haskell packages are also provided by nix
         nixDevShells = {
           haskell-language-server-dev-nix = mkDevShellWithNixDeps ghcDefault "cabal.project";
           haskell-language-server-902-dev-nix = mkDevShellWithNixDeps ghc902 "cabal.project";
-          haskell-language-server-925-dev-nix = mkDevShellWithNixDeps ghc925 "cabal.project";
-          haskell-language-server-943-dev-nix = mkDevShellWithNixDeps ghc943 "cabal.project";
+          haskell-language-server-926-dev-nix = mkDevShellWithNixDeps ghc926 "cabal.project";
+          haskell-language-server-944-dev-nix = mkDevShellWithNixDeps ghc944 "cabal.project";
         };
 
         # The default shell provided by Nixpkgs for a Haskell package (i.e. the
@@ -389,15 +327,15 @@
         envShells = {
           haskell-language-server-dev-env = mkEnvShell ghcDefault;
           haskell-language-server-902-dev-env = mkEnvShell ghc902;
-          haskell-language-server-925-dev-env = mkEnvShell ghc925;
-          haskell-language-server-943-dev-env = mkEnvShell ghc943;
+          haskell-language-server-926-dev-env = mkEnvShell ghc926;
+          haskell-language-server-944-dev-env = mkEnvShell ghc944;
         };
 
         allPackages = {
           haskell-language-server = mkExe ghcDefault;
           haskell-language-server-902 = mkExe ghc902;
-          haskell-language-server-925 = mkExe ghc925;
-          haskell-language-server-943 = mkExe ghc943;
+          haskell-language-server-926 = mkExe ghc926;
+          haskell-language-server-944 = mkExe ghc944;
         };
 
         devShells = simpleDevShells // nixDevShells // envShells // {
@@ -420,7 +358,9 @@
           # working (especially on darwing), so this list is limited.
           all-nix-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique [nixDevShells.haskell-language-server-dev-nix]));
 
-          all-simple-dev-shells = linkFarmFromDrvs "all-dev-shells" (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues simpleDevShells)));
+          all-simple-dev-shells = linkFarmFromDrvs "all-simple-dev-shells"
+            (builtins.map (shell: shell.inputDerivation) (lib.unique (builtins.attrValues simpleDevShells)));
+
           docs = docs;
         };
 

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -32,9 +32,7 @@ library
     , hls-plugin-api  ^>=1.3 || ^>=1.4 || ^>= 1.5 || ^>= 1.6
     , lens
     , lsp
-    -- we are incompatible with 0.5.3.
-    -- See upstream ticket: https://github.com/tweag/ormolu/issues/981
-    , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || (>= 0.5 && < 0.5.3)
+    , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || ^>= 0.5
     , text
 
   default-language: Haskell2010

--- a/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
+++ b/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
@@ -45,7 +46,11 @@ provider ideState typ contents fp _ = withIndefiniteProgress title Cancellable $
     mkConf o region = defaultConfig { cfgDynOptions = o, cfgRegion = region }
     fmt :: T.Text -> Config RegionIndices -> IO (Either OrmoluException T.Text)
     fmt cont conf =
+#if MIN_VERSION_ormolu(0,5,3)
+      try @OrmoluException $ ormolu conf (fromNormalizedFilePath fp) cont
+#else
       try @OrmoluException $ ormolu conf (fromNormalizedFilePath fp) $ T.unpack cont
+#endif
 
   case typ of
     FormatText -> ret <$> fmt contents (mkConf fileOpts fullRegion)


### PR DESCRIPTION
This branch includes #3373, which was approved, but needed to be rebased. Only the last two commits need to be reviewed.