### PR TITLE
Monitor actions/setup-build/action.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: ".github/actions/setup-buil"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
As the [document](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory) says: `For GitHub Actions, set the directory to / to check for workflow files in .github/workflows.`