### PR TITLE
Draft: Introduce hierarchical error types and error handling for plugins

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -153,6 +153,7 @@ library
         Development.IDE.Core.FileUtils
         Development.IDE.Core.IdeConfiguration
         Development.IDE.Core.OfInterest
+        Development.IDE.Core.PluginUtils
         Development.IDE.Core.PositionMapping
         Development.IDE.Core.Preprocessor
         Development.IDE.Core.ProgressReporting

--- a/ghcide/src/Development/IDE/Core/PluginUtils.hs
+++ b/ghcide/src/Development/IDE/Core/PluginUtils.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE GADTs #-}
+module Development.IDE.Core.PluginUtils where
+
+import           Control.Monad.Extra
+import           Control.Monad.IO.Class
+import           Control.Monad.Reader                 (runReaderT)
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Maybe
+import           Data.Either.Extra                    (maybeToEither)
+import           Data.Functor.Identity
+import qualified Data.Text                            as T
+import           Development.IDE.Core.PositionMapping
+import           Development.IDE.Core.Shake           (IdeAction, IdeRule,
+                                                       IdeState (shakeExtras),
+                                                       mkDelayedAction,
+                                                       shakeEnqueue)
+import qualified Development.IDE.Core.Shake           as Shake
+import           Development.IDE.GHC.Orphans          ()
+import           Development.IDE.Graph                hiding (ShakeValue)
+import           Development.IDE.Types.Location       (NormalizedFilePath)
+import qualified Development.IDE.Types.Location       as Location
+import qualified Development.IDE.Types.Logger         as Logger
+import qualified Ide.PluginUtils                      as PluginUtils
+import qualified Language.LSP.Types                   as LSP
+import           Prettyprinter
+import           Prettyprinter.Render.Text            (renderStrict)
+
+-- ----------------------------------------------------------------------------
+-- Plugin Error wrapping
+-- ----------------------------------------------------------------------------
+
+data GhcidePluginError
+    = forall a . Show a => FastRuleNotReady a
+    | forall a . Show a => RuleFailed a
+    | CoreError PluginUtils.PluginError
+
+instance Pretty GhcidePluginError where
+  pretty = \case
+    FastRuleNotReady rule -> "FastRuleNotReady:" <+> viaShow rule
+    RuleFailed rule       -> "RuleFailed:" <+> viaShow rule
+    CoreError perror      -> pretty $ PluginUtils.prettyPluginError perror
+
+pluginResponse ::
+    Monad m =>
+    ExceptT GhcidePluginError m a ->
+    m (Either LSP.ResponseError a)
+pluginResponse = PluginUtils.pluginResponse' handlePluginError
+
+withPluginError :: Functor m => ExceptT PluginUtils.PluginError m a -> ExceptT GhcidePluginError m a
+withPluginError = PluginUtils.withError CoreError
+
+mkPluginErrorMessage :: T.Text -> GhcidePluginError
+mkPluginErrorMessage = CoreError . PluginUtils.mkPluginErrorMessage
+
+handlePluginError :: GhcidePluginError -> LSP.ResponseError
+handlePluginError msg = PluginUtils.mkSimpleResponseError $ renderStrict simpleDoc
+    where
+        simpleDoc = layoutPretty defaultLayoutOptions $ pretty msg
+
+-- ----------------------------------------------------------------------------
+-- Action wrappers
+-- ----------------------------------------------------------------------------
+
+runAction :: MonadIO m => String -> IdeState -> ExceptT e Action a -> ExceptT e m a
+runAction herald ide act =
+  PluginUtils.hoistExceptT . ExceptT $
+    join $ shakeEnqueue (shakeExtras ide) (mkDelayedAction herald Logger.Debug $ runExceptT act)
+
+-- | Request a Rule result, it not available return the last computed result which may be stale.
+--   Errors out if none available.
+useWithStale_ ::(IdeRule k v)
+    => k -> NormalizedFilePath -> ExceptT e Action (v, PositionMapping)
+useWithStale_ key file = ExceptT $ fmap Right $ Shake.useWithStale_ key file
+
+useWithStale :: IdeRule k v
+    => k -> NormalizedFilePath -> ExceptT GhcidePluginError Action (v, PositionMapping)
+useWithStale key file = maybeToExceptT (FastRuleNotReady key) $ useWithStaleMaybeT key file
+
+-- | useE is useful to implement functions that aren’t rules but need shortcircuiting
+-- e.g. getDefinition.
+use :: IdeRule k v => k -> NormalizedFilePath -> ExceptT GhcidePluginError Action v
+use k = maybeToExceptT (RuleFailed k) . MaybeT . Shake.use k
+
+useWithStaleMaybeT :: IdeRule k v
+    => k -> NormalizedFilePath -> MaybeT Action (v, PositionMapping)
+useWithStaleMaybeT key file = MaybeT $ runIdentity <$> Shake.usesWithStale key (Identity file)
+
+-- ----------------------------------------------------------------------------
+-- IdeAction wrappers
+-- ----------------------------------------------------------------------------
+
+runIdeAction :: MonadIO m => String -> Shake.ShakeExtras -> ExceptT e IdeAction a -> ExceptT e m a
+runIdeAction _herald s i = ExceptT $ liftIO $ runReaderT (Shake.runIdeActionT $ runExceptT i) s
+
+-- | useE is useful to implement functions that aren’t rules but need shortcircuiting
+-- e.g. getDefinition.
+useWithStaleFast :: IdeRule k v => k -> NormalizedFilePath -> ExceptT GhcidePluginError IdeAction (v, PositionMapping)
+useWithStaleFast k = maybeToExceptT (RuleFailed k) . MaybeT . Shake.useWithStaleFast k
+
+uriToFilePath' :: Monad m => LSP.Uri -> ExceptT GhcidePluginError m FilePath
+uriToFilePath' uri = ExceptT . pure . maybeToEither (CoreError $ PluginUtils.PluginUriToFilePath uri) $ Location.uriToFilePath' uri
+
+-- ----------------------------------------------------------------------------
+-- Internal Helper function, not exported
+-- ----------------------------------------------------------------------------
+
+hoistAction :: Action a -> ExceptT e Action a
+hoistAction = ExceptT . fmap Right

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -35,6 +35,8 @@ import qualified Language.LSP.Server              as LSP
 import qualified Language.LSP.Types               as LSP
 
 import           Control.Monad
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Maybe        (MaybeT (runMaybeT))
 import qualified Development.IDE.Core.FileExists  as FileExists
 import qualified Development.IDE.Core.OfInterest  as OfInterest
 import           Development.IDE.Core.Shake       hiding (Log)

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -77,7 +77,7 @@ module Development.IDE.Core.Shake(
     garbageCollectDirtyKeys,
     garbageCollectDirtyKeysOlderThan,
     Log(..),
-    VFSModified(..), getClientConfigAction
+    VFSModified(..), getClientConfigAction,
     ) where
 
 import           Control.Concurrent.Async
