### PR TITLE
Bump supported ormolu, allow for 9.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,11 +166,11 @@ jobs:
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.6'
+      - if: matrix.test 
         name: Test hls-ormolu-plugin
         run: cabal test hls-ormolu-plugin --test-options="$TEST_OPTS" || cabal test hls-ormolu-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.6'
+      - if: matrix.test
         name: Test hls-fourmolu-plugin
         run: cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS" || cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS"
 

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -53,12 +53,12 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-explicit-fixity-plugin`        | 2    |                          |
 | `hls-explicit-record-fields-plugin` | 2    |                          |
 | `hls-floskell-plugin`               | 2    | 9.6                      |
-| `hls-fourmolu-plugin`               | 2    | 9.6                      |
+| `hls-fourmolu-plugin`               | 2    |                          |
 | `hls-gadt-plugin`                   | 2    |                          |
 | `hls-hlint-plugin`                  | 2    | 9.6                      |
 | `hls-module-name-plugin`            | 2    |                          |
 | `hls-qualify-imported-names-plugin` | 2    |                          |
-| `hls-ormolu-plugin`                 | 2    | 9.6                      |
+| `hls-ormolu-plugin`                 | 2    |                          |
 | `hls-rename-plugin`                 | 2    |                          |
 | `hls-refine-imports-plugin`         | 2    |                          |
 | `hls-stylish-haskell-plugin`        | 2    | 9.6                      |

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -349,7 +349,7 @@ common fourmolu
     cpp-options: -Dhls_fourmolu
 
 common ormolu
-  if flag(ormolu) && impl(ghc < 9.5)
+  if flag(ormolu) && impl(ghc < 9.7)
     build-depends: hls-ormolu-plugin == 2.1.0.0
     cpp-options: -Dhls_ormolu
 

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -23,7 +23,7 @@ source-repository head
     location: https://github.com/haskell/haskell-language-server.git
 
 library
-  if impl(ghc >= 9.5)
+  if impl(ghc >= 9.7)
     buildable: False
   exposed-modules:  Ide.Plugin.Ormolu
   hs-source-dirs:   src
@@ -36,13 +36,13 @@ library
     , hls-plugin-api  == 2.1.0.0
     , lens
     , lsp
-    , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || ^>= 0.5
+    , ormolu          ^>=0.1.2 || ^>= 0.2 || ^>= 0.3 || ^>= 0.5 || ^>= 0.6 || ^>= 0.7
     , text
 
   default-language: Haskell2010
 
 test-suite tests
-  if impl(ghc >= 9.5)
+  if impl(ghc >= 9.7)
     buildable: False
   type:             exitcode-stdio-1.0
   default-language: Haskell2010

--- a/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
+++ b/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
@@ -56,9 +56,14 @@ provider ideState typ contents fp _ = withIndefiniteProgress title Cancellable $
         CabalNotFound                -> Nothing
         CabalDidNotMention cabalInfo -> Just cabalInfo
         CabalFound cabalInfo         -> Just cabalInfo
+#if MIN_VERSION_ormolu(0,7,0)
+      (fixityOverrides, moduleReexports) <- getDotOrmoluForSourceFile fp'
+      let conf' = refineConfig ModuleSource cabalInfo (Just fixityOverrides) (Just moduleReexports) conf
+#else
       fixityOverrides <- traverse getFixityOverridesForSourceFile cabalInfo
       let conf' = refineConfig ModuleSource cabalInfo fixityOverrides conf
-          cont' = cont
+#endif
+      let cont' = cont
 #else
       let conf' = conf
           cont' = T.unpack cont


### PR DESCRIPTION
And note that `fourmolu` already works for 9.6.