### PR TITLE
check in `.envrc`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ test/testdata/**/hie.yaml
 
 # direnv
 /.direnv/
-/.envrc
 
 # bench
 *.identifierPosition


### PR DESCRIPTION
Some projects check in `.envrc`, i.e.: https://github.com/input-output-hk/haskell.nix/blob/master/.envrc

Can we consider this?