### PR TITLE
bump lock, downgrade fourmolu to 0.11

### DIFF
--- a/configuration-ghc-94.nix
+++ b/configuration-ghc-94.nix
@@ -15,9 +15,13 @@ let
     } // (builtins.mapAttrs (_: drv: disableLibraryProfiling drv) {
       apply-refact = hsuper.apply-refact_0_13_0_0;
 
-      fourmolu = dontCheck (hself.callCabal2nix "fourmolu" inputs.fourmolu-011 {});
-
-      stylish-haskell = appendConfigureFlag  hsuper.stylish-haskell "-fghc-lib";
+      fourmolu = dontCheck (hself.callCabal2nix "fourmolu" inputs.fourmolu-013 {});
+      Cabal-syntax = hsuper.Cabal-syntax_3_10_1_0;
+      Cabal = hsuper.Cabal_3_10_1_0;
+      ghc-lib-parser-ex = hsuper.ghc-lib-parser-ex_9_6_0_1;
+      ormolu = hsuper.ormolu_0_7_1_0;
+      ghc-lib-parser = hsuper.ghc-lib-parser_9_6_2_20230523;
+      stylish-haskell = appendConfigureFlag  hsuper.stylish-haskell_0_14_5_0 "-fghc-lib";
 
       lsp = hself.callCabal2nix "lsp" inputs.lsp {};
       lsp-types = hself.callCabal2nix "lsp-types" inputs.lsp-types {};

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     "gitignore": {
       "flake": false,
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1694102001,
+        "narHash": "sha256-vky6VPK1n1od6vXbqzOXnekrQpTL4hbPAwUhT5J9c9E=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "9e21c80adf67ebcb077d75bd5e7d724d21eeafd6",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     "haskell-hie-bios": {
       "flake": false,
       "locked": {
-        "lastModified": 1686930638,
-        "narHash": "sha256-gfcxxHtZ2jUsiKNn/O4jEkfWF/2H04aTnaIvPDbtNlQ=",
+        "lastModified": 1693897916,
+        "narHash": "sha256-2gbvfYZIIY8TdzgqmSD5YUNR2XwNZwzlfNaXvQ1IwGs=",
         "owner": "haskell",
         "repo": "hie-bios",
-        "rev": "3d4fadfb0dc44cb287db9897ecfb503899d33513",
+        "rev": "a4c5b4f5a8e23733b7a37ece6001918cc088ed35",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686874404,
-        "narHash": "sha256-u2Ss8z+sGaVlKtq7sCovQ8WvXY+OoXJmY1zmyxITiaY=",
+        "lastModified": 1694131899,
+        "narHash": "sha256-14c1Kz+sw0IaZYOx0yuGMpDCvBc+RlBIY1NTBsFCOm0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "efc10371d5c5b8d2d58bab6c1100753efacfe550",
+        "rev": "9895283e265dff86996a33c772e7dcc346f3e55c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -58,6 +58,30 @@
         "url": "https://hackage.haskell.org/package/fourmolu-0.12.0.0/fourmolu-0.12.0.0.tar.gz"
       }
     },
+    "fourmolu-013": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-F2j2aKp7XB0OOeRHdRO4I1UiNmt907W/qOvYYRFesew=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/fourmolu-0.13.0.0/fourmolu-0.13.0.0.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/fourmolu-0.13.0.0/fourmolu-0.13.0.0.tar.gz"
+      }
+    },
+    "fourmolu-014": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-s4ucw2kSwna2SpWB2jxsRRa/cnyqHSYEFoPBdKTpDq4=",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/fourmolu-0.14.0.0/fourmolu-0.14.0.0.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/fourmolu-0.14.0.0/fourmolu-0.14.0.0.tar.gz"
+      }
+    },
     "gitignore": {
       "flake": false,
       "locked": {
@@ -213,6 +237,8 @@
         "flake-utils": "flake-utils",
         "fourmolu-011": "fourmolu-011",
         "fourmolu-012": "fourmolu-012",
+        "fourmolu-013": "fourmolu-013",
+        "fourmolu-014": "fourmolu-014",
         "gitignore": "gitignore",
         "haskell-hie-bios": "haskell-hie-bios",
         "haskell-implicit-hie-cradle": "haskell-implicit-hie-cradle",

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,14 @@
       url = "https://hackage.haskell.org/package/fourmolu-0.12.0.0/fourmolu-0.12.0.0.tar.gz";
       flake = false;
     };
+    fourmolu-013 = {
+      url = "https://hackage.haskell.org/package/fourmolu-0.13.0.0/fourmolu-0.13.0.0.tar.gz";
+      flake = false;
+    };
+    fourmolu-014 = {
+      url = "https://hackage.haskell.org/package/fourmolu-0.14.0.0/fourmolu-0.14.0.0.tar.gz";
+      flake = false;
+    };
     ormolu-052 = {
       url = "https://hackage.haskell.org/package/ormolu-0.5.2.0/ormolu-0.5.2.0.tar.gz";
       flake = false;
@@ -337,6 +345,10 @@
               '';
             }))).overrideAttrs(old: {
               pname = old.pname + "-ghc${hpkgs.ghc.version}";
+
+              buildInputs = [
+                pkgs.pkg-config
+              ];
             });
       in with pkgs; rec {
         # Developement shell with only compiler

--- a/flake.nix
+++ b/flake.nix
@@ -345,10 +345,6 @@
               '';
             }))).overrideAttrs(old: {
               pname = old.pname + "-ghc${hpkgs.ghc.version}";
-
-              buildInputs = [
-                pkgs.pkg-config
-              ];
             });
       in with pkgs; rec {
         # Developement shell with only compiler

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -47,7 +47,7 @@ library
   elif impl(ghc >= 9.0) && impl(ghc < 9.2)
     build-depends: fourmolu ^>= 0.11
   elif impl(ghc >= 9.2) && impl(ghc < 9.8)
-    build-depends: fourmolu ^>= 0.13
+    build-depends: fourmolu ^>= 0.11
   else
     buildable: false
 

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -47,7 +47,7 @@ library
   elif impl(ghc >= 9.0) && impl(ghc < 9.2)
     build-depends: fourmolu ^>= 0.11
   elif impl(ghc >= 9.2) && impl(ghc < 9.8)
-    build-depends: fourmolu ^>= 0.11
+    build-depends: fourmolu ^>= 0.13
   else
     buildable: false
 


### PR DESCRIPTION
Would be glad on some help getting nix packages building again. This fixes build for 9.4.6 (and actually bumps nixpkgs to include 9.4.6), alas that required downgrading fourmolu — without that I cannot resolve dependencies :(