### PR TITLE
Clean up Release CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,9 +21,6 @@ build_task:
     GITHUB_WORKSPACE: ${CIRRUS_WORKING_DIR}
     CABAL_CACHE_NONFATAL: "yes"
   matrix:
-    - name: build-ghc-8.10.7
-      env:
-        GHC_VERSION: 8.10.7
     - name: build-ghc-9.0.2
       env:
         GHC_VERSION: 9.0.2
@@ -46,7 +43,6 @@ build_task:
 bindist_task:
   name: bindist
   depends_on:
-    - build-ghc-8.10.7
     - build-ghc-9.0.2
     - build-ghc-9.2.5
     - build-ghc-9.2.7
@@ -63,10 +59,6 @@ bindist_task:
   script:
     - tzsetup Etc/GMT
     - adjkerntz -a
-
-    - curl -o binaries-8.10.7.tar.xz -L https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build-ghc-8.10.7/binaries/out.tar.xz
-    - tar xvf binaries-8.10.7.tar.xz
-    - rm -f binaries-8.10.7.tar.xz
 
     - curl -o binaries-9.0.2.tar.xz -L https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build-ghc-9.0.2/binaries/out.tar.xz
     - tar xvf binaries-9.0.2.tar.xz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.4.6", "9.4.5", "9.2.8", "9.0.2", "8.10.7"]
