### PR TITLE
Simplify cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -34,47 +34,26 @@ packages:
          ./plugins/hls-refactor-plugin
          ./plugins/hls-overloaded-record-dot-plugin
 
--- Standard location for temporary packages needed for particular environments
--- For example it is used in the project gitlab mirror to help in the MAcOS M1 build script
--- See https://github.com/haskell/haskell-language-server/blob/master/.gitlab-ci.yml
-optional-packages: vendored/*/*.cabal
+index-state: 2023-10-06T06:12:29Z
 
 tests: True
+test-show-details: direct
 
--- mfsolve has duplicate instances in its test suite
--- See: https://github.com/kuribas/mfsolve/issues/8
-package mfsolve
-  tests: False
-
-package *
-  ghc-options: -haddock
-  test-show-details: direct
+benchmarks: True
 
 write-ghc-environment-files: never
 
-index-state: 2023-10-06T06:12:29Z
+-- Make sure dependencies are build with haddock so we get
+-- haddock shown on hover
+package *
+  ghc-options: -haddock
 
 constraints:
   -- C++ is hard to distribute, especially on older GHCs
   -- See https://github.com/haskell/haskell-language-server/issues/3822
   text -simdutf,
-  -- For GHC 9.4, older versions of entropy fail to build on Windows
-  entropy >= 0.4.1.10,
-  -- For GHC 9.4
-  basement >= 0.0.15,
-  -- For GHC 9.4
-  hw-prim >= 0.6.3.2,
-  hyphenation +embed,
-  -- remove this when hlint sets ghc-lib to true by default
-  -- https://github.com/ndmitchell/hlint/issues/1376
-  hlint +ghc-lib,
   ghc-check -ghc-check-use-package-abis,
   ghc-lib-parser-ex -auto,
-  stylish-haskell +ghc-lib,
-  fourmolu -fixity-th,
-  setup.happy == 1.20.1.1,
-  happy == 1.20.1.1,
-  filepath installed,
   -- Centos 7 comes with an old gcc version that doesn't know about
   -- the flag '-fopen-simd', which blocked the release 2.2.0.0.
   -- We want to be able to benefit from the performance optimisations
@@ -94,20 +73,17 @@ source-repository-package
   tag: 7a0af7a8fd38045fd15fb13445bdcc7085325460
 -- END DELETE
 
-allow-newer:
-  -- ghc-9.4
-  ekg-json:base,
-  ekg-wai:time,
-
-if impl(ghc >= 9.5)
+if impl(ghc >= 9.1)
+  -- ekg packagess are old and unmaintained, but we 
+  -- don't rely on them for the mainline build, so 
+  -- this is okay
   allow-newer:
-    -- ghc-9.6
-    ekg-core:ghc-prim,
-    stm-hamt:transformers,
+    ekg-json:base,
+    ekg-wai:time,
+    ekg-core:ghc-prim
 
 if impl(ghc >= 9.7)
   allow-newer:
-    -- ghc-9.8
     base,
     template-haskell,
     ghc,
@@ -122,7 +98,6 @@ if impl(ghc >= 9.7)
     unix,
     deepseq,
 
-if impl(ghc >= 9.7)
   repository head.hackage.ghc.haskell.org
      url: https://ghc.gitlab.haskell.org/head.hackage/
      secure: True

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -570,6 +570,9 @@ test-suite wrapper-test
   main-is:            Main.hs
 
 benchmark benchmark
+    -- Depends on shake-bench which is unbuildable after this point
+    if impl(ghc >= 9.5)
+      buildable: False
     type: exitcode-stdio-1.0
     default-language: Haskell2010
     ghc-options: -Wall -Wno-name-shadowing -threaded

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -52,7 +52,7 @@ library
     , ghc-exactprint        >=0.6.3.4
     , ghcide                == 2.4.0.0
     , hashable
-    , hlint                 < 3.7
+    , hlint                 >= 3.5 && < 3.7
     , hls-plugin-api        == 2.4.0.0
     , lens
     , lsp

--- a/shake-bench/shake-bench.cabal
+++ b/shake-bench/shake-bench.cabal
@@ -16,6 +16,7 @@ source-repository head
     location: https://github.com/haskell/haskell-language-server.git
 
 library
+  -- Depends on Chart which is unbuildable after this point
   if impl(ghc >= 9.5)
     buildable: False
   exposed-modules:  Development.Benchmark.Rules

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -66,11 +66,6 @@ flags:
     pedantic: true
   retrie:
     BuildExecutable: false
-  # Stack doesn't support automatic flags.
-  hyphenation:
-    embed: true
-  stylish-haskell:
-    ghc-lib: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -67,9 +67,6 @@ flags:
     pedantic: true
   retrie:
     BuildExecutable: false
-  # Stack doesn't support automatic flags.
-  hyphenation:
-    embed: true
 
 nix:
   packages: [ icu libcxx zlib ]


### PR DESCRIPTION
- entropy has had bounds revised in
- basement/hw-prim bounds empirically unnecessariy
- hyphenation was for wingman
- bound hlint to a version that uses ghc-lib by default
- stylish-haskell has never had a ghc-lib flag
- none of the versions of fourmolu that we use have a fixity-th flag
- remove some other things that lack justification speculatively
- make shake-bench buildable on later GHCs