### PR TITLE
Give plugins descriptions, include versions of key dependencies 

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -13,7 +13,11 @@ import           Data.Function                 ((&))
 import           Data.Functor                  ((<&>))
 import           Data.Maybe                    (catMaybes)
 import           Data.Text                     (Text)
-import           Ide.Logger  (Doc, Priority (Error, Info),
+import qualified HlsPlugins                    as Plugins
+import           Ide.Arguments                 (Arguments (..),
+                                                GhcideArguments (..),
+                                                getArguments)
+import           Ide.Logger                    (Doc, Priority (Error, Info),
                                                 Recorder,
                                                 WithPriority (WithPriority, priority),
                                                 cfilter, cmapWithPrio,
@@ -21,11 +25,7 @@ import           Ide.Logger  (Doc, Priority (Error, Info),
                                                 layoutPretty, logWith,
                                                 makeDefaultStderrRecorder,
                                                 renderStrict, withFileRecorder)
-import qualified Ide.Logger  as Logger
-import qualified HlsPlugins                    as Plugins
-import           Ide.Arguments                 (Arguments (..),
-                                                GhcideArguments (..),
-                                                getArguments)
+import qualified Ide.Logger                    as Logger
 import           Ide.Main                      (defaultMain)
 import qualified Ide.Main                      as IdeMain
 import           Ide.PluginUtils               (pluginDescToIdePlugins)
@@ -70,7 +70,7 @@ main = do
                 ])
     -- This plugin just installs a handler for the `initialized` notification, which then
     -- picks up the LSP environment and feeds it to our recorders
