### PR TITLE
Restore short option for logfile

### DIFF
--- a/src/Ide/Arguments.hs
+++ b/src/Ide/Arguments.hs
@@ -149,6 +149,7 @@ arguments plugins = GhcideArguments
           <> help "Send logs to a file"
            )) <|> (optional (strOption
            ( long "logfile"
+          <> short 'l'
           <> metavar "LOGFILE"
           <> help "Send logs to a file"
           -- deprecated alias so users don't need to update their CLI calls


### PR DESCRIPTION
I meant to leave the old options in place. The short option is only there for the hidden old option, so it's not shown. That means what new users see is consistent across all the options.