### PR TITLE
Add golden tests for public configs

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -314,12 +314,12 @@ common floskell
     cpp-options: -Dhls_floskell
 
 common fourmolu
-  if flag(fourmolu) 
+  if flag(fourmolu)
     build-depends: hls-fourmolu-plugin == 2.5.0.0
     cpp-options: -Dhls_fourmolu
 
 common ormolu
-  if flag(ormolu) 
+  if flag(ormolu)
     build-depends: hls-ormolu-plugin == 2.5.0.0
     cpp-options: -Dhls_ormolu
 
@@ -522,7 +522,6 @@ test-suite func-test
     , data-default
     , deepseq
     , hashable
-    , hspec-expectations
     , lens
     , lens-aeson
     , ghcide
@@ -541,6 +540,7 @@ test-suite func-test
   main-is:            Main.hs
   other-modules:
     Config
+    ConfigSchema
     Format
     FunctionalBadProject
     HieBios
@@ -556,7 +556,7 @@ test-suite func-test
   if flag(eval)
     cpp-options: -Dhls_eval
 -- formatters
-  if flag(floskell) 
+  if flag(floskell)
     cpp-options: -Dhls_floskell
   if flag(fourmolu)
     cpp-options: -Dhls_fourmolu

--- a/test/functional/ConfigSchema.hs
+++ b/test/functional/ConfigSchema.hs
@@ -1,0 +1,49 @@
+module ConfigSchema where
+
+
+import qualified Data.ByteString.Lazy.Char8 as BS
+import           Data.Char                  (toLower)
+import           System.FilePath            ((</>))
+import           System.Process.Extra
+import           Test.Hls
+import           Test.Hls.Command
+
+-- | Integration test to capture changes to the generated default config and the vscode schema.
+--
+-- Changes to the vscode schema need to be communicated to vscode-haskell plugin maintainers,
+-- otherwise users can't make use of the new configurations.
+--
+-- In general, changes to the schema need to be done consciously when new plugin or features are added.
+-- To fix a failing of these tests, review the change. If it is expected, accept the change via:
+--
+-- @
+--   TASTY_PATTERN="generate schema" cabal test func-test --test-options=--accept
+-- @
+--
+-- As changes need to be applied for all GHC version specific configs, you either need to run this command for each
+-- GHC version that is affected by the config change, or manually add the change to all other golden config files.
+-- Likely, the easiest way is to run CI and apply the generated diffs manually.
+tests :: TestTree
+tests = testGroup "generate schema"
+  [ goldenGitDiff "vscode-extension-schema" (vscodeSchemaFp ghcVersion) $ do
+      stdout <- readProcess hlsExeCommand ["vscode-extension-schema"] ""
+      pure $ BS.pack stdout
+  , goldenGitDiff "generate-default-config" (defaultConfigFp ghcVersion) $ do
+      stdout <- readProcess hlsExeCommand ["generate-default-config"] ""
+      pure $ BS.pack stdout
+  ]
+
+vscodeSchemaFp :: GhcVersion -> FilePath
+vscodeSchemaFp ghcVer = "test" </> "testdata" </> "schema" </> prettyGhcVersion ghcVer </> vscodeSchemaJson
+
+defaultConfigFp :: GhcVersion -> FilePath
+defaultConfigFp ghcVer = "test" </> "testdata" </> "schema" </> prettyGhcVersion ghcVer </> generateDefaultConfigJson
+
+vscodeSchemaJson :: FilePath
+vscodeSchemaJson = "vscode-extension-schema.golden.json"
+
+generateDefaultConfigJson :: FilePath
+generateDefaultConfigJson = "default-config.golden.json"
+
+prettyGhcVersion :: GhcVersion -> String
+prettyGhcVersion ghcVer = map toLower (show ghcVer)

--- a/test/functional/Format.hs
+++ b/test/functional/Format.hs
@@ -23,7 +23,7 @@ tests = testGroup "format document"
 
 providerTests :: TestTree
 providerTests = testGroup "lsp formatting provider"