@@ -964,11 +964,15 @@ useWithStale key file = runIdentity <$> usesWithStale key (Identity file)
 
 -- | Request a Rule result, it not available return the last computed result which may be stale.
 --   Errors out if none available.
+--
+-- The thrown error is a 'BadDependency' error which is caught by the rule system.
 useWithStale_ :: IdeRule k v
     => k -> NormalizedFilePath -> Action (v, PositionMapping)
 useWithStale_ key file = runIdentity <$> usesWithStale_ key (Identity file)
 
 -- | Plural version of 'useWithStale_'
+--
+-- The thrown error is a 'BadDependency' error which is caught by the rule system.
 usesWithStale_ :: (Traversable f, IdeRule k v) => k -> f NormalizedFilePath -> Action (f (v, PositionMapping))
 usesWithStale_ key files = do
     res <- usesWithStale key files

--- a/ghcide/src/Development/IDE/Core/Tracing.hs
+++ b/ghcide/src/Development/IDE/Core/Tracing.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE PackageImports  #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# HLINT ignore #-}
+
 module Development.IDE.Core.Tracing
     ( otTracedHandler
     , otTracedAction

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -28,9 +28,9 @@ import           Development.IDE                      (GhcSession (..),
                                                        HscEnvEq (hscEnv),
                                                        RuleResult, Rules,
                                                        define, srcSpanToRange,
-                                                       usePropertyAction,
-                                                       useWithStale)
+                                                       usePropertyAction)
 import           Development.IDE.Core.Compile         (TcModuleResult (..))
+import qualified Development.IDE.Core.PluginUtils     as PluginUtils
 import           Development.IDE.Core.PositionMapping (PositionMapping,
                                                        toCurrentRange)
 import           Development.IDE.Core.Rules           (IdeState, runAction)
