### PR TITLE
Release 2.3.0.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ build_task:
     ARTIFACT: "x86_64-freebsd"
     DISTRO: "na"
     RUNNER_OS: "FreeBSD"
-    ADD_CABAL_ARGS: "--enable-split-sections"
+    ADD_CABAL_ARGS: "--enable-split-sections --constraint='text -simdutf'"
     GITHUB_WORKSPACE: ${CIRRUS_WORKING_DIR}
     CABAL_CACHE_NONFATAL: "yes"
   matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
                     , toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf"
                     , DISTRO: "CentOS"
                     , ARTIFACT: "x86_64-linux-centos7"
-                    , ADD_CABAL_ARGS: "--enable-split-sections"
+                    , ADD_CABAL_ARGS: "--enable-split-sections --constraint='text -simdutf'" # centos7 gcc is too old to build text +simdutf
                     }
                   ]
         # TODO: rm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
+        ghc: ["9.6.3", "9.6.2", "9.4.7", "9.2.8", "9.0.2"]
         platform: [ { image: "debian:9"
                     , installCmd: "sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && sed -i /-updates/d /etc/apt/sources.list && apt-get update && apt-get install -y"
                     , toolRequirements: "libnuma-dev zlib1g-dev libgmp-dev libgmp10 libssl-dev liblzma-dev libbz2-dev git wget lsb-release software-properties-common gnupg2 apt-transport-https gcc autoconf automake build-essential curl ghc gzip libffi-dev libncurses-dev libncurses5 libtinfo5 patchelf"
@@ -154,6 +154,15 @@ jobs:
               , ARTIFACT: "x86_64-linux-unknown"
               , ADD_CABAL_ARGS: "--enable-split-sections"
               }
+          - ghc: 9.6.3
+            platform:
+              { image: "rockylinux:8"
+              , installCmd: "yum -y install epel-release && yum install -y --allowerasing"
+              , toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf"
+              , DISTRO: "Unknown"
+              , ARTIFACT: "x86_64-linux-unknown"
+              , ADD_CABAL_ARGS: "--enable-split-sections"
+              }
     container:
       image: ${{ matrix.platform.image }}
     steps:
@@ -213,7 +222,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
+        ghc: ["9.6.3", "9.6.2", "9.4.7", "9.2.8", "9.0.2"]
     steps:
       - uses: docker://arm64v8/ubuntu:focal
         name: Cleanup (aarch64 linux)
@@ -273,7 +282,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
+        ghc: ["9.6.3", "9.6.2", "9.4.7", "9.2.8", "9.0.2"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -318,7 +327,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.2.8"]
+        ghc: ["9.6.3", "9.6.2", "9.4.7", "9.2.8"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -363,7 +372,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2", "9.4.7", "9.2.8", "9.0.2"]
+        ghc: ["9.6.3", "9.6.2", "9.4.7", "9.2.8", "9.0.2"]
     steps:
       - name: install windows deps
         shell: pwsh

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,62 @@
 # Changelog for haskell-language-server
 
+## 2.3.0.0.0
+
+* Binaries for GHC 9.6.3
+* Drop support for GHC 8.10
+* Remove `hls-haddock-comments-plugin`, `hls-stan-plugin`, and `hls-tactics-plugin`
+* Don't suggest bogus modules names in `hls-module-name-plugin` (#3784)
+* Add support for external Ormolu (#3771)
+* Improve refine imports behaviour for qualified imports (#3806)
+
+### Pull Requests
+
+- Switch chat room to matrix
+  ([#3817](https://github.com/haskell/haskell-language-server/pull/3817)) by @July541
+- Fix flaky hie bios test
+  ([#3814](https://github.com/haskell/haskell-language-server/pull/3814)) by @fendor
+- Revert "Bump actions/checkout from 3 to 4"
+  ([#3813](https://github.com/haskell/haskell-language-server/pull/3813)) by @wz1000
+- Add test directories to hls-retrie-plugin
+  ([#3808](https://github.com/haskell/haskell-language-server/pull/3808)) by @Vekhir
+- Change refine imports behaviour for qualified imports
+  ([#3806](https://github.com/haskell/haskell-language-server/pull/3806)) by @joyfulmantis
+- Update links to Nix documentation
+  ([#3805](https://github.com/haskell/haskell-language-server/pull/3805)) by @maralorn
+- Bump actions/checkout from 3 to 4
+  ([#3802](https://github.com/haskell/haskell-language-server/pull/3802)) by @dependabot[bot]
+- Bump cachix/install-nix-action from 22 to 23
+  ([#3801](https://github.com/haskell/haskell-language-server/pull/3801)) by @dependabot[bot]
+- Add support for Fourmolu 0.14.0.0
+  ([#3796](https://github.com/haskell/haskell-language-server/pull/3796)) by @brandonchinn178
+- Add code lens  and fix code actions experiments
+  ([#3791](https://github.com/haskell/haskell-language-server/pull/3791)) by @joyfulmantis
+- Bump lsp versions in flake
+  ([#3790](https://github.com/haskell/haskell-language-server/pull/3790)) by @colonelpanic8
+- Clean up Release CI
+  ([#3787](https://github.com/haskell/haskell-language-server/pull/3787)) by @fendor
+- Do not suggest bogus module names
+  ([#3784](https://github.com/haskell/haskell-language-server/pull/3784)) by @Bodigrim
+- Delete `hls-haddock-comments-plugin`, `hls-stan-plugin`, and `hls-tactics-plugin`
+  ([#3782](https://github.com/haskell/haskell-language-server/pull/3782)) by @michaelpj
+- Enhance/releasing checklist
+  ([#3781](https://github.com/haskell/haskell-language-server/pull/3781)) by @fendor
+- Add cradle dependencies to session loading errors
+  ([#3779](https://github.com/haskell/haskell-language-server/pull/3779)) by @VeryMilkyJoe
+- Prepare release 2.2.0.0
+  ([#3775](https://github.com/haskell/haskell-language-server/pull/3775)) by @fendor
+- Add support for external Ormolu
+  ([#3771](https://github.com/haskell/haskell-language-server/pull/3771)) by @sir4ur0n
+- Support for resolve for class-plugin lenses
+  ([#3769](https://github.com/haskell/haskell-language-server/pull/3769)) by @joyfulmantis
+- Introduce declarative test project definition for plugin tests
+  ([#3767](https://github.com/haskell/haskell-language-server/pull/3767)) by @fendor
+- Use latest version of fourmolu possible
+  ([#3764](https://github.com/haskell/haskell-language-server/pull/3764)) by @brandonchinn178
+- Drop support for GHC 8.10
+  ([#3434](https://github.com/haskell/haskell-language-server/pull/3434)) by @michaelpj
+
+
 ## 2.2.0.0
 
 * Binaries for GHC 9.4.7

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -60,7 +60,7 @@ BINDIST_BASE_DIR := out/bindist/$(ARTIFACT)
 BINDIST_OUT_DIR  := $(BINDIST_BASE_DIR)/haskell-language-server-$(HLS_VERSION)
 
 CABAL_BASE_ARGS         ?= --store-dir=$(ROOT_DIR)/$(STORE_DIR)
-CABAL_ARGS              ?= --disable-tests --disable-profiling -O2
+CABAL_ARGS              ?= --disable-tests --disable-profiling -O2 $(ADD_CABAL_ARGS)
 CABAL_INSTALL_ARGS      ?= --overwrite-policy=always --install-method=copy
 CABAL_INSTALL           := $(CABAL) $(CABAL_BASE_ARGS) v2-install
 PROJECT_FILE            := cabal.project

--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -17,11 +17,12 @@ Support status (see the support policy below for more details):
 
 | GHC version  | Last supporting HLS version                                                          | Support status                                                              |
 |--------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| 9.6.2        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | basic support                                                               |
+| 9.6.3        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | basic support                                                               |
+| 9.6.2        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/latest)        | basic support                                                               |
 | 9.6.1        | [2.0.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.0.0.0)   | basic support                                                               |
 | 9.4.7        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
-| 9.4.6        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
-| 9.4.5        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
+| 9.4.6        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/latest)        | full support                                                                |
+| 9.4.5        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/latest)        | full support                                                                |
 | 9.4.4        | [1.10.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.10.0.0) | deprecated                                                                  |
 | 9.4.3        | [1.9.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.9.1.0)   | deprecated                                                                  |
 | 9.4.(1,2)    | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0)   | deprecated                                                                  |

--- a/ghcide-bench/ghcide-bench.cabal
+++ b/ghcide-bench/ghcide-bench.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide-bench
-version:            2.2.0.0
+version:            2.3.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             The Haskell IDE team

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            2.2.0.0
+version:            2.3.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -69,7 +69,7 @@ library
         haddock-library >= 1.8 && < 1.12,
         hashable,
         hie-compat ^>= 0.3.0.0,
-        hls-plugin-api == 2.2.0.0,
+        hls-plugin-api == 2.3.0.0,
         lens,
         list-t,
         hiedb == 0.4.3.*,
@@ -85,7 +85,7 @@ library
         row-types,
         text-rope,
         safe-exceptions,
-        hls-graph == 2.2.0.0,
+        hls-graph == 2.3.0.0,
         sorted-list,
         sqlite-simple,
         stm,

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 category:           Development
 name:               haskell-language-server
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -198,129 +198,129 @@ flag cabalfmt
 
 common cabalfmt
   if flag(cabalfmt)
-    build-depends: hls-cabal-fmt-plugin == 2.2.0.0
+    build-depends: hls-cabal-fmt-plugin == 2.3.0.0
     cpp-options: -Dhls_cabalfmt
 
 common cabal
   if flag(cabal)
-    build-depends: hls-cabal-plugin == 2.2.0.0
+    build-depends: hls-cabal-plugin == 2.3.0.0
     cpp-options: -Dhls_cabal
 
 common class
   if flag(class)
-    build-depends: hls-class-plugin == 2.2.0.0
+    build-depends: hls-class-plugin == 2.3.0.0
     cpp-options: -Dhls_class
 
 common callHierarchy
   if flag(callHierarchy)
-    build-depends: hls-call-hierarchy-plugin == 2.2.0.0
+    build-depends: hls-call-hierarchy-plugin == 2.3.0.0
     cpp-options: -Dhls_callHierarchy
 
 common eval
   if flag(eval)
-    build-depends: hls-eval-plugin == 2.2.0.0
+    build-depends: hls-eval-plugin == 2.3.0.0
     cpp-options: -Dhls_eval
 
 common importLens
   if flag(importLens)
-    build-depends: hls-explicit-imports-plugin == 2.2.0.0
+    build-depends: hls-explicit-imports-plugin == 2.3.0.0
     cpp-options: -Dhls_importLens
 
 common rename
   if flag(rename)
-    build-depends: hls-rename-plugin == 2.2.0.0
+    build-depends: hls-rename-plugin == 2.3.0.0
     cpp-options: -Dhls_rename
 
 common retrie
   if flag(retrie)
-    build-depends: hls-retrie-plugin == 2.2.0.0
+    build-depends: hls-retrie-plugin == 2.3.0.0
     cpp-options: -Dhls_retrie
 
 common hlint
   if flag(hlint)
-    build-depends: hls-hlint-plugin == 2.2.0.0
+    build-depends: hls-hlint-plugin == 2.3.0.0
     cpp-options: -Dhls_hlint
 
 common moduleName
   if flag(moduleName)
-    build-depends: hls-module-name-plugin == 2.2.0.0
+    build-depends: hls-module-name-plugin == 2.3.0.0
     cpp-options: -Dhls_moduleName
 
 common pragmas
   if flag(pragmas)
-    build-depends: hls-pragmas-plugin == 2.2.0.0
+    build-depends: hls-pragmas-plugin == 2.3.0.0
     cpp-options: -Dhls_pragmas
 
 common splice
   if flag(splice)
-    build-depends: hls-splice-plugin == 2.2.0.0
+    build-depends: hls-splice-plugin == 2.3.0.0
     cpp-options: -Dhls_splice
 
 common alternateNumberFormat
   if flag(alternateNumberFormat)
-    build-depends: hls-alternate-number-format-plugin == 2.2.0.0
+    build-depends: hls-alternate-number-format-plugin == 2.3.0.0
     cpp-options: -Dhls_alternateNumberFormat
 
 common qualifyImportedNames
   if flag(qualifyImportedNames)
-    build-depends: hls-qualify-imported-names-plugin == 2.2.0.0
+    build-depends: hls-qualify-imported-names-plugin == 2.3.0.0
     cpp-options: -Dhls_qualifyImportedNames
 
 common codeRange
   if flag(codeRange)
-    build-depends: hls-code-range-plugin == 2.2.0.0
+    build-depends: hls-code-range-plugin == 2.3.0.0
     cpp-options: -Dhls_codeRange
 
 common changeTypeSignature
   if flag(changeTypeSignature)
-    build-depends: hls-change-type-signature-plugin == 2.2.0.0
+    build-depends: hls-change-type-signature-plugin == 2.3.0.0
     cpp-options: -Dhls_changeTypeSignature
 
 common gadt
   if flag(gadt)
-    build-depends: hls-gadt-plugin == 2.2.0.0
+    build-depends: hls-gadt-plugin == 2.3.0.0
     cpp-options: -Dhls_gadt
 
 common explicitFixity
   if flag(explicitFixity)
-    build-depends: hls-explicit-fixity-plugin == 2.2.0.0
+    build-depends: hls-explicit-fixity-plugin == 2.3.0.0
     cpp-options: -DexplicitFixity
 
 common explicitFields
   if flag(explicitFields)
-    build-depends: hls-explicit-record-fields-plugin == 2.2.0.0
+    build-depends: hls-explicit-record-fields-plugin == 2.3.0.0
     cpp-options: -DexplicitFields
 
 common overloadedRecordDot
   if flag(overloadedRecordDot) && (impl(ghc >= 9.2.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-overloaded-record-dot-plugin == 2.2.0.0
+    build-depends: hls-overloaded-record-dot-plugin == 2.3.0.0
     cpp-options: -Dhls_overloaded_record_dot
 
 -- formatters
 
 common floskell
   if flag(floskell) && impl(ghc < 9.5)
-    build-depends: hls-floskell-plugin == 2.2.0.0
+    build-depends: hls-floskell-plugin == 2.3.0.0
     cpp-options: -Dhls_floskell
 
 common fourmolu
   if flag(fourmolu)
-    build-depends: hls-fourmolu-plugin == 2.2.0.0
+    build-depends: hls-fourmolu-plugin == 2.3.0.0
     cpp-options: -Dhls_fourmolu
 
 common ormolu
   if flag(ormolu) && impl(ghc < 9.7)
-    build-depends: hls-ormolu-plugin == 2.2.0.0
+    build-depends: hls-ormolu-plugin == 2.3.0.0
     cpp-options: -Dhls_ormolu
 
 common stylishHaskell
   if flag(stylishHaskell)
-    build-depends: hls-stylish-haskell-plugin == 2.2.0.0
+    build-depends: hls-stylish-haskell-plugin == 2.3.0.0
     cpp-options: -Dhls_stylishHaskell
 
 common refactor
   if flag(refactor)
-    build-depends: hls-refactor-plugin == 2.2.0.0
+    build-depends: hls-refactor-plugin == 2.3.0.0
     cpp-options: -Dhls_refactor
 
 library
@@ -372,12 +372,12 @@ library
     , cryptohash-sha1
     , data-default
     , ghc
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , githash               >=0.1.6.1
     , lsp                   >= 2.2.0.0
     , hie-bios
     , hiedb
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , optparse-applicative
     , optparse-simple
     , process
@@ -516,7 +516,7 @@ test-suite func-test
     , lens-aeson
     , ghcide
     , ghcide-test-utils
-    , hls-test-utils == 2.2.0.0
+    , hls-test-utils == 2.3.0.0
     , lsp-types
     , aeson
     , hls-plugin-api

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-graph
-version:       2.2.0.0
+version:       2.3.0.0
 synopsis:      Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       2.2.0.0
+version:       2.3.0.0
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -59,7 +59,7 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             == 2.2.0.0
+    , hls-graph             == 2.3.0.0
     , lens
     , lens-aeson
     , lsp                   ^>=2.2

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       2.2.0.0
+version:       2.3.0.0
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -42,9 +42,9 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  == 2.2.0.0
+    , ghcide                  == 2.3.0.0
     , hls-graph
-    , hls-plugin-api          == 2.2.0.0
+    , hls-plugin-api          == 2.3.0.0
     , lens
     , lsp                     ^>=2.2
     , lsp-test                ^>=0.16

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-alternate-number-format-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Provide Alternate Number Formats plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,10 +32,10 @@ library
     , base                 >=4.12 && < 5
     , containers
     , extra
-    , ghcide               == 2.2.0.0
+    , ghcide               == 2.3.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       == 2.2.0.0
+    , hls-plugin-api       == 2.3.0.0
     , hie-compat
     , lens
     , lsp                  ^>=2.2.0.0
@@ -64,7 +64,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-alternate-number-format-plugin
-    , hls-test-utils       == 2.2.0.0
+    , hls-test-utils       == 2.3.0.0
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
+++ b/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-cabal-fmt-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Integration with the cabal-fmt code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -33,8 +33,8 @@ library
     , base            >=4.12 && <5
     , directory
     , filepath
-    , ghcide          == 2.2.0.0
-    , hls-plugin-api  == 2.2.0.0
+    , ghcide          == 2.3.0.0
+    , hls-plugin-api  == 2.3.0.0
     , lens
     , lsp-types
     , mtl
@@ -56,7 +56,7 @@ test-suite tests
     , directory
     , filepath
     , hls-cabal-fmt-plugin
-    , hls-test-utils        == 2.2.0.0
+    , hls-test-utils        == 2.3.0.0
 
   if flag(isolateTests)
     build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.6

--- a/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
+++ b/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-cabal-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Cabal integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -49,10 +49,10 @@ library
     , directory
     , filepath
     , extra                 >=1.7.4
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hashable
-    , hls-plugin-api        == 2.2.0.0
-    , hls-graph             == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
+    , hls-graph             == 2.3.0.0
     , lens
     , lsp                   ^>=2.2
     , lsp-types             ^>=2.0.2
@@ -84,7 +84,7 @@ test-suite tests
     , filepath
     , ghcide
     , hls-cabal-plugin
-    , hls-test-utils    == 2.2.0.0
+    , hls-test-utils    == 2.3.0.0
     , lens
     , lsp
     , lsp-types

--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-call-hierarchy-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Call hierarchy plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-call-hierarchy-plugin#readme>
@@ -33,9 +33,9 @@ library
     , base                  >=4.12 && <5
     , containers
     , extra
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hiedb
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lens
     , lsp                    >=2.2.0.0
     , sqlite-simple
@@ -59,7 +59,7 @@ test-suite tests
     , extra
     , filepath
     , hls-call-hierarchy-plugin
-    , hls-test-utils              == 2.2.0.0
+    , hls-test-utils              == 2.3.0.0
     , ghcide-test-utils
     , lens
     , lsp

--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-change-type-signature-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Change a declarations type signature with a Code Action
 description:
   Please see the README on GitHub at <https://github.com/haskell/plugins/hls-change-type-signature-plugin/README.md>
@@ -28,8 +28,8 @@ library
   hs-source-dirs:   src
   build-depends:
     , base             >=4.12 && < 5
-    , ghcide           == 2.2.0.0
-    , hls-plugin-api   == 2.2.0.0
+    , ghcide           == 2.3.0.0
+    , hls-plugin-api   == 2.3.0.0
     , lsp-types
     , regex-tdfa
     , syb
@@ -61,7 +61,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-change-type-signature-plugin
-    , hls-test-utils       == 2.2.0.0
+    , hls-test-utils       == 2.3.0.0
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-class-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:
   Class/instance management plugin for Haskell Language Server
 
@@ -39,10 +39,10 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide          == 2.2.0.0
+    , ghcide          == 2.3.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api  == 2.2.0.0
+    , hls-plugin-api  == 2.3.0.0
     , lens
     , lsp
     , mtl
@@ -75,7 +75,7 @@ test-suite tests
     , ghcide
     , hls-class-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.2.0.0
+    , hls-test-utils     == 2.3.0.0
     , lens
     , lsp-types
     , row-types

--- a/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
+++ b/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-code-range-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:
   HLS Plugin to support smart selection range and Folding range
 
@@ -37,9 +37,9 @@ library
     , containers
     , deepseq
     , extra
-    , ghcide           == 2.2.0.0
+    , ghcide           == 2.3.0.0
     , hashable
-    , hls-plugin-api   == 2.2.0.0
+    , hls-plugin-api   == 2.3.0.0
     , lens
     , lsp
     , mtl
@@ -62,10 +62,10 @@ test-suite tests
     , bytestring
     , containers
     , filepath
-    , ghcide                     == 2.2.0.0
+    , ghcide                     == 2.3.0.0
     , hls-code-range-plugin
     , hls-plugin-api
-    , hls-test-utils             == 2.2.0.0
+    , hls-test-utils             == 2.3.0.0
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-eval-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Eval plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -67,10 +67,10 @@ library
     , ghc
     , ghc-boot-th
     , ghc-paths
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hashable
     , hls-graph
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lens
     , lsp
     , lsp-types
@@ -112,7 +112,7 @@ test-suite tests
     , filepath
     , hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   == 2.2.0.0
+    , hls-test-utils   == 2.3.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
+++ b/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-explicit-fixity-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Show fixity explicitly while hovering
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-explicit-fixity-plugin#readme>
@@ -30,9 +30,9 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hashable
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lsp                   >=2.2
     , text
     , transformers
@@ -55,5 +55,5 @@ test-suite tests
     , base
     , filepath
     , hls-explicit-fixity-plugin
-    , hls-test-utils              == 2.2.0.0
+    , hls-test-utils              == 2.3.0.0
     , text

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-explicit-imports-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Explicit imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -38,9 +38,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hls-graph
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lens
     , lsp
     , mtl

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-explicit-record-fields-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Explicit record fields plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -35,8 +35,8 @@ library
     build-depends:
       , base                  >=4.12 && <5
       , ghc
-      , ghcide                == 2.2.0.0
-      , hls-plugin-api        == 2.2.0.0
+      , ghcide                == 2.3.0.0
+      , hls-plugin-api        == 2.3.0.0
       , lsp
       , lens
       , hls-graph

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-floskell-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Integration with the Floskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,8 +28,8 @@ library
   build-depends:
     , base            >=4.12 && <5
     , floskell        ^>=0.10
-    , ghcide          == 2.2.0.0
-    , hls-plugin-api  == 2.2.0.0
+    , ghcide          == 2.3.0.0
+    , hls-plugin-api  == 2.3.0.0
     , lsp-types       ^>=2.0.2.0
     , mtl
     , text
@@ -49,4 +49,4 @@ test-suite tests
     , base
     , filepath
     , hls-floskell-plugin
-    , hls-test-utils       == 2.2.0.0
+    , hls-test-utils       == 2.3.0.0

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -47,7 +47,7 @@ library
   elif impl(ghc >= 9.2) && impl(ghc < 9.8)
     build-depends: fourmolu ^>= 0.14
   else
-    buildable: false
+    buildable: False
 
   -- fourmolu 0.9.0 fails to build on Windows CI for reasons unknown
   if impl(ghc >= 9.2) && os(windows) && impl(ghc < 9.4)
@@ -64,7 +64,7 @@ test-suite tests
   build-tool-depends:
     fourmolu:fourmolu
   build-depends:
-    , base
+    , base            >=4.12 && <5
     , aeson
     , containers
     , filepath

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-fourmolu-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Integration with the Fourmolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -33,8 +33,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          == 2.2.0.0
-    , hls-plugin-api  == 2.2.0.0
+    , ghcide          == 2.3.0.0
+    , hls-plugin-api  == 2.3.0.0
     , lens
     , lsp
     , mtl
@@ -70,5 +70,5 @@ test-suite tests
     , filepath
     , hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       == 2.2.0.0
+    , hls-test-utils       == 2.3.0.0
     , lsp-test

--- a/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
+++ b/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-gadt-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Convert to GADT syntax plugin
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-gadt-plugin#readme>
@@ -30,10 +30,10 @@ library
     , containers
     , extra
     , ghc
-    , ghcide                 == 2.2.0.0
+    , ghcide                 == 2.3.0.0
     , ghc-boot-th
     , ghc-exactprint
-    , hls-plugin-api         == 2.2.0.0
+    , hls-plugin-api         == 2.3.0.0
     , hls-refactor-plugin
     , lens
     , lsp                    >=2.2.0.0
@@ -59,7 +59,7 @@ test-suite tests
     , base
     , filepath
     , hls-gadt-plugin
-    , hls-test-utils              == 2.2.0.0
+    , hls-test-utils              == 2.3.0.0
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-hlint-plugin
-version:       2.2.0.0
+version:       2.3.0.0
 synopsis:      Hlint integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -45,10 +45,10 @@ library
     , extra
     , filepath
     , ghc-exactprint        >=0.6.3.4
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hashable
     , hlint                 < 3.7
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lens
     , lsp
     , mtl
@@ -89,7 +89,7 @@ test-suite tests
     , filepath
     , hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.2.0.0
+    , hls-test-utils      == 2.3.0.0
     , lens
     , lsp-types
     , row-types

--- a/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
+++ b/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-module-name-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Module name plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -33,8 +33,8 @@ library
     , containers
     , directory
     , filepath
-    , ghcide                == 2.2.0.0
-    , hls-plugin-api        == 2.2.0.0
+    , ghcide                == 2.3.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lsp
     , text
     , transformers
@@ -53,4 +53,4 @@ test-suite tests
     , base
     , filepath
     , hls-module-name-plugin
-    , hls-test-utils          == 2.2.0.0
+    , hls-test-utils          == 2.3.0.0

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-ormolu-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Integration with the Ormolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -33,8 +33,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          == 2.2.0.0
-    , hls-plugin-api  == 2.2.0.0
+    , ghcide          == 2.3.0.0
+    , hls-plugin-api  == 2.3.0.0
     , lens
     , lsp
     , mtl
@@ -62,7 +62,7 @@ test-suite tests
     , filepath
     , hls-ormolu-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.2.0.0
+    , hls-test-utils     == 2.3.0.0
     , lsp-types
     , text
     , ormolu

--- a/plugins/hls-overloaded-record-dot-plugin/hls-overloaded-record-dot-plugin.cabal
+++ b/plugins/hls-overloaded-record-dot-plugin/hls-overloaded-record-dot-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-overloaded-record-dot-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Overloaded record dot plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
+++ b/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-pragmas-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Pragmas plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,8 +30,8 @@ library
     , extra
     , fuzzy
     , ghc
-    , ghcide                == 2.2.0.0
-    , hls-plugin-api        == 2.2.0.0
+    , ghcide                == 2.3.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lens
     , lsp
     , text
@@ -53,7 +53,7 @@ test-suite tests
     , base
     , filepath
     , hls-pragmas-plugin
-    , hls-test-utils      == 2.2.0.0
+    , hls-test-utils      == 2.3.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
+++ b/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-qualify-imported-names-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           A Haskell Language Server plugin that qualifies imported names
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,9 +30,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hls-graph
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lens
     , lsp
     , text
@@ -56,4 +56,4 @@ test-suite tests
     , text
     , filepath
     , hls-qualify-imported-names-plugin
-    , hls-test-utils             == 2.2.0.0
+    , hls-test-utils             == 2.3.0.0

--- a/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
+++ b/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-refactor-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Exactprint refactorings for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -68,8 +68,8 @@ library
     , ghc-boot
     , regex-tdfa
     , text-rope
-    , ghcide                == 2.2.0.0
-    , hls-plugin-api        == 2.2.0.0
+    , ghcide                == 2.3.0.0
+    , hls-plugin-api        == 2.3.0.0
     , lsp
     , text
     , transformers
@@ -103,7 +103,7 @@ test-suite tests
     , base
     , filepath
     , hls-refactor-plugin
-    , hls-test-utils      == 2.2.0.0
+    , hls-test-utils      == 2.3.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-rename-plugin/hls-rename-plugin.cabal
+++ b/plugins/hls-rename-plugin/hls-rename-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-rename-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Rename plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,11 +29,11 @@ library
     , extra
     , ghc
     , ghc-exactprint
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hashable
     , hiedb
     , hie-compat
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , hls-refactor-plugin
     , lens
     , lsp
@@ -60,4 +60,4 @@ test-suite tests
     , filepath
     , hls-plugin-api
     , hls-rename-plugin
-    , hls-test-utils             == 2.2.0.0
+    , hls-test-utils             == 2.3.0.0

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-retrie-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Retrie integration plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,9 +32,9 @@ library
     , directory
     , extra
     , ghc
-    , ghcide                == 2.2.0.0
+    , ghcide                == 2.3.0.0
     , hashable
-    , hls-plugin-api        == 2.2.0.0
+    , hls-plugin-api        == 2.3.0.0
     , hls-refactor-plugin
     , lens
     , lsp
@@ -69,5 +69,5 @@ test-suite tests
     , hls-plugin-api
     , hls-refactor-plugin
     , hls-retrie-plugin
-    , hls-test-utils             == 2.2.0.0
+    , hls-test-utils             == 2.3.0.0
     , text

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-splice-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:
   HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 
@@ -42,8 +42,8 @@ library
     , foldl
     , ghc
     , ghc-exactprint
-    , ghcide                == 2.2.0.0
-    , hls-plugin-api        == 2.2.0.0
+    , ghcide                == 2.3.0.0
+    , hls-plugin-api        == 2.3.0.0
     , hls-refactor-plugin
     , lens
     , lsp
@@ -70,6 +70,6 @@ test-suite tests
     , base
     , filepath
     , hls-splice-plugin
-    , hls-test-utils == 2.2.0.0
+    , hls-test-utils == 2.3.0.0
     , text
     , row-types

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-stylish-haskell-plugin
-version:            2.2.0.0
+version:            2.3.0.0
 synopsis:           Integration with the Stylish Haskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,8 +28,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide           == 2.2.0.0
-    , hls-plugin-api   == 2.2.0.0
+    , ghcide           == 2.3.0.0
+    , hls-plugin-api   == 2.3.0.0
     , lsp-types
     , mtl
     , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14.2
@@ -47,4 +47,4 @@ test-suite tests
     , base
     , filepath
     , hls-stylish-haskell-plugin
-    , hls-test-utils              == 2.2.0.0
+    , hls-test-utils              == 2.3.0.0


### PR DESCRIPTION
- Prepare release 2.3.0.0
- Switch darwin release CI to nix

## Checklist

- [x] check ghcup supports new GHC releases if any
- [x] set the supported GHCs in workflow file `.github/workflows/release.yaml`
  - There is currently a list of GHC versions for each major platform. Search for `ghc: [` to find all lists.
  - Look for `TODO:` to find locations that require extra care for GHC versions.
- [x] check all plugins still work if release includes code changes
- [x] bump package versions in all `*.cabal` files (same version as hls)
  - HLS uses lockstep versioning. The core packages and all plugins use the same version number, and only support exactly this version.
    - Exceptions:
      - `hie-compat` requires no automatic version bump.
      - `shake-bench` is an internal testing tool, not exposed to the outside world. Thus, no version bump required for releases.
  - For updating cabal files, the following script can be used:
    - ```sh
      # Update all `version:` fields
      sed -ri "s/^version:( +)2.2.0.0/version:\12.3.0.0/" **/*.cabal
      # Update all constraints expected to be in the form `== <version>`.
      # We usually don't force an exact version, so this is relatively unambiguous.
      # We could introduce some more ad-hoc parsing, if there is still ambiguity.
      sed -ri "s/== 2.2.0.0/== 2.3.0.0/" **/*.cabal
      ```
    - It still requires manual verification and review
- [x] generate and update changelog
  - Generate a ChangeLog via `./GenChangelogs.hs <api-key> <tag>`
    - `<tag>` is the git tag you want to generate the ChangeLog from.
    - `<api-key>` is a github access key: https://github.com/settings/tokens
- [x] create release branch as `wip/<version>`
  - `git switch -c wip/<version>`
- [x] create release tag as `<version>`
  - `git tag <version>`
- [x] trigger release pipeline by pushing the tag
  - this creates a draft release
  - `git push <remote> <version>`
- [x] run `sh scripts/release/download-gh-artifacts.sh <version> <your-gpg-email>`
  - downloads artifacts to `gh-release-artifacts/haskell-language-server-<version>/`
  - also downloads FreeBSD bindist from circle CI
  - adds signatures
- [x] upload artifacts to downloads.haskell.org from `gh-release-artifacts/haskell-language-server-<version>/`
  - You require sftp access, contact wz1000, bgamari or chreekat
  - `cd gh-release-artifacts/haskell-language-server-<version>`
  - `SIGNING_KEY=... ../../release/upload.sh upload`
    - Your SIGNING_KEY can be obtained with `gpg --list-secret-keys --keyid-format=long`
  - Afterwards, the artifacts are available at: `https://downloads.haskell.org/~hls/haskell-language-server-<version>/`
  - Run `SIGNING_KEY=... ../../release/upload.sh purge_all` to remove CDN caches
- [x] create PR to [ghcup-metadata](https://github.com/haskell/ghcup-metadata)
  - [x] update `ghcup-0.0.7.yaml` and `ghcup-vanilla-0.0.7.yaml`
    - can use `sh scripts/release/create-yaml-snippet.sh <version>` to generate a snippet that can be manually inserted into the yaml files
  - [x] update `hls-metadata-0.0.1.json`
    - utilize `cabal run ghcup-gen -- generate-hls-ghcs -f ghcup-0.0.7.yaml --format json --stdout` in the root of ghcup-metadata repository
  - Be sure to mark the correct latest version and add the 'recommended' tag to the latest release.
- [ ] get sign-off on release
  - from wz1000, michealpj, maerwald and fendor
- [x] publish release on github
- [x] upload hackage packages
  - requires credentials
- [ ] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
- [ ] Supported tools table needs to be updated:
  - https://www.haskell.org/ghcup/install/#supported-platforms
  - https://github.com/haskell/ghcup-hs/blob/master/docs/install.md#supported-platforms
  - https://github.com/haskell/ghcup-metadata/blob/44c6e2b5d0fcae15abeffff03e87544edf76dd7a/ghcup-gen/Main.hs#L67
- [x] post release on discourse and reddit
- [ ] merge release PR to master or forward port relevant changes
