### PR TITLE
Correctly pass VersionedTextDocumentIdentifier through hls

### DIFF
--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -98,7 +98,7 @@ data WithDeletions = IncludeDeletions | SkipDeletions
   deriving Eq
 
 -- | Generate a 'WorkspaceEdit' value from a pair of source Text
-diffText :: ClientCapabilities -> (Uri,T.Text) -> T.Text -> WithDeletions -> WorkspaceEdit
+diffText :: ClientCapabilities -> (Uri,T.Text) -> T.Text -> WithDeletions -> TextDocumentVersion -> WorkspaceEdit
 diffText clientCaps old new withDeletions =
   let
     supports = clientSupportsDocumentChanges clientCaps
@@ -161,8 +161,8 @@ diffTextEdit fText f2Text withDeletions = J.List r
 
 
 -- | A pure version of 'diffText' for testing
-diffText' :: Bool -> (Uri,T.Text) -> T.Text -> WithDeletions -> WorkspaceEdit
-diffText' supports (f,fText) f2Text withDeletions  =
+diffText' :: Bool -> (Uri,T.Text) -> T.Text -> WithDeletions -> TextDocumentVersion -> WorkspaceEdit
+diffText' supports (f,fText) f2Text withDeletions version =
   if supports
     then WorkspaceEdit Nothing (Just docChanges) Nothing
     else WorkspaceEdit (Just h) Nothing Nothing
@@ -170,7 +170,7 @@ diffText' supports (f,fText) f2Text withDeletions  =
     diff = diffTextEdit fText f2Text withDeletions
     h = H.singleton f diff
     docChanges = J.List [InL docEdit]
-    docEdit = J.TextDocumentEdit (J.VersionedTextDocumentIdentifier f (Just 0)) $ fmap InL diff
+    docEdit = J.TextDocumentEdit (J.VersionedTextDocumentIdentifier f version) $ fmap InL diff
 
 -- ---------------------------------------------------------------------
 

--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class/CodeAction.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class/CodeAction.hs
@@ -57,8 +57,8 @@ addMethodPlaceholders _ state param@AddMinimalMethodsParams{..} = do
         pragmaInsertion <- insertPragmaIfNotPresent state nfp InstanceSigs
         let edit =
                 if withSig
-                then mergeEdit (workspaceEdit caps old new) pragmaInsertion
-                else workspaceEdit caps old new
+                then mergeEdit (workspaceEdit caps old new textVersion) pragmaInsertion
+                else workspaceEdit caps old new textVersion
 
         void $ lift $ sendRequest SWorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing edit) (\_ -> pure ())
 

