### PR TITLE
Remove constraint on stm-hamt

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -72,8 +72,6 @@ constraints:
   setup.happy == 1.20.1.1,
   happy == 1.20.1.1,
   filepath installed,
-  -- for ghc 8.10, stm-hamt 1.2.0.10 doesn't build
-  stm-hamt < 1.2.0.10,
   -- Centos 7 comes with an old gcc version that doesn't know about
   -- the flag '-fopen-simd', which blocked the release 2.2.0.0.
   -- We want to be able to benefit from the performance optimisations


### PR DESCRIPTION
GHC 8.10 was dropped in the last release. This constraint is not needed anymore.

Fixes (with ghc 9.6.2):

==> cabal v2-install --with-compiler=/opt/homebrew/opt/ghc/bin/ghc --flags=-dynamic --jobs=4 --max-backjumps=100000 --install-method=copy --installdir=/opt/homebrew/Cellar/haskell-language-server/2.3.0.0/bin
  Error: cabal: Could not resolve dependencies:
  [__0] trying: ekg-json-0.1.0.7 (user goal)
  [__1] trying: base-4.18.0.0/installed-4.18.0.0 (dependency of ekg-json)
  [__2] trying: ghcide-2.3.0.0 (user goal)
  [__3] trying: stm-containers-1.2.0.2 (dependency of ghcide)
  [__4] next goal: stm-hamt (dependency of stm-containers)
  [__4] rejecting: stm-hamt-1.2.0.11, stm-hamt-1.2.0.10 (constraint from project
  config
  /private/tmp/haskell-language-server-20231005-27723-12xdk3f/haskell-language-server-2.3.0.0/cabal.project
  requires <1.2.0.10)
  [__4] trying: stm-hamt-1.2.0.9
  [__5] trying: primitive-0.8.0.0 (dependency of stm-hamt)
  [__6] trying: filepath-1.4.100.1/installed-1.4.100.1 (dependency of ghcide)
  [__7] next goal: exceptions (dependency of ghcide)
  [__7] rejecting: exceptions-0.10.7/installed-0.10.7 (conflict: stm-hamt =>
  transformers>=0.5 && <0.6, exceptions =>
  transformers==0.6.1.0/installed-0.6.1.0)
  [__7] rejecting: exceptions-0.10.7, exceptions-0.10.5, exceptions-0.10.4,
  exceptions-0.10.3, exceptions-0.10.2, exceptions-0.10.1, exceptions-0.10.0,
  exceptions-0.8.3, exceptions-0.8.2.1, exceptions-0.8.1, exceptions-0.8.0.2,
  exceptions-0.8.0.1, exceptions-0.8, exceptions-0.7, exceptions-0.6.1,
  exceptions-0.6, exceptions-0.5, exceptions-0.4, exceptions-0.3.3.1,
  exceptions-0.3.3, exceptions-0.3.2, exceptions-0.3.1, exceptions-0.3,
  exceptions-0.2, exceptions-0.1.1, exceptions-0.1.0.1, exceptions-0.1,
  exceptions-0.10.6, exceptions-0.9.0 (conflict: filepath =>
  exceptions==0.10.7/installed-0.10.7)
  [__7] fail (backjumping, conflict set: exceptions, filepath, ghcide, stm-hamt)
  After searching the rest of the dependency tree exhaustively, these were the
  goals I've had most trouble fulfilling: filepath, exceptions, ghcide,
  primitive, stm-containers, stm-hamt, base, ekg-json
  Try running with --minimize-conflict-set to improve the error message.

See https://github.com/Homebrew/homebrew-core/pull/141617