### PR TITLE
hls-cabal-fmt-plugin: Use the file contents of the LSP request

### DIFF
--- a/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
+++ b/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
@@ -38,7 +38,7 @@ library
     , lens
     , lsp-types
     , mtl
-    , process
+    , process-extras
     , text
     , transformers
 

--- a/plugins/hls-cabal-fmt-plugin/test/Main.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/Main.hs
@@ -39,7 +39,7 @@ tests found = testGroup "cabal-fmt"
     cabalFmtGolden found "formats a simple document" "simple_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
 
-  , knownBrokenOnWindows "expand:src comment bug in cabal-fmt on windows" $
+  , expectFailBecause "cabal-fmt can't expand modules if .cabal file is read from stdin. Tracking issue: https://github.com/phadej/cabal-fmt/pull/82" $
     cabalFmtGolden found "formats a document with expand:src comment" "commented_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
 


### PR DESCRIPTION
Reported in https://github.com/haskell/vscode-haskell/issues/945


The fix is basic: don't read from disk.