### PR TITLE
Add test directories to hls-retrie-plugin

### DIFF
--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -10,7 +10,11 @@ author:             Pepe Iborra
 maintainer:         pepeiborra@gmail.com
 category:           Development
 build-type:         Simple
-extra-source-files: LICENSE
+extra-source-files:
+  LICENSE
+  test/Main.hs
+  test/testdata/*.hs
+  test/testdata/*.yaml
 
 source-repository head
     type:     git


### PR DESCRIPTION
Fixes #3807 

Adds the files in the `test/` directory to the resulting package via the `extra-source-files`