### PR TITLE
Some versions of stylish-haskell do need the ghc-lib flag

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -54,6 +54,10 @@ constraints:
   text -simdutf,
   ghc-check -ghc-check-use-package-abis,
   ghc-lib-parser-ex -auto,
+  -- This is only present in some versions, and it's on by default since 
+  -- 0.14.5.0, but there are some versions we allow that need this 
+  -- setting
+  stylish-haskell +ghc-lib,
   -- Centos 7 comes with an old gcc version that doesn't know about
   -- the flag '-fopen-simd', which blocked the release 2.2.0.0.
   -- We want to be able to benefit from the performance optimisations


### PR DESCRIPTION
I convinced myself we didn't need this but we do for just a few minor versions of stylish-haskell. That apparently includes the one that the (non-required) stack build uses, so I missed the failure.