### PR TITLE
Sending `workspace/configuration` request while handling `Initilized`

### DIFF
--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -40,6 +40,7 @@ import           Development.IDE.Types.Location
 import           Development.IDE.Types.Shake           (toKey)
 import           Ide.Logger
 import           Ide.Types
+import           Language.LSP.Server                   (sendRequest)
 import           Numeric.Natural
 
 data Log
@@ -127,6 +128,12 @@ descriptor recorder plId = (defaultPluginDescriptor plId) { pluginNotificationHa
         setSomethingModified (VFSModified vfs) ide [toKey GetClientSettings emptyFilePath] "config change"
 
   , mkPluginNotificationHandler LSP.SMethod_Initialized $ \ide _ _ _ -> do
+
+      let params = ConfigurationParams [ConfigurationItem Nothing (Just "haskell.formattingProvider")]
+      void $ sendRequest LSP.SMethod_WorkspaceConfiguration params $ \res -> do
+        liftIO $ logWarning (ideLogger ide) $ "zltest: " <> (Text.pack $ show res)
+        pure ()
+
       --------- Initialize Shake session --------------------------------------------------------------------
       liftIO $ shakeSessionInit (cmapWithPrio LogShake recorder) ide
 


### PR DESCRIPTION
We *can* rely on `workspace/configuration` to keep track of the configuration after we resolve the following problems.

- [ ] How to upgrade the config in the `Initialized` handler, seems we can't modify the `IdeState` in place.
- [ ] We have dozens of configurations, do these config field names all available for different clients like vscode and emacs?
- [ ] How to test this pr? Ideally I think we can add a test in vscode-haskell.

I'll try to investigate these questions, and also very welcome any suggestions or guidance in case I have to browse through lsp protocol and some of their implementations :)
