### PR TITLE
Reintroduce cabal-install in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -237,6 +237,7 @@
           buildInputs = [
             # our compiling toolchain
             hpkgs.ghc
+            hpkgs.cabal-install
             # @guibou: I'm not sure hie-bios is needed
             # pkgs.haskellPackages.hie-bios
             # Dependencies needed to build some parts of hackage


### PR DESCRIPTION
PR #3555 removes `cabal-install` from `flake.nix` in order to "make CI green" but that makes it impractical to build the project using nix. Since the PR mentions not being sure of the details and more people at ZuriHac are having trouble with this, I suggest reintroducing it.