### PR TITLE
Revert "Bump actions/checkout from 3 to 4"

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,7 +56,7 @@ jobs:
     # change of the strategy may require changing the bootstrapping/run code
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with:
 
         # By default, the `pull_request` event has a `GITHUB_SHA` env variable

--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -58,7 +58,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       # Need the repo checked out in order to read the file
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - id: ghcs
         run: echo "ghcs=$(cat ./.github/workflows/supported-ghc-versions.json)" >> $GITHUB_OUTPUT
       - id: skip_check
@@ -91,7 +91,7 @@ jobs:
           - macOS-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-build
         with:

--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -22,7 +22,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       # Need the repo checked out in order to read the file
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - id: ghcs
         run: echo "ghcs=$(cat ./.github/workflows/supported-ghc-versions.json)" >> $GITHUB_OUTPUT
       - id: skip_check
@@ -54,7 +54,7 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
 
             # By default, the `pull_request` event has a `GITHUB_SHA` env variable

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -10,7 +10,7 @@ jobs:
     name: "Hlint check run"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     - name: 'Installing'
       uses: rwe/actions-hlint-setup@v1

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -53,7 +53,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     - uses: cachix/install-nix-action@v23
       with:
@@ -85,7 +85,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     - uses: cachix/install-nix-action@v23
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
       git-diff: ${{ steps.git-diff.outputs.diff }}
     steps:
         - name: Checkout code
-          uses: actions/checkout@v4
+          uses: actions/checkout@v3
         - name: Find changed files
           uses: technote-space/get-diff-action@v6.1.2
           id: git-diff
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: file-diff
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-build
       with:
         # select a stable GHC version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,7 @@ jobs:
           echo "ID=linux" >> /etc/os-release
           echo "PRETTY_NAME=Linux" >> /etc/os-release
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Run build
         run: |
@@ -226,7 +226,7 @@ jobs:
         shell: bash
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - uses: docker://hasufell/arm64v8-ubuntu-haskell:focal
         name: Run build (aarch64 linux)
@@ -276,7 +276,7 @@ jobs:
         ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Run build
         run: |
@@ -321,7 +321,7 @@ jobs:
         ghc: ["9.6.2", "9.4.7", "9.2.8"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Run build
         run: |
@@ -374,7 +374,7 @@ jobs:
           taskkill /F /FI "MODULES eq msys-2.0.dll"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Run build (windows)
         run: |
@@ -483,7 +483,7 @@ jobs:
           echo "ID=linux" >> /etc/os-release
           echo "PRETTY_NAME=Linux" >> /etc/os-release
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -535,7 +535,7 @@ jobs:
           git config --global --get-all safe.directory | grep '^\*$' || git config --global --add safe.directory "*"
         shell: bash
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -574,7 +574,7 @@ jobs:
       ARCH: 64
       ARTIFACT: "x86_64-apple-darwin"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -612,7 +612,7 @@ jobs:
       ARCH: ARM64
       ARTIFACT: "aarch64-apple-darwin"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -664,7 +664,7 @@ jobs:
           C:\msys64\usr\bin\bash -lc "pacman --disable-download-timeout --noconfirm -S unzip zip git"
           taskkill /F /FI "MODULES eq msys-2.0.dll"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -778,7 +778,7 @@ jobs:
           echo "ID=linux" >> /etc/os-release
           echo "PRETTY_NAME=Linux" >> /etc/os-release
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -814,7 +814,7 @@ jobs:
         shell: bash
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -838,7 +838,7 @@ jobs:
       DISTRO: na
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -863,7 +863,7 @@ jobs:
       HOMEBREW_CHANGE_ARCH_TO_ARM: 1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -902,7 +902,7 @@ jobs:
           taskkill /F /FI "MODULES eq msys-2.0.dll"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -923,7 +923,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       ghcs: ${{ steps.ghcs.outputs.ghcs }}
     steps:
       # Need the repo checked out in order to read the file
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - id: ghcs
         run: echo "ghcs=$(cat ./.github/workflows/supported-ghc-versions.json)" >> $GITHUB_OUTPUT
       - id: skip_check
@@ -83,7 +83,7 @@ jobs:
              test: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-build
         with:


### PR DESCRIPTION
This caused release CI to fail, see https://github.com/haskell/haskell-language-server/actions/runs/6230276461

actions/checkout@v4 uses node 20 which requires GLIBC that is too new for our distributions
