### PR TITLE
Keep type lenses stable

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -165,7 +165,8 @@ commandHandler _ideState wedit = do
 --------------------------------------------------------------------------------
 
 suggestSignature :: Bool -> Maybe HscEnv -> Maybe GlobalBindingTypeSigsResult -> Maybe TcModuleResult -> Maybe Bindings -> Diagnostic -> [(T.Text, [TextEdit])]
-suggestSignature isQuickFix env mGblSigs mTmr mBindings diag = suggestGlobalSignature isQuickFix mGblSigs diag <> suggestLocalSignature isQuickFix env mTmr mBindings diag
+suggestSignature isQuickFix env mGblSigs mTmr mBindings diag =
+  suggestGlobalSignature isQuickFix mGblSigs diag <> suggestLocalSignature isQuickFix env mTmr mBindings diag
 
 suggestGlobalSignature :: Bool -> Maybe GlobalBindingTypeSigsResult -> Diagnostic -> [(T.Text, [TextEdit])]
 suggestGlobalSignature isQuickFix mGblSigs Diagnostic{_message, _range}

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -212,8 +212,9 @@ gblBindingTypeSigToEdit GlobalBindingTypeSig{..} mmp
   | Just Range{..} <- srcSpanToRange $ getSrcSpan gbName
     , startOfLine <- Position (_line _start) 0
     , beforeLine <- Range startOfLine startOfLine
-    , Just mp <- mmp
-    , Just range <- toCurrentRange mp beforeLine
+    -- If `mmp` is `Nothing`, return the original range, it used by lenses from diagnostic,
+    -- otherwise we apply `toCurrentRange`, and the guard should fail if `toCurrentRange` failed.
+    , Just range <- maybe (Just beforeLine) (flip toCurrentRange beforeLine) mmp
     = Just $ TextEdit range $ T.pack gbRendered <> "\n"
   | otherwise = Nothing
 

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -165,17 +165,17 @@ commandHandler _ideState wedit = do
 --------------------------------------------------------------------------------
 
 suggestSignature :: Bool -> Maybe HscEnv -> Maybe GlobalBindingTypeSigsResult -> Maybe TcModuleResult -> Maybe Bindings -> Diagnostic -> [(T.Text, [TextEdit])]
-suggestSignature isQuickFix env mGblSigs mTmr mBindings diag = suggestGlobalSignature isQuickFix mGblSigs Nothing diag <> suggestLocalSignature isQuickFix env mTmr mBindings diag
+suggestSignature isQuickFix env mGblSigs mTmr mBindings diag = suggestGlobalSignature isQuickFix mGblSigs diag <> suggestLocalSignature isQuickFix env mTmr mBindings diag
 
-suggestGlobalSignature :: Bool -> Maybe GlobalBindingTypeSigsResult -> Maybe PositionMapping -> Diagnostic -> [(T.Text, [TextEdit])]
-suggestGlobalSignature isQuickFix mGblSigs mmp Diagnostic{_message, _range}
+suggestGlobalSignature :: Bool -> Maybe GlobalBindingTypeSigsResult -> Diagnostic -> [(T.Text, [TextEdit])]
+suggestGlobalSignature isQuickFix mGblSigs Diagnostic{_message, _range}
   | _message
       =~ ("(Top-level binding|Pattern synonym) with no type signature" :: T.Text)
     , Just (GlobalBindingTypeSigsResult sigs) <- mGblSigs
     , Just sig <- find (\x -> sameThing (gbSrcSpan x) _range) sigs
     , signature <- T.pack $ gbRendered sig
     , title <- if isQuickFix then "add signature: " <> signature else signature
-    , Just action <- gblBindingTypeSigToEdit sig mmp =
+    , Just action <- gblBindingTypeSigToEdit sig Nothing =
     [(title, [action])]
   | otherwise = []
 

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -22,8 +22,7 @@ import           Data.Aeson.Types                     (Value (..), toJSON)
 import qualified Data.Aeson.Types                     as A
 import qualified Data.HashMap.Strict                  as Map
 import           Data.List                            (find)
-import           Data.Maybe                           (catMaybes, fromMaybe,
-                                                       mapMaybe)
+import           Data.Maybe                           (catMaybes, mapMaybe)
 import qualified Data.Text                            as T
 import           Development.IDE                      (GhcSession (..),
                                                        HscEnvEq (hscEnv),
@@ -211,8 +210,9 @@ gblBindingTypeSigToEdit GlobalBindingTypeSig{..} mmp
   | Just Range{..} <- srcSpanToRange $ getSrcSpan gbName
     , startOfLine <- Position (_line _start) 0
     , beforeLine <- Range startOfLine startOfLine
-    , range' <- fromMaybe beforeLine (flip toCurrentRange beforeLine =<< mmp)
-    = Just $ TextEdit range' $ T.pack gbRendered <> "\n"
+    , Just mp <- mmp
+    , Just range <- toCurrentRange mp beforeLine
+    = Just $ TextEdit range $ T.pack gbRendered <> "\n"
   | otherwise = Nothing
 
 data Mode

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -142,6 +142,8 @@ codeLensProvider ideState pId CodeLensParams{_textDocument = TextDocumentIdentif
               , (title, tedit) <- f dDiag
               , let edit = toWorkSpaceEdit tedit
               ]
+    -- `suggestLocalSignature` relies on diagnostic, if diagnostics don't have the local signature warning,
+    -- the `bindings` is useless, and if diagnostic has, that means we parsed success, and the `bindings` is fresh.
     pure $ List $ case mode of
         Always ->
           mapMaybe (generateLensForGlobal gblSigsMp) gblSigs'

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -969,6 +969,18 @@ addSigLensesTests =
             [ sigSession "with GHC warnings" True "diagnostics" "" (second Just $ head cases) []
             , sigSession "without GHC warnings" False "diagnostics" "" (second (const Nothing) $ head cases) []
             ]
+        , testSession "keep stale lens" $ do
+            let content = T.unlines
+                    [ "module Stale where"
+                    , "f = _"
+                    ]
+            doc <- createDoc "Stale.hs" "haskell" content
+            oldLens <- getCodeLenses doc
+            liftIO $ length oldLens @?= 1
+            let edit = TextEdit (mkRange 0 4 0 5) "" -- Remove the `_`
+            _ <- applyEdit doc edit
+            newLens <- getCodeLenses doc
+            liftIO $ newLens @?= oldLens
         ]
 
 linkToLocation :: [LocationLink] -> [Location]


### PR DESCRIPTION
I got the same effect without using `PositionMapping` compared to instance lenses, but don't know why.

Can anyone explain this?