### PR TITLE
Remove extra call to newHscEnvEqWithImportPaths

### DIFF
--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -799,6 +799,11 @@ ghcSessionDepsDefinition fullModSummary GhcSessionDepsConfig{..} env file = do
 #endif
             session' <- liftIO $ mergeEnvs hsc moduleNode inLoadOrder depSessions
 
+            -- Here we avoid a call to to `newHscEnvEqWithImportPaths`, which creates a new
+            -- ExportsMap when it is called. We only need to create the ExportsMap once per
+            -- session, while `ghcSessionDepsDefinition` will be called for each file we need
+            -- to compile. `updateHscEnvEq` will refresh the HscEnv (session') and also
+            -- generate a new Unique.
             Just <$> liftIO (updateHscEnvEq env session')
 
 -- | Load a iface from disk, or generate it if there isn't one or it is out of date

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -799,7 +799,7 @@ ghcSessionDepsDefinition fullModSummary GhcSessionDepsConfig{..} env file = do
 #endif
             session' <- liftIO $ mergeEnvs hsc moduleNode inLoadOrder depSessions
 
-            Just <$> liftIO (newHscEnvEqWithImportPaths (envImportPaths env) session' [])
+            Just <$> liftIO (updateHscEnvEq env session')
 
 -- | Load a iface from disk, or generate it if there isn't one or it is out of date
 -- This rule also ensures that the `.hie` and `.o` (if needed) files are written out.

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -100,7 +100,6 @@ import qualified Data.Text.Encoding                           as T
 import           Data.Time                                    (UTCTime (..))
 import           Data.Tuple.Extra
 import           Data.Typeable                                (cast)
-import qualified Data.Unique                                  as Unique
 import           Development.IDE.Core.Compile
 import           Development.IDE.Core.FileExists hiding (LogShake, Log)
 import           Development.IDE.Core.FileStore               (getFileContents,
@@ -772,13 +771,35 @@ ghcSessionDepsDefinition
         Bool ->
         GhcSessionDepsConfig -> HscEnvEq -> NormalizedFilePath -> Action (Maybe HscEnvEq)
 ghcSessionDepsDefinition fullModSummary GhcSessionDepsConfig{..} env file = do
+    let hsc = hscEnv env
+
     mbdeps <- mapM(fmap artifactFilePath . snd) <$> use_ GetLocatedImports file
     case mbdeps of
         Nothing -> return Nothing
         Just deps -> do
             when checkForImportCycles $ void $ uses_ ReportImportCycles deps
-            let updateUnique newUnique = env { envUnique = newUnique }
-            Just . updateUnique <$> liftIO Unique.newUnique
+            ms <- msrModSummary <$> if fullModSummary
+                then use_ GetModSummary file
+                else use_ GetModSummaryWithoutTimestamps file
+
+            depSessions <- map hscEnv <$> uses_ (GhcSessionDeps_ fullModSummary) deps
+            ifaces <- uses_ GetModIface deps
+            let inLoadOrder = map (\HiFileResult{..} -> HomeModInfo hirModIface hirModDetails emptyHomeModInfoLinkable) ifaces
+#if MIN_VERSION_ghc(9,3,0)
+            -- On GHC 9.4+, the module graph contains not only ModSummary's but each `ModuleNode` in the graph
+            -- also points to all the direct descendants of the current module. To get the keys for the descendants
+            -- we must get their `ModSummary`s
+            !final_deps <- do
+              dep_mss <- map msrModSummary <$> uses_ GetModSummaryWithoutTimestamps deps
+             -- Don't want to retain references to the entire ModSummary when just the key will do
+              return $!! map (NodeKey_Module . msKey) dep_mss
+            let moduleNode = (ms, final_deps)
+#else
+            let moduleNode = ms
+#endif
+            session' <- liftIO $ mergeEnvs hsc moduleNode inLoadOrder depSessions
+
+            Just <$> liftIO (newHscEnvEqWithImportPaths (envImportPaths env) session' [])
 
 -- | Load a iface from disk, or generate it if there isn't one or it is out of date
 -- This rule also ensures that the `.hie` and `.o` (if needed) files are written out.

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -1,5 +1,5 @@
 module Development.IDE.Types.HscEnvEq
-(   HscEnvEq(envUnique),
+(   HscEnvEq,
     hscEnv, newHscEnvEq,
     hscEnvWithImportPaths,
     newHscEnvEqPreserveImportPaths,

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -1,5 +1,5 @@
 module Development.IDE.Types.HscEnvEq
-(   HscEnvEq,
+(   HscEnvEq(envUnique),
     hscEnv, newHscEnvEq,
     hscEnvWithImportPaths,
     newHscEnvEqPreserveImportPaths,

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -33,7 +33,8 @@ import           System.Directory                (makeAbsolute)
 import           System.FilePath
 
 -- | An 'HscEnv' with equality. Two values are considered equal
---   if they are created with the same call to 'newHscEnvEq'.
+--   if they are created with the same call to 'newHscEnvEq' or
+--   'updateHscEnvEq'.
 data HscEnvEq = HscEnvEq
     { envUnique             :: !Unique
     , hscEnv                :: !HscEnv

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -4,6 +4,7 @@ module Development.IDE.Types.HscEnvEq
     hscEnvWithImportPaths,
     newHscEnvEqPreserveImportPaths,
     newHscEnvEqWithImportPaths,
+    updateHscEnvEq,
     envImportPaths,
     envPackageExports,
     envVisibleModuleNames,
@@ -50,6 +51,11 @@ data HscEnvEq = HscEnvEq
         -- So it's wrapped in IO here for error handling
         -- If Nothing, 'listVisibleModuleNames' panic
     }
+
+updateHscEnvEq :: HscEnvEq -> HscEnv -> IO HscEnvEq
+updateHscEnvEq oldHscEnvEq newHscEnv = do
+  let update newUnique = oldHscEnvEq { envUnique = newUnique, hscEnv = newHscEnv }
+  update <$> Unique.newUnique
 
 -- | Wrap an 'HscEnv' into an 'HscEnvEq'.
 newHscEnvEq :: FilePath -> HscEnv -> [(UnitId, DynFlags)] -> IO HscEnvEq


### PR DESCRIPTION
Submitting this at the request of @wz1000 
Instead of calling `newHscEnvEqWithImportPaths` again in `ghcSessionDepsDefinition`, we only generate a new `Unique` for the `HscEnvEq` and update the `envUnique` field.