### PR TITLE
use versioned hackage libraries

### DIFF
--- a/configuration-ghc-92.nix
+++ b/configuration-ghc-92.nix
@@ -19,7 +19,7 @@ let
           doCheck = false;
         });
     } // (builtins.mapAttrs (_: drv: disableLibraryProfiling drv) {
-      apply-refact = hsuper.apply-refact_0_13_0_0;
+      apply-refact = hself.callHackage "apply-refact" "0.13.0.0" { };
 
       # ptr-poker breaks on MacOS without SSE2 optimizations
       # https://github.com/nikita-volkov/ptr-poker/issues/11

--- a/configuration-ghc-94.nix
+++ b/configuration-ghc-94.nix
@@ -13,7 +13,7 @@ let
     {
       hlsDisabledPlugins = disabledPlugins;
     } // (builtins.mapAttrs (_: drv: disableLibraryProfiling drv) {
-      apply-refact = hsuper.apply-refact_0_13_0_0;
+      apply-refact = hself.callHackage "apply-refact" "0.13.0.0" { };
 
       stylish-haskell = appendConfigureFlag  hsuper.stylish-haskell "-fghc-lib";
 

--- a/configuration-ghc-96.nix
+++ b/configuration-ghc-96.nix
@@ -28,7 +28,8 @@ let
             broken = false;
             doCheck = false;
           });
-      apply-refact = hsuper.apply-refact_0_13_0_0;
+
+      apply-refact = hself.callHackage "apply-refact" "0.13.0.0" { };
       tagged = hself.callHackage "tagged" "0.8.7" { };
       primitive = hself.callHackage "primitive" "0.8.0.0" { };
       unix-compat = hself.callCabal2nix "unix-compat" inputs.haskell-unix-compat { };
@@ -42,7 +43,7 @@ let
       # https://github.com/nikita-volkov/ptr-poker/issues/11
       ptr-poker = hself.callCabal2nix "ptr-poker" inputs.ptr-poker { };
 
-      ormolu = hself.ormolu_0_5_3_0;
+      ormolu = hself.callHackage "ormolu" "0.5.3.0" { };
 
       # TODO: smunix: nix fails to build fourmolu-0.13 from Hackage with these errors:
       #   tar: */fourmolu/0.13.0.0/fourmolu.json: Not found in archive

--- a/configuration-ghc-96.nix
+++ b/configuration-ghc-96.nix
@@ -43,7 +43,7 @@ let
       # https://github.com/nikita-volkov/ptr-poker/issues/11
       ptr-poker = hself.callCabal2nix "ptr-poker" inputs.ptr-poker { };
 
-      ormolu = hself.callHackage "ormolu" "0.5.3.0" { };
+      ormolu = hself.callHackage "ormolu" "0.7.0.1" { };
 
       # TODO: smunix: nix fails to build fourmolu-0.13 from Hackage with these errors:
       #   tar: */fourmolu/0.13.0.0/fourmolu.json: Not found in archive


### PR DESCRIPTION
`ormolu_0_5_3_3` has been removed from nixpkgs. To prevent future breaks, let's pull specific versions from hackage when they are available.