### PR TITLE
Enable stylish-haskell for 9.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
         name: Test hls-splice-plugin
         run: cabal test hls-splice-plugin --test-options="$TEST_OPTS" || cabal test hls-splice-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.6'
+      - if: matrix.test 
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS"
 

--- a/cabal.project
+++ b/cabal.project
@@ -56,7 +56,7 @@ package *
 
 write-ghc-environment-files: never
 
-index-state: 2023-06-17T12:00:00Z
+index-state: 2023-06-25T00:00:00Z
 
 constraints:
   -- For GHC 9.4, older versions of entropy fail to build on Windows

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -61,7 +61,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-ormolu-plugin`                 | 2    |                          |
 | `hls-rename-plugin`                 | 2    |                          |
 | `hls-refine-imports-plugin`         | 2    |                          |
-| `hls-stylish-haskell-plugin`        | 2    | 9.6                      |
+| `hls-stylish-haskell-plugin`        | 2    |                          |
 | `hls-tactics-plugin`                | 2    | 9.2, 9.4, 9.6            |
 | `hls-overloaded-recrod-dot-plugin`  | 2    | 8.10, 9.0                |
 | `hls-haddock-comments-plugin`       | 3    | 9.2, 9.4, 9.6            |

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -354,7 +354,7 @@ common ormolu
     cpp-options: -Dhls_ormolu
 
 common stylishHaskell
-  if flag(stylishHaskell) && impl(ghc < 9.5)
+  if flag(stylishHaskell) 
     build-depends: hls-stylish-haskell-plugin == 2.1.0.0
     cpp-options: -Dhls_stylishHaskell
 

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -20,8 +20,6 @@ source-repository head
     location: https://github.com/haskell/haskell-language-server.git
 
 library
-  if impl(ghc >= 9.5)
-    buildable: False
   exposed-modules:  Ide.Plugin.StylishHaskell
   hs-source-dirs:   src
   build-depends:
@@ -39,8 +37,6 @@ library
   default-language: Haskell2010
 
 test-suite tests
-  if impl(ghc >= 9.5)
-    buildable: False
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test


### PR DESCRIPTION
There is a 9.6-compatible release now.