### PR TITLE
Enable RTS options to be specified at runtime

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -50,6 +50,9 @@ tests: True
 package mfsolve
   tests: False
 
+package haskell-language-server
+  ghc-options: -rtsopts
+
 package *
   ghc-options: -haddock
   test-show-details: direct


### PR DESCRIPTION
This allows downstream consumers to set the `GHCRTS` environment variable to limit memory consumption, without having to recompile HLS from source.