### PR TITLE
Rewrite plugin tutorial

### DIFF
--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -69,6 +69,7 @@ import           Data.GADT.Compare
 import           Data.Hashable                   (Hashable)
 import           Data.HashMap.Strict             (HashMap)
 import qualified Data.HashMap.Strict             as HashMap
+import           Data.Kind                       (Type)
 import           Data.List.Extra                 (find, sortOn)
 import           Data.List.NonEmpty              (NonEmpty (..), toList)
 import qualified Data.Map                        as Map
@@ -269,7 +270,7 @@ instance ToJSON PluginConfig where
 
 -- ---------------------------------------------------------------------
 
-data PluginDescriptor (ideState :: *) =
+data PluginDescriptor (ideState :: Type) =
   PluginDescriptor { pluginId           :: !PluginId
                    -- ^ Unique identifier of the plugin.
                    , pluginPriority     :: Natural
@@ -499,7 +500,7 @@ instance PluginMethod Request TextDocumentDocumentSymbol where
       uri = msgParams ^. J.textDocument . J.uri
 
 instance PluginMethod Request CompletionItemResolve where
-  pluginEnabled _ msgParams pluginDesc config = pluginEnabledConfig plcCompletionOn (configForPlugin config pluginDesc)
+  pluginEnabled _ _ pluginDesc config = pluginEnabledConfig plcCompletionOn (configForPlugin config pluginDesc)
 
 instance PluginMethod Request TextDocumentCompletion where
   pluginEnabled _ msgParams pluginDesc config = pluginResponsible uri pluginDesc


### PR DESCRIPTION
This is an almost-complete rewrite of the outdated plugin tutorial. The section about the code lens provider is still unchanged and probably incorrect. I'll try to get to it at some point.

To view the new docs locally follow the instructions from the [docs](https://haskell-language-server.readthedocs.io/en/latest/contributing/contributing.html#building-the-docs). TLDR: `cd docs; make html`

It also contains some minor refactors to the files mentioned in the plugin since it aided in my understanding of what was going on.