### PR TITLE
Mark hls-floskell-plugin as tier 3

### DIFF
--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -52,7 +52,6 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-eval-plugin`                   | 2    |                          |
 | `hls-explicit-fixity-plugin`        | 2    |                          |
 | `hls-explicit-record-fields-plugin` | 2    |                          |
-| `hls-floskell-plugin`               | 2    | 9.6                      |
 | `hls-fourmolu-plugin`               | 2    |                          |
 | `hls-gadt-plugin`                   | 2    |                          |
 | `hls-hlint-plugin`                  | 2    |                          |
@@ -64,6 +63,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-stylish-haskell-plugin`        | 2    |                          |
 | `hls-tactics-plugin`                | 2    | 9.2, 9.4, 9.6            |
 | `hls-overloaded-record-dot-plugin`  | 2    | 8.10, 9.0                |
+| `hls-floskell-plugin`               | 3    | 9.6                      |
 | `hls-haddock-comments-plugin`       | 3    | 9.2, 9.4, 9.6            |
 | `hls-stan-plugin`                   | 3    | 8.6, 9.0, 9.2, 9.4, 9.6  |
 | `hls-retrie-plugin`                 | 3    |                          |


### PR DESCRIPTION
It's been a half year since the latest update for floskell, and doesn't have a pr for ghc-9.6 yet. 

I'd propose marking `hls-floskell-plugin` as tier 3 until someone explicitly announces to maintain. 