--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class/Types.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class/Types.hs
@@ -1,10 +1,10 @@
+
 {-# LANGUAGE DeriveAnyClass   #-}
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase       #-}
 {-# LANGUAGE TypeFamilies     #-}
 {-# LANGUAGE ViewPatterns     #-}
-{-# LANGUAGE BangPatterns     #-}
 
 module Ide.Plugin.Class.Types where
 
@@ -21,6 +21,7 @@ import           Development.IDE.Graph.Classes
 import           GHC.Generics
 import           Ide.Plugin.Class.Utils
 import           Ide.Types
+import           Language.LSP.Types            (TextDocumentVersion)
 
 typeLensCommandId :: CommandId
 typeLensCommandId = "classplugin.typelens"
@@ -38,6 +39,7 @@ data AddMinimalMethodsParams = AddMinimalMethodsParams
     , methodGroup :: List (T.Text, T.Text)
     -- ^ (name text, signature text)
     , withSig     :: Bool
+    , textVersion :: TextDocumentVersion
     }
     deriving (Show, Eq, Generic, ToJSON, FromJSON)
 

--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class/Types.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class/Types.hs
@@ -1,4 +1,3 @@
-
 {-# LANGUAGE DeriveAnyClass   #-}
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class/Types.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class/Types.hs
@@ -20,7 +20,7 @@ import           Development.IDE.Graph.Classes
 import           GHC.Generics
 import           Ide.Plugin.Class.Utils
 import           Ide.Types
-import           Language.LSP.Types            (TextDocumentVersion)
+import           Language.LSP.Types            (VersionedTextDocumentIdentifier)
 
 typeLensCommandId :: CommandId
 typeLensCommandId = "classplugin.typelens"
@@ -33,12 +33,11 @@ defaultIndent :: Int
 defaultIndent = 2
 
 data AddMinimalMethodsParams = AddMinimalMethodsParams
-    { uri         :: Uri
+    { verTxtDocId :: VersionedTextDocumentIdentifier
     , range       :: Range
     , methodGroup :: List (T.Text, T.Text)
     -- ^ (name text, signature text)
     , withSig     :: Bool
-    , textVersion :: TextDocumentVersion
     }
     deriving (Show, Eq, Generic, ToJSON, FromJSON)
 

--- a/plugins/hls-class-plugin/test/Main.hs
+++ b/plugins/hls-class-plugin/test/Main.hs
@@ -76,7 +76,7 @@ codeActionTests = testGroup
       [ "Add placeholders for 'f','g'"
       , "Add placeholders for 'f','g' with signature(s)"
       ]
-  , testCase "" $ runSessionWithServer classPlugin testDataDir $ do
+  , testCase "Update text document version" $ runSessionWithServer classPlugin testDataDir $ do
     doc <- createDoc "Version.hs" "haskell" "module Version where"
     ver1 <- (^.J.version) <$> getVersionedDoc doc
     liftIO $ ver1 @?= Just 0

--- a/plugins/hls-class-plugin/test/Main.hs
+++ b/plugins/hls-class-plugin/test/Main.hs
@@ -76,6 +76,30 @@ codeActionTests = testGroup
       [ "Add placeholders for 'f','g'"
       , "Add placeholders for 'f','g' with signature(s)"
       ]
+  , testCase "" $ runSessionWithServer classPlugin testDataDir $ do
+    doc <- createDoc "Version.hs" "haskell" "module Version where"
+    ver1 <- (^.J.version) <$> getVersionedDoc doc
+    liftIO $ ver1 @?= Just 0
+
+    -- Change the doc to ensure the version is not 0
+    changeDoc doc
+        [ TextDocumentContentChangeEvent
+            Nothing
+            Nothing
+            (T.unlines ["module Version where", "data A a = A a", "instance Functor A where"])
+        ]
+    ver2 <- (^.J.version) <$> getVersionedDoc doc
+    _ <- waitForDiagnostics
+    liftIO $ ver2 @?= Just 1
+
+    -- Execute the action and see what the version is
+    action <- head . concatMap (^.. _CACodeAction) <$> getAllCodeActions doc
+    executeCodeAction action
+    _ <- waitForDiagnostics
+    -- TODO: uncomment this after lsp-test fixed
+    -- ver3 <- (^.J.version) <$> getVersionedDoc doc
+    -- liftIO $ ver3 @?= Just 3
+    pure mempty
   ]
 
 codeLensTests :: TestTree

--- a/plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs
@@ -210,16 +210,15 @@ instance Monad m => Monoid (Graft m a) where
 transform ::
     DynFlags ->
     ClientCapabilities ->
-    Uri ->
-    TextDocumentVersion ->
+    VersionedTextDocumentIdentifier ->
     Graft (Either String) ParsedSource ->
     Annotated ParsedSource ->
     Either String WorkspaceEdit
-transform dflags ccs uri version f a = do
+transform dflags ccs verTxtDocId f a = do
     let src = printA a
     a' <- transformA a $ runGraft f dflags
     let res = printA a'
-    pure $ diffText ccs (uri, T.pack src) (T.pack res) IncludeDeletions version
+    pure $ diffText ccs (verTxtDocId, T.pack src) (T.pack res) IncludeDeletions
 
 ------------------------------------------------------------------------------
 
@@ -228,17 +227,16 @@ transformM ::
     Monad m =>
     DynFlags ->
     ClientCapabilities ->
-    Uri ->
-    TextDocumentVersion ->
+    VersionedTextDocumentIdentifier ->
     Graft (ExceptStringT m) ParsedSource ->
     Annotated ParsedSource ->
     m (Either String WorkspaceEdit)
-transformM dflags ccs uri version f a = runExceptT $
+transformM dflags ccs verTextDocId f a = runExceptT $
     runExceptString $ do
         let src = printA a
         a' <- transformA a $ runGraft f dflags
         let res = printA a'
-        pure $ diffText ccs (uri, T.pack src) (T.pack res) IncludeDeletions version
+        pure $ diffText ccs (verTextDocId, T.pack src) (T.pack res) IncludeDeletions
 
 
 -- | Returns whether or not this node requires its immediate children to have

--- a/plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs
@@ -211,14 +211,15 @@ transform ::
     DynFlags ->
     ClientCapabilities ->
     Uri ->
+    TextDocumentVersion ->
     Graft (Either String) ParsedSource ->
     Annotated ParsedSource ->
     Either String WorkspaceEdit
-transform dflags ccs uri f a = do
+transform dflags ccs uri version f a = do
     let src = printA a
     a' <- transformA a $ runGraft f dflags
     let res = printA a'
-    pure $ diffText ccs (uri, T.pack src) (T.pack res) IncludeDeletions
+    pure $ diffText ccs (uri, T.pack src) (T.pack res) IncludeDeletions version
 
 ------------------------------------------------------------------------------
 
@@ -228,15 +229,16 @@ transformM ::
     DynFlags ->
     ClientCapabilities ->
     Uri ->
+    TextDocumentVersion ->
     Graft (ExceptStringT m) ParsedSource ->
     Annotated ParsedSource ->
     m (Either String WorkspaceEdit)
-transformM dflags ccs uri f a = runExceptT $
+transformM dflags ccs uri version f a = runExceptT $
     runExceptString $ do
         let src = printA a
         a' <- transformA a $ runGraft f dflags
         let res = printA a'
-        pure $ diffText ccs (uri, T.pack src) (T.pack res) IncludeDeletions
+        pure $ diffText ccs (uri, T.pack src) (T.pack res) IncludeDeletions version
 
 
 -- | Returns whether or not this node requires its immediate children to have

--- a/plugins/hls-rename-plugin/hls-rename-plugin.cabal
+++ b/plugins/hls-rename-plugin/hls-rename-plugin.cabal
@@ -35,6 +35,7 @@ library
     , hie-compat
     , hls-plugin-api        == 2.0.0.0
     , hls-refactor-plugin
+    , lens
     , lsp
     , lsp-types
     , mod

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -6,9 +6,9 @@
 {-# LANGUAGE OverloadedLabels    #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE RecordWildCards     #-}
 
 module Ide.Plugin.Rename (descriptor, E.Log) where
 
@@ -17,20 +17,21 @@ import           GHC.Parser.Annotation                 (AnnContext, AnnList,
                                                         AnnParen, AnnPragma)
 #endif
 
+import           Compat.HieTypes
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Except
-import           Data.Generics
 import           Data.Bifunctor                        (first)
+import           Data.Generics
 import           Data.Hashable
 import           Data.HashSet                          (HashSet)
 import qualified Data.HashSet                          as HS
 import           Data.List.Extra                       hiding (length)
 import qualified Data.Map                              as M
-import qualified Data.Set                              as S
 import           Data.Maybe
 import           Data.Mod.Word
+import qualified Data.Set                              as S
 import qualified Data.Text                             as T
 import           Development.IDE                       (Recorder, WithPriority,
                                                         usePropertyAction)
@@ -54,7 +55,7 @@ import           Ide.PluginUtils
 import           Ide.Types
 import           Language.LSP.Server
 import           Language.LSP.Types
-import           Compat.HieTypes
+import qualified Language.LSP.Types.Lens               as J
 
 instance Hashable (Mod a) where hash n = hash (unMod n)
 
@@ -66,9 +67,10 @@ descriptor recorder pluginId = mkExactprintPluginDescriptor recorder $ (defaultP
     }
 
 renameProvider :: PluginMethodHandler IdeState TextDocumentRename
-renameProvider state pluginId (RenameParams (TextDocumentIdentifier uri) pos _prog newNameText) =
+renameProvider state pluginId (RenameParams docId@(TextDocumentIdentifier uri) pos _prog newNameText) =
     pluginResponse $ do
         nfp <- handleUriToNfp uri
+        VersionedTextDocumentIdentifier{_version = version} <- lift $ getVersionedTextDoc docId
         directOldNames <- getNamesAtPos state nfp pos
         directRefs <- concat <$> mapM (refsAtName state nfp) directOldNames
 
@@ -78,7 +80,7 @@ renameProvider state pluginId (RenameParams (TextDocumentIdentifier uri) pos _pr
            See the `IndirectPuns` test for an example. -}
         indirectOldNames <- concat . filter ((>1) . Prelude.length) <$>
             mapM (uncurry (getNamesAtPos state) . locToFilePos) directRefs
-        let oldNames = (filter matchesDirect indirectOldNames) ++ directOldNames
+        let oldNames = filter matchesDirect indirectOldNames ++ directOldNames
             matchesDirect n = occNameFS (nameOccName n) `elem` directFS
               where
                 directFS = map (occNameFS. nameOccName) directOldNames
@@ -92,7 +94,7 @@ renameProvider state pluginId (RenameParams (TextDocumentIdentifier uri) pos _pr
         -- Perform rename
         let newName = mkTcOcc $ T.unpack newNameText
             filesRefs = collectWith locToUri refs
-            getFileEdit = flip $ getSrcEdit state . replaceRefs newName
+            getFileEdit = flip $ getSrcEdit state version . replaceRefs newName
         fileEdits <- mapM (uncurry getFileEdit) filesRefs
         pure $ foldl' (<>) mempty fileEdits
 
@@ -125,10 +127,11 @@ failWhenImportOrExport state nfp refLocs names = do
 getSrcEdit ::
     (MonadLsp config m) =>
     IdeState ->
+    TextDocumentVersion ->
     (ParsedSource -> ParsedSource) ->
     Uri ->
     ExceptT String m WorkspaceEdit
-getSrcEdit state updatePs uri = do
+getSrcEdit state version updatePs uri = do
     ccs <- lift getClientCapabilities
     nfp <- handleUriToNfp uri
     annAst <- handleMaybeM ("No parsed source for: " ++ show nfp) $ liftIO $ runAction
@@ -143,7 +146,7 @@ getSrcEdit state updatePs uri = do
     let src = T.pack $ exactPrint ps
         res = T.pack $ exactPrint (updatePs ps)
 #endif
-    pure $ diffText ccs (uri, src) res IncludeDeletions
+    pure $ diffText ccs (uri, src) res IncludeDeletions version
 
 -- | Replace names at every given `Location` (in a given `ParsedSource`) with a given new name.
 replaceRefs ::

--- a/plugins/hls-splice-plugin/src/Ide/Plugin/Splice/Types.hs
+++ b/plugins/hls-splice-plugin/src/Ide/Plugin/Splice/Types.hs
@@ -11,12 +11,14 @@ import           Development.IDE            (Uri)
 import           Development.IDE.GHC.Compat (RealSrcSpan)
 import           GHC.Generics               (Generic)
 import           Ide.Types                  (CommandId)
+import           Language.LSP.Types         (TextDocumentVersion)
 
 -- | Parameter for the addMethods PluginCommand.
 data ExpandSpliceParams = ExpandSpliceParams
     { uri           :: Uri
     , spliceSpan    :: RealSrcSpan
     , spliceContext :: SpliceContext
+    , textVersion   :: TextDocumentVersion
     }
     deriving (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)

--- a/plugins/hls-splice-plugin/src/Ide/Plugin/Splice/Types.hs
+++ b/plugins/hls-splice-plugin/src/Ide/Plugin/Splice/Types.hs
@@ -7,18 +7,18 @@ module Ide.Plugin.Splice.Types where
 
 import           Data.Aeson                 (FromJSON, ToJSON)
 import qualified Data.Text                  as T
-import           Development.IDE            (Uri)
+ -- This import is needed for the ToJSON/FromJSON instances of RealSrcSpan
+import           Development.IDE            ()
 import           Development.IDE.GHC.Compat (RealSrcSpan)
 import           GHC.Generics               (Generic)
 import           Ide.Types                  (CommandId)
-import           Language.LSP.Types         (TextDocumentVersion)
+import           Language.LSP.Types         (VersionedTextDocumentIdentifier)
 
 -- | Parameter for the addMethods PluginCommand.
 data ExpandSpliceParams = ExpandSpliceParams
-    { uri           :: Uri
+    { verTxtDocId   :: VersionedTextDocumentIdentifier
     , spliceSpan    :: RealSrcSpan
     , spliceContext :: SpliceContext
-    , textVersion   :: TextDocumentVersion
     }
     deriving (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)

--- a/plugins/hls-tactics-plugin/old/src/Wingman/AbstractLSP.hs
+++ b/plugins/hls-tactics-plugin/old/src/Wingman/AbstractLSP.hs
@@ -96,7 +96,7 @@ runContinuation plId cont state (fc, b) = do
               , _xdata =  Nothing
               } ) $ do
       env@LspEnv{..} <- buildEnv state plId fc
-      nfp <- getNfp $ fc_uri le_fileContext
+      nfp <- getNfp $ fc_verTxtDocId le_fileContext ^. J.uri
       let stale a = runStaleIde "runContinuation" state nfp a
       args <- fetchTargetArgs @a env
       res <- c_runCommand cont env args fc b
@@ -113,7 +113,7 @@ runContinuation plId cont state (fc, b) = do
           GraftEdit gr -> do
             ccs <- lift getClientCapabilities
             TrackedStale pm _ <- mapMaybeT liftIO $ stale GetAnnotatedParsedSource
-            case mkWorkspaceEdits (enableQuasiQuotes le_dflags) ccs (fc_uri le_fileContext) (textVersion fc) (unTrack pm) gr of
+            case mkWorkspaceEdits (enableQuasiQuotes le_dflags) ccs (fc_verTxtDocId le_fileContext) (unTrack pm) gr of
               Left errs ->
                 pure $ Just $ ResponseError
                   { _code    = InternalError
@@ -155,7 +155,7 @@ buildEnv
     -> MaybeT (LspM Plugin.Config) LspEnv
 buildEnv state plId fc = do
   cfg <- liftIO $ runIde "plugin" "config" state $ getTacticConfigAction plId
-  nfp <- getNfp $ fc_uri fc
+  nfp <- getNfp $ fc_verTxtDocId fc ^. J.uri
   dflags <- mapMaybeT liftIO $ getIdeDynflags state nfp
   pure $ LspEnv
     { le_ideState = state
@@ -178,13 +178,12 @@ codeActionProvider
        )
     -> PluginMethodHandler IdeState TextDocumentCodeAction
 codeActionProvider sort k state plId
-                   (CodeActionParams _ _ docId@(TextDocumentIdentifier uri) range _) = do
-  version <- (^. J.version) <$> getVersionedTextDoc docId
+                   (CodeActionParams _ _ docId range _) = do
+  verTxtDocId <- getVersionedTextDoc docId
   fromMaybeT (Right $ List []) $ do
     let fc = FileContext
-                { fc_uri   = uri
+                { fc_verTxtDocId = verTxtDocId
                 , fc_range = Just $ unsafeMkCurrent range
-                , textVersion = version
                 }
     env <- buildEnv state plId fc
     args <- fetchTargetArgs @target env
@@ -207,13 +206,12 @@ codeLensProvider
       )
     -> PluginMethodHandler IdeState TextDocumentCodeLens
 codeLensProvider sort k state plId
-                 (CodeLensParams _ _ docId@(TextDocumentIdentifier uri)) = do
-      version <- (^. J.version) <$> getVersionedTextDoc docId
+                 (CodeLensParams _ _ docId) = do
+      verTxtDocId <- getVersionedTextDoc docId
       fromMaybeT (Right $ List []) $ do
         let fc = FileContext
-                   { fc_uri   = uri
+                   { fc_verTxtDocId = verTxtDocId
                    , fc_range = Nothing
-                   , textVersion = version
                    }
         env <- buildEnv state plId fc
         args <- fetchTargetArgs @target env

--- a/plugins/hls-tactics-plugin/old/src/Wingman/AbstractLSP/TacticActions.hs
+++ b/plugins/hls-tactics-plugin/old/src/Wingman/AbstractLSP/TacticActions.hs
@@ -4,6 +4,7 @@
 
 module Wingman.AbstractLSP.TacticActions where
 
+import           Control.Lens ((^.))
 import           Control.Monad (when)
 import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans (lift)
@@ -16,6 +17,7 @@ import           Development.IDE.Core.UseStale
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.ExactPrint
 import           Generics.SYB.GHC (mkBindListT, everywhereM')
+import qualified Language.LSP.Types.Lens as LSP
 import           Wingman.AbstractLSP.Types
 import           Wingman.CaseSplit
 import           Wingman.GHC (liftMaybe, isHole, pattern AMatch)
@@ -45,7 +47,7 @@ makeTacticInteraction cmd =
               }
     )
     $ \LspEnv{..} HoleJudgment{..} FileContext{..} var_name -> do
-        nfp <- getNfp fc_uri
+        nfp <- getNfp (fc_verTxtDocId ^. LSP.uri)
         let stale a = runStaleIde "tacticCmd" le_ideState nfp a
 
         let span = fmap (rangeToRealSrcSpan (fromNormalizedFilePath nfp)) hj_range

--- a/plugins/hls-tactics-plugin/old/src/Wingman/AbstractLSP/Types.hs
+++ b/plugins/hls-tactics-plugin/old/src/Wingman/AbstractLSP/Types.hs
@@ -124,6 +124,7 @@ data FileContext = FileContext
   , fc_range    :: Maybe (Tracked 'Current Range)
     -- ^ For code actions, this is 'Just'. For code lenses, you'll get
     -- a 'Nothing' in the request, and a 'Just' in the response.
+  , textVersion     :: TextDocumentVersion
   }
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (A.ToJSON, A.FromJSON)

--- a/plugins/hls-tactics-plugin/old/src/Wingman/AbstractLSP/Types.hs
+++ b/plugins/hls-tactics-plugin/old/src/Wingman/AbstractLSP/Types.hs
@@ -9,6 +9,7 @@ module Wingman.AbstractLSP.Types where
 
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Maybe (MaybeT (MaybeT), mapMaybeT)
+import           Control.Lens ((^.))
 import qualified Data.Aeson as A
 import           Data.Text (Text)
 import           Development.IDE (IdeState)
@@ -20,6 +21,7 @@ import qualified Ide.Plugin.Config as Plugin
 import           Ide.Types hiding (Config)
 import           Language.LSP.Server (LspM)
 import           Language.LSP.Types hiding (CodeLens, CodeAction)
+import qualified Language.LSP.Types.Lens as LSP
 import           Wingman.LanguageServer (judgementForHole)
 import           Wingman.Types
 
@@ -120,13 +122,12 @@ data Continuation sort target payload = Continuation
 ------------------------------------------------------------------------------
 -- | What file are we looking at, and what bit of it?
 data FileContext = FileContext
-  { fc_uri      :: Uri
-  , fc_range    :: Maybe (Tracked 'Current Range)
+  { fc_verTxtDocId :: VersionedTextDocumentIdentifier
+  , fc_range       :: Maybe (Tracked 'Current Range)
     -- ^ For code actions, this is 'Just'. For code lenses, you'll get
     -- a 'Nothing' in the request, and a 'Just' in the response.
-  , textVersion     :: TextDocumentVersion
   }
-  deriving stock (Eq, Ord, Show, Generic)
+  deriving stock (Eq, Show, Generic)
   deriving anyclass (A.ToJSON, A.FromJSON)
 
 
@@ -165,6 +166,6 @@ instance IsTarget HoleTarget where
   fetchTargetArgs LspEnv{..} = do
     let FileContext{..} = le_fileContext
     range <- MaybeT $ pure fc_range
-    nfp <- getNfp fc_uri
+    nfp <- getNfp (fc_verTxtDocId ^. LSP.uri)
     mapMaybeT liftIO $ judgementForHole le_ideState nfp range le_config
 

--- a/plugins/hls-tactics-plugin/old/src/Wingman/EmptyCase.hs
+++ b/plugins/hls-tactics-plugin/old/src/Wingman/EmptyCase.hs
@@ -7,6 +7,7 @@
 module Wingman.EmptyCase where
 
 import           Control.Applicative (empty)
+import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Except (runExcept)
 import           Control.Monad.Trans
@@ -27,6 +28,7 @@ import           Development.IDE.Spans.LocalBindings (getLocalScope)
 import           Ide.Types
 import           Language.LSP.Server
 import           Language.LSP.Types
+import qualified Language.LSP.Types.Lens as LSP
 import           Prelude hiding (span)
 import           Wingman.AbstractLSP.Types
 import           Wingman.CodeGen (destructionFor)
@@ -50,7 +52,7 @@ emptyCaseInteraction = Interaction $
   Continuation @EmptyCaseT @EmptyCaseT @WorkspaceEdit EmptyCaseT
     (SynthesizeCodeLens $ \LspEnv{..} _ -> do
       let FileContext{..} = le_fileContext
-      nfp <- getNfp fc_uri
+      nfp <- getNfp (fc_verTxtDocId ^. LSP.uri)
 
       let stale a = runStaleIde "codeLensProvider" le_ideState nfp a
 
@@ -69,7 +71,7 @@ emptyCaseInteraction = Interaction $
               (foldMap (hySingleton . occName . fst) bindings)
               ty
         edits <- liftMaybe $ hush $
-              mkWorkspaceEdits le_dflags ccs fc_uri textVersion (unTrack pm) $
+              mkWorkspaceEdits le_dflags ccs fc_verTxtDocId (unTrack pm) $
                 graftMatchGroup (RealSrcSpan (unTrack ss) Nothing) $
                   noLoc matches
         pure

--- a/plugins/hls-tactics-plugin/old/src/Wingman/EmptyCase.hs
+++ b/plugins/hls-tactics-plugin/old/src/Wingman/EmptyCase.hs
@@ -69,7 +69,7 @@ emptyCaseInteraction = Interaction $
               (foldMap (hySingleton . occName . fst) bindings)
               ty
         edits <- liftMaybe $ hush $
-              mkWorkspaceEdits le_dflags ccs fc_uri (unTrack pm) $
+              mkWorkspaceEdits le_dflags ccs fc_uri textVersion (unTrack pm) $
                 graftMatchGroup (RealSrcSpan (unTrack ss) Nothing) $
                   noLoc matches
         pure

--- a/plugins/hls-tactics-plugin/old/src/Wingman/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/old/src/Wingman/LanguageServer.hs
@@ -622,12 +622,13 @@ mkWorkspaceEdits
     :: DynFlags
     -> ClientCapabilities
     -> Uri
+    -> TextDocumentVersion
     -> Annotated ParsedSource
     -> Graft (Either String) ParsedSource
     -> Either UserFacingMessage WorkspaceEdit
-mkWorkspaceEdits dflags ccs uri pm g = do
+mkWorkspaceEdits dflags ccs uri version pm g = do
   let pm' = runIdentity $ transformA pm annotateMetaprograms
-  let response = transform dflags ccs uri g pm'
+  let response = transform dflags ccs uri version g pm'
    in first (InfrastructureError . T.pack) response
 
 

--- a/plugins/hls-tactics-plugin/old/src/Wingman/LanguageServer.hs
+++ b/plugins/hls-tactics-plugin/old/src/Wingman/LanguageServer.hs
@@ -621,14 +621,13 @@ mkDiagnostic severity r =
 mkWorkspaceEdits
     :: DynFlags
     -> ClientCapabilities
-    -> Uri
-    -> TextDocumentVersion
+    -> VersionedTextDocumentIdentifier
     -> Annotated ParsedSource
     -> Graft (Either String) ParsedSource
     -> Either UserFacingMessage WorkspaceEdit
-mkWorkspaceEdits dflags ccs uri version pm g = do
+mkWorkspaceEdits dflags ccs verTxtDocId pm g = do
   let pm' = runIdentity $ transformA pm annotateMetaprograms
-  let response = transform dflags ccs uri version g pm'
+  let response = transform dflags ccs verTxtDocId g pm'
    in first (InfrastructureError . T.pack) response
 
 


### PR DESCRIPTION
This is an attempt at a continuation of #3566 because I don’t have rights to push to that branch.

Sadly, while I can’t reproduce the concrete error message we are trying to fix here. There are still a lot of files in which hlint fixes don’t get applied for me.