### PR TITLE
Keep plugin id of cabal-fmt in sync with default config id

### DIFF
--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -200,6 +200,7 @@ instance Default Config where
     -- , formattingProvider          = "floskell"
     -- , formattingProvider          = "stylish-haskell"
     , cabalFormattingProvider     = "cabal-fmt"
+    -- this string value needs to kept in sync with the value provided in HlsPlugins
     , maxCompletions              = 40
     , plugins                     = mempty
     }

--- a/src/HlsPlugins.hs
+++ b/src/HlsPlugins.hs
@@ -161,7 +161,9 @@ idePlugins recorder = pluginDescToIdePlugins allPlugins
       let pId = "fourmolu" in Fourmolu.descriptor (pluginRecorder pId) pId:
 #endif
 #if hls_cabalfmt
-      let pId = "cabalfmt" in CabalFmt.descriptor (pluginRecorder pId) pId:
+      -- this pId needs to be kept in sync with the hardcoded
+      -- cabalFormattingProvider in the Default Config
+      let pId = "cabal-fmt" in CabalFmt.descriptor (pluginRecorder pId) pId:
 #endif
 #if hls_tactic
       let pId = "tactics" in Tactic.descriptor (pluginRecorder pId) pId:


### PR DESCRIPTION
Add documentation to note that these values are to be kept in sync

Fixes #3613