-    let lspRecorderPlugin = (defaultPluginDescriptor "LSPRecorderCallback")
+    let lspRecorderPlugin = (defaultPluginDescriptor "LSPRecorderCallback" "Internal plugin")
           { pluginNotificationHandlers = mkPluginNotificationHandler LSP.SMethod_Initialized $ \_ _ _ _ -> do
               env <- LSP.getLspEnv
               liftIO $ (cb1 <> cb2) env

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -100,7 +100,7 @@ main = withTelemetryLogger $ \telemetryLogger -> do
     (lspMessageRecorder, cb2) <- Logger.withBacklog Logger.lspClientMessageRecorder
     -- This plugin just installs a handler for the `initialized` notification, which then
     -- picks up the LSP environment and feeds it to our recorders
-    let lspRecorderPlugin = (defaultPluginDescriptor "LSPRecorderCallback")
+    let lspRecorderPlugin = (defaultPluginDescriptor "LSPRecorderCallback" "Internal plugin")
           { pluginNotificationHandlers = mkPluginNotificationHandler LSP.SMethod_Initialized $ \_ _ _ _ -> do
               env <- LSP.getLspEnv
               liftIO $ (cb1 <> cb2) env

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -54,7 +54,7 @@ whenUriFile :: Uri -> (NormalizedFilePath -> IO ()) -> IO ()
 whenUriFile uri act = whenJust (LSP.uriToFilePath uri) $ act . toNormalizedFilePath'
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder plId = (defaultPluginDescriptor plId) { pluginNotificationHandlers = mconcat
+descriptor recorder plId = (defaultPluginDescriptor plId desc) { pluginNotificationHandlers = mconcat
   [ mkPluginNotificationHandler LSP.SMethod_TextDocumentDidOpen $
       \ide vfs _ (DidOpenTextDocumentParams TextDocumentItem{_uri,_version}) -> liftIO $ do
       atomically $ updatePositionMapping ide (VersionedTextDocumentIdentifier _uri _version) []
@@ -142,6 +142,8 @@ descriptor recorder plId = (defaultPluginDescriptor plId) { pluginNotificationHa
     -- (which restart the Shake build) run after everything else
         pluginPriority = ghcideNotificationsPluginPriority
     }
+  where
+    desc = "Handles basic notifications for ghcide"
 
 ghcideNotificationsPluginPriority :: Natural
 ghcideNotificationsPluginPriority = defaultPluginPriority - 900

--- a/ghcide/src/Development/IDE/Plugin/Completions.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions.hs
@@ -71,13 +71,15 @@ ghcideCompletionsPluginPriority :: Natural
 ghcideCompletionsPluginPriority = defaultPluginPriority
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder plId = (defaultPluginDescriptor plId)
+descriptor recorder plId = (defaultPluginDescriptor plId desc)
   { pluginRules = produceCompletions recorder
   , pluginHandlers = mkPluginHandler SMethod_TextDocumentCompletion getCompletionsLSP
                      <> mkResolveHandler SMethod_CompletionItemResolve resolveCompletion
   , pluginConfigDescriptor = defaultConfigDescriptor {configCustomConfig = mkCustomConfig properties}
   , pluginPriority = ghcideCompletionsPluginPriority
   }
+  where
+    desc = "Provides Haskell completions"
 
 
 produceCompletions :: Recorder (WithPriority Log) -> Rules ()

--- a/ghcide/src/Development/IDE/Plugin/HLS/GhcIde.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS/GhcIde.hs
@@ -42,7 +42,7 @@ descriptors recorder =
 -- ---------------------------------------------------------------------
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId)
+descriptor plId = (defaultPluginDescriptor plId desc)
   { pluginHandlers = mkPluginHandler SMethod_TextDocumentHover hover'
                   <> mkPluginHandler SMethod_TextDocumentDocumentSymbol moduleOutline
                   <> mkPluginHandler SMethod_TextDocumentDefinition (\ide _ DefinitionParams{..} ->
@@ -56,6 +56,8 @@ descriptor plId = (defaultPluginDescriptor plId)
 
     pluginConfigDescriptor = defaultConfigDescriptor
   }
+  where
+    desc = "Provides core IDE features for Haskell"
 
 -- ---------------------------------------------------------------------
 

--- a/ghcide/src/Development/IDE/Plugin/Test.hs
+++ b/ghcide/src/Development/IDE/Plugin/Test.hs
@@ -77,7 +77,7 @@ newtype WaitForIdeRuleResult = WaitForIdeRuleResult { ideResultSuccess::Bool}
     deriving newtype (FromJSON, ToJSON)
 
 plugin :: PluginDescriptor IdeState
-plugin = (defaultPluginDescriptor "test") {
+plugin = (defaultPluginDescriptor "test" "") {
     pluginHandlers = mkPluginHandler (SMethod_CustomMethod (Proxy @"test")) $ \st _ ->
         testRequestHandler' st
     }
@@ -166,7 +166,7 @@ blockCommandId :: Text
 blockCommandId = "ghcide.command.block"
 
 blockCommandDescriptor :: PluginId -> PluginDescriptor state
-blockCommandDescriptor plId = (defaultPluginDescriptor plId) {
+blockCommandDescriptor plId = (defaultPluginDescriptor plId "") {
     pluginCommands = [PluginCommand (CommandId blockCommandId) "blocks forever" blockCommandHandler]
 }
 

--- a/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
+++ b/ghcide/src/Development/IDE/Plugin/TypeLenses.hs
@@ -94,13 +94,15 @@ typeLensCommandId = "typesignature.add"
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-  (defaultPluginDescriptor plId)
+  (defaultPluginDescriptor plId desc)
     { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeLens codeLensProvider
                     <> mkResolveHandler SMethod_CodeLensResolve codeLensResolveProvider
     , pluginCommands = [PluginCommand (CommandId typeLensCommandId) "adds a signature" commandHandler]
     , pluginRules = rules recorder
     , pluginConfigDescriptor = defaultConfigDescriptor {configCustomConfig = mkCustomConfig properties}
     }
+  where
+    desc = "Provides code lenses type signatures"
 
 properties :: Properties '[ 'PropertyKey "mode" (TEnum Mode)]
 properties = emptyProperties

--- a/ghcide/test/exe/ExceptionTests.hs
+++ b/ghcide/test/exe/ExceptionTests.hs
@@ -41,7 +41,7 @@ tests recorder logger = do
       [ testCase "PluginHandlers" $ do
           let pluginId = "plugin-handler-exception"
               plugins = pluginDescToIdePlugins $
-                  [ (defaultPluginDescriptor pluginId)
+                  [ (defaultPluginDescriptor pluginId "")
                       { pluginHandlers = mconcat
                           [ mkPluginHandler SMethod_TextDocumentCodeLens $ \_ _ _-> do
                               _ <- liftIO $ throwIO DivideByZero
@@ -62,7 +62,7 @@ tests recorder logger = do
           let pluginId = "command-exception"
               commandId = CommandId "exception"
               plugins = pluginDescToIdePlugins $
-                  [ (defaultPluginDescriptor pluginId)
+                  [ (defaultPluginDescriptor pluginId "")
                       { pluginCommands =
                           [ PluginCommand commandId "Causes an exception" $ \_ (_::Int) -> do
                               _ <- liftIO $ throwIO DivideByZero
@@ -84,7 +84,7 @@ tests recorder logger = do
         , testCase "Notification Handlers" $ do
           let pluginId = "notification-exception"
               plugins = pluginDescToIdePlugins $
-                  [ (defaultPluginDescriptor pluginId)
+                  [ (defaultPluginDescriptor pluginId "")
                       { pluginNotificationHandlers = mconcat
                           [  mkPluginNotificationHandler SMethod_TextDocumentDidOpen $ \_ _ _ _ ->
                               liftIO $ throwIO DivideByZero
@@ -137,7 +137,7 @@ pluginOrderTestCase recorder logger msg err1 err2 =
   testCase msg $ do
       let pluginId = "error-order-test"
           plugins = pluginDescToIdePlugins $
-              [ (defaultPluginDescriptor pluginId)
+              [ (defaultPluginDescriptor pluginId "")
                   { pluginHandlers = mconcat
                       [ mkPluginHandler SMethod_TextDocumentCodeLens $ \_ _ _-> do
                           throwError $ err1 "error test"

--- a/ghcide/test/exe/UnitTests.hs
+++ b/ghcide/test/exe/UnitTests.hs
@@ -80,7 +80,7 @@ tests recorder logger = do
                     }
                     | i <- [1..20]
                 ] ++ Ghcide.descriptors (cmapWithPrio LogGhcIde recorder)
-            priorityPluginDescriptor i = (defaultPluginDescriptor $ fromString $ show i){pluginPriority = i}
+            priorityPluginDescriptor i = (defaultPluginDescriptor (fromString $ show i) ""){pluginPriority = i}
 
         testIde recorder (IDE.testing (cmapWithPrio LogIDEMain recorder) logger plugins) $ do
             _ <- createDoc "A.hs" "haskell" "module A where"

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -25,6 +25,7 @@
 module Ide.Types
 ( PluginDescriptor(..), defaultPluginDescriptor, defaultCabalPluginDescriptor
 , defaultPluginPriority
+, describePlugin
 , IdeCommand(..)
 , IdeMethod(..)
 , IdeNotification(..)
@@ -104,6 +105,7 @@ import           Language.LSP.VFS
 import           Numeric.Natural
 import           OpenTelemetry.Eventlog
 import           Options.Applicative           (ParserInfo)
+import           Prettyprinter                 as PP
 import           System.FilePath
 import           System.IO.Unsafe
 import           Text.Regex.TDFA.Text          ()
@@ -266,6 +268,7 @@ instance ToJSON PluginConfig where
 
 data PluginDescriptor (ideState :: Type) =
   PluginDescriptor { pluginId           :: !PluginId
+                   , pluginDescription  :: !T.Text
                    -- ^ Unique identifier of the plugin.
                    , pluginPriority     :: Natural
                    -- ^ Plugin handlers are called in priority order, higher priority first
@@ -282,6 +285,13 @@ data PluginDescriptor (ideState :: Type) =
                    --   When writing handlers, etc. for this plugin it can be assumed that all handled files are of this type.
                    --   The file extension must have a leading '.'.
                    }
+
+describePlugin :: PluginDescriptor c -> Doc ann
+describePlugin p =
+  let
+    PluginId pid = pluginId p
+    pdesc = pluginDescription p
+  in pretty pid <> ":" <> nest 4 (PP.line <> pretty pdesc)
 
 -- | Check whether the given plugin descriptor is responsible for the file with the given path.
 --   Compares the file extension of the file at the given path with the file extension
@@ -894,10 +904,11 @@ defaultPluginPriority = 1000
 --
 -- and handlers will be enabled for files with the appropriate file
 -- extensions.
-defaultPluginDescriptor :: PluginId -> PluginDescriptor ideState
-defaultPluginDescriptor plId =
+defaultPluginDescriptor :: PluginId -> T.Text -> PluginDescriptor ideState
+defaultPluginDescriptor plId desc =
   PluginDescriptor
     plId
+    desc
     defaultPluginPriority
     mempty
     mempty
@@ -914,10 +925,11 @@ defaultPluginDescriptor plId =
 --
 -- Handles files with the following extensions:
 --   * @.cabal@
-defaultCabalPluginDescriptor :: PluginId -> PluginDescriptor ideState
-defaultCabalPluginDescriptor plId =
+defaultCabalPluginDescriptor :: PluginId -> T.Text -> PluginDescriptor ideState
+defaultCabalPluginDescriptor plId desc =
   PluginDescriptor
     plId
+    desc
     defaultPluginPriority
     mempty
     mempty

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
@@ -44,7 +44,7 @@ instance Pretty Log where
     LogShake log -> pretty log
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder pId = (defaultPluginDescriptor pId)
+descriptor recorder pId = (defaultPluginDescriptor pId "Provides code actions to convert numeric literals to different formats")
     { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeAction codeActionHandler
     , pluginRules = collectLiteralsRule recorder
     }

--- a/plugins/hls-cabal-fmt-plugin/src/Ide/Plugin/CabalFmt.hs
+++ b/plugins/hls-cabal-fmt-plugin/src/Ide/Plugin/CabalFmt.hs
@@ -39,7 +39,7 @@ instance Pretty Log where
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-  (defaultCabalPluginDescriptor plId)
+  (defaultCabalPluginDescriptor plId "Provides formatting of cabal files with cabal-fmt")
     { pluginHandlers = mkFormattingHandlers (provider recorder)
     }
 

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -80,7 +80,7 @@ instance Pretty Log where
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-  (defaultCabalPluginDescriptor plId)
+  (defaultCabalPluginDescriptor plId "Provides a variety of IDE features in cabal files")
     { pluginRules = cabalRules recorder
     , pluginHandlers =
         mconcat

--- a/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy.hs
+++ b/plugins/hls-call-hierarchy-plugin/src/Ide/Plugin/CallHierarchy.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Ide.Plugin.CallHierarchy (descriptor) where
 
 import           Development.IDE
@@ -6,7 +7,7 @@ import           Ide.Types
 import           Language.LSP.Protocol.Message
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId)
+descriptor plId = (defaultPluginDescriptor plId "Provides call-hierarchy support in Haskell")
     { Ide.Types.pluginHandlers =
         mkPluginHandler SMethod_TextDocumentPrepareCallHierarchy X.prepareCallHierarchy
      <> mkPluginHandler SMethod_CallHierarchyIncomingCalls X.incomingCalls

--- a/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
+++ b/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
@@ -33,7 +33,8 @@ import           Language.LSP.Protocol.Types
 import           Text.Regex.TDFA                  ((=~))
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId) { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeAction (codeActionHandler plId) }
+descriptor plId = (defaultPluginDescriptor plId "Provides a code action to change the type signature of a binding if it is wrong")
+  { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeAction (codeActionHandler plId) }
 
 codeActionHandler :: PluginId -> PluginMethodHandler IdeState 'Method_TextDocumentCodeAction
 codeActionHandler plId ideState _ CodeActionParams {_textDocument = TextDocumentIdentifier uri, _context = CodeActionContext diags _ _} = do

--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class.hs
@@ -8,7 +8,7 @@ import           Ide.Plugin.Class.Types
 import           Ide.Types
 import           Language.LSP.Protocol.Message
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder plId = (defaultPluginDescriptor plId)
+descriptor recorder plId = (defaultPluginDescriptor plId "Provides code actions and lenses for working with typeclasses")
     { pluginCommands = commands plId
     , pluginRules = getInstanceBindTypeSigsRule recorder >> getInstanceBindLensRule recorder
     , pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeAction (codeAction recorder)

--- a/plugins/hls-code-range-plugin/src/Ide/Plugin/CodeRange.hs
+++ b/plugins/hls-code-range-plugin/src/Ide/Plugin/CodeRange.hs
@@ -57,7 +57,7 @@ import           Language.LSP.Protocol.Types          (FoldingRange (..),
 import           Prelude                              hiding (log, span)
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder plId = (defaultPluginDescriptor plId)
+descriptor recorder plId = (defaultPluginDescriptor plId "Provides selection and folding ranges for Haskell")
     { pluginHandlers = mkPluginHandler SMethod_TextDocumentSelectionRange (selectionRangeHandler recorder)
     <> mkPluginHandler SMethod_TextDocumentFoldingRange (foldingRangeHandler recorder)
     , pluginRules = codeRangeRule (cmapWithPrio LogRules recorder)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# OPTIONS_GHC -Wwarn #-}
 {-# LANGUAGE LambdaCase            #-}
@@ -34,7 +35,7 @@ instance Pretty Log where
 -- |Plugin descriptor
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-    (defaultPluginDescriptor plId)
+    (defaultPluginDescriptor plId "Provies a code lens to evaluate expressions in doctest comments")
         { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeLens CL.codeLens
         , pluginCommands = [CL.evalCommand plId]
         , pluginRules = rules (cmapWithPrio LogEvalRules recorder)

--- a/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
+++ b/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
@@ -34,7 +34,7 @@ import           Language.LSP.Protocol.Message
 import           Language.LSP.Protocol.Types
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder pluginId = (defaultPluginDescriptor pluginId)
+descriptor recorder pluginId = (defaultPluginDescriptor pluginId "Provides fixity information in hovers")
     { pluginRules = fixityRule recorder
     , pluginHandlers = mkPluginHandler SMethod_TextDocumentHover hover
     -- Make this plugin has a lower priority than ghcide's plugin to ensure

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -91,7 +91,7 @@ descriptorForModules
 descriptorForModules recorder modFilter plId =
   let resolveRecorder = cmapWithPrio LogResolve recorder
       codeActionHandlers = mkCodeActionHandlerWithResolve resolveRecorder (codeActionProvider recorder) (codeActionResolveProvider recorder)
-  in (defaultPluginDescriptor plId)
+  in (defaultPluginDescriptor plId "Provides a code action to make imports explicit")
     {
       -- This plugin provides a command handler
       pluginCommands = [PluginCommand importCommandId "Explicit import command" (runImportCommand recorder)],

--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -106,7 +106,7 @@ descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeSta
 descriptor recorder plId =
   let resolveRecorder = cmapWithPrio LogResolve recorder
       (carCommands, caHandlers) = mkCodeActionWithResolveAndCommand resolveRecorder plId codeActionProvider codeActionResolveProvider
-  in (defaultPluginDescriptor plId)
+  in (defaultPluginDescriptor plId "Provides a code action to make record wildcards explicit")
   { pluginHandlers = caHandlers
   , pluginCommands = carCommands
   , pluginRules = collectRecordsRule recorder *> collectNamesRule

--- a/plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs
+++ b/plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Ide.Plugin.Floskell
@@ -20,9 +21,11 @@ import           Language.LSP.Protocol.Types
 -- ---------------------------------------------------------------------
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId "Provides formatting of Haskell files via floskell")
+descriptor plId = (defaultPluginDescriptor plId desc)
   { pluginHandlers = mkFormattingHandlers provider
   }
+  where
+    desc = "Provides formatting of Haskell files via floskell. Built with floskell-" <> VERSION_floskell
 
 -- ---------------------------------------------------------------------
 

--- a/plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs
+++ b/plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs
@@ -20,7 +20,7 @@ import           Language.LSP.Protocol.Types
 -- ---------------------------------------------------------------------
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId)
+descriptor plId = (defaultPluginDescriptor plId "Provides formatting of Haskell files via floskell")
   { pluginHandlers = mkFormattingHandlers provider
   }
 

--- a/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
@@ -49,7 +49,7 @@ import           Text.Read                       (readMaybe)
 
 descriptor :: Recorder (WithPriority LogEvent) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-    (defaultPluginDescriptor plId)
+    (defaultPluginDescriptor plId "Provides formatting of Haskell files via fourmolu")
         { pluginHandlers = mkFormattingHandlers $ provider recorder plId
         , pluginConfigDescriptor = defaultConfigDescriptor{configCustomConfig = mkCustomConfig properties}
         }

--- a/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
+++ b/plugins/hls-fourmolu-plugin/src/Ide/Plugin/Fourmolu.hs
@@ -49,10 +49,12 @@ import           Text.Read                       (readMaybe)
 
 descriptor :: Recorder (WithPriority LogEvent) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-    (defaultPluginDescriptor plId "Provides formatting of Haskell files via fourmolu")
+    (defaultPluginDescriptor plId desc)
         { pluginHandlers = mkFormattingHandlers $ provider recorder plId
         , pluginConfigDescriptor = defaultConfigDescriptor{configCustomConfig = mkCustomConfig properties}
         }
+  where
+    desc = "Provides formatting of Haskell files via fourmolu. Built with fourmolu-" <> VERSION_fourmolu
 
 properties :: Properties '[ 'PropertyKey "external" 'TBoolean]
 properties =

--- a/plugins/hls-gadt-plugin/src/Ide/Plugin/GADT.hs
+++ b/plugins/hls-gadt-plugin/src/Ide/Plugin/GADT.hs
@@ -38,7 +38,7 @@ import           Language.LSP.Protocol.Types
 import           Language.LSP.Server              (sendRequest)
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId)
+descriptor plId = (defaultPluginDescriptor plId "Provides a code action to convert datatypes to GADT syntax")
     { Ide.Types.pluginHandlers =
         mkPluginHandler SMethod_TextDocumentCodeAction codeActionHandler
     , pluginCommands =

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -195,7 +195,8 @@ descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeSta
 descriptor recorder plId =
   let resolveRecorder = cmapWithPrio LogResolve recorder
       (pluginCommands, pluginHandlers) = mkCodeActionWithResolveAndCommand resolveRecorder plId codeActionProvider (resolveProvider recorder)
-  in (defaultPluginDescriptor plId "Provides HLint diagnostics and code actions")
+      desc = "Provides HLint diagnostics and code actions. Built with hlint-" <> VERSION_hlint
+  in (defaultPluginDescriptor plId desc)
   { pluginRules = rules recorder plId
   , pluginCommands = pluginCommands
   , pluginHandlers = pluginHandlers

--- a/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
+++ b/plugins/hls-hlint-plugin/src/Ide/Plugin/Hlint.hs
@@ -195,7 +195,7 @@ descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeSta
 descriptor recorder plId =
   let resolveRecorder = cmapWithPrio LogResolve recorder
       (pluginCommands, pluginHandlers) = mkCodeActionWithResolveAndCommand resolveRecorder plId codeActionProvider (resolveProvider recorder)
-  in (defaultPluginDescriptor plId)
+  in (defaultPluginDescriptor plId "Provides HLint diagnostics and code actions")
   { pluginRules = rules recorder plId
   , pluginCommands = pluginCommands
   , pluginHandlers = pluginHandlers

--- a/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
+++ b/plugins/hls-module-name-plugin/src/Ide/Plugin/ModuleName.hs
@@ -69,7 +69,7 @@ import           System.FilePath                      (dropExtension, normalise,
 -- |Plugin descriptor
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-    (defaultPluginDescriptor plId)
+    (defaultPluginDescriptor plId "Provides a code action to alter the module name if it is wrong")
         { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeLens (codeLens recorder)
         , pluginCommands = [PluginCommand updateModuleNameCommand "set name of module to match with file path" (command recorder)]
         }

--- a/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
+++ b/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
@@ -52,10 +52,12 @@ import           Text.Read                       (readMaybe)
 
 descriptor :: Recorder (WithPriority LogEvent) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-  (defaultPluginDescriptor plId "Provides formatting of Haskell files via ormolu")
+  (defaultPluginDescriptor plId desc)
     { pluginHandlers = mkFormattingHandlers $ provider recorder plId,
       pluginConfigDescriptor = defaultConfigDescriptor {configCustomConfig = mkCustomConfig properties}
     }
+  where
+    desc = "Provides formatting of Haskell files via ormolu. Built with ormolu-" <> VERSION_ormolu
 
 properties :: Properties '[ 'PropertyKey "external" 'TBoolean]
 properties =

--- a/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
+++ b/plugins/hls-ormolu-plugin/src/Ide/Plugin/Ormolu.hs
@@ -52,7 +52,7 @@ import           Text.Read                       (readMaybe)
 
 descriptor :: Recorder (WithPriority LogEvent) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-  (defaultPluginDescriptor plId)
+  (defaultPluginDescriptor plId "Provides formatting of Haskell files via ormolu")
     { pluginHandlers = mkFormattingHandlers $ provider recorder plId,
       pluginConfigDescriptor = defaultConfigDescriptor {configCustomConfig = mkCustomConfig properties}
     }

--- a/plugins/hls-overloaded-record-dot-plugin/src/Ide/Plugin/OverloadedRecordDot.hs
+++ b/plugins/hls-overloaded-record-dot-plugin/src/Ide/Plugin/OverloadedRecordDot.hs
@@ -160,7 +160,7 @@ descriptor :: Recorder (WithPriority Log) -> PluginId
 descriptor recorder plId =
   let resolveRecorder = cmapWithPrio LogResolve recorder
       pluginHandler = mkCodeActionHandlerWithResolve resolveRecorder codeActionProvider resolveProvider
-  in (defaultPluginDescriptor plId)
+  in (defaultPluginDescriptor plId "Provides a code action to convert record selector usage to use overloaded record dot syntax")
     { pluginHandlers = pluginHandler
     , pluginRules = collectRecSelsRule recorder
     }

--- a/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
@@ -43,19 +43,19 @@ import qualified Text.Fuzzy                         as Fuzzy
 -- ---------------------------------------------------------------------
 
 suggestPragmaDescriptor :: PluginId -> PluginDescriptor IdeState
-suggestPragmaDescriptor plId = (defaultPluginDescriptor plId)
+suggestPragmaDescriptor plId = (defaultPluginDescriptor plId "Provides a code action to add missing LANGUAGE pragmas")
   { pluginHandlers = mkPluginHandler LSP.SMethod_TextDocumentCodeAction suggestPragmaProvider
   , pluginPriority = defaultPluginPriority + 1000
   }
 
 completionDescriptor :: PluginId -> PluginDescriptor IdeState
-completionDescriptor plId = (defaultPluginDescriptor plId)
+completionDescriptor plId = (defaultPluginDescriptor plId "Provides completion of LANGAUGE pragmas")
   { pluginHandlers = mkPluginHandler LSP.SMethod_TextDocumentCompletion completion
   , pluginPriority = ghcideCompletionsPluginPriority + 1
   }
 
 suggestDisableWarningDescriptor :: PluginId -> PluginDescriptor IdeState
-suggestDisableWarningDescriptor plId = (defaultPluginDescriptor plId)
+suggestDisableWarningDescriptor plId = (defaultPluginDescriptor plId "Provides a code action to disable warnings")
   { pluginHandlers = mkPluginHandler LSP.SMethod_TextDocumentCodeAction suggestDisableWarningProvider
     -- #3636 Suggestions to disable warnings should appear last.
   , pluginPriority = 0

--- a/plugins/hls-qualify-imported-names-plugin/src/Ide/Plugin/QualifyImportedNames.hs
+++ b/plugins/hls-qualify-imported-names-plugin/src/Ide/Plugin/QualifyImportedNames.hs
@@ -87,7 +87,7 @@ thenCmp EQ       ordering = ordering
 thenCmp ordering _        = ordering
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor pluginId = (defaultPluginDescriptor pluginId) {
+descriptor pluginId = (defaultPluginDescriptor pluginId "Provides a code action to qualify imported names") {
   pluginHandlers = mconcat
     [ mkPluginHandler SMethod_TextDocumentCodeAction codeActionProvider
     ]

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -145,6 +145,7 @@ iePluginDescriptor recorder plId =
           , wrap suggestAddRecordFieldImport
           ]
           plId
+          "Provides various quick fixes"
    in mkExactprintPluginDescriptor recorder $ old {pluginHandlers = pluginHandlers old <> mkPluginHandler SMethod_TextDocumentCodeAction codeAction }
 
 typeSigsPluginDescriptor :: Recorder (WithPriority E.Log) -> PluginId -> PluginDescriptor IdeState
@@ -157,6 +158,7 @@ typeSigsPluginDescriptor recorder plId = mkExactprintPluginDescriptor recorder $
     , wrap suggestConstraint
     ]
     plId
+    "Provides various quick fixes for type signatures"
 
 bindingsPluginDescriptor :: Recorder (WithPriority E.Log) ->  PluginId -> PluginDescriptor IdeState
 bindingsPluginDescriptor recorder plId = mkExactprintPluginDescriptor recorder $
@@ -168,12 +170,13 @@ bindingsPluginDescriptor recorder plId = mkExactprintPluginDescriptor recorder $
     , wrap suggestDeleteUnusedBinding
     ]
     plId
+    "Provides various quick fixes for bindings"
 
 fillHolePluginDescriptor :: Recorder (WithPriority E.Log) -> PluginId -> PluginDescriptor IdeState
-fillHolePluginDescriptor recorder plId = mkExactprintPluginDescriptor recorder (mkGhcideCAPlugin (wrap suggestFillHole) plId)
+fillHolePluginDescriptor recorder plId = mkExactprintPluginDescriptor recorder (mkGhcideCAPlugin (wrap suggestFillHole) plId "Provides a code action to fill a hole")
 
 extendImportPluginDescriptor :: Recorder (WithPriority E.Log) -> PluginId -> PluginDescriptor IdeState
-extendImportPluginDescriptor recorder plId = mkExactprintPluginDescriptor recorder $ (defaultPluginDescriptor plId)
+extendImportPluginDescriptor recorder plId = mkExactprintPluginDescriptor recorder $ (defaultPluginDescriptor plId "Provides a command to extend the import list")
   { pluginCommands = [extendImportCommand] }
 
 

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Args.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Args.hs
@@ -93,9 +93,9 @@ mkCA :: T.Text -> Maybe CodeActionKind -> Maybe Bool -> [Diagnostic] -> Workspac
 mkCA title kind isPreferred diags edit =
   InR $ CodeAction title kind (Just $ diags) isPreferred Nothing (Just edit) Nothing Nothing
 
-mkGhcideCAPlugin :: GhcideCodeAction -> PluginId -> PluginDescriptor IdeState
-mkGhcideCAPlugin codeAction plId =
-  (defaultPluginDescriptor plId)
+mkGhcideCAPlugin :: GhcideCodeAction -> PluginId -> T.Text -> PluginDescriptor IdeState
+mkGhcideCAPlugin codeAction plId desc =
+  (defaultPluginDescriptor plId desc)
     { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeAction $
         \state _ params@(CodeActionParams _ _ (TextDocumentIdentifier uri) _ CodeActionContext {_diagnostics = diags}) -> do
           results <- lift $ runGhcideCodeAction state params codeAction
@@ -107,7 +107,7 @@ mkGhcideCAPlugin codeAction plId =
                 ]
     }
 
-mkGhcideCAsPlugin :: [GhcideCodeAction] -> PluginId -> PluginDescriptor IdeState
+mkGhcideCAsPlugin :: [GhcideCodeAction] -> PluginId -> T.Text -> PluginDescriptor IdeState
 mkGhcideCAsPlugin codeActions = mkGhcideCAPlugin $ mconcat codeActions
 
 -------------------------------------------------------------------------------------------------

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -63,7 +63,7 @@ import           Language.LSP.Server
 instance Hashable (Mod a) where hash n = hash (unMod n)
 
 descriptor :: Recorder (WithPriority E.Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder pluginId = mkExactprintPluginDescriptor recorder $ (defaultPluginDescriptor pluginId)
+descriptor recorder pluginId = mkExactprintPluginDescriptor recorder $ (defaultPluginDescriptor pluginId "Provides renaming of Haskell identifiers")
     { pluginHandlers = mkPluginHandler SMethod_TextDocumentRename renameProvider
     , pluginConfigDescriptor = defaultConfigDescriptor
         { configCustomConfig = mkCustomConfig properties }

--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -173,7 +173,7 @@ import           Retrie.GHC                           (ann)
 
 descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId =
-  (defaultPluginDescriptor plId)
+  (defaultPluginDescriptor plId "Provides code actions to inline Haskell definitions")
     { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeAction provider,
       pluginCommands = [retrieCommand, retrieInlineThisCommand]
     }

--- a/plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs
+++ b/plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs
@@ -80,7 +80,7 @@ import Ide.Plugin.Error (PluginError(PluginInternalError))
 
 descriptor :: PluginId -> PluginDescriptor IdeState
 descriptor plId =
-    (defaultPluginDescriptor plId)
+    (defaultPluginDescriptor plId "Provides a code action to evaluate a TemplateHaskell splice")
         { pluginCommands = commands
         , pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeAction codeAction
         }

--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Ide.Plugin.Stan (descriptor, Log) where
 
 import           Compat.HieTypes                (HieASTs, HieFile)
@@ -43,12 +44,14 @@ import           Stan.Inspection.All            (inspectionsIds, inspectionsMap)
 import           Stan.Observation               (Observation (..))
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder plId = (defaultPluginDescriptor plId "Provides stan diagnostics")
+descriptor recorder plId = (defaultPluginDescriptor plId desc)
   { pluginRules = rules recorder plId
   , pluginConfigDescriptor = defaultConfigDescriptor
       { configHasDiagnostics = True
       }
     }
+  where
+    desc = "Provides stan diagnostics. Built with stan-" <> VERSION_stan
 
 newtype Log = LogShake Shake.Log deriving (Show)
 

--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -43,7 +43,7 @@ import           Stan.Inspection.All            (inspectionsIds, inspectionsMap)
 import           Stan.Observation               (Observation (..))
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
-descriptor recorder plId = (defaultPluginDescriptor plId)
+descriptor recorder plId = (defaultPluginDescriptor plId "Provides stan diagnostics")
   { pluginRules = rules recorder plId
   , pluginConfigDescriptor = defaultConfigDescriptor
       { configHasDiagnostics = True

--- a/plugins/hls-stylish-haskell-plugin/src/Ide/Plugin/StylishHaskell.hs
+++ b/plugins/hls-stylish-haskell-plugin/src/Ide/Plugin/StylishHaskell.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
 module Ide.Plugin.StylishHaskell
@@ -25,9 +26,11 @@ import           System.Directory
 import           System.FilePath
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId "Provides formatting of Haskell files via stylish-haskell")
+descriptor plId = (defaultPluginDescriptor plId desc)
   { pluginHandlers = mkFormattingHandlers provider
   }
+  where
+    desc = "Provides formatting of Haskell files via stylish-haskell. Built with stylish-haskell-" <> VERSION_stylish_haskell
 
 -- | Formatter provider of stylish-haskell.
 -- Formats the given source in either a given Range or the whole Document.

--- a/plugins/hls-stylish-haskell-plugin/src/Ide/Plugin/StylishHaskell.hs
+++ b/plugins/hls-stylish-haskell-plugin/src/Ide/Plugin/StylishHaskell.hs
@@ -25,7 +25,7 @@ import           System.Directory
 import           System.FilePath
 
 descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId)
+descriptor plId = (defaultPluginDescriptor plId "Provides formatting of Haskell files via stylish-haskell")
   { pluginHandlers = mkFormattingHandlers provider
   }
 

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -14,6 +14,7 @@ import           Control.Monad.Extra
 import qualified Data.Aeson.Encode.Pretty      as A
 import           Data.Coerce                   (coerce)
 import           Data.Default
+import           Data.List                     (sortOn)
 import           Data.Text                     (Text)
 import qualified Data.Text                     as T
 import           Data.Text.Lazy.Encoding       (decodeUtf8)
@@ -88,6 +89,7 @@ defaultMain recorder args idePlugins = do
             let pluginSummary =
                   PP.vsep
                     $ map describePlugin
+                    $ sortOn pluginId
                     $ ipMap idePlugins
             putStrLn $ show pluginSummary
 

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -14,7 +14,6 @@ import           Control.Monad.Extra
 import qualified Data.Aeson.Encode.Pretty      as A
 import           Data.Coerce                   (coerce)
 import           Data.Default
-import           Data.List                     (sort)
 import           Data.Text                     (Text)
 import qualified Data.Text                     as T
 import           Data.Text.Lazy.Encoding       (decodeUtf8)
@@ -34,8 +33,9 @@ import           Ide.Logger                    as G
 import           Ide.Plugin.ConfigUtils        (pluginsToDefaultConfig,
                                                 pluginsToVSCodeExtensionSchema)
 import           Ide.Types                     (IdePlugins, PluginId (PluginId),
-                                                ipMap, pluginId)
+                                                describePlugin, ipMap, pluginId)
 import           Ide.Version
+import           Prettyprinter                 as PP
 import           System.Directory
 import qualified System.Directory.Extra        as IO
 import           System.FilePath
@@ -85,10 +85,11 @@ defaultMain recorder args idePlugins = do
             putStrLn haskellLanguageServerNumericVersion
 
         ListPluginsMode -> do
-            let pluginNames = sort
-                    $ map ((\(PluginId t) -> T.unpack t) . pluginId)
+            let pluginSummary =
+                  PP.vsep
+                    $ map describePlugin
                     $ ipMap idePlugins
-            mapM_ putStrLn pluginNames
+            putStrLn $ show pluginSummary
 
         BiosMode PrintCradleType -> do
             dir <- IO.getCurrentDirectory

--- a/test/functional/Config.hs
+++ b/test/functional/Config.hs
@@ -76,7 +76,7 @@ genericConfigTests = testGroup "generic plugin config"
         testPluginId = "testplugin"
         -- A disabled-by-default plugin that creates diagnostics
         plugin = mkPluginTestDescriptor' @() pd testPluginId
-        pd plId = (defaultPluginDescriptor plId)
+        pd plId = (defaultPluginDescriptor plId "")
           {
             pluginConfigDescriptor = configDisabled
           , pluginRules = do


### PR DESCRIPTION
Some steps towards https://github.com/haskell/haskell-language-server/issues/3660

Output of `--list-plugins` now looks like this:
```
LSPRecorderCallback:                                                                                                                                                                                                                                                                                                       
    Internal plugin                                                                                                                                                                                                                                                                                                        
alternateNumberFormat:                                                                                                                                                                                                                                                                                                     
    Provides code actions to convert numeric literals to different formats                                                                                                                                                                                                                                                 
cabal:                                                                                                                                                                                                                                                                                                                     
    Provides a variety of IDE features in cabal files                                                                                                                                                                                                                                                                      
cabal-fmt:                                                                                                                                                                                                                                                                                                                 
    Provides formatting of cabal files with cabal-fmt                                                                                                                                                                                                                                                                      
callHierarchy:                                                                                                                                                                                                                                                                                                             
    Provides call-hierarchy support in Haskell                                                                                                                                                                                                                                                                             
changeTypeSignature:                                                                                                                                                                                                                                                                                                       
    Provides a code action to change the type signature of a binding if it is wrong                                                                                                                                                                                                                                        
class:                                                                                                                                                                                                                                                                                                                     
    Provides code actions and lenses for working with typeclasses                                                                                                                                                                                                                                                          
codeRange:                                                                                                                                                                                                                                                                                                                 
    Provides selection and folding ranges for Haskell                                                                                                                                                                                                                                                                      
eval:                                                                                                                                                                                                                                                                                                                      
    Provies a code lens to evaluate expressions in doctest comments                                                                                                                                                                                                                                                        
explicit-fields:                                                                                                                                                                                                                                                                                                           
    Provides a code action to make record wildcards explicit                                                                                                                                                                                                                                                               
explicit-fixity:                                                                                                                                                                                                                                                                                                           
    Provides fixity information in hovers                                                                                                                                                                                                                                                                                  
floskell:                                                                                                                                                                                                                                                                                                                  
    Provides formatting of Haskell files via floskell. Built with floskell-0.10.8                                                                                                                                                                                                                                          
fourmolu:                                                                                                                                                                                                                                                                                                                  
    Provides formatting of Haskell files via fourmolu. Built with fourmolu-0.14.0.0                                                                                                                                                                                                                                        
gadt:                                                                                                                                                                                                                                                                                                                      
    Provides a code action to convert datatypes to GADT syntax                                                                                                                                                                                                                                                             
ghcide-code-actions-bindings:
    Provides various quick fixes for bindings
ghcide-code-actions-fill-holes:
    Provides a code action to fill a hole
ghcide-code-actions-imports-exports:
    Provides various quick fixes
ghcide-code-actions-type-signatures:
    Provides various quick fixes for type signatures
ghcide-completions:
    Provides Haskell completions
ghcide-core:
    Handles basic notifications for ghcide
ghcide-extend-import-action:
    Provides a command to extend the import list
ghcide-hover-and-symbols:
    Provides core IDE features for Haskell
ghcide-type-lenses:
    Provides code lenses type signatures
hlint:
    Provides HLint diagnostics and code actions. Built with hlint-3.6.1
importLens:
    Provides a code action to make imports explicit
moduleName:
    Provides a code action to alter the module name if it is wrong
ormolu:
    Provides formatting of Haskell files via ormolu. Built with ormolu-0.7.2.0 
overloaded-record-dot:
    Provides a code action to convert record selector usage to use overloaded record dot syntax
pragmas-completion:
    Provides completion of LANGAUGE pragmas
pragmas-disable:
    Provides a code action to disable warnings
pragmas-suggest:
    Provides a code action to add missing LANGUAGE pragmas
qualifyImportedNames:
    Provides a code action to qualify imported names
rename:
    Provides renaming of Haskell identifiers
retrie:
    Provides code actions to inline Haskell definitions
splice:
    Provides a code action to evaluate a TemplateHaskell splice
stan:
    Provides stan diagnostics. Built with stan-0.1.1.0
stylish-haskell:
    Provides formatting of Haskell files via stylish-haskell. Built with stylish-haskell-0.14.5.0
```