### PR TITLE
Require aeson 2

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -43,7 +43,7 @@ flag pedantic
 library
     default-language:   Haskell2010
     build-depends:
-        aeson,
+        aeson >= 2,
         array,
         async,
         base == 4.*,


### PR DESCRIPTION
Just want to see if this is okay. It would let us simplify some things in `lsp`.