-    [ testCase "respects none" $ runSessionWithConfig (formatConfig "none") hlsCommand fullCaps "test/testdata/format" $ do
+    [ testCase "respects none" $ runSessionWithConfig (formatConfig "none") hlsLspCommand fullCaps "test/testdata/format" $ do
         void configurationRequest
         doc <- openDoc "Format.hs" "haskell"
         resp <- request SMethod_TextDocumentFormatting $ DocumentFormattingParams Nothing doc (FormattingOptions 2 True Nothing Nothing Nothing)
@@ -34,7 +34,7 @@ providerTests = testGroup "lsp formatting provider"
             _ -> assertFailure $ "strange response from formatting provider:" ++ show result
           result -> assertFailure $ "strange response from formatting provider:" ++ show result
 
-    , requiresOrmoluPlugin . requiresFloskellPlugin $ testCase "can change on the fly" $ runSessionWithConfig (formatConfig "none") hlsCommand fullCaps "test/testdata/format" $ do
+    , requiresOrmoluPlugin . requiresFloskellPlugin $ testCase "can change on the fly" $ runSessionWithConfig (formatConfig "none") hlsLspCommand fullCaps "test/testdata/format" $ do
         void configurationRequest
         formattedOrmolu <- liftIO $ T.readFile "test/testdata/format/Format.ormolu.formatted.hs"
         formattedFloskell <- liftIO $ T.readFile "test/testdata/format/Format.floskell.formatted.hs"

--- a/test/functional/FunctionalBadProject.hs
+++ b/test/functional/FunctionalBadProject.hs
@@ -12,13 +12,13 @@ import           Test.Hls.Command
 tests :: TestTree
 tests = testGroup "behaviour on malformed projects"
     [ testCase "Missing module diagnostic" $ do
-        runSession hlsCommand fullCaps "test/testdata/missingModuleTest/missingModule/" $ do
+        runSession hlsLspCommand fullCaps "test/testdata/missingModuleTest/missingModule/" $ do
             doc <- openDoc "src/MyLib.hs" "haskell"
             [diag] <- waitForDiagnosticsFrom doc
             liftIO $ assertBool "missing module name" $ "MyLib" `T.isInfixOf` (diag ^. L.message)
             liftIO $ assertBool "module missing context" $ "may not be listed" `T.isInfixOf` (diag ^. L.message)
     , testCase "Missing module diagnostic - no matching prefix" $ do
-        runSession hlsCommand fullCaps "test/testdata/missingModuleTest/noPrefixMatch/" $ do
+        runSession hlsLspCommand fullCaps "test/testdata/missingModuleTest/noPrefixMatch/" $ do
             doc <- openDoc "app/Other.hs" "haskell"
             [diag] <- waitForDiagnosticsFrom doc
             liftIO $ assertBool "missing module name" $

--- a/test/functional/HieBios.hs
+++ b/test/functional/HieBios.hs
@@ -11,7 +11,7 @@ import           Test.Hls.Command
 tests :: TestTree
 tests = testGroup "hie-bios"
   [ testCase "loads main-is module" $ do
-    runSession hlsCommand fullCaps "test/testdata/hieBiosMainIs" $ do
+    runSession hlsLspCommand fullCaps "test/testdata/hieBiosMainIs" $ do
       _ <- openDoc "Main.hs" "haskell"
       (diag:_) <- waitForDiagnostics
       liftIO $ "Top-level binding with no type signature:" `T.isInfixOf` (diag ^. L.message)

--- a/test/functional/Main.hs
+++ b/test/functional/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import           Config
+import           ConfigSchema
 import           Format
 import           FunctionalBadProject
 import           HieBios
@@ -10,6 +11,7 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner $ testGroup "haskell-language-server"
     [ Config.tests
+    , ConfigSchema.tests
     , ignoreInEnv [HostOS Windows, GhcVer GHC90, GhcVer GHC92] "Tests gets stuck in ci" $ Format.tests
     , FunctionalBadProject.tests
     , HieBios.tests

--- a/test/functional/Progress.hs
+++ b/test/functional/Progress.hs
@@ -28,12 +28,12 @@ tests =
     testGroup
         "window/workDoneProgress"
         [ testCase "sends indefinite progress notifications" $
-            runSession hlsCommand progressCaps "test/testdata/diagnostics" $ do
+            runSession hlsLspCommand progressCaps "test/testdata/diagnostics" $ do
                 let path = "Foo.hs"
                 _ <- openDoc path "haskell"
                 expectProgressMessages [pack ("Setting up diagnostics (for " ++ path ++ ")"), "Processing", "Indexing"] []
         , requiresEvalPlugin $ testCase "eval plugin sends progress reports" $
-            runSession hlsCommand progressCaps "plugins/hls-eval-plugin/test/testdata" $ do
+            runSession hlsLspCommand progressCaps "plugins/hls-eval-plugin/test/testdata" $ do
               doc <- openDoc "T1.hs" "haskell"
               lspId <- sendRequest SMethod_TextDocumentCodeLens (CodeLensParams Nothing Nothing doc)
 
@@ -57,7 +57,7 @@ tests =
                       expectProgressMessages ["Evaluating"] activeProgressTokens
                   _ -> error $ "Unexpected response result: " ++ show response
         , requiresOrmoluPlugin $ testCase "ormolu plugin sends progress notifications" $ do
-            runSessionWithConfig (def { ignoreConfigurationRequests = False }) hlsCommand progressCaps "test/testdata/format" $ do
+            runSessionWithConfig (def { ignoreConfigurationRequests = False }) hlsLspCommand progressCaps "test/testdata/format" $ do
                 void configurationRequest
                 setHlsConfig (formatLspConfig "ormolu")
                 doc <- openDoc "Format.hs" "haskell"
@@ -65,7 +65,7 @@ tests =
                 _ <- sendRequest SMethod_TextDocumentFormatting $ DocumentFormattingParams Nothing doc (FormattingOptions 2 True Nothing Nothing Nothing)
                 expectProgressMessages ["Formatting Format.hs"] []
         , requiresFourmoluPlugin $ testCase "fourmolu plugin sends progress notifications" $ do
-            runSessionWithConfig (def { ignoreConfigurationRequests = False }) hlsCommand progressCaps "test/testdata/format" $ do
+            runSessionWithConfig (def { ignoreConfigurationRequests = False }) hlsLspCommand progressCaps "test/testdata/format" $ do
                 void configurationRequest
                 setHlsConfig (formatLspConfig "fourmolu")
                 doc <- openDoc "Format.hs" "haskell"

--- a/test/testdata/schema/ghc92/default-config.golden.json
+++ b/test/testdata/schema/ghc92/default-config.golden.json
@@ -1,0 +1,121 @@
+{
+    "checkParents": "CheckOnSave",
+    "checkProject": true,
+    "formattingProvider": "ormolu",
+    "maxCompletions": 40,
+    "plugin": {
+        "alternateNumberFormat": {
+            "globalOn": true
+        },
+        "cabal": {
+            "codeActionsOn": true,
+            "completionOn": true
+        },
+        "callHierarchy": {
+            "globalOn": true
+        },
+        "changeTypeSignature": {
+            "globalOn": true
+        },
+        "class": {
+            "codeActionsOn": true,
+            "codeLensOn": true
+        },
+        "eval": {
+            "config": {
+                "diff": true,
+                "exception": false
+            },
+            "globalOn": true
+        },
+        "explicit-fields": {
+            "globalOn": true
+        },
+        "explicit-fixity": {
+            "globalOn": true
+        },
+        "fourmolu": {
+            "config": {
+                "external": false
+            }
+        },
+        "gadt": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-bindings": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-fill-holes": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-imports-exports": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-type-signatures": {
+            "globalOn": true
+        },
+        "ghcide-completions": {
+            "config": {
+                "autoExtendOn": true,
+                "snippetsOn": true
+            },
+            "globalOn": true
+        },
+        "ghcide-hover-and-symbols": {
+            "hoverOn": true,
+            "symbolsOn": true
+        },
+        "ghcide-type-lenses": {
+            "config": {
+                "mode": "always"
+            },
+            "globalOn": true
+        },
+        "hlint": {
+            "codeActionsOn": true,
+            "config": {
+                "flags": []
+            },
+            "diagnosticsOn": true
+        },
+        "importLens": {
+            "codeActionsOn": true,
+            "codeLensOn": true
+        },
+        "moduleName": {
+            "globalOn": true
+        },
+        "ormolu": {
+            "config": {
+                "external": false
+            }
+        },
+        "overloaded-record-dot": {
+            "globalOn": true
+        },
+        "pragmas-completion": {
+            "globalOn": true
+        },
+        "pragmas-disable": {
+            "globalOn": true
+        },
+        "pragmas-suggest": {
+            "globalOn": true
+        },
+        "qualifyImportedNames": {
+            "globalOn": true
+        },
+        "rename": {
+            "config": {
+                "crossModule": false
+            },
+            "globalOn": true
+        },
+        "retrie": {
+            "globalOn": true
+        },
+        "splice": {
+            "globalOn": true
+        }
+    }
+}

--- a/test/testdata/schema/ghc92/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc92/vscode-extension-schema.golden.json
@@ -1,0 +1,258 @@
+{
+    "haskell.plugin.alternateNumberFormat.globalOn": {
+        "default": true,
+        "description": "Enables alternateNumberFormat plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.cabal.codeActionsOn": {
+        "default": true,
+        "description": "Enables cabal code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.cabal.completionOn": {
+        "default": true,
+        "description": "Enables cabal completions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.callHierarchy.globalOn": {
+        "default": true,
+        "description": "Enables callHierarchy plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.changeTypeSignature.globalOn": {
+        "default": true,
+        "description": "Enables changeTypeSignature plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.class.codeActionsOn": {
+        "default": true,
+        "description": "Enables class code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.class.codeLensOn": {
+        "default": true,
+        "description": "Enables class code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.config.diff": {
+        "default": true,
+        "markdownDescription": "Enable the diff output (WAS/NOW) of eval lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.config.exception": {
+        "default": false,
+        "markdownDescription": "Enable marking exceptions with `*** Exception:` similarly to doctest and GHCi.",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.globalOn": {
+        "default": true,
+        "description": "Enables eval plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.explicit-fields.globalOn": {
+        "default": true,
+        "description": "Enables explicit-fields plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.explicit-fixity.globalOn": {
+        "default": true,
+        "description": "Enables explicit-fixity plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.fourmolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"fourmolu\" executable, rather than using the bundled library",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.gadt.globalOn": {
+        "default": true,
+        "description": "Enables gadt plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-bindings.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-bindings plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-fill-holes.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-fill-holes plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-imports-exports.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-imports-exports plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-type-signatures.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-type-signatures plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.config.autoExtendOn": {
+        "default": true,
+        "markdownDescription": "Extends the import list automatically when completing a out-of-scope identifier",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.config.snippetsOn": {
+        "default": true,
+        "markdownDescription": "Inserts snippets when using code completions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-completions plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-hover-and-symbols.hoverOn": {
+        "default": true,
+        "description": "Enables ghcide-hover-and-symbols hover",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-hover-and-symbols.symbolsOn": {
+        "default": true,
+        "description": "Enables ghcide-hover-and-symbols symbols",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-type-lenses.config.mode": {
+        "default": "always",
+        "description": "Control how type lenses are shown",
+        "enum": [
+            "always",
+            "exported",
+            "diagnostics"
+        ],
+        "enumDescriptions": [
+            "Always displays type lenses of global bindings",
+            "Only display type lenses of exported global bindings",
+            "Follows error messages produced by GHC about missing signatures"
+        ],
+        "scope": "resource",
+        "type": "string"
+    },
+    "haskell.plugin.ghcide-type-lenses.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-type-lenses plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.hlint.codeActionsOn": {
+        "default": true,
+        "description": "Enables hlint code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.hlint.config.flags": {
+        "default": [],
+        "markdownDescription": "Flags used by hlint",
+        "scope": "resource",
+        "type": "array"
+    },
+    "haskell.plugin.hlint.diagnosticsOn": {
+        "default": true,
+        "description": "Enables hlint diagnostics",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.importLens.codeActionsOn": {
+        "default": true,
+        "description": "Enables importLens code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.importLens.codeLensOn": {
+        "default": true,
+        "description": "Enables importLens code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.moduleName.globalOn": {
+        "default": true,
+        "description": "Enables moduleName plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ormolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"ormolu\" executable, rather than using the bundled library",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.overloaded-record-dot.globalOn": {
+        "default": true,
+        "description": "Enables overloaded-record-dot plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-completion.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-completion plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-disable.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-disable plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-suggest.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-suggest plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.qualifyImportedNames.globalOn": {
+        "default": true,
+        "description": "Enables qualifyImportedNames plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.rename.config.crossModule": {
+        "default": false,
+        "markdownDescription": "Enable experimental cross-module renaming",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.rename.globalOn": {
+        "default": true,
+        "description": "Enables rename plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.retrie.globalOn": {
+        "default": true,
+        "description": "Enables retrie plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.splice.globalOn": {
+        "default": true,
+        "description": "Enables splice plugin",
+        "scope": "resource",
+        "type": "boolean"
+    }
+}

--- a/test/testdata/schema/ghc94/default-config.golden.json
+++ b/test/testdata/schema/ghc94/default-config.golden.json
@@ -1,0 +1,124 @@
+{
+    "checkParents": "CheckOnSave",
+    "checkProject": true,
+    "formattingProvider": "ormolu",
+    "maxCompletions": 40,
+    "plugin": {
+        "alternateNumberFormat": {
+            "globalOn": true
+        },
+        "cabal": {
+            "codeActionsOn": true,
+            "completionOn": true
+        },
+        "callHierarchy": {
+            "globalOn": true
+        },
+        "changeTypeSignature": {
+            "globalOn": true
+        },
+        "class": {
+            "codeActionsOn": true,
+            "codeLensOn": true
+        },
+        "eval": {
+            "config": {
+                "diff": true,
+                "exception": false
+            },
+            "globalOn": true
+        },
+        "explicit-fields": {
+            "globalOn": true
+        },
+        "explicit-fixity": {
+            "globalOn": true
+        },
+        "fourmolu": {
+            "config": {
+                "external": false
+            }
+        },
+        "gadt": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-bindings": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-fill-holes": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-imports-exports": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-type-signatures": {
+            "globalOn": true
+        },
+        "ghcide-completions": {
+            "config": {
+                "autoExtendOn": true,
+                "snippetsOn": true
+            },
+            "globalOn": true
+        },
+        "ghcide-hover-and-symbols": {
+            "hoverOn": true,
+            "symbolsOn": true
+        },
+        "ghcide-type-lenses": {
+            "config": {
+                "mode": "always"
+            },
+            "globalOn": true
+        },
+        "hlint": {
+            "codeActionsOn": true,
+            "config": {
+                "flags": []
+            },
+            "diagnosticsOn": true
+        },
+        "importLens": {
+            "codeActionsOn": true,
+            "codeLensOn": true
+        },
+        "moduleName": {
+            "globalOn": true
+        },
+        "ormolu": {
+            "config": {
+                "external": false
+            }
+        },
+        "overloaded-record-dot": {
+            "globalOn": true
+        },
+        "pragmas-completion": {
+            "globalOn": true
+        },
+        "pragmas-disable": {
+            "globalOn": true
+        },
+        "pragmas-suggest": {
+            "globalOn": true
+        },
+        "qualifyImportedNames": {
+            "globalOn": true
+        },
+        "rename": {
+            "config": {
+                "crossModule": false
+            },
+            "globalOn": true
+        },
+        "retrie": {
+            "globalOn": true
+        },
+        "splice": {
+            "globalOn": true
+        },
+        "stan": {
+            "globalOn": false
+        }
+    }
+}

--- a/test/testdata/schema/ghc94/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc94/vscode-extension-schema.golden.json
@@ -1,0 +1,264 @@
+{
+    "haskell.plugin.alternateNumberFormat.globalOn": {
+        "default": true,
+        "description": "Enables alternateNumberFormat plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.cabal.codeActionsOn": {
+        "default": true,
+        "description": "Enables cabal code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.cabal.completionOn": {
+        "default": true,
+        "description": "Enables cabal completions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.callHierarchy.globalOn": {
+        "default": true,
+        "description": "Enables callHierarchy plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.changeTypeSignature.globalOn": {
+        "default": true,
+        "description": "Enables changeTypeSignature plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.class.codeActionsOn": {
+        "default": true,
+        "description": "Enables class code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.class.codeLensOn": {
+        "default": true,
+        "description": "Enables class code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.config.diff": {
+        "default": true,
+        "markdownDescription": "Enable the diff output (WAS/NOW) of eval lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.config.exception": {
+        "default": false,
+        "markdownDescription": "Enable marking exceptions with `*** Exception:` similarly to doctest and GHCi.",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.globalOn": {
+        "default": true,
+        "description": "Enables eval plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.explicit-fields.globalOn": {
+        "default": true,
+        "description": "Enables explicit-fields plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.explicit-fixity.globalOn": {
+        "default": true,
+        "description": "Enables explicit-fixity plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.fourmolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"fourmolu\" executable, rather than using the bundled library",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.gadt.globalOn": {
+        "default": true,
+        "description": "Enables gadt plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-bindings.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-bindings plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-fill-holes.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-fill-holes plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-imports-exports.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-imports-exports plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-type-signatures.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-type-signatures plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.config.autoExtendOn": {
+        "default": true,
+        "markdownDescription": "Extends the import list automatically when completing a out-of-scope identifier",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.config.snippetsOn": {
+        "default": true,
+        "markdownDescription": "Inserts snippets when using code completions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-completions plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-hover-and-symbols.hoverOn": {
+        "default": true,
+        "description": "Enables ghcide-hover-and-symbols hover",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-hover-and-symbols.symbolsOn": {
+        "default": true,
+        "description": "Enables ghcide-hover-and-symbols symbols",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-type-lenses.config.mode": {
+        "default": "always",
+        "description": "Control how type lenses are shown",
+        "enum": [
+            "always",
+            "exported",
+            "diagnostics"
+        ],
+        "enumDescriptions": [
+            "Always displays type lenses of global bindings",
+            "Only display type lenses of exported global bindings",
+            "Follows error messages produced by GHC about missing signatures"
+        ],
+        "scope": "resource",
+        "type": "string"
+    },
+    "haskell.plugin.ghcide-type-lenses.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-type-lenses plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.hlint.codeActionsOn": {
+        "default": true,
+        "description": "Enables hlint code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.hlint.config.flags": {
+        "default": [],
+        "markdownDescription": "Flags used by hlint",
+        "scope": "resource",
+        "type": "array"
+    },
+    "haskell.plugin.hlint.diagnosticsOn": {
+        "default": true,
+        "description": "Enables hlint diagnostics",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.importLens.codeActionsOn": {
+        "default": true,
+        "description": "Enables importLens code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.importLens.codeLensOn": {
+        "default": true,
+        "description": "Enables importLens code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.moduleName.globalOn": {
+        "default": true,
+        "description": "Enables moduleName plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ormolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"ormolu\" executable, rather than using the bundled library",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.overloaded-record-dot.globalOn": {
+        "default": true,
+        "description": "Enables overloaded-record-dot plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-completion.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-completion plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-disable.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-disable plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-suggest.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-suggest plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.qualifyImportedNames.globalOn": {
+        "default": true,
+        "description": "Enables qualifyImportedNames plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.rename.config.crossModule": {
+        "default": false,
+        "markdownDescription": "Enable experimental cross-module renaming",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.rename.globalOn": {
+        "default": true,
+        "description": "Enables rename plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.retrie.globalOn": {
+        "default": true,
+        "description": "Enables retrie plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.splice.globalOn": {
+        "default": true,
+        "description": "Enables splice plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.stan.globalOn": {
+        "default": true,
+        "description": "Enables stan plugin",
+        "scope": "resource",
+        "type": "boolean"
+    }
+}

--- a/test/testdata/schema/ghc96/default-config.golden.json
+++ b/test/testdata/schema/ghc96/default-config.golden.json
@@ -1,0 +1,124 @@
+{
+    "checkParents": "CheckOnSave",
+    "checkProject": true,
+    "formattingProvider": "ormolu",
+    "maxCompletions": 40,
+    "plugin": {
+        "alternateNumberFormat": {
+            "globalOn": true
+        },
+        "cabal": {
+            "codeActionsOn": true,
+            "completionOn": true
+        },
+        "callHierarchy": {
+            "globalOn": true
+        },
+        "changeTypeSignature": {
+            "globalOn": true
+        },
+        "class": {
+            "codeActionsOn": true,
+            "codeLensOn": true
+        },
+        "eval": {
+            "config": {
+                "diff": true,
+                "exception": false
+            },
+            "globalOn": true
+        },
+        "explicit-fields": {
+            "globalOn": true
+        },
+        "explicit-fixity": {
+            "globalOn": true
+        },
+        "fourmolu": {
+            "config": {
+                "external": false
+            }
+        },
+        "gadt": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-bindings": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-fill-holes": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-imports-exports": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-type-signatures": {
+            "globalOn": true
+        },
+        "ghcide-completions": {
+            "config": {
+                "autoExtendOn": true,
+                "snippetsOn": true
+            },
+            "globalOn": true
+        },
+        "ghcide-hover-and-symbols": {
+            "hoverOn": true,
+            "symbolsOn": true
+        },
+        "ghcide-type-lenses": {
+            "config": {
+                "mode": "always"
+            },
+            "globalOn": true
+        },
+        "hlint": {
+            "codeActionsOn": true,
+            "config": {
+                "flags": []
+            },
+            "diagnosticsOn": true
+        },
+        "importLens": {
+            "codeActionsOn": true,
+            "codeLensOn": true
+        },
+        "moduleName": {
+            "globalOn": true
+        },
+        "ormolu": {
+            "config": {
+                "external": false
+            }
+        },
+        "overloaded-record-dot": {
+            "globalOn": true
+        },
+        "pragmas-completion": {
+            "globalOn": true
+        },
+        "pragmas-disable": {
+            "globalOn": true
+        },
+        "pragmas-suggest": {
+            "globalOn": true
+        },
+        "qualifyImportedNames": {
+            "globalOn": true
+        },
+        "rename": {
+            "config": {
+                "crossModule": false
+            },
+            "globalOn": true
+        },
+        "retrie": {
+            "globalOn": true
+        },
+        "splice": {
+            "globalOn": true
+        },
+        "stan": {
+            "globalOn": false
+        }
+    }
+}

--- a/test/testdata/schema/ghc96/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc96/vscode-extension-schema.golden.json
@@ -1,0 +1,264 @@
+{
+    "haskell.plugin.alternateNumberFormat.globalOn": {
+        "default": true,
+        "description": "Enables alternateNumberFormat plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.cabal.codeActionsOn": {
+        "default": true,
+        "description": "Enables cabal code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.cabal.completionOn": {
+        "default": true,
+        "description": "Enables cabal completions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.callHierarchy.globalOn": {
+        "default": true,
+        "description": "Enables callHierarchy plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.changeTypeSignature.globalOn": {
+        "default": true,
+        "description": "Enables changeTypeSignature plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.class.codeActionsOn": {
+        "default": true,
+        "description": "Enables class code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.class.codeLensOn": {
+        "default": true,
+        "description": "Enables class code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.config.diff": {
+        "default": true,
+        "markdownDescription": "Enable the diff output (WAS/NOW) of eval lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.config.exception": {
+        "default": false,
+        "markdownDescription": "Enable marking exceptions with `*** Exception:` similarly to doctest and GHCi.",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.globalOn": {
+        "default": true,
+        "description": "Enables eval plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.explicit-fields.globalOn": {
+        "default": true,
+        "description": "Enables explicit-fields plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.explicit-fixity.globalOn": {
+        "default": true,
+        "description": "Enables explicit-fixity plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.fourmolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"fourmolu\" executable, rather than using the bundled library",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.gadt.globalOn": {
+        "default": true,
+        "description": "Enables gadt plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-bindings.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-bindings plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-fill-holes.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-fill-holes plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-imports-exports.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-imports-exports plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-type-signatures.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-type-signatures plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.config.autoExtendOn": {
+        "default": true,
+        "markdownDescription": "Extends the import list automatically when completing a out-of-scope identifier",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.config.snippetsOn": {
+        "default": true,
+        "markdownDescription": "Inserts snippets when using code completions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-completions plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-hover-and-symbols.hoverOn": {
+        "default": true,
+        "description": "Enables ghcide-hover-and-symbols hover",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-hover-and-symbols.symbolsOn": {
+        "default": true,
+        "description": "Enables ghcide-hover-and-symbols symbols",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-type-lenses.config.mode": {
+        "default": "always",
+        "description": "Control how type lenses are shown",
+        "enum": [
+            "always",
+            "exported",
+            "diagnostics"
+        ],
+        "enumDescriptions": [
+            "Always displays type lenses of global bindings",
+            "Only display type lenses of exported global bindings",
+            "Follows error messages produced by GHC about missing signatures"
+        ],
+        "scope": "resource",
+        "type": "string"
+    },
+    "haskell.plugin.ghcide-type-lenses.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-type-lenses plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.hlint.codeActionsOn": {
+        "default": true,
+        "description": "Enables hlint code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.hlint.config.flags": {
+        "default": [],
+        "markdownDescription": "Flags used by hlint",
+        "scope": "resource",
+        "type": "array"
+    },
+    "haskell.plugin.hlint.diagnosticsOn": {
+        "default": true,
+        "description": "Enables hlint diagnostics",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.importLens.codeActionsOn": {
+        "default": true,
+        "description": "Enables importLens code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.importLens.codeLensOn": {
+        "default": true,
+        "description": "Enables importLens code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.moduleName.globalOn": {
+        "default": true,
+        "description": "Enables moduleName plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ormolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"ormolu\" executable, rather than using the bundled library",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.overloaded-record-dot.globalOn": {
+        "default": true,
+        "description": "Enables overloaded-record-dot plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-completion.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-completion plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-disable.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-disable plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-suggest.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-suggest plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.qualifyImportedNames.globalOn": {
+        "default": true,
+        "description": "Enables qualifyImportedNames plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.rename.config.crossModule": {
+        "default": false,
+        "markdownDescription": "Enable experimental cross-module renaming",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.rename.globalOn": {
+        "default": true,
+        "description": "Enables rename plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.retrie.globalOn": {
+        "default": true,
+        "description": "Enables retrie plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.splice.globalOn": {
+        "default": true,
+        "description": "Enables splice plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.stan.globalOn": {
+        "default": true,
+        "description": "Enables stan plugin",
+        "scope": "resource",
+        "type": "boolean"
+    }
+}

--- a/test/testdata/schema/ghc98/default-config.golden.json
+++ b/test/testdata/schema/ghc98/default-config.golden.json
@@ -1,0 +1,86 @@
+{
+    "checkParents": "CheckOnSave",
+    "checkProject": true,
+    "formattingProvider": "ormolu",
+    "maxCompletions": 40,
+    "plugin": {
+        "alternateNumberFormat": {
+            "globalOn": true
+        },
+        "cabal": {
+            "codeActionsOn": true,
+            "completionOn": true
+        },
+        "callHierarchy": {
+            "globalOn": true
+        },
+        "changeTypeSignature": {
+            "globalOn": true
+        },
+        "eval": {
+            "config": {
+                "diff": true,
+                "exception": false
+            },
+            "globalOn": true
+        },
+        "explicit-fields": {
+            "globalOn": true
+        },
+        "explicit-fixity": {
+            "globalOn": true
+        },
+        "fourmolu": {
+            "config": {
+                "external": false
+            }
+        },
+        "ghcide-completions": {
+            "config": {
+                "autoExtendOn": true,
+                "snippetsOn": true
+            },
+            "globalOn": true
+        },
+        "ghcide-hover-and-symbols": {
+            "hoverOn": true,
+            "symbolsOn": true
+        },
+        "ghcide-type-lenses": {
+            "config": {
+                "mode": "always"
+            },
+            "globalOn": true
+        },
+        "importLens": {
+            "codeActionsOn": true,
+            "codeLensOn": true
+        },
+        "moduleName": {
+            "globalOn": true
+        },
+        "ormolu": {
+            "config": {
+                "external": false
+            }
+        },
+        "overloaded-record-dot": {
+            "globalOn": true
+        },
+        "pragmas-completion": {
+            "globalOn": true
+        },
+        "pragmas-disable": {
+            "globalOn": true
+        },
+        "pragmas-suggest": {
+            "globalOn": true
+        },
+        "qualifyImportedNames": {
+            "globalOn": true
+        },
+        "stan": {
+            "globalOn": false
+        }
+    }
+}

--- a/test/testdata/schema/ghc98/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc98/vscode-extension-schema.golden.json
@@ -1,0 +1,180 @@
+{
+    "haskell.plugin.alternateNumberFormat.globalOn": {
+        "default": true,
+        "description": "Enables alternateNumberFormat plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.cabal.codeActionsOn": {
+        "default": true,
+        "description": "Enables cabal code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.cabal.completionOn": {
+        "default": true,
+        "description": "Enables cabal completions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.callHierarchy.globalOn": {
+        "default": true,
+        "description": "Enables callHierarchy plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.changeTypeSignature.globalOn": {
+        "default": true,
+        "description": "Enables changeTypeSignature plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.config.diff": {
+        "default": true,
+        "markdownDescription": "Enable the diff output (WAS/NOW) of eval lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.config.exception": {
+        "default": false,
+        "markdownDescription": "Enable marking exceptions with `*** Exception:` similarly to doctest and GHCi.",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.globalOn": {
+        "default": true,
+        "description": "Enables eval plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.explicit-fields.globalOn": {
+        "default": true,
+        "description": "Enables explicit-fields plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.explicit-fixity.globalOn": {
+        "default": true,
+        "description": "Enables explicit-fixity plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.fourmolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"fourmolu\" executable, rather than using the bundled library",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.config.autoExtendOn": {
+        "default": true,
+        "markdownDescription": "Extends the import list automatically when completing a out-of-scope identifier",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.config.snippetsOn": {
+        "default": true,
+        "markdownDescription": "Inserts snippets when using code completions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-completions.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-completions plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-hover-and-symbols.hoverOn": {
+        "default": true,
+        "description": "Enables ghcide-hover-and-symbols hover",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-hover-and-symbols.symbolsOn": {
+        "default": true,
+        "description": "Enables ghcide-hover-and-symbols symbols",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-type-lenses.config.mode": {
+        "default": "always",
+        "description": "Control how type lenses are shown",
+        "enum": [
+            "always",
+            "exported",
+            "diagnostics"
+        ],
+        "enumDescriptions": [
+            "Always displays type lenses of global bindings",
+            "Only display type lenses of exported global bindings",
+            "Follows error messages produced by GHC about missing signatures"
+        ],
+        "scope": "resource",
+        "type": "string"
+    },
+    "haskell.plugin.ghcide-type-lenses.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-type-lenses plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.importLens.codeActionsOn": {
+        "default": true,
+        "description": "Enables importLens code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.importLens.codeLensOn": {
+        "default": true,
+        "description": "Enables importLens code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.moduleName.globalOn": {
+        "default": true,
+        "description": "Enables moduleName plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ormolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"ormolu\" executable, rather than using the bundled library",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.overloaded-record-dot.globalOn": {
+        "default": true,
+        "description": "Enables overloaded-record-dot plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-completion.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-completion plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-disable.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-disable plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.pragmas-suggest.globalOn": {
+        "default": true,
+        "description": "Enables pragmas-suggest plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.qualifyImportedNames.globalOn": {
+        "default": true,
+        "description": "Enables qualifyImportedNames plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.stan.globalOn": {
+        "default": true,
+        "description": "Enables stan plugin",
+        "scope": "resource",
+        "type": "boolean"
+    }
+}

--- a/test/utils/Test/Hls/Command.hs
+++ b/test/utils/Test/Hls/Command.hs
@@ -1,5 +1,8 @@
 module Test.Hls.Command
-  ( hlsCommand
+  ( hlsExeCommand
+  , hlsLspCommand
+  , hlsWrapperLspCommand
+  , hlsWrapperExeCommand
   )
 where
 
@@ -12,8 +15,20 @@ import           System.IO.Unsafe   (unsafePerformIO)
 -- Both @stack test@ and @cabal new-test@ setup the environment so @hls@ is
 -- on PATH. Cabal seems to respond to @build-tool-depends@ specifically while
 -- stack just puts all project executables on PATH.
-hlsCommand :: String
-{-# NOINLINE hlsCommand #-}
-hlsCommand = unsafePerformIO $ do
+hlsExeCommand :: String
+{-# NOINLINE hlsExeCommand #-}
+hlsExeCommand = unsafePerformIO $ do
   testExe <- fromMaybe "haskell-language-server" <$> lookupEnv "HLS_TEST_EXE"
-  pure $ testExe ++ " --lsp -d -j4"
+  pure testExe
+
+hlsLspCommand :: String
+hlsLspCommand = hlsExeCommand ++ " --lsp -d -j4"
+
+hlsWrapperLspCommand :: String
+hlsWrapperLspCommand = hlsWrapperExeCommand ++ " --lsp -d -j4"
+
+hlsWrapperExeCommand :: String
+{-# NOINLINE hlsWrapperExeCommand #-}
+hlsWrapperExeCommand = unsafePerformIO $ do
+  testExe <- fromMaybe "haskell-language-server-wrapper" <$> lookupEnv "HLS_WRAPPER_TEST_EXE"
+  pure testExe


### PR DESCRIPTION
Changes to the vscode schema need to be communicated to vscode-haskell plugin maintainers, otherwise users can't make use of the new configurations.

In general, changes to the schema need to be done consciously when new plugin or features are added. We add these golden tests as an additional contract to inform relevant parties whenever the configs change.

To fix a failing of these tests, review the change. If it is expected, accept the change via:

    TASTY_PATTERN="generate schema" cabal test func-test --test-options=--accept

As changes need to be applied for all GHC version specific configs, you either need to run this command for each GHC version that is affected by the config change, or manually add the change to all other golden config files. Likely, the easiest way is to run CI and apply the generated diffs manually.