### PR TITLE
Make vscode-extension-schema honour default values

### DIFF
--- a/test/testdata/schema/ghc92/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc92/vscode-extension-schema.golden.json
@@ -250,7 +250,7 @@
         "type": "boolean"
     },
     "haskell.plugin.semanticTokens.globalOn": {
-        "default": true,
+        "default": false,
         "description": "Enables semanticTokens plugin",
         "scope": "resource",
         "type": "boolean"

--- a/test/testdata/schema/ghc94/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc94/vscode-extension-schema.golden.json
@@ -250,7 +250,7 @@
         "type": "boolean"
     },
     "haskell.plugin.semanticTokens.globalOn": {
-        "default": true,
+        "default": false,
         "description": "Enables semanticTokens plugin",
         "scope": "resource",
         "type": "boolean"
@@ -262,7 +262,7 @@
         "type": "boolean"
     },
     "haskell.plugin.stan.globalOn": {
-        "default": true,
+        "default": false,
         "description": "Enables stan plugin",
         "scope": "resource",
         "type": "boolean"

--- a/test/testdata/schema/ghc96/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc96/vscode-extension-schema.golden.json
@@ -250,7 +250,7 @@
         "type": "boolean"
     },
     "haskell.plugin.semanticTokens.globalOn": {
-        "default": true,
+        "default": false,
         "description": "Enables semanticTokens plugin",
         "scope": "resource",
         "type": "boolean"
@@ -262,7 +262,7 @@
         "type": "boolean"
     },
     "haskell.plugin.stan.globalOn": {
-        "default": true,
+        "default": false,
         "description": "Enables stan plugin",
         "scope": "resource",
         "type": "boolean"

--- a/test/testdata/schema/ghc98/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc98/vscode-extension-schema.golden.json
@@ -172,13 +172,13 @@
         "type": "boolean"
     },
     "haskell.plugin.semanticTokens.globalOn": {
-        "default": true,
+        "default": false,
         "description": "Enables semanticTokens plugin",
         "scope": "resource",
         "type": "boolean"
     },
     "haskell.plugin.stan.globalOn": {
-        "default": true,
+        "default": false,
         "description": "Enables stan plugin",
         "scope": "resource",
         "type": "boolean"


### PR DESCRIPTION
Follow up to #3917, where the command `hls vscode-extension-schema` did not to honour the default values of the plugin description.

The first commit of this PR fixes that shortcoming.
The second commit unifies the plugin config generation. I am not sure whether that's a good idea, as I feel it obfuscates the code more. I am leaving it in for discussion, but I am completely open to dropping the second commit.