### PR TITLE
Prepare 2.0.0.1 release (for GHC 9.6.2 and 9.2.8)

### DIFF
--- a/.github/scripts/bindist.sh
+++ b/.github/scripts/bindist.sh
@@ -25,7 +25,6 @@ case "${TARBALL_EXT}" in
 		: "${GHCS:="$(cd "$CI_PROJECT_DIR/out/${ARTIFACT}" && rm -f ./*.json && for ghc in * ; do printf "%s\n" "$ghc" ; done | sort -r | tr '\n' ' ')"}"
 		emake --version
 		emake GHCUP=ghcup ARTIFACT="${ARTIFACT}" GHCS="${GHCS}" bindist
-		emake GHCUP=ghcup                        GHCS="${GHCS}" clean-ghcs
 		emake GHCUP=ghcup ARTIFACT="${ARTIFACT}"                bindist-tar
         ;;
     *)

--- a/.github/scripts/bindist.sh
+++ b/.github/scripts/bindist.sh
@@ -25,8 +25,8 @@ case "${TARBALL_EXT}" in
 		: "${GHCS:="$(cd "$CI_PROJECT_DIR/out/${ARTIFACT}" && rm -f ./*.json && for ghc in * ; do printf "%s\n" "$ghc" ; done | sort -r | tr '\n' ' ')"}"
 		emake --version
 		emake GHCUP=ghcup ARTIFACT="${ARTIFACT}" GHCS="${GHCS}" bindist
-		emake GHCUP=ghcup ARTIFACT="${ARTIFACT}"                bindist-tar
 		emake GHCUP=ghcup                        GHCS="${GHCS}" clean-ghcs
+		emake GHCUP=ghcup ARTIFACT="${ARTIFACT}"                bindist-tar
         ;;
     *)
         fail "Unknown TARBALL_EXT: ${TARBALL_EXT}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.1", "9.4.5", "9.2.7", "9.0.2", "8.10.7"]
+        ghc: ["9.6.2", "9.4.5", "9.2.8", "9.2.7", "9.0.2", "8.10.7"]
         platform: [ { image: "debian:9"
                     , installCmd: "sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && sed -i /-updates/d /etc/apt/sources.list && apt-get update && apt-get install -y"
                     , toolRequirements: "libnuma-dev zlib1g-dev libgmp-dev libgmp10 libssl-dev liblzma-dev libbz2-dev git wget lsb-release software-properties-common gnupg2 apt-transport-https gcc autoconf automake build-essential curl ghc gzip libffi-dev libncurses-dev libncurses5 libtinfo5 patchelf"
@@ -113,9 +113,11 @@ jobs:
             platform: { image: "rockylinux:8", installCmd: "yum -y install epel-release && yum install -y --allowerasing", toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf", DISTRO: "Unknown", ARTIFACT: "x86_64-linux-unknown", ADD_CABAL_ARGS: "--enable-split-sections" }
           - ghc: 9.2.7
             platform: { image: "rockylinux:8", installCmd: "yum -y install epel-release && yum install -y --allowerasing", toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf", DISTRO: "Unknown", ARTIFACT: "x86_64-linux-unknown", ADD_CABAL_ARGS: "--enable-split-sections" }
+          - ghc: 9.2.8
+            platform: { image: "rockylinux:8", installCmd: "yum -y install epel-release && yum install -y --allowerasing", toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf", DISTRO: "Unknown", ARTIFACT: "x86_64-linux-unknown", ADD_CABAL_ARGS: "--enable-split-sections" }
           - ghc: 9.4.5
             platform: { image: "fedora:33", installCmd: "dnf install -y", toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf tree", DISTRO: "Unknown", ARTIFACT: "x86_64-linux-unknown", ADD_CABAL_ARGS: "--enable-split-sections" }
-          - ghc: 9.6.1
+          - ghc: 9.6.2
             platform: { image: "rockylinux:8", installCmd: "yum -y install epel-release && yum install -y --allowerasing", toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf", DISTRO: "Unknown", ARTIFACT: "x86_64-linux-unknown", ADD_CABAL_ARGS: "--enable-split-sections" }
     container:
       image: ${{ matrix.platform.image }}
@@ -171,7 +173,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: ["9.6.1","9.4.5", "9.2.7", "9.0.2", "8.10.7"]
+        ghc: ["9.6.2", "9.2.8", "9.2.7", "9.0.2", "8.10.7"]
     steps:
       - uses: docker://arm64v8/ubuntu:focal
         name: Cleanup (aarch64 linux)
@@ -226,7 +228,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.1", "9.4.5", "9.2.7", "9.0.2", "8.10.7"]
+        ghc: ["9.6.2", "9.4.5", "9.2.8", "9.2.7", "9.0.2", "8.10.7"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -266,7 +268,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.1", "9.4.5", "9.2.7", "8.10.7"]
+        ghc: ["9.6.2", "9.4.5", "9.2.8", "9.2.7", "8.10.7"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -315,7 +317,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.1", "9.4.5", "9.2.7", "9.0.2", "8.10.7"]
+        ghc: ["9.6.2", "9.4.5", "9.2.8", "9.2.7", "9.0.2", "8.10.7"]
     steps:
       - name: install windows deps
         shell: pwsh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,7 +158,7 @@ jobs:
 
   build-arm:
     name: Build ARM binary
-    runs-on: [self-hosted, Linux, ARM64, beefy]
+    runs-on: [self-hosted, Linux, ARM64]
     env:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -352,7 +352,7 @@ jobs:
 
   bindist-linux:
     name: Tar linux bindists (linux)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux-space]
     needs: ["build-linux"]
     env:
       TARBALL_EXT: tar.xz

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for haskell-language-server
 
+## 2.0.0.1
+
+- Add overloaded record dot plugin intial version (closes #3350) (#3560)
+- Binaries for GHC 9.2.8 and GHC 9.6.2
+
 ## 2.0.0.0
 
 - New versioning scheme for all packages distributed as part of HLS,
@@ -95,7 +100,7 @@
 ([#3411](https://github.com/haskell/haskell-language-server/pull/3411)) by @pepeiborra
 - Support fourmolu 0.10
 ([#3410](https://github.com/haskell/haskell-language-server/pull/3410)) by @brandonchinn178
-- Fix nix build CI 
+- Fix nix build CI
 ([#3404](https://github.com/haskell/haskell-language-server/pull/3404)) by @wavewave
 - Fix fourmolu with -f-fixity-th in nix env
 ([#3400](https://github.com/haskell/haskell-language-server/pull/3400)) by @wavewave
@@ -145,7 +150,7 @@
 ([#3339](https://github.com/haskell/haskell-language-server/pull/3339)) by @santiweight
 - Add hls-cabal-fmt-plugin to hackage release CI script and HLS library
 ([#3335](https://github.com/haskell/haskell-language-server/pull/3335)) by @fendor
-- Ensure at least 1 capability 
+- Ensure at least 1 capability
 ([#3334](https://github.com/haskell/haskell-language-server/pull/3334)) by @pepeiborra
 - Add support for Fourmolu 0.9
 ([#3331](https://github.com/haskell/haskell-language-server/pull/3331)) by @brandonchinn178
@@ -324,7 +329,7 @@
 - Initial support for GHC 9.4 with binaries for GHC 9.4.1 and GHC 9.4.2
 - Startup time and performance improvements on projects using Template Haskell by serializing intermediate core (#2813)
 - Memory usage improvements due to using a packed representation for filepaths (#3067, @kokobd)
-- Improvements for hls-class-plugin (#2920, @July541) 
+- Improvements for hls-class-plugin (#2920, @July541)
 - The new hls-gadt-plugin (#2899, @July541)
 - Moving code actions from ghcide to the new hls-refactor-plugin (#3091, @wz1000)
 - Many more improvements and bug fixes thanks to our contributors!
@@ -549,7 +554,7 @@
 ([#2873](https://github.com/haskell/haskell-language-server/pull/2873)) by @pepeiborra
 - Expand input to pragma if available
 ([#2871](https://github.com/haskell/haskell-language-server/pull/2871)) by @July541
-- Fix hanging redundant import on Unicode function 
+- Fix hanging redundant import on Unicode function
 ([#2870](https://github.com/haskell/haskell-language-server/pull/2870)) by @drsooch
 - Compatibility with older aeson releases
 ([#2868](https://github.com/haskell/haskell-language-server/pull/2868)) by @pepeiborra
@@ -754,7 +759,7 @@
 - Improve logging
 ([#2558](https://github.com/haskell/haskell-language-server/pull/2558)) by @eddiemundo
 - Improve recompilation avoidance in the presence of TH
-([#2316](https://github.com/haskell/haskell-language-server/pull/2316)) by @wz1000 
+([#2316](https://github.com/haskell/haskell-language-server/pull/2316)) by @wz1000
 
 ## 1.6.1.1 (*only hackage release*)
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -43,6 +43,7 @@ CP        := cp
 # by default don't run ghcup
 GHCUP       ?= echo
 GHCUP_GC    ?= $(GHCUP) gc
+GHCUP_RM    ?= $(GHCUP) rm
 
 CABAL_CACHE_BIN ?= echo
 
@@ -87,7 +88,8 @@ hls:
 	for ghc in $(GHCS) ; do \
 		$(GHCUP) install ghc `echo $$ghc` && \
 		$(GHCUP_GC) -p -s -c -t && \
-		$(MAKE) GHC_VERSION=`echo $$ghc` hls-ghc || exit 1 ; \
+		$(MAKE) GHC_VERSION=`echo $$ghc` hls-ghc || exit 1 && \
+		$(GHCUP_RM) `echo $$ghc` ; \
 	done
 
 hls-ghc:
@@ -108,7 +110,8 @@ bindist:
 	for ghc in $(GHCS) ; do \
 		$(GHCUP) install ghc `echo $$ghc` && \
 		$(GHCUP_GC) -p -s -c -t && \
-		$(MAKE) GHC_VERSION=`echo $$ghc` bindist-ghc || exit 1 ; \
+		$(MAKE) GHC_VERSION=`echo $$ghc` bindist-ghc || exit 1 && \
+		$(GHCUP_RM) `echo $$ghc` ; \
 	done
 	$(SED) -e "s/@@HLS_VERSION@@/$(HLS_VERSION)/" \
 		bindist/GNUmakefile.in > "$(BINDIST_OUT_DIR)/GNUmakefile"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,30 @@
+# Releasing
+
+## Release checklist
+
+- [ ] check ghcup supports new GHC releases if any
+- [ ] set the supported GHCs in workflow file `.github/workflows/release.yaml`
+- [ ] check all plugins still work if release includes code changes
+- [ ] bump package versions in all `*.cabal` files (same version as hls)
+- [ ] generate and update changelog
+- [ ] create release branch as `wip/<version>`
+- [ ] create release tag as `<version>`
+- [ ] trigger release pipeline by pushing the tag
+  - this creates a draft release
+- [ ] run `sh scripts/release/download-gh-artifacts <version> <your-gpg-email>`
+  - downloads artifacts to `gh-release-artifacts/<version>/`
+  - also downloads FreeBSD bindist from circle CI
+  - adds signatures
+- [ ] upload artifacts to downloads.haskell.org manually from `gh-release-artifacts/<version>/`
+- [ ] create PR to [ghcup-metadata](https://github.com/haskell/ghcup-metadata)
+  - [ ] update `ghcup-0.0.7.yaml` and `ghcup-vanilla-0.0.7.yaml`
+    - can use `sh scripts/release/create-yaml-snippet.sh <version>` to generate a snippet that can be manually inserted into the yaml files
+  - [ ] update `hls-metadata-0.0.1.json`
+    - utilize `cabal run ghcup-gen -- generate-hls-ghcs -f ghcup-0.0.7.yaml --format json --stdout` in the root of ghcup-metadata repository
+- [ ] get sign-off on release
+  - from wz1000, michealpj, maerwald and fendor
+- [ ] publish release on github
+- [ ] upload hackage packages
+  - requires credentials
+- [ ] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
+- [ ] post release on discourse and reddit

--- a/ghcide-bench/ghcide-bench.cabal
+++ b/ghcide-bench/ghcide-bench.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide-bench
-version:            2.0.0.0
+version:            2.0.0.1
 license:            Apache-2.0
 license-file:       LICENSE
 author:             The Haskell IDE team

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            2.0.0.0
+version:            2.0.0.1
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -65,7 +65,7 @@ library
         haddock-library >= 1.8 && < 1.12,
         hashable,
         hie-compat ^>= 0.3.0.0,
-        hls-plugin-api == 2.0.0.0,
+        hls-plugin-api == 2.0.0.1,
         lens,
         list-t,
         hiedb == 0.4.3.*,
@@ -80,7 +80,7 @@ library
         regex-tdfa >= 1.3.1.0,
         text-rope,
         safe-exceptions,
-        hls-graph == 2.0.0.0,
+        hls-graph == 2.0.0.1,
         sorted-list,
         sqlite-simple,
         stm,

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 category:           Development
 name:               haskell-language-server
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -218,149 +218,149 @@ flag cabalfmt
 
 common cabalfmt
   if flag(cabalfmt)
-    build-depends: hls-cabal-fmt-plugin == 2.0.0.0
+    build-depends: hls-cabal-fmt-plugin == 2.0.0.1
     cpp-options: -Dhls_cabalfmt
 
 common cabal
   if flag(cabal)
-    build-depends: hls-cabal-plugin == 2.0.0.0
+    build-depends: hls-cabal-plugin == 2.0.0.1
     cpp-options: -Dhls_cabal
 
 common class
   if flag(class)
-    build-depends: hls-class-plugin == 2.0.0.0
+    build-depends: hls-class-plugin == 2.0.0.1
     cpp-options: -Dhls_class
 
 common callHierarchy
   if flag(callHierarchy)
-    build-depends: hls-call-hierarchy-plugin == 2.0.0.0
+    build-depends: hls-call-hierarchy-plugin == 2.0.0.1
     cpp-options: -Dhls_callHierarchy
 
 common haddockComments
   if flag(haddockComments) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-haddock-comments-plugin == 2.0.0.0
+    build-depends: hls-haddock-comments-plugin == 2.0.0.1
     cpp-options: -Dhls_haddockComments
 
 common eval
   if flag(eval)
-    build-depends: hls-eval-plugin == 2.0.0.0
+    build-depends: hls-eval-plugin == 2.0.0.1
     cpp-options: -Dhls_eval
 
 common importLens
   if flag(importLens)
-    build-depends: hls-explicit-imports-plugin == 2.0.0.0
+    build-depends: hls-explicit-imports-plugin == 2.0.0.1
     cpp-options: -Dhls_importLens
 
 common refineImports
   if flag(refineImports)
-    build-depends: hls-refine-imports-plugin == 2.0.0.0
+    build-depends: hls-refine-imports-plugin == 2.0.0.1
     cpp-options: -Dhls_refineImports
 
 common rename
   if flag(rename)
-    build-depends: hls-rename-plugin == 2.0.0.0
+    build-depends: hls-rename-plugin == 2.0.0.1
     cpp-options: -Dhls_rename
 
 common retrie
   if flag(retrie)
-    build-depends: hls-retrie-plugin == 2.0.0.0
+    build-depends: hls-retrie-plugin == 2.0.0.1
     cpp-options: -Dhls_retrie
 
 common tactic
   if flag(tactic) && (impl(ghc < 9.2.1) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-tactics-plugin == 2.0.0.0
+    build-depends: hls-tactics-plugin == 2.0.0.1
     cpp-options: -Dhls_tactic
 
 common hlint
   if flag(hlint) && impl(ghc < 9.5)
-    build-depends: hls-hlint-plugin == 2.0.0.0
+    build-depends: hls-hlint-plugin == 2.0.0.1
     cpp-options: -Dhls_hlint
 
 common stan
   if flag(stan) && (impl(ghc >= 8.10) && impl(ghc < 9.0))
-    build-depends: hls-stan-plugin == 2.0.0.0
+    build-depends: hls-stan-plugin == 2.0.0.1
     cpp-options: -Dhls_stan
 
 common moduleName
   if flag(moduleName)
-    build-depends: hls-module-name-plugin == 2.0.0.0
+    build-depends: hls-module-name-plugin == 2.0.0.1
     cpp-options: -Dhls_moduleName
 
 common pragmas
   if flag(pragmas)
-    build-depends: hls-pragmas-plugin == 2.0.0.0
+    build-depends: hls-pragmas-plugin == 2.0.0.1
     cpp-options: -Dhls_pragmas
 
 common splice
   if flag(splice)
-    build-depends: hls-splice-plugin == 2.0.0.0
+    build-depends: hls-splice-plugin == 2.0.0.1
     cpp-options: -Dhls_splice
 
 common alternateNumberFormat
   if flag(alternateNumberFormat)
-    build-depends: hls-alternate-number-format-plugin == 2.0.0.0
+    build-depends: hls-alternate-number-format-plugin == 2.0.0.1
     cpp-options: -Dhls_alternateNumberFormat
 
 common qualifyImportedNames
   if flag(qualifyImportedNames)
-    build-depends: hls-qualify-imported-names-plugin == 2.0.0.0
+    build-depends: hls-qualify-imported-names-plugin == 2.0.0.1
     cpp-options: -Dhls_qualifyImportedNames
 
 common codeRange
   if flag(codeRange)
-    build-depends: hls-code-range-plugin == 2.0.0.0
+    build-depends: hls-code-range-plugin == 2.0.0.1
     cpp-options: -Dhls_codeRange
 
 common changeTypeSignature
   if flag(changeTypeSignature)
-    build-depends: hls-change-type-signature-plugin == 2.0.0.0
+    build-depends: hls-change-type-signature-plugin == 2.0.0.1
     cpp-options: -Dhls_changeTypeSignature
 
 common gadt
   if flag(gadt)
-    build-depends: hls-gadt-plugin == 2.0.0.0
+    build-depends: hls-gadt-plugin == 2.0.0.1
     cpp-options: -Dhls_gadt
 
 common explicitFixity
   if flag(explicitFixity)
-    build-depends: hls-explicit-fixity-plugin == 2.0.0.0
+    build-depends: hls-explicit-fixity-plugin == 2.0.0.1
     cpp-options: -DexplicitFixity
 
 common explicitFields
   if flag(explicitFields)
-    build-depends: hls-explicit-record-fields-plugin == 2.0.0.0
+    build-depends: hls-explicit-record-fields-plugin == 2.0.0.1
     cpp-options: -DexplicitFields
 
 common overloadedRecordDot
   if flag(overloadedRecordDot) && (impl(ghc >= 9.2.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-overloaded-record-dot-plugin == 2.0.0.0
+    build-depends: hls-overloaded-record-dot-plugin == 2.0.0.1
     cpp-options: -Dhls_overloaded_record_dot
 
 -- formatters
 
 common floskell
   if flag(floskell) && impl(ghc < 9.5)
-    build-depends: hls-floskell-plugin == 2.0.0.0
+    build-depends: hls-floskell-plugin == 2.0.0.1
     cpp-options: -Dhls_floskell
 
 common fourmolu
   if flag(fourmolu)
-    build-depends: hls-fourmolu-plugin == 2.0.0.0
+    build-depends: hls-fourmolu-plugin == 2.0.0.1
     cpp-options: -Dhls_fourmolu
 
 common ormolu
   if flag(ormolu) && impl(ghc < 9.5)
-    build-depends: hls-ormolu-plugin == 2.0.0.0
+    build-depends: hls-ormolu-plugin == 2.0.0.1
     cpp-options: -Dhls_ormolu
 
 common stylishHaskell
   if flag(stylishHaskell) && impl(ghc < 9.5)
-    build-depends: hls-stylish-haskell-plugin == 2.0.0.0
+    build-depends: hls-stylish-haskell-plugin == 2.0.0.1
     cpp-options: -Dhls_stylishHaskell
 
 common refactor
   if flag(refactor)
-    build-depends: hls-refactor-plugin == 2.0.0.0
+    build-depends: hls-refactor-plugin == 2.0.0.1
     cpp-options: -Dhls_refactor
 
 library
@@ -416,12 +416,12 @@ library
     , cryptohash-sha1
     , data-default
     , ghc
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , githash               >=0.1.6.1
     , lsp
     , hie-bios
     , hiedb
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , optparse-applicative
     , optparse-simple
     , process
@@ -560,7 +560,7 @@ test-suite func-test
     , lens-aeson
     , ghcide
     , ghcide-test-utils
-    , hls-test-utils == 2.0.0.0
+    , hls-test-utils == 2.0.0.1
     , lsp-types
     , aeson
     , hls-plugin-api

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-graph
-version:       2.0.0.0
+version:       2.0.0.1
 synopsis:      Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       2.0.0.0
+version:       2.0.0.1
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -55,7 +55,7 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             == 2.0.0.0
+    , hls-graph             == 2.0.0.1
     , lens
     , lens-aeson
     , lsp                   ^>=1.6.0.0

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       2.0.0.0
+version:       2.0.0.1
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -41,9 +41,9 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  == 2.0.0.0
+    , ghcide                  == 2.0.0.1
     , hls-graph
-    , hls-plugin-api          == 2.0.0.0
+    , hls-plugin-api          == 2.0.0.1
     , lens
     , lsp                     ^>=1.6.0.0
     , lsp-test                ^>=0.14

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-alternate-number-format-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Provide Alternate Number Formats plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,10 +32,10 @@ library
     , base                 >=4.12 && < 5
     , containers
     , extra
-    , ghcide               == 2.0.0.0
+    , ghcide               == 2.0.0.1
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       == 2.0.0.0
+    , hls-plugin-api       == 2.0.0.1
     , hie-compat
     , lens
     , lsp                  ^>=1.6
@@ -64,7 +64,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-alternate-number-format-plugin
-    , hls-test-utils       == 2.0.0.0
+    , hls-test-utils       == 2.0.0.1
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
+++ b/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-cabal-fmt-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Integration with the cabal-fmt code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -33,8 +33,8 @@ library
     , base            >=4.12 && <5
     , directory
     , filepath
-    , ghcide          == 2.0.0.0
-    , hls-plugin-api  == 2.0.0.0
+    , ghcide          == 2.0.0.1
+    , hls-plugin-api  == 2.0.0.1
     , lens
     , lsp-types
     , process
@@ -55,7 +55,7 @@ test-suite tests
     , directory
     , filepath
     , hls-cabal-fmt-plugin
-    , hls-test-utils        == 2.0.0.0
+    , hls-test-utils        == 2.0.0.1
 
   if flag(isolateTests)
     build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.6

--- a/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
+++ b/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-cabal-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Cabal integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -48,10 +48,10 @@ library
     , deepseq
     , directory
     , extra                 >=1.7.4
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hashable
-    , hls-plugin-api        == 2.0.0.0
-    , hls-graph             == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
+    , hls-graph             == 2.0.0.1
     , lsp                   ^>=1.6.0.0
     , lsp-types             ^>=1.6.0.0
     , regex-tdfa            ^>=1.3.1
@@ -74,7 +74,7 @@ test-suite tests
     , filepath
     , ghcide
     , hls-cabal-plugin
-    , hls-test-utils    == 2.0.0.0
+    , hls-test-utils    == 2.0.0.1
     , lens
     , lsp-types
     , tasty-hunit

--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-call-hierarchy-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Call hierarchy plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-call-hierarchy-plugin#readme>
@@ -33,9 +33,9 @@ library
     , base                  >=4.12 && <5
     , containers
     , extra
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hiedb
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , lens
     , lsp                    >=1.2.0.1
     , sqlite-simple
@@ -59,7 +59,7 @@ test-suite tests
     , extra
     , filepath
     , hls-call-hierarchy-plugin
-    , hls-test-utils              == 2.0.0.0
+    , hls-test-utils              == 2.0.0.1
     , ghcide-test-utils
     , lens
     , lsp

--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-change-type-signature-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Change a declarations type signature with a Code Action
 description:
   Please see the README on GitHub at <https://github.com/haskell/plugins/hls-change-type-signature-plugin/README.md>
@@ -28,8 +28,8 @@ library
   hs-source-dirs:   src
   build-depends:
     , base             >=4.12 && < 5
-    , ghcide           == 2.0.0.0
-    , hls-plugin-api   == 2.0.0.0
+    , ghcide           == 2.0.0.1
+    , hls-plugin-api   == 2.0.0.1
     , lsp-types
     , regex-tdfa
     , syb
@@ -61,7 +61,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-change-type-signature-plugin
-    , hls-test-utils       == 2.0.0.0
+    , hls-test-utils       == 2.0.0.1
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-class-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:
   Class/instance management plugin for Haskell Language Server
 
@@ -39,10 +39,10 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide          == 2.0.0.0
+    , ghcide          == 2.0.0.1
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api  == 2.0.0.0
+    , hls-plugin-api  == 2.0.0.1
     , lens
     , lsp
     , text
@@ -74,7 +74,7 @@ test-suite tests
     , ghcide
     , hls-class-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.0.0.0
+    , hls-test-utils     == 2.0.0.1
     , lens
     , lsp-types
     , text

--- a/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
+++ b/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-code-range-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:
   HLS Plugin to support smart selection range and Folding range
 
@@ -37,9 +37,9 @@ library
     , containers
     , deepseq
     , extra
-    , ghcide           == 2.0.0.0
+    , ghcide           == 2.0.0.1
     , hashable
-    , hls-plugin-api   == 2.0.0.0
+    , hls-plugin-api   == 2.0.0.1
     , lens
     , lsp
     , mtl
@@ -62,9 +62,9 @@ test-suite tests
     , bytestring
     , containers
     , filepath
-    , ghcide                     == 2.0.0.0
+    , ghcide                     == 2.0.0.1
     , hls-code-range-plugin
-    , hls-test-utils             == 2.0.0.0
+    , hls-test-utils             == 2.0.0.1
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-eval-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Eval plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -66,10 +66,10 @@ library
     , ghc
     , ghc-boot-th
     , ghc-paths
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hashable
     , hls-graph
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , lens
     , lsp
     , lsp-types
@@ -111,7 +111,7 @@ test-suite tests
     , filepath
     , hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   == 2.0.0.0
+    , hls-test-utils   == 2.0.0.1
     , lens
     , lsp-types
     , text

--- a/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
+++ b/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-explicit-fixity-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Show fixity explicitly while hovering
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-explicit-fixity-plugin#readme>
@@ -30,9 +30,9 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hashable
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , lsp                   >=1.2.0.1
     , text
     , transformers
@@ -55,5 +55,5 @@ test-suite tests
     , base
     , filepath
     , hls-explicit-fixity-plugin
-    , hls-test-utils              == 2.0.0.0
+    , hls-test-utils              == 2.0.0.1
     , text

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-explicit-imports-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Explicit imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,9 +29,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hls-graph
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , lsp
     , text
     , unordered-containers

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-explicit-record-fields-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Explicit record fields plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,8 +29,8 @@ library
     -- other-extensions:
     build-depends:
       , base                  >=4.12 && <5
-      , ghcide                == 2.0.0.0
-      , hls-plugin-api        == 2.0.0.0
+      , ghcide                == 2.0.0.1
+      , hls-plugin-api        == 2.0.0.1
       , lsp
       , lens
       , hls-graph

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-floskell-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Integration with the Floskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,8 +28,8 @@ library
   build-depends:
     , base            >=4.12 && <5
     , floskell        ^>=0.10
-    , ghcide          == 2.0.0.0
-    , hls-plugin-api  == 2.0.0.0
+    , ghcide          == 2.0.0.1
+    , hls-plugin-api  == 2.0.0.1
     , lsp-types       ^>=1.6
     , text
     , transformers
@@ -48,4 +48,4 @@ test-suite tests
     , base
     , filepath
     , hls-floskell-plugin
-    , hls-test-utils       == 2.0.0.0
+    , hls-test-utils       == 2.0.0.1

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-fourmolu-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Integration with the Fourmolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -35,8 +35,8 @@ library
     , fourmolu        ^>=0.3 || ^>=0.4 || ^>= 0.6 || ^>= 0.7 || ^>= 0.8 || ^>= 0.9 || ^>= 0.10 || ^>= 0.11 || ^>= 0.12
     , ghc
     , ghc-boot-th
-    , ghcide          == 2.0.0.0
-    , hls-plugin-api  == 2.0.0.0
+    , ghcide          == 2.0.0.1
+    , hls-plugin-api  == 2.0.0.1
     , lens
     , lsp
     , process-extras  >= 0.7.1
@@ -63,5 +63,5 @@ test-suite tests
     , filepath
     , hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       == 2.0.0.0
+    , hls-test-utils       == 2.0.0.1
     , lsp-test

--- a/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
+++ b/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-gadt-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Convert to GADT syntax plugin
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-gadt-plugin#readme>
@@ -30,10 +30,10 @@ library
     , containers
     , extra
     , ghc
-    , ghcide                 == 2.0.0.0
+    , ghcide                 == 2.0.0.1
     , ghc-boot-th
     , ghc-exactprint
-    , hls-plugin-api         == 2.0.0.0
+    , hls-plugin-api         == 2.0.0.1
     , hls-refactor-plugin
     , lens
     , lsp                    >=1.2.0.1
@@ -59,7 +59,7 @@ test-suite tests
     , base
     , filepath
     , hls-gadt-plugin
-    , hls-test-utils              == 2.0.0.0
+    , hls-test-utils              == 2.0.0.1
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
+++ b/plugins/hls-haddock-comments-plugin/hls-haddock-comments-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-haddock-comments-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Haddock comments plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server>
@@ -40,8 +40,8 @@ library
     , containers
     , ghc
     , ghc-exactprint        < 1
-    , ghcide                == 2.0.0.0
-    , hls-plugin-api        == 2.0.0.0
+    , ghcide                == 2.0.0.1
+    , hls-plugin-api        == 2.0.0.1
     , hls-refactor-plugin
     , lsp-types
     , text
@@ -68,5 +68,5 @@ test-suite tests
     , base
     , filepath
     , hls-haddock-comments-plugin
-    , hls-test-utils               == 2.0.0.0
+    , hls-test-utils               == 2.0.0.1
     , text

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-hlint-plugin
-version:       2.0.0.0
+version:            2.0.0.1
 synopsis:      Hlint integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -47,10 +47,10 @@ library
     , extra
     , filepath
     , ghc-exactprint        >=0.6.3.4
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hashable
     , hlint                 < 3.6
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , lens
     , lsp
     , refact
@@ -92,7 +92,7 @@ test-suite tests
     , filepath
     , hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.0.0.0
+    , hls-test-utils      == 2.0.0.1
     , lens
     , lsp-types
     , text

--- a/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
+++ b/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-module-name-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Module name plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,8 +32,8 @@ library
     , base                  >=4.12 && <5
     , directory
     , filepath
-    , ghcide                == 2.0.0.0
-    , hls-plugin-api        == 2.0.0.0
+    , ghcide                == 2.0.0.1
+    , hls-plugin-api        == 2.0.0.1
     , lsp
     , text
     , transformers
@@ -52,4 +52,4 @@ test-suite tests
     , base
     , filepath
     , hls-module-name-plugin
-    , hls-test-utils          == 2.0.0.0
+    , hls-test-utils          == 2.0.0.1

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-ormolu-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Integration with the Ormolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,8 +32,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          == 2.0.0.0
-    , hls-plugin-api  == 2.0.0.0
+    , ghcide          == 2.0.0.1
+    , hls-plugin-api  == 2.0.0.1
     , lens
     , lsp
     , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || ^>= 0.5
@@ -53,6 +53,6 @@ test-suite tests
     , base
     , filepath
     , hls-ormolu-plugin
-    , hls-test-utils     == 2.0.0.0
+    , hls-test-utils     == 2.0.0.1
     , lsp-types
     , ormolu

--- a/plugins/hls-overloaded-record-dot-plugin/hls-overloaded-record-dot-plugin.cabal
+++ b/plugins/hls-overloaded-record-dot-plugin/hls-overloaded-record-dot-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-overloaded-record-dot-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Overloaded record dot plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
+++ b/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-pragmas-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Pragmas plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,8 +30,8 @@ library
     , extra
     , fuzzy
     , ghc
-    , ghcide                == 2.0.0.0
-    , hls-plugin-api        == 2.0.0.0
+    , ghcide                == 2.0.0.1
+    , hls-plugin-api        == 2.0.0.1
     , lens
     , lsp
     , text
@@ -52,7 +52,7 @@ test-suite tests
     , base
     , filepath
     , hls-pragmas-plugin
-    , hls-test-utils      == 2.0.0.0
+    , hls-test-utils      == 2.0.0.1
     , lens
     , lsp-types
     , text

--- a/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
+++ b/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-qualify-imported-names-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           A Haskell Language Server plugin that qualifies imported names
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,9 +30,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hls-graph
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , lsp
     , text
     , unordered-containers
@@ -55,4 +55,4 @@ test-suite tests
     , text
     , filepath
     , hls-qualify-imported-names-plugin
-    , hls-test-utils             == 2.0.0.0
+    , hls-test-utils             == 2.0.0.1

--- a/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
+++ b/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-refactor-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Exactprint refactorings for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -68,8 +68,8 @@ library
     , ghc-boot
     , regex-tdfa
     , text-rope
-    , ghcide                == 2.0.0.0
-    , hls-plugin-api        == 2.0.0.0
+    , ghcide                == 2.0.0.1
+    , hls-plugin-api        == 2.0.0.1
     , lsp
     , text
     , transformers
@@ -100,7 +100,7 @@ test-suite tests
     , base
     , filepath
     , hls-refactor-plugin
-    , hls-test-utils      == 2.0.0.0
+    , hls-test-utils      == 2.0.0.1
     , lens
     , lsp-types
     , text

--- a/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
+++ b/plugins/hls-refine-imports-plugin/hls-refine-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-refine-imports-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Refine imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,10 +29,10 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                       == 2.0.0.0
-    , hls-explicit-imports-plugin  == 2.0.0.0
+    , ghcide                       == 2.0.0.1
+    , hls-explicit-imports-plugin  == 2.0.0.1
     , hls-graph
-    , hls-plugin-api               == 2.0.0.0
+    , hls-plugin-api               == 2.0.0.1
     , lsp
     , text
     , unordered-containers

--- a/plugins/hls-rename-plugin/hls-rename-plugin.cabal
+++ b/plugins/hls-rename-plugin/hls-rename-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-rename-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Rename plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,11 +29,11 @@ library
     , extra
     , ghc
     , ghc-exactprint
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hashable
     , hiedb
     , hie-compat
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , hls-refactor-plugin
     , lsp
     , lsp-types
@@ -58,4 +58,4 @@ test-suite tests
     , filepath
     , hls-plugin-api
     , hls-rename-plugin
-    , hls-test-utils             == 2.0.0.0
+    , hls-test-utils             == 2.0.0.1

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-retrie-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Retrie integration plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,9 +28,9 @@ library
     , directory
     , extra
     , ghc
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hashable
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , hls-refactor-plugin
     , lsp
     , lsp-types
@@ -63,5 +63,5 @@ test-suite tests
     , hls-plugin-api
     , hls-refactor-plugin
     , hls-retrie-plugin
-    , hls-test-utils             == 2.0.0.0
+    , hls-test-utils             == 2.0.0.1
     , text

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-splice-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:
   HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 
@@ -42,8 +42,8 @@ library
     , foldl
     , ghc
     , ghc-exactprint
-    , ghcide                == 2.0.0.0
-    , hls-plugin-api        == 2.0.0.0
+    , ghcide                == 2.0.0.1
+    , hls-plugin-api        == 2.0.0.1
     , hls-refactor-plugin
     , lens
     , lsp
@@ -69,5 +69,5 @@ test-suite tests
     , base
     , filepath
     , hls-splice-plugin
-    , hls-test-utils == 2.0.0.0
+    , hls-test-utils == 2.0.0.1
     , text

--- a/plugins/hls-stan-plugin/hls-stan-plugin.cabal
+++ b/plugins/hls-stan-plugin/hls-stan-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-stan-plugin
-version:       2.0.0.0
+version:            2.0.0.1
 synopsis:      Stan integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -74,7 +74,7 @@ test-suite test
     , filepath
     , hls-stan-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.0.0.0
+    , hls-test-utils      == 2.0.0.1
     , lens
     , lsp-types
     , text

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-stylish-haskell-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Integration with the Stylish Haskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,8 +30,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide           == 2.0.0.0
-    , hls-plugin-api   == 2.0.0.0
+    , ghcide           == 2.0.0.1
+    , hls-plugin-api   == 2.0.0.1
     , lsp-types
     , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14.2
     , text
@@ -50,4 +50,4 @@ test-suite tests
     , base
     , filepath
     , hls-stylish-haskell-plugin
-    , hls-test-utils              == 2.0.0.0
+    , hls-test-utils              == 2.0.0.1

--- a/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
+++ b/plugins/hls-tactics-plugin/hls-tactics-plugin.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 category:           Development
 name:               hls-tactics-plugin
-version:            2.0.0.0
+version:            2.0.0.1
 synopsis:           Wingman plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -99,9 +99,9 @@ library
     , ghc-boot-th
     , ghc-exactprint
     , ghc-source-gen        ^>=0.4.1
-    , ghcide                == 2.0.0.0
+    , ghcide                == 2.0.0.1
     , hls-graph
-    , hls-plugin-api        == 2.0.0.0
+    , hls-plugin-api        == 2.0.0.1
     , hls-refactor-plugin
     , hyphenation
     , lens
@@ -185,7 +185,7 @@ test-suite tests
     , ghcide
     , hls-plugin-api
     , hls-tactics-plugin
-    , hls-test-utils      == 2.0.0.0
+    , hls-test-utils      == 2.0.0.1
     , hspec
     , hspec-expectations
     , lens

--- a/scripts/release/create-yaml-snippet.sh
+++ b/scripts/release/create-yaml-snippet.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+RELEASE=$1
+
+cd "gh-release-artifacts/${RELEASE}"
+
+cat <<EOF > /dev/stdout
+    $RELEASE:
+      viTags:
+        - Latest
+      viChangeLog: https://github.com/haskell/haskell-language-server/blob/master/ChangeLog.md
+      viPostInstall: *hls-post-install
+      viSourceDL:
+        dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-src.tar.gz
+        dlSubdir: haskell-language-server-$RELEASE
+        dlHash: $(sha256sum "haskell-language-server-$RELEASE-src.tar.gz" | awk '{ print $1 }')
+      viArch:
+        A_64:
+          Linux_Debian:
+            '< 10': &hls-${RELEASE//./}-64-deb9
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-deb9.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-deb9.tar.xz" | awk '{ print $1 }')
+            '(>= 10 && < 11)': &hls-${RELEASE//./}-64-deb10
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-deb10.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-deb10.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: &hls-${RELEASE//./}-64-deb11
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-deb11.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-deb11.tar.xz" | awk '{ print $1 }')
+          Linux_Ubuntu:
+            '( >= 16 && < 19 )': &hls-${RELEASE//./}-64-ubuntu18
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-ubuntu18.04.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-ubuntu18.04.tar.xz" | awk '{ print $1 }')
+            '( >= 20 && < 22 )': &hls-${RELEASE//./}-64-ubuntu20
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-ubuntu20.04.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-ubuntu20.04.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: &hls-${RELEASE//./}-64-ubuntu22
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-ubuntu22.04.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-ubuntu22.04.tar.xz" | awk '{ print $1 }')
+          Linux_Mint:
+            '< 20':
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-mint19.3.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-mint19.3.tar.xz" | awk '{ print $1 }')
+            '(>= 20 && < 21)':
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-mint20.2.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-mint20.2.tar.xz" | awk '{ print $1 }')
+            '>= 21': *hls-${RELEASE//./}-64-ubuntu22
+          Linux_Fedora:
+            '< 33': &hls-${RELEASE//./}-64-fedora27
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-fedora27.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-fedora27.tar.xz" | awk '{ print $1 }')
+            '>= 33': &hls-${RELEASE//./}-64-fedora33
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-fedora33.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-fedora33.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: *hls-${RELEASE//./}-64-fedora27
+          Linux_CentOS:
+            '( >= 7 && < 8 )': &hls-${RELEASE//./}-64-centos
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-centos7.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-centos7.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: *hls-${RELEASE//./}-64-centos
+          Linux_RedHat:
+            unknown_versioning: *hls-${RELEASE//./}-64-centos
+          Linux_UnknownLinux:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-linux-unknown.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-linux-unknown.tar.xz" | awk '{ print $1 }')
+          Darwin:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-apple-darwin.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-apple-darwin.tar.xz" | awk '{ print $1 }')
+          Windows:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-mingw64.zip
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-mingw64.zip" | awk '{ print $1 }')
+          FreeBSD:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-x86_64-freebsd.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-x86_64-freebsd.tar.xz" | awk '{ print $1 }')
+        A_ARM64:
+          Linux_UnknownLinux:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-aarch64-linux-ubuntu20.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-aarch64-linux-ubuntu20.tar.xz" | awk '{ print $1 }')
+          Darwin:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~hls/haskell-language-server-$RELEASE/haskell-language-server-$RELEASE-aarch64-apple-darwin.tar.xz
+              dlSubdir: haskell-language-server-$RELEASE
+              dlHash: $(sha256sum "haskell-language-server-$RELEASE-aarch64-apple-darwin.tar.xz" | awk '{ print $1 }')
+EOF
+


### PR DESCRIPTION
## Changelog 2.0.0.1

- Add overloaded record dot plugin intial version (closes #3350) (#3560)
- Binaries for GHC 9.2.8 and GHC 9.6.2

----

@michaelpj @fendor @wz1000 @mpickering 

----

## Release checklist

- [x] check ghcup supports new GHC releases if any
- [x] set the supported GHCs in workflow file
- [x] check all plugins still work
- [x] bump package versions
- [x] generate and update changelog
- [x] create release branch
    - https://github.com/haskell/haskell-language-server/tree/wip/2.0.0.1
- [x] create release tag
    - https://github.com/haskell/haskell-language-server/tree/2.0.0.1
- [x] trigger release pipeline (creates a draft)
- [x] run `scripts/release/download-gh-artifacts` to add FreeBSD bindist and signatures
- [x] upload bindists to downloads.haskell.org
- [x] create PR to ghcup-metadata
- [x] get sign-off on release
- [x] publish release on github
- [x] upload hackage packages
- [x] update https://github.com/haskell/ghcup-metadata/blob/develop/hls-metadata-0.0.1.json
- [x] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
- [ ] post release on discourse and reddit

