### PR TITLE
Add missing Monad constraint in the eval plugin

### DIFF
--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Parse/Comments.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Parse/Comments.hs
@@ -496,7 +496,7 @@ consume style =
         Line     -> (,) <$> takeRest <*> getPosition
         Block {} -> manyTill_ anySingle (getPosition <* eob)
 
-getPosition :: (Ord v, TraversableStream s) => ParsecT v s m Position
+getPosition :: (Monad m, Ord v, TraversableStream s) => ParsecT v s m Position
 getPosition = sourcePosToPosition <$> getSourcePos
 
 -- | Parses example test line.


### PR DESCRIPTION
Resolves the following build error when building HLS with GHC 9.2.8 via haskell.nix:

```
hls-eval-plugin-lib-hls-eval-plugin> src/Ide/Plugin/Eval/Parse/Comments.hs:500:39: error:
hls-eval-plugin-lib-hls-eval-plugin>     • Could not deduce (Monad m) arising from a use of ‘getSourcePos’
hls-eval-plugin-lib-hls-eval-plugin>       from the context: (Ord v, TraversableStream s)
hls-eval-plugin-lib-hls-eval-plugin>         bound by the type signature for:
hls-eval-plugin-lib-hls-eval-plugin>                    getPosition :: forall v s (m :: * -> *).
hls-eval-plugin-lib-hls-eval-plugin>                                   (Ord v, TraversableStream s) =>
hls-eval-plugin-lib-hls-eval-plugin>                                   ParsecT v s m Position
hls-eval-plugin-lib-hls-eval-plugin>         at src/Ide/Plugin/Eval/Parse/Comments.hs:499:1-69
hls-eval-plugin-lib-hls-eval-plugin>       Possible fix:
hls-eval-plugin-lib-hls-eval-plugin>         add (Monad m) to the context of
hls-eval-plugin-lib-hls-eval-plugin>           the type signature for:
hls-eval-plugin-lib-hls-eval-plugin>             getPosition :: forall v s (m :: * -> *).
hls-eval-plugin-lib-hls-eval-plugin>                            (Ord v, TraversableStream s) =>
hls-eval-plugin-lib-hls-eval-plugin>                            ParsecT v s m Position
hls-eval-plugin-lib-hls-eval-plugin>     • In the second argument of ‘(<$>)’, namely ‘getSourcePos’
hls-eval-plugin-lib-hls-eval-plugin>       In the expression: sourcePosToPosition <$> getSourcePos
hls-eval-plugin-lib-hls-eval-plugin>       In an equation for ‘getPosition’:
hls-eval-plugin-lib-hls-eval-plugin>           getPosition = sourcePosToPosition <$> getSourcePos
hls-eval-plugin-lib-hls-eval-plugin>     |
hls-eval-plugin-lib-hls-eval-plugin> 500 | getPosition = sourcePosToPosition <$> getSourcePos
hls-eval-plugin-lib-hls-eval-plugin>     |                                       ^^^^^^^^^^^^
```