@@ -51,7 +51,8 @@ import           Development.IDE.Types.Logger         (Pretty (pretty),
                                                        cmapWithPrio)
 import           GHC.Generics                         (Generic)
 import           Ide.Plugin.Properties
-import           Ide.PluginUtils
+import           Ide.PluginUtils                      (getNormalizedFilePath,
+                                                       mkLspCommand)
 import           Ide.Types                            (CommandFunction,
                                                        CommandId (CommandId),
                                                        PluginCommand (PluginCommand),
@@ -103,28 +104,22 @@ properties = emptyProperties
     ] Always
 
 codeLensProvider :: PluginMethodHandler IdeState TextDocumentCodeLens
-codeLensProvider ideState pId CodeLensParams{_textDocument = TextDocumentIdentifier uri} = pluginResponse $ do
+codeLensProvider ideState pId CodeLensParams{_textDocument = TextDocumentIdentifier uri} = PluginUtils.pluginResponse $ do
     mode <- liftIO $ runAction "codeLens.config" ideState $ usePropertyAction #mode pId properties
-    nfp <- getNormalizedFilePath uri
-    env <- hscEnv . fst
-            <$> (handleMaybeM "Unable to get GhcSession"
-                $ liftIO
-                $ runAction "codeLens.GhcSession" ideState (useWithStale GhcSession nfp)
-                )
-    tmr <- fst <$> (
-                handleMaybeM "Unable to TypeCheck"
-              $ liftIO
-              $ runAction "codeLens.TypeCheck" ideState (useWithStale TypeCheck nfp)
-              )
-    bindings <- fst <$> (
-                handleMaybeM "Unable to GetBindings"
-                $ liftIO
-                $ runAction "codeLens.GetBindings" ideState (useWithStale GetBindings nfp)
-                )
+    nfp <- PluginUtils.withPluginError $ getNormalizedFilePath uri
+    env <- hscEnv . fst <$>
+      PluginUtils.runAction "codeLens.GhcSession" ideState
+        (PluginUtils.useWithStale GhcSession nfp)
+
+    (tmr, _) <- PluginUtils.runAction "codeLens.TypeCheck" ideState
+      (PluginUtils.useWithStale TypeCheck nfp)
+
+    (bindings, _) <- PluginUtils.runAction "codeLens.GetBindings" ideState
+      (PluginUtils.useWithStale GetBindings nfp)
+
     (gblSigs@(GlobalBindingTypeSigsResult gblSigs'), gblSigsMp) <-
-      handleMaybeM "Unable to GetGlobalBindingTypeSigs"
-      $ liftIO
-      $ runAction "codeLens.GetGlobalBindingTypeSigs" ideState (useWithStale GetGlobalBindingTypeSigs nfp)
+      PluginUtils.runAction "codeLens.GetGlobalBindingTypeSigs" ideState
+        (PluginUtils.useWithStale GetGlobalBindingTypeSigs nfp)
 
     diag <- liftIO $ atomically $ getDiagnostics ideState
     hDiag <- liftIO $ atomically $ getHiddenDiagnostics ideState

--- a/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy/Internal.hs
+++ b/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy/Internal.hs
@@ -13,34 +13,34 @@ module Ide.Plugin.CallHierarchy.Internal (
 , outgoingCalls
 ) where
 
-import           Control.Lens                   ((^.))
+import           Control.Lens                     ((^.))
 import           Control.Monad.IO.Class
-import           Data.Aeson                     as A
-import           Data.List                      (groupBy, sortBy)
-import qualified Data.Map                       as M
+import           Data.Aeson                       as A
+import           Data.List                        (groupBy, sortBy)
+import qualified Data.Map                         as M
 import           Data.Maybe
-import qualified Data.Set                       as S
-import qualified Data.Text                      as T
+import qualified Data.Set                         as S
+import qualified Data.Text                        as T
 import           Data.Tuple.Extra
 import           Development.IDE
+import qualified Development.IDE.Core.PluginUtils as PluginUtils
 import           Development.IDE.Core.Shake
-import           Development.IDE.GHC.Compat     as Compat
+import           Development.IDE.GHC.Compat       as Compat
 import           Development.IDE.Spans.AtPoint
-import           HieDb                          (Symbol (Symbol))
-import qualified Ide.Plugin.CallHierarchy.Query as Q
+import           HieDb                            (Symbol (Symbol))
+import qualified Ide.Plugin.CallHierarchy.Query   as Q
 import           Ide.Plugin.CallHierarchy.Types
-import           Ide.PluginUtils                (getNormalizedFilePath,
-                                                 handleMaybe, pluginResponse,
-                                                 throwPluginError)
+import           Ide.PluginUtils                  (getNormalizedFilePath,
+                                                   handleMaybe)
 import           Ide.Types
 import           Language.LSP.Types
-import qualified Language.LSP.Types.Lens        as L
-import           Text.Read                      (readMaybe)
+import qualified Language.LSP.Types.Lens          as L
+import           Text.Read                        (readMaybe)
 
 -- | Render prepare call hierarchy request.
 prepareCallHierarchy :: PluginMethodHandler IdeState TextDocumentPrepareCallHierarchy
-prepareCallHierarchy state _ param = pluginResponse $ do
-    nfp <- getNormalizedFilePath (param ^. L.textDocument ^. L.uri)
+prepareCallHierarchy state _ param = PluginUtils.pluginResponse $ do
+    nfp <- PluginUtils.withPluginError $ getNormalizedFilePath (param ^. L.textDocument ^. L.uri)
     items <- liftIO
         $ runAction "CallHierarchy.prepareHierarchy" state
         $ prepareCallHierarchyItem nfp (param ^. L.position)
@@ -174,7 +174,7 @@ deriving instance Ord Value
 
 -- | Render incoming calls request.
 incomingCalls :: PluginMethodHandler IdeState CallHierarchyIncomingCalls
-incomingCalls state pluginId param = pluginResponse $ do
+incomingCalls state pluginId param = PluginUtils.pluginResponse $ do
     calls <- liftIO
         $ runAction "CallHierarchy.incomingCalls" state
         $ queryCalls
@@ -189,7 +189,7 @@ incomingCalls state pluginId param = pluginResponse $ do
 
 -- | Render outgoing calls request.
 outgoingCalls :: PluginMethodHandler IdeState CallHierarchyOutgoingCalls
-outgoingCalls state pluginId param = pluginResponse $ do
+outgoingCalls state pluginId param = PluginUtils.pluginResponse $ do
     calls <- liftIO
         $ runAction "CallHierarchy.outgoingCalls" state
         $ queryCalls

--- a/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
+++ b/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
@@ -11,7 +11,6 @@ module Ide.Plugin.ExplicitFixity(descriptor, Log) where
 
 import           Control.DeepSeq
 import           Control.Monad.IO.Class               (MonadIO, liftIO)
-import           Control.Monad.Trans.Maybe
 import           Data.Either.Extra
 import           Data.Hashable
 import qualified Data.Map.Strict                      as M
@@ -20,6 +19,7 @@ import qualified Data.Set                             as S
 import qualified Data.Text                            as T
 import           Development.IDE                      hiding (pluginHandlers,
                                                        pluginRules)
+import qualified Development.IDE.Core.PluginUtils     as PluginUtils
 import           Development.IDE.Core.PositionMapping (idDelta)
 import           Development.IDE.Core.Shake           (addPersistentRule)
 import qualified Development.IDE.Core.Shake           as Shake
@@ -28,9 +28,7 @@ import qualified Development.IDE.GHC.Compat.Util      as Util
 import           Development.IDE.LSP.Notifications    (ghcideNotificationsPluginPriority)
 import           Development.IDE.Spans.AtPoint
 import           GHC.Generics                         (Generic)
-import           Ide.PluginUtils                      (getNormalizedFilePath,
-                                                       handleMaybeM,
-                                                       pluginResponse)
+import           Ide.PluginUtils                      (getNormalizedFilePath)
 import           Ide.Types                            hiding (pluginId)
 import           Language.LSP.Types
 
@@ -44,14 +42,14 @@ descriptor recorder pluginId = (defaultPluginDescriptor pluginId)
     }
 
 hover :: PluginMethodHandler IdeState TextDocumentHover
-hover state _ (HoverParams (TextDocumentIdentifier uri) pos _) = pluginResponse $ do
-    nfp <- getNormalizedFilePath uri
-    handleMaybeM "ExplicitFixity: Unable to get fixity" $ liftIO $ runIdeAction "ExplicitFixity" (shakeExtras state) $ runMaybeT $ do
-      (FixityMap fixmap, _) <- useE GetFixity nfp
-      (HAR{hieAst}, mapping) <- useE GetHieAst nfp
+hover state _ (HoverParams (TextDocumentIdentifier uri) pos _) = PluginUtils.pluginResponse $ do
+    nfp <- PluginUtils.withPluginError $ getNormalizedFilePath uri
+    PluginUtils.runIdeAction "ExplicitFixity" (shakeExtras state) $ do
+      (FixityMap fixmap, _) <-  PluginUtils.useE GetFixity nfp
+      (HAR{hieAst}, mapping) <- PluginUtils.useE GetHieAst nfp
       let ns = getNamesAtPoint hieAst pos mapping
           fs = mapMaybe (\n -> (n,) <$> M.lookup n fixmap) ns
-      pure $ toHover $ fs
+      pure $ toHover fs
     where
         toHover :: [(Name, Fixity)] -> Maybe Hover
         toHover [] = Nothing

--- a/plugins/hls-gadt-plugin/src/Ide/Plugin/GADT.hs
+++ b/plugins/hls-gadt-plugin/src/Ide/Plugin/GADT.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -8,28 +9,30 @@
 {-# LANGUAGE ViewPatterns      #-}
 module Ide.Plugin.GADT (descriptor) where
 
-import           Control.Monad.Trans.Class
-import           Control.Monad.IO.Class
-import           Control.Lens                  ((^.))
+import           Control.Lens                     ((^.))
 import           Control.Monad.Except
-import           Data.Aeson                    (FromJSON, ToJSON, Value (Null),
-                                                toJSON)
-import           Data.Either.Extra             (maybeToEither)
-import qualified Data.HashMap.Lazy             as HashMap
-import qualified Data.Text                     as T
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Data.Aeson                       (FromJSON, ToJSON,
+                                                   Value (Null), toJSON)
+import           Data.Either.Extra                (maybeToEither)
+import qualified Data.HashMap.Lazy                as HashMap
+import qualified Data.Text                        as T
 import           Development.IDE
 import           Development.IDE.GHC.Compat
 
-import           Control.Monad.Trans.Except    (throwE)
-import           Data.Maybe                    (mapMaybe)
-import           Development.IDE.Spans.Pragmas (getFirstPragma, insertNewPragma)
-import           GHC.Generics                  (Generic)
+import           Control.Monad.Trans.Except       (throwE)
+import           Data.Maybe                       (mapMaybe)
+import qualified Development.IDE.Core.PluginUtils as PluginUtils
+import           Development.IDE.Spans.Pragmas    (getFirstPragma,
+                                                   insertNewPragma)
+import           GHC.Generics                     (Generic)
 import           Ide.Plugin.GHC
 import           Ide.PluginUtils
 import           Ide.Types
-import           Language.LSP.Server           (sendRequest)
+import           Language.LSP.Server              (sendRequest)
 import           Language.LSP.Types
-import qualified Language.LSP.Types.Lens       as L
+import qualified Language.LSP.Types.Lens          as L
 
 descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId = (defaultPluginDescriptor plId)
@@ -50,20 +53,21 @@ toGADTSyntaxCommandId = "GADT.toGADT"
 
 -- | A command replaces H98 data decl with GADT decl in place
 toGADTCommand :: PluginId -> CommandFunction IdeState ToGADTParams
-toGADTCommand pId@(PluginId pId') state ToGADTParams{..} = pluginResponse $ do
-    nfp <- getNormalizedFilePath uri
+toGADTCommand pId@(PluginId pId') state ToGADTParams{..} = pluginResponseM handleGhcidePluginError $ do
+    nfp <- withError (GhcidePluginErrors . PluginUtils.CoreError) $ getNormalizedFilePath uri
     (decls, exts) <- getInRangeH98DeclsAndExts state range nfp
     (L ann decl) <- case decls of
         [d] -> pure d
-        _   -> throwE $ "Expected 1 declaration, but got " <> show (Prelude.length decls)
-    deps <- liftIO $ runAction (T.unpack pId' <> ".GhcSessionDeps") state $ use GhcSessionDeps nfp
-    (hsc_dflags . hscEnv -> df) <- liftEither
-        $ maybeToEither "Get GhcSessionDeps failed" deps
-    txt <- liftEither $ T.pack <$> (prettyGADTDecl df . h98ToGADTDecl) decl
+        _   -> throwE $ UnexpectedNumberOfDeclarations (Prelude.length decls)
+    deps <- withError GhcidePluginErrors
+        $ PluginUtils.runAction (T.unpack pId' <> ".GhcSessionDeps") state
+        $ PluginUtils.use GhcSessionDeps nfp
+    (hsc_dflags . hscEnv -> df) <- pure deps
+    txt <- withError (PrettyGadtError . T.pack) $ liftEither $ T.pack <$> (prettyGADTDecl df . h98ToGADTDecl) decl
     range <- liftEither
-        $ maybeToEither "Unable to get data decl range"
+        $ maybeToEither FailedToFindDataDeclRange
         $ srcSpanToRange $ locA ann
-    pragma <- getFirstPragma pId state nfp
+    pragma <- withError GhcidePluginErrors $ getFirstPragma pId state nfp
     let insertEdit = [insertNewPragma pragma GADTs | all (`notElem` exts) [GADTSyntax, GADTs]]
 
     _ <- lift $ sendRequest
@@ -80,8 +84,8 @@ toGADTCommand pId@(PluginId pId') state ToGADTParams{..} = pluginResponse $ do
                  Nothing Nothing
 
 codeActionHandler :: PluginMethodHandler IdeState TextDocumentCodeAction
-codeActionHandler state plId (CodeActionParams _ _ doc range _) = pluginResponse $ do
-    nfp <- getNormalizedFilePath (doc ^. L.uri)
+codeActionHandler state plId (CodeActionParams _ _ doc range _) = pluginResponseM handleGhcidePluginError $ do
+    nfp <- withError (GhcidePluginErrors . PluginUtils.CoreError) $ getNormalizedFilePath (doc ^. L.uri)
     (inRangeH98Decls, _) <- getInRangeH98DeclsAndExts state range nfp
     let actions = map (mkAction . printOutputable . tcdLName . unLoc) inRangeH98Decls
     pure $ List actions
@@ -106,15 +110,34 @@ getInRangeH98DeclsAndExts :: (MonadIO m) =>
     IdeState
     -> Range
     -> NormalizedFilePath
-    -> ExceptT String m ([LTyClDecl GP], [Extension])
+    -> ExceptT GadtPluginError m ([LTyClDecl GP], [Extension])
 getInRangeH98DeclsAndExts state range nfp = do
-    pm <- handleMaybeM "Unable to get ParsedModuleWithComments"
-        $ liftIO
-        $ runAction "GADT.GetParsedModuleWithComments" state
-        $ use GetParsedModuleWithComments nfp
+    pm <- withError GhcidePluginErrors
+        $ PluginUtils.runAction "GADT.GetParsedModuleWithComments" state
+        $ PluginUtils.use GetParsedModuleWithComments nfp
     let (L _ hsDecls) = hsmodDecls <$> pm_parsed_source pm
         decls = filter isH98DataDecl
             $ mapMaybe getDataDecl
             $ filter (inRange range) hsDecls
         exts = getExtensions pm
     pure (decls, exts)
+
+data GadtPluginError
+    = UnexpectedNumberOfDeclarations Int
+    | FailedToFindDataDeclRange
+    | PrettyGadtError T.Text
+    | GhcidePluginErrors PluginUtils.GhcidePluginError
+
+handleGhcidePluginError ::
+    Monad m =>
+    GadtPluginError ->
+    m (Either ResponseError a)
+handleGhcidePluginError = \case
+    UnexpectedNumberOfDeclarations nums -> do
+        pure $ Left $ mkSimpleResponseError $ "Expected one declaration but found: " <> T.pack (show nums)
+    FailedToFindDataDeclRange ->
+        pure $ Left $ mkSimpleResponseError $ "Unable to get data decl range"
+    PrettyGadtError errMsg ->
+        pure $ Left $ mkSimpleResponseError $ errMsg
+    GhcidePluginErrors errors ->
+        pure $ Left $ PluginUtils.handlePluginError errors


### PR DESCRIPTION
Essentially, infuse the existing `pluginResponse` infrastructure with steroids:

* Provide a simple interface for performing the work you usually want to do
* Allow fine-grained control how errors are finally reported to the client
* Hierarchical error types, somewhat analogous to the logger