### PR TITLE
Remove isovector as an owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,7 +30,7 @@
 /plugins/hls-code-range-plugin @kokobd
 /plugins/hls-splice-plugin @konn
 /plugins/hls-stylish-haskell-plugin @Ailrun
-/plugins/hls-tactics-plugin @isovector
+/plugins/hls-tactics-plugin
 /plugins/hls-stan-plugin @uhbif19
 /plugins/hls-explicit-record-fields-plugin @ozkutuk
 /plugins/hls-overloaded-record-dot-plugin @joyfulmantis


### PR DESCRIPTION
I haven't touched this codebase in over a year, and it's now bitrotten and doesn't compile on any modern targets, so I think it's time to move on!