### PR TITLE
Bump all packages to version 2.0.0.0 and prepare the release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -212,7 +212,7 @@ jobs:
 
   build-mac-x86_64:
     name: Build binary (Mac x86_64)
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -519,7 +519,7 @@ jobs:
 
   bindist-mac-x86_64:
     name: Tar bindists (Mac x86_64)
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     needs: ["build-mac-x86_64"]
     env:
       TARBALL_EXT: tar.xz
@@ -780,7 +780,7 @@ jobs:
 
   test-mac-x86_64:
     name: Test binary (Mac x86_64)
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     needs: ["bindist-mac-x86_64"]
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         ghc: ["9.6.1", "9.4.5", "9.2.7", "9.0.2", "8.10.7"]
         platform: [ { image: "debian:9"
-                    , installCmd: "apt-get update && apt-get install -y"
+                    , installCmd: "sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && sed -i /-updates/d /etc/apt/sources.list && apt-get update && apt-get install -y"
                     , toolRequirements: "libnuma-dev zlib1g-dev libgmp-dev libgmp10 libssl-dev liblzma-dev libbz2-dev git wget lsb-release software-properties-common gnupg2 apt-transport-https gcc autoconf automake build-essential curl ghc gzip libffi-dev libncurses-dev libncurses5 libtinfo5 patchelf"
                     , DISTRO: "Debian"
                     , ARTIFACT: "x86_64-linux-deb9"
@@ -362,7 +362,7 @@ jobs:
       matrix:
         include:
           - image: debian:9
-            installCmd: apt-get update && apt-get install -y
+            installCmd: sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && sed -i /-updates/d /etc/apt/sources.list && apt-get update && apt-get install -y
             toolRequirements: libnuma-dev zlib1g-dev libgmp-dev libgmp10 libssl-dev liblzma-dev libbz2-dev git wget lsb-release software-properties-common gnupg2 apt-transport-https gcc autoconf automake build-essential curl ghc gzip libffi-dev libncurses-dev libncurses5 libtinfo5 patchelf tree
             DISTRO: Debian
             ARTIFACT: "x86_64-linux-deb9"
@@ -657,7 +657,7 @@ jobs:
       matrix:
         include:
           - image: debian:9
-            installCmd: apt-get update && apt-get install -y
+            installCmd: sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && sed -i /-updates/d /etc/apt/sources.list && apt-get update && apt-get install -y
             toolRequirements: libnuma-dev zlib1g-dev libgmp-dev libgmp10 libssl-dev liblzma-dev libbz2-dev git wget lsb-release software-properties-common gnupg2 apt-transport-https gcc autoconf automake build-essential curl ghc gzip libffi-dev libncurses-dev libncurses5 libtinfo5 patchelf tree
             DISTRO: Debian
             ARTIFACT: "x86_64-linux-deb9"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog for haskell-language-server
 
+## 2.0.0.0
+
+- New versioning scheme for all packages distributed as part of HLS,
+  versioning them in lockstep for each release.
+- Binaries for GHC 9.4.5
+- Keep instance lenses stable even if parsed results are unavailable (#3545)
+- Keep stale lenses for module name (#3570)
+- Keep type lenses stable (#3558)
+
 ## 1.10.0.0
 
 - Support for GHC 9.6

--- a/ghcide-bench/ghcide-bench.cabal
+++ b/ghcide-bench/ghcide-bench.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide-bench
-version:            0.1.1
+version:            2.0.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             The Haskell IDE team

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            1.10.0.0
+version:            2.0.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -65,7 +65,7 @@ library
         haddock-library >= 1.8 && < 1.12,
         hashable,
         hie-compat ^>= 0.3.0.0,
-        hls-plugin-api ^>= 1.6,
+        hls-plugin-api == 2.0.0.0,
         lens,
         list-t,
         hiedb == 0.4.3.*,
@@ -80,7 +80,7 @@ library
         regex-tdfa >= 1.3.1.0,
         text-rope,
         safe-exceptions,
-        hls-graph ^>= 1.9,
+        hls-graph == 2.0.0.0,
         sorted-list,
         sqlite-simple,
         stm,

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 category:           Development
 name:               haskell-language-server
-version:            1.10.0.0
+version:            2.0.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -213,144 +213,144 @@ flag cabalfmt
 
 common cabalfmt
   if flag(cabalfmt)
-    build-depends: hls-cabal-fmt-plugin ^>= 0.1.0.0
+    build-depends: hls-cabal-fmt-plugin == 2.0.0.0
     cpp-options: -Dhls_cabalfmt
 
 common cabal
   if flag(cabal)
-    build-depends: hls-cabal-plugin ^>= 0.1
+    build-depends: hls-cabal-plugin == 2.0.0.0
     cpp-options: -Dhls_cabal
 
 common class
   if flag(class)
-    build-depends: hls-class-plugin ^>= 1.1
+    build-depends: hls-class-plugin == 2.0.0.0
     cpp-options: -Dhls_class
 
 common callHierarchy
   if flag(callHierarchy)
-    build-depends: hls-call-hierarchy-plugin ^>= 1.2
+    build-depends: hls-call-hierarchy-plugin == 2.0.0.0
     cpp-options: -Dhls_callHierarchy
 
 common haddockComments
   if flag(haddockComments) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-haddock-comments-plugin ^>= 1.1
+    build-depends: hls-haddock-comments-plugin == 2.0.0.0
     cpp-options: -Dhls_haddockComments
 
 common eval
   if flag(eval)
-    build-depends: hls-eval-plugin ^>= 1.5
+    build-depends: hls-eval-plugin == 2.0.0.0
     cpp-options: -Dhls_eval
 
 common importLens
   if flag(importLens)
-    build-depends: hls-explicit-imports-plugin ^>= 1.2
+    build-depends: hls-explicit-imports-plugin == 2.0.0.0
     cpp-options: -Dhls_importLens
 
 common refineImports
   if flag(refineImports)
-    build-depends: hls-refine-imports-plugin ^>=1.0
+    build-depends: hls-refine-imports-plugin == 2.0.0.0
     cpp-options: -Dhls_refineImports
 
 common rename
   if flag(rename)
-    build-depends: hls-rename-plugin ^>= 1.0
+    build-depends: hls-rename-plugin == 2.0.0.0
     cpp-options: -Dhls_rename
 
 common retrie
   if flag(retrie)
-    build-depends: hls-retrie-plugin ^>= 1.0
+    build-depends: hls-retrie-plugin == 2.0.0.0
     cpp-options: -Dhls_retrie
 
 common tactic
   if flag(tactic) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-tactics-plugin ^>= 1.8.1
+    build-depends: hls-tactics-plugin == 2.0.0.0
     cpp-options: -Dhls_tactic
 
 common hlint
   if flag(hlint) && impl(ghc < 9.5)
-    build-depends: hls-hlint-plugin ^>= 1.1
+    build-depends: hls-hlint-plugin == 2.0.0.0
     cpp-options: -Dhls_hlint
 
 common stan
   if flag(stan) && (impl(ghc >= 8.10) && impl(ghc < 9.0))
-    build-depends: hls-stan-plugin ^>= 1.0
+    build-depends: hls-stan-plugin == 2.0.0.0
     cpp-options: -Dhls_stan
 
 common moduleName
   if flag(moduleName)
-    build-depends: hls-module-name-plugin ^>= 1.1
+    build-depends: hls-module-name-plugin == 2.0.0.0
     cpp-options: -Dhls_moduleName
 
 common pragmas
   if flag(pragmas)
-    build-depends: hls-pragmas-plugin ^>= 1.0
+    build-depends: hls-pragmas-plugin == 2.0.0.0
     cpp-options: -Dhls_pragmas
 
 common splice
   if flag(splice)
-    build-depends: hls-splice-plugin ^>=1.1
+    build-depends: hls-splice-plugin == 2.0.0.0
     cpp-options: -Dhls_splice
 
 common alternateNumberFormat
   if flag(alternateNumberFormat)
-    build-depends: hls-alternate-number-format-plugin ^>= 1.3
+    build-depends: hls-alternate-number-format-plugin == 2.0.0.0
     cpp-options: -Dhls_alternateNumberFormat
 
 common qualifyImportedNames
   if flag(qualifyImportedNames)
-    build-depends: hls-qualify-imported-names-plugin ^>=1.0
+    build-depends: hls-qualify-imported-names-plugin == 2.0.0.0
     cpp-options: -Dhls_qualifyImportedNames
 
 common codeRange
   if flag(codeRange)
-    build-depends: hls-code-range-plugin ^>= 1.1
+    build-depends: hls-code-range-plugin == 2.0.0.0
     cpp-options: -Dhls_codeRange
 
 common changeTypeSignature
   if flag(changeTypeSignature)
-    build-depends: hls-change-type-signature-plugin ^>= 1.1
+    build-depends: hls-change-type-signature-plugin == 2.0.0.0
     cpp-options: -Dhls_changeTypeSignature
 
 common gadt
   if flag(gadt)
-    build-depends: hls-gadt-plugin ^>= 1.0
+    build-depends: hls-gadt-plugin == 2.0.0.0
     cpp-options: -Dhls_gadt
 
 common explicitFixity
   if flag(explicitFixity)
-    build-depends: hls-explicit-fixity-plugin ^>= 1.1
+    build-depends: hls-explicit-fixity-plugin == 2.0.0.0
     cpp-options: -DexplicitFixity
 
 common explicitFields
   if flag(explicitFields)
-    build-depends: hls-explicit-record-fields-plugin ^>= 1.0
+    build-depends: hls-explicit-record-fields-plugin == 2.0.0.0
     cpp-options: -DexplicitFields
 
 -- formatters
 
 common floskell
   if flag(floskell) && impl(ghc < 9.5) 
-    build-depends: hls-floskell-plugin ^>= 1.0
+    build-depends: hls-floskell-plugin == 2.0.0.0
     cpp-options: -Dhls_floskell
 
 common fourmolu
   if flag(fourmolu)
-    build-depends: hls-fourmolu-plugin ^>= 1.1
+    build-depends: hls-fourmolu-plugin == 2.0.0.0
     cpp-options: -Dhls_fourmolu
 
 common ormolu
   if flag(ormolu) && impl(ghc < 9.5)
-    build-depends: hls-ormolu-plugin ^>= 1.0
+    build-depends: hls-ormolu-plugin == 2.0.0.0
     cpp-options: -Dhls_ormolu
 
 common stylishHaskell
   if flag(stylishHaskell) && impl(ghc < 9.5)
-    build-depends: hls-stylish-haskell-plugin ^>= 1.0
+    build-depends: hls-stylish-haskell-plugin == 2.0.0.0
     cpp-options: -Dhls_stylishHaskell
 
 common refactor
   if flag(refactor)
-    build-depends: hls-refactor-plugin ^>= 1.2
+    build-depends: hls-refactor-plugin == 2.0.0.0
     cpp-options: -Dhls_refactor
 
 library
@@ -405,12 +405,12 @@ library
     , cryptohash-sha1
     , data-default
     , ghc
-    , ghcide                ==1.10.0.0
+    , ghcide                == 2.0.0.0
     , githash               >=0.1.6.1
     , lsp
     , hie-bios
     , hiedb
-    , hls-plugin-api        ^>=1.6
+    , hls-plugin-api        == 2.0.0.0
     , optparse-applicative
     , optparse-simple
     , process
@@ -549,7 +549,7 @@ test-suite func-test
     , lens-aeson
     , ghcide
     , ghcide-test-utils
-    , hls-test-utils ^>=1.6
+    , hls-test-utils == 2.0.0.0
     , lsp-types
     , aeson
     , hls-plugin-api

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-graph
-version:       1.9.0.0
+version:       2.0.0.0
 synopsis:      Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       1.6.0.0
+version:       2.0.0.0
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -55,7 +55,7 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             ^>= 1.9
+    , hls-graph             == 2.0.0.0
     , lens
     , lens-aeson
     , lsp                   ^>=1.6.0.0

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       1.6.0.0
+version:       2.0.0.0
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -41,9 +41,9 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  ^>= 1.10
+    , ghcide                  == 2.0.0.0
     , hls-graph
-    , hls-plugin-api          ^>=1.6
+    , hls-plugin-api          == 2.0.0.0
     , lens
     , lsp                     ^>=1.6.0.0
     , lsp-test                ^>=0.14

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-alternate-number-format-plugin
-version:            1.3.0.1
+version:            2.0.0.0
 synopsis:           Provide Alternate Number Formats plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,10 +32,10 @@ library
     , base                 >=4.12 && < 5
     , containers
     , extra
-    , ghcide               ^>= 1.10
+    , ghcide               == 2.0.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       ^>= 1.6
+    , hls-plugin-api       == 2.0.0.0
     , hie-compat
     , lens
     , lsp                  ^>=1.6
@@ -64,7 +64,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-alternate-number-format-plugin
-    , hls-test-utils       ^>=1.6
+    , hls-test-utils       == 2.0.0.0
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
+++ b/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-cabal-fmt-plugin
-version:            0.1.0.0
+version:            2.0.0.0
 synopsis:           Integration with the cabal-fmt code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -33,8 +33,8 @@ library
     , base            >=4.12 && <5
     , directory
     , filepath
-    , ghcide          ^>= 1.9 || ^>= 1.10
-    , hls-plugin-api  ^>= 1.6
+    , ghcide          == 2.0.0.0
+    , hls-plugin-api  == 2.0.0.0
     , lens
     , lsp-types
     , process
@@ -55,7 +55,7 @@ test-suite tests
     , directory
     , filepath
     , hls-cabal-fmt-plugin
-    , hls-test-utils        ^>=1.6
+    , hls-test-utils        == 2.0.0.0
 
   if flag(isolateTests)
     build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.6

--- a/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
+++ b/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-cabal-plugin
-version:            0.1.0.0
+version:            2.0.0.0
 synopsis:           Cabal integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -48,10 +48,10 @@ library
     , deepseq
     , directory
     , extra                 >=1.7.4
-    , ghcide                ^>= 1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hashable
-    , hls-plugin-api        ^>=1.6
-    , hls-graph             ^>=1.9
+    , hls-plugin-api        == 2.0.0.0
+    , hls-graph             == 2.0.0.0
     , lsp                   ^>=1.6.0.0
     , lsp-types             ^>=1.6.0.0
     , regex-tdfa            ^>=1.3.1
@@ -74,7 +74,7 @@ test-suite tests
     , filepath
     , ghcide
     , hls-cabal-plugin
-    , hls-test-utils    ^>=1.6
+    , hls-test-utils    == 2.0.0.0
     , lens
     , lsp-types
     , tasty-hunit

--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-call-hierarchy-plugin
-version:            1.2.0.0
+version:            2.0.0.0
 synopsis:           Call hierarchy plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-call-hierarchy-plugin#readme>
@@ -33,9 +33,9 @@ library
     , base                  >=4.12 && <5
     , containers
     , extra
-    , ghcide                ^>= 1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hiedb
-    , hls-plugin-api        ^>= 1.6
+    , hls-plugin-api        == 2.0.0.0
     , lens
     , lsp                    >=1.2.0.1
     , sqlite-simple
@@ -59,7 +59,7 @@ test-suite tests
     , extra
     , filepath
     , hls-call-hierarchy-plugin
-    , hls-test-utils              ^>=1.6
+    , hls-test-utils              == 2.0.0.0
     , ghcide-test-utils
     , lens
     , lsp

--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-change-type-signature-plugin
-version:            1.1.0.1
+version:            2.0.0.0
 synopsis:           Change a declarations type signature with a Code Action
 description:
   Please see the README on GitHub at <https://github.com/haskell/plugins/hls-change-type-signature-plugin/README.md>
@@ -28,8 +28,8 @@ library
   hs-source-dirs:   src
   build-depends:
     , base             >=4.12 && < 5
-    , ghcide          ^>=1.9 || ^>= 1.10
-    , hls-plugin-api  ^>=1.6
+    , ghcide           == 2.0.0.0
+    , hls-plugin-api   == 2.0.0.0
     , lsp-types
     , regex-tdfa
     , syb
@@ -61,7 +61,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-change-type-signature-plugin
-    , hls-test-utils       ^>=1.6
+    , hls-test-utils       == 2.0.0.0
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-class-plugin
-version:            1.1.1.1
+version:            2.0.0.0
 synopsis:
   Class/instance management plugin for Haskell Language Server
 
@@ -39,10 +39,10 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide          ^>=1.9 || ^>= 1.10
+    , ghcide          == 2.0.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api  ^>=1.6
+    , hls-plugin-api  == 2.0.0.0
     , lens
     , lsp
     , text
@@ -74,7 +74,7 @@ test-suite tests
     , ghcide
     , hls-class-plugin
     , hls-plugin-api
-    , hls-test-utils     ^>=1.6
+    , hls-test-utils     == 2.0.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
+++ b/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-code-range-plugin
-version:            1.1.0.0
+version:            2.0.0.0
 synopsis:
   HLS Plugin to support smart selection range and Folding range
 
@@ -37,9 +37,9 @@ library
     , containers
     , deepseq
     , extra
-    , ghcide           ^>=1.9 || ^>= 1.10
+    , ghcide           == 2.0.0.0
     , hashable
-    , hls-plugin-api   ^>=1.6
+    , hls-plugin-api   == 2.0.0.0
     , lens
     , lsp
     , mtl
@@ -62,9 +62,9 @@ test-suite tests
     , bytestring
     , containers
     , filepath
-    , ghcide                     ^>=1.8 || ^>= 1.9 || ^>= 1.10
+    , ghcide                     == 2.0.0.0
     , hls-code-range-plugin
-    , hls-test-utils             ^>=1.6
+    , hls-test-utils             == 2.0.0.0
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-eval-plugin
-version:            1.5.0.0
+version:            2.0.0.0
 synopsis:           Eval plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -66,10 +66,10 @@ library
     , ghc
     , ghc-boot-th
     , ghc-paths
-    , ghcide                ^>=1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hashable
     , hls-graph
-    , hls-plugin-api        ^>=1.6
+    , hls-plugin-api        == 2.0.0.0
     , lens
     , lsp
     , lsp-types
@@ -111,7 +111,7 @@ test-suite tests
     , filepath
     , hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   ^>=1.6
+    , hls-test-utils   == 2.0.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
+++ b/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-explicit-fixity-plugin
-version:            1.1.0.0
+version:            2.0.0.0
 synopsis:           Show fixity explicitly while hovering
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-explicit-fixity-plugin#readme>
@@ -30,9 +30,9 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide               ^>=1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hashable
-    , hls-plugin-api       ^>=1.6
+    , hls-plugin-api        == 2.0.0.0
     , lsp                   >=1.2.0.1
     , text
     , transformers
@@ -55,5 +55,5 @@ test-suite tests
     , base
     , filepath
     , hls-explicit-fixity-plugin
-    , hls-test-utils              ^>=1.6
+    , hls-test-utils              == 2.0.0.0
     , text

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-explicit-imports-plugin
-version:            1.2.1.0
+version:            2.0.0.0
 synopsis:           Explicit imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,9 +29,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                ^>=1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hls-graph
-    , hls-plugin-api        ^>=1.6
+    , hls-plugin-api        == 2.0.0.0
     , lsp
     , text
     , unordered-containers

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-explicit-record-fields-plugin
-version:            1.0.1.0
+version:            2.0.0.0
 synopsis:           Explicit record fields plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,8 +29,8 @@ library
     -- other-extensions:
     build-depends:
       , base                  >=4.12 && <5
-      , ghcide                ^>=1.10
-      , hls-plugin-api        ^>=1.6
+      , ghcide                == 2.0.0.0
+      , hls-plugin-api        == 2.0.0.0
       , lsp
       , lens
       , hls-graph

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-floskell-plugin
-version:            1.0.2.1
+version:            2.0.0.0
 synopsis:           Integration with the Floskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,8 +28,8 @@ library
   build-depends:
     , base            >=4.12 && <5
     , floskell        ^>=0.10
-    , ghcide          ^>=1.6 || ^>=1.7 || ^>= 1.8 || ^>= 1.9 || ^>= 1.10
-    , hls-plugin-api  ^>=1.3 || ^>=1.4 || ^>= 1.5 || ^>= 1.6
+    , ghcide          == 2.0.0.0
+    , hls-plugin-api  == 2.0.0.0
     , lsp-types       ^>=1.6
     , text
     , transformers
@@ -48,4 +48,4 @@ test-suite tests
     , base
     , filepath
     , hls-floskell-plugin
-    , hls-test-utils       ^>=1.6
+    , hls-test-utils       == 2.0.0.0

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-fourmolu-plugin
-version:            1.1.1.0
+version:            2.0.0.0
 synopsis:           Integration with the Fourmolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -35,8 +35,8 @@ library
     , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7 || ^>= 0.8 || ^>= 0.9 || ^>= 0.10 || ^>= 0.11 || ^>= 0.12
     , ghc
     , ghc-boot-th
-    , ghcide          ^>= 1.9 || ^>= 1.10
-    , hls-plugin-api  ^>=1.5 || ^>= 1.6
+    , ghcide          == 2.0.0.0
+    , hls-plugin-api  == 2.0.0.0
     , lens
     , lsp
     , process-extras  >= 0.7.1
@@ -63,5 +63,5 @@ test-suite tests
     , filepath
     , hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       ^>=1.6
+    , hls-test-utils       == 2.0.0.0
     , lsp-test

--- a/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
+++ b/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-gadt-plugin
-version:            1.0.2.0
+version:            2.0.0.0
 synopsis:           Convert to GADT syntax plugin
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-gadt-plugin#readme>
@@ -30,10 +30,10 @@ library
     , containers
     , extra
     , ghc
-    , ghcide                ^>= 1.10
+    , ghcide                 == 2.0.0.0
     , ghc-boot-th
     , ghc-exactprint
-    , hls-plugin-api        ^>= 1.6
+    , hls-plugin-api         == 2.0.0.0
     , hls-refactor-plugin
     , lens
     , lsp                    >=1.2.0.1
@@ -59,7 +59,7 @@ test-suite tests
     , base
     , filepath
     , hls-gadt-plugin
-    , hls-test-utils              ^>=1.6
+    , hls-test-utils              == 2.0.0.0
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
+++ b/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-haddock-comments-plugin
-version:            1.1.1.0
+version:            2.0.0.0
 synopsis:           Haddock comments plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server>
@@ -40,8 +40,8 @@ library
     , containers
     , ghc
     , ghc-exactprint        < 1
-    , ghcide                ^>=1.8 || ^>= 1.9 || ^>= 1.10
-    , hls-plugin-api        ^>=1.5 || ^>= 1.6
+    , ghcide                == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.0
     , hls-refactor-plugin
     , lsp-types
     , text
@@ -68,5 +68,5 @@ test-suite tests
     , base
     , filepath
     , hls-haddock-comments-plugin
-    , hls-test-utils               ^>=1.6
+    , hls-test-utils               == 2.0.0.0
     , text

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-hlint-plugin
-version:       1.1.2.0
+version:       2.0.0.0
 synopsis:      Hlint integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -47,10 +47,10 @@ library
     , extra
     , filepath
     , ghc-exactprint        >=0.6.3.4
-    , ghcide                ^>=1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hashable
     , hlint                 < 3.6
-    , hls-plugin-api        ^>=1.6
+    , hls-plugin-api        == 2.0.0.0
     , lens
     , lsp
     , refact
@@ -92,7 +92,7 @@ test-suite tests
     , filepath
     , hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      ^>=1.6
+    , hls-test-utils      == 2.0.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
+++ b/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-module-name-plugin
-version:            1.1.1.0
+version:            2.0.0.0
 synopsis:           Module name plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,8 +32,8 @@ library
     , base                  >=4.12 && <5
     , directory
     , filepath
-    , ghcide                ^>=1.9 || ^>= 1.10
-    , hls-plugin-api        ^>=1.6
+    , ghcide                == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.0
     , lsp
     , text
     , transformers
@@ -52,4 +52,4 @@ test-suite tests
     , base
     , filepath
     , hls-module-name-plugin
-    , hls-test-utils          ^>=1.6
+    , hls-test-utils          == 2.0.0.0

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-ormolu-plugin
-version:            1.0.4.0
+version:            2.0.0.0
 synopsis:           Integration with the Ormolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,8 +32,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          ^>=1.6 || ^>=1.7 || ^>= 1.8 || ^>= 1.9 || ^>= 1.10
-    , hls-plugin-api  ^>=1.3 || ^>=1.4 || ^>= 1.5 || ^>= 1.6
+    , ghcide          == 2.0.0.0
+    , hls-plugin-api  == 2.0.0.0
     , lens
     , lsp
     , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || ^>= 0.5
@@ -53,6 +53,6 @@ test-suite tests
     , base
     , filepath
     , hls-ormolu-plugin
-    , hls-test-utils     ^>=1.6
+    , hls-test-utils     == 2.0.0.0
     , lsp-types
     , ormolu

--- a/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
+++ b/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-pragmas-plugin
-version:            1.0.4.0
+version:            2.0.0.0
 synopsis:           Pragmas plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,8 +30,8 @@ library
     , extra
     , fuzzy
     , ghc
-    , ghcide                ^>=1.8 || ^>= 1.9 || ^>= 1.10
-    , hls-plugin-api        ^>=1.5 || ^>= 1.6
+    , ghcide                == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.0
     , lens
     , lsp
     , text
@@ -52,7 +52,7 @@ test-suite tests
     , base
     , filepath
     , hls-pragmas-plugin
-    , hls-test-utils      ^>=1.6
+    , hls-test-utils      == 2.0.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
+++ b/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-qualify-imported-names-plugin
-version:            1.0.2.0
+version:            2.0.0.0
 synopsis:           A Haskell Language Server plugin that qualifies imported names
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,9 +30,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                ^>=1.6 || ^>=1.7 || ^>= 1.8 || ^>= 1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hls-graph
-    , hls-plugin-api        ^>=1.3 || ^>=1.4 || ^>= 1.5 || ^>= 1.6
+    , hls-plugin-api        == 2.0.0.0
     , lsp
     , text
     , unordered-containers
@@ -55,4 +55,4 @@ test-suite tests
     , text
     , filepath
     , hls-qualify-imported-names-plugin
-    , hls-test-utils             ^>= 1.6
+    , hls-test-utils             == 2.0.0.0

--- a/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
+++ b/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-refactor-plugin
-version:            1.2.0.0
+version:            2.0.0.0
 synopsis:           Exactprint refactorings for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -68,8 +68,8 @@ library
     , ghc-boot
     , regex-tdfa
     , text-rope
-    , ghcide                ^>=1.10
-    , hls-plugin-api        ^>=1.6
+    , ghcide                == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.0
     , lsp
     , text
     , transformers
@@ -100,7 +100,7 @@ test-suite tests
     , base
     , filepath
     , hls-refactor-plugin
-    , hls-test-utils      ^>=1.6
+    , hls-test-utils      == 2.0.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
+++ b/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-refine-imports-plugin
-version:            1.0.5.0
+version:            2.0.0.0
 synopsis:           Refine imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,10 +29,10 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                       ^>=1.10
-    , hls-explicit-imports-plugin  ^>=1.2
+    , ghcide                       == 2.0.0.0
+    , hls-explicit-imports-plugin  == 2.0.0.0
     , hls-graph
-    , hls-plugin-api               ^>=1.6
+    , hls-plugin-api               == 2.0.0.0
     , lsp
     , text
     , unordered-containers

--- a/plugins/hls-rename-plugin/hls-rename-plugin.cabal
+++ b/plugins/hls-rename-plugin/hls-rename-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-rename-plugin
-version:            1.0.2.1
+version:            2.0.0.0
 synopsis:           Rename plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,11 +29,11 @@ library
     , extra
     , ghc
     , ghc-exactprint
-    , ghcide                ^>= 1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hashable
     , hiedb
     , hie-compat
-    , hls-plugin-api        ^>= 1.3 || ^>=1.4 || ^>= 1.5 || ^>= 1.6
+    , hls-plugin-api        == 2.0.0.0
     , hls-refactor-plugin
     , lsp
     , lsp-types
@@ -58,4 +58,4 @@ test-suite tests
     , filepath
     , hls-plugin-api
     , hls-rename-plugin
-    , hls-test-utils             ^>=1.6
+    , hls-test-utils             == 2.0.0.0

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-retrie-plugin
-version:            1.0.4.0
+version:            2.0.0.0
 synopsis:           Retrie integration plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,9 +28,9 @@ library
     , directory
     , extra
     , ghc
-    , ghcide                ^>=1.10
+    , ghcide                == 2.0.0.0
     , hashable
-    , hls-plugin-api        ^>=1.6
+    , hls-plugin-api        == 2.0.0.0
     , hls-refactor-plugin
     , lsp
     , lsp-types
@@ -63,5 +63,5 @@ test-suite tests
     , hls-plugin-api
     , hls-refactor-plugin
     , hls-retrie-plugin
-    , hls-test-utils             ^>=1.6
+    , hls-test-utils             == 2.0.0.0
     , text

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-splice-plugin
-version:            1.1.0.0
+version:            2.0.0.0
 synopsis:
   HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 
@@ -42,8 +42,8 @@ library
     , foldl
     , ghc
     , ghc-exactprint
-    , ghcide                ^>=1.10
-    , hls-plugin-api        ^>= 1.6
+    , ghcide                == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.0
     , hls-refactor-plugin
     , lens
     , lsp
@@ -69,5 +69,5 @@ test-suite tests
     , base
     , filepath
     , hls-splice-plugin
-    , hls-test-utils ^>= 1.6
+    , hls-test-utils == 2.0.0.0
     , text

--- a/plugins/hls-stan-plugin/hls-stan-plugin.cabal
+++ b/plugins/hls-stan-plugin/hls-stan-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-stan-plugin
-version:       1.0.1.0
+version:       2.0.0.0
 synopsis:      Stan integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -74,7 +74,7 @@ test-suite test
     , filepath
     , hls-stan-plugin
     , hls-plugin-api
-    , hls-test-utils      ^>=1.6
+    , hls-test-utils      == 2.0.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-stylish-haskell-plugin
-version:            1.0.1.3
+version:            2.0.0.0
 synopsis:           Integration with the Stylish Haskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,8 +30,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide           ^>=1.7 || ^>= 1.8 || ^>= 1.9 || ^>= 1.10
-    , hls-plugin-api   ^>=1.4 || ^>= 1.5 || ^>= 1.6
+    , ghcide           == 2.0.0.0
+    , hls-plugin-api   == 2.0.0.0
     , lsp-types
     , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14.2
     , text
@@ -50,4 +50,4 @@ test-suite tests
     , base
     , filepath
     , hls-stylish-haskell-plugin
-    , hls-test-utils              ^>=1.6
+    , hls-test-utils              == 2.0.0.0

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 category:           Development
 name:               hls-tactics-plugin
-version:            1.8.1.0
+version:            2.0.0.0
 synopsis:           Wingman plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -99,9 +99,9 @@ library
     , ghc-boot-th
     , ghc-exactprint
     , ghc-source-gen        ^>=0.4.1
-    , ghcide                ^>= 1.9 || ^>= 1.10
+    , ghcide                == 2.0.0.0
     , hls-graph
-    , hls-plugin-api        ^>=1.6
+    , hls-plugin-api        == 2.0.0.0
     , hls-refactor-plugin
     , hyphenation
     , lens
@@ -185,7 +185,7 @@ test-suite tests
     , ghcide
     , hls-plugin-api
     , hls-tactics-plugin
-    , hls-test-utils      ^>=1.6
+    , hls-test-utils      == 2.0.0.0
     , hspec
     , hspec-expectations
     , lens


### PR DESCRIPTION
Bump all packages to version 2.0.0.0.
    
This simplifies the release process as we can bump all package versions in
lockstep prior to a release instead of having to decide version bumps on a case
to case basis while adhering to PVP.

We don't test arbitrary configurations mixing versions of plugins/ghcide which
you might get if you install HLS from hackage. With this in mind, it makes sense
to pin the versions of all packages in this repository

Exceptions include:
- hie-compat (it is used by hiedb and is mostly separate from the other packages - it changes about once a GHC release)
- shake-bench (not meant to be distributed for users, for internal testing only
