### PR TITLE
Update ghc-version-support.md for 2.5.0

### DIFF
--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -21,7 +21,8 @@ Support status (see the support policy below for more details):
 | 9.6.3        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
 | 9.6.2        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |
 | 9.6.1        | [2.0.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.0.0.0)   | deprecated                                                                  |
-| 9.4.7        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
+| 9.4.8        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
+| 9.4.7        | [2.5.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.5.0.0)   | deprecated                                                                  |
 | 9.4.6        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |
 | 9.4.5        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |
 | 9.4.4        | [1.10.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.10.0.0) | deprecated                                                                  |


### PR DESCRIPTION
2.5.0 added support for 9.4.8 but this isn't listed on the supported versions page yet. Adding it and saying that 9.4.7 is deprecated per the deprecation policy below.