### PR TITLE
Do not suggest bogus module names

### DIFF
--- a/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
+++ b/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
@@ -26,10 +26,11 @@ import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Maybe
 import           Data.Aeson                           (toJSON)
 import           Data.Char                            (isLower)
-import           Data.List                            (intercalate, isPrefixOf,
-                                                       minimumBy)
+import           Data.List                            (intercalate, minimumBy,
+                                                       stripPrefix)
 import qualified Data.List.NonEmpty                   as NE
 import qualified Data.Map                             as Map
+import           Data.Maybe                           (mapMaybe)
 import           Data.Ord                             (comparing)
 import           Data.String                          (IsString)
 import qualified Data.Text                            as T
@@ -154,15 +155,14 @@ pathModuleNames recorder state normFilePath filePath
       mdlPath <- liftIO $ makeAbsolute filePath
       logWith recorder Debug (AbsoluteFilePath mdlPath)
 
-      let prefixes = filter (`isPrefixOf` mdlPath) paths
-      pure (map (moduleNameFrom mdlPath) prefixes)
+      let suffixes = mapMaybe (`stripPrefix` mdlPath) paths
+      pure (map moduleNameFrom suffixes)
   where
-    moduleNameFrom mdlPath prefix =
+    moduleNameFrom =
       T.pack
         . intercalate "."
         . splitDirectories
-        . drop (length prefix)
-        $ dropExtension mdlPath
+        . dropExtension
 
 -- | The module name, as stated in the module
 codeModuleName :: IdeState -> NormalizedFilePath -> IO (Maybe (Range, T.Text))

--- a/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
+++ b/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
@@ -25,9 +25,9 @@ import           Control.Monad.Trans.Class            (lift)
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Maybe
 import           Data.Aeson                           (toJSON)
-import           Data.Char                            (isLower)
+import           Data.Char                            (isLower, isUpper)
 import           Data.List                            (intercalate, minimumBy,
-                                                       stripPrefix)
+                                                       stripPrefix, uncons)
 import qualified Data.List.NonEmpty                   as NE
 import qualified Data.Map                             as Map
 import           Data.Maybe                           (mapMaybe)
@@ -161,6 +161,9 @@ pathModuleNames recorder state normFilePath filePath
     moduleNameFrom =
       T.pack
         . intercalate "."
+        -- Do not suggest names whose components start from a lower-case char,
+        -- they are guaranteed to be malformed.
+        . filter (maybe False (isUpper . fst) . uncons)
         . splitDirectories
         . dropExtension
 


### PR DESCRIPTION
In one of my projects HLS sometimes suggests bogus module names such as `src.Foo.Bar` or `test.Foo.Quux`. It's not quite clear what's exactly going on: it's a complex project with a custom `shake`-based build system and intricate environment, so I cannot distill a reproducer to share. It might very well be a deeper issue (with dysfunctional GHC session?), but what I propose here is a simple sanity check: under no circumstances we should suggest malformed module names with components starting from lower-case characters. 