+        ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
         platform: [ { image: "debian:9"
                     , installCmd: "sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && sed -i /-updates/d /etc/apt/sources.list && apt-get update && apt-get install -y"
                     , toolRequirements: "libnuma-dev zlib1g-dev libgmp-dev libgmp10 libssl-dev liblzma-dev libbz2-dev git wget lsb-release software-properties-common gnupg2 apt-transport-https gcc autoconf automake build-essential curl ghc gzip libffi-dev libncurses-dev libncurses5 libtinfo5 patchelf"
@@ -118,15 +118,6 @@ jobs:
         # Perhaps we can migrate *all* unknown linux builds to a uniform
         # image.
         include:
-          - ghc: 8.10.7
-            platform:
-              { image: "rockylinux:8"
-              , installCmd: "yum -y install epel-release && yum install -y --allowerasing"
-              , toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf"
-              , DISTRO: "Unknown"
-              , ARTIFACT: "x86_64-linux-unknown"
-              , ADD_CABAL_ARGS: "--enable-split-sections"
-              }
           - ghc: 9.0.2
             platform:
               { image: "rockylinux:8"
@@ -140,24 +131,6 @@ jobs:
             platform:
               { image: "rockylinux:8"
               , installCmd: "yum -y install epel-release && yum install -y --allowerasing"
-              , toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf"
-              , DISTRO: "Unknown"
-              , ARTIFACT: "x86_64-linux-unknown"
-              , ADD_CABAL_ARGS: "--enable-split-sections"
-              }
-          - ghc: 9.4.5
-            platform:
-              { image: "fedora:27"
-              , installCmd: "dnf install -y"
-              , toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf"
-              , DISTRO: "Unknown"
-              , ARTIFACT: "x86_64-linux-unknown"
-              , ADD_CABAL_ARGS: "--enable-split-sections"
-              }
-          - ghc: 9.4.6
-            platform:
-              { image: "fedora:27"
-              , installCmd: "dnf install -y"
               , toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf"
               , DISTRO: "Unknown"
               , ARTIFACT: "x86_64-linux-unknown"
@@ -240,7 +213,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.4.6", "9.4.5", "9.2.8", "9.0.2", "8.10.7"]
+        ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
     steps:
       - uses: docker://arm64v8/ubuntu:focal
         name: Cleanup (aarch64 linux)
@@ -300,7 +273,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.4.6", "9.4.5", "9.2.8", "9.0.2", "8.10.7"]
+        ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -345,26 +318,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.4.6", "9.4.5", "9.2.8", "8.10.7"]
+        ghc: ["9.6.2", "9.4.7", "9.2.8"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Run build
         run: |
-          if test "${GHC_VERSION}" = "8.10.7"; then
-            bash .github/scripts/brew.sh git coreutils llvm@11 autoconf automake tree
-            export PATH="$HOME/.brew/bin:$HOME/.brew/sbin:$HOME/.brew/opt/llvm@11/bin:$PATH"
-            export CC="$HOME/.brew/opt/llvm@11/bin/clang"
-            export CXX="$HOME/.brew/opt/llvm@11/bin/clang++"
-            export AR="$HOME/.brew/opt/llvm@11/bin/llvm-ar"
-            export LLC="$HOME/.brew/opt/llvm@11/bin/llc"
-            export OPT="$HOME/.brew/opt/llvm@11/bin/opt"
-            export RANLIB="$HOME/.brew/opt/llvm@11/bin/llvm-ranlib"
-          else
-            bash .github/scripts/brew.sh git coreutils autoconf automake tree
-            export PATH="$HOME/.brew/bin:$HOME/.brew/sbin:$PATH"
-          fi
+          bash .github/scripts/brew.sh git coreutils autoconf automake tree
+          export PATH="$HOME/.brew/bin:$HOME/.brew/sbin:$PATH"
           export LD=ld
           bash .github/scripts/build.sh
           tar cf out-${ARTIFACT}-${GHC_VERSION}.tar out/ store/
@@ -401,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.4.6", "9.4.5", "9.2.8", "9.0.2", "8.10.7"]
+        ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
     steps:
       - name: install windows deps
         shell: pwsh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,12 +34,11 @@
   - this creates a draft release
   - `git push <remote> <version>`
 - [ ] run `sh scripts/release/download-gh-artifacts.sh <version> <your-gpg-email>`
-  - downloads artifacts to `gh-release-artifacts/<version>/`
+  - downloads artifacts to `gh-release-artifacts/haskell-language-server-<version>/`
   - also downloads FreeBSD bindist from circle CI
   - adds signatures
-- [ ] upload artifacts to downloads.haskell.org manually from `gh-release-artifacts/<version>/`
+- [ ] upload artifacts to downloads.haskell.org from `gh-release-artifacts/haskell-language-server-<version>/`
   - You require sftp access, contact wz1000, bgamari or chreekat
-  - For uploading, rename `gh-release-artifacts/<version>` to `gh-release-artifacts/haskell-language-server-<version>`
   - `cd gh-release-artifacts/haskell-language-server-<version>`
   - `SIGNING_KEY=... ../../release/upload.sh upload`
     - Your SIGNING_KEY can be obtained with `gpg --list-secret-keys --keyid-format=long`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,7 +154,7 @@ Homebrew users can install `haskell-language-server` using the following command
 brew install haskell-language-server
 ```
 
-This formula contains HLS binaries compiled with GHC versions available via Homebrew; at the moment those are: 8.10.7.
+This formula contains HLS binaries compiled with GHC versions available via Homebrew.
 
 You need to provide your own GHC/Cabal/Stack as required by your project, possibly via Homebrew.
 

--- a/scripts/release/create-yaml-snippet.sh
+++ b/scripts/release/create-yaml-snippet.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 RELEASE=$1
 
-cd "gh-release-artifacts/${RELEASE}"
+cd "gh-release-artifacts/haskell-language-server-${RELEASE}"
 
 cat <<EOF > /dev/stdout
     $RELEASE:

--- a/scripts/release/download-gh-artifacts.sh
+++ b/scripts/release/download-gh-artifacts.sh
@@ -13,11 +13,11 @@ for com in gh gpg curl sha256sum ; do
 	command -V ${com} >/dev/null 2>&1
 done
 
-[ ! -e "gh-release-artifacts/${RELEASE}" ]
+[ ! -e "gh-release-artifacts/haskell-language-server-${RELEASE}" ]
 
-mkdir -p "gh-release-artifacts/${RELEASE}"
+mkdir -p "gh-release-artifacts/haskell-language-server-${RELEASE}"
 
-cd "gh-release-artifacts/${RELEASE}"
+cd "gh-release-artifacts/haskell-language-server-${RELEASE}"
 
 # github
 gh release download "$RELEASE"


### PR DESCRIPTION
Drops GHC 8.10.7 from the release CI.

Unifies the download directory for release binaries and the upload directory for uploading the binaries to downloads.haskell.org.