### PR TITLE
update Floskell to 0.11.*

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 /plugins/hls-class-plugin @Ailrun
 /plugins/hls-eval-plugin
 /plugins/hls-explicit-imports-plugin @pepeiborra
-/plugins/hls-floskell-plugin @Ailrun
+/plugins/hls-floskell-plugin @Ailrun @peterbecich
 /plugins/hls-fourmolu-plugin @georgefst
 /plugins/hls-gadt-plugin @July541
 /plugins/hls-hlint-plugin @eddiemundo

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 category:           Development
 name:               haskell-language-server
-version:            2.5.0.0
+version:            2.5.0.1
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -315,7 +315,7 @@ common overloadedRecordDot
 
 common floskell
   if flag(floskell) && (impl(ghc < 9.7) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-floskell-plugin == 2.5.0.0
+    build-depends: hls-floskell-plugin == 2.5.*
     cpp-options: -Dhls_floskell
 
 common fourmolu

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 category:           Development
 name:               haskell-language-server
-version:            2.5.0.1
+version:            2.5.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -315,7 +315,7 @@ common overloadedRecordDot
 
 common floskell
   if flag(floskell) && (impl(ghc < 9.7) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-floskell-plugin == 2.5.*
+    build-depends: hls-floskell-plugin == 2.5.0.0
     cpp-options: -Dhls_floskell
 
 common fourmolu

--- a/plugins/hls-floskell-plugin/CHANGELOG.md
+++ b/plugins/hls-floskell-plugin/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Revision history for hls-floskell-plugin
+
+## 2.5.1.0 -- 2024-01-05
+Updates Floskell dependency to 0.11.*, which supports Aeson 2.2.*

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-floskell-plugin
-version:            2.5.1.0
+version:            2.5.0.0
 synopsis:           Integration with the Floskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-floskell-plugin
-version:            2.5.0.0
+version:            2.5.1.0
 synopsis:           Integration with the Floskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -28,7 +28,7 @@ library
   hs-source-dirs:   src
   build-depends:
     , base            >=4.12 && <5
-    , floskell        ^>=0.10.8
+    , floskell        ^>=0.11.0
     , ghcide          == 2.5.0.0
     , hls-plugin-api  == 2.5.0.0
     , lsp-types       ^>=2.1

--- a/plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs
+++ b/plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs
@@ -39,10 +39,10 @@ provider _ideState typ contents fp _ = do
     let (range, selectedContents) = case typ of
           FormatText    -> (fullRange contents, contents)
           FormatRange r -> (normalize r, extractTextInRange (extendToFullLines r) contents)
-        result = reformat config (Just file) . TL.encodeUtf8 $ TL.fromStrict selectedContents
+        result = reformat config (Just file) $ TL.fromStrict selectedContents
     case result of
       Left  err -> throwError $ PluginInternalError $ T.pack $ "floskellCmd: " ++ err
-      Right new -> pure $ InL [TextEdit range . TL.toStrict $ TL.decodeUtf8 new]
+      Right new -> pure $ InL [TextEdit range $ TL.toStrict new]
 
 -- | Find Floskell Config, user and system wide or provides a default style.
 -- Every directory of the filepath will be searched to find a user configuration.

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.2 # ghc-9.4
+resolver: lts-21.25 # ghc-9.4
 
 packages:
   - .
@@ -49,7 +49,6 @@ extra-deps:
 - hie-bios-0.13.1
 - implicit-hie-0.1.4.0
 - monad-dijkstra-0.1.1.3
-- algebraic-graphs-0.6.1
 - retrie-1.2.2
 - stylish-haskell-0.14.4.0
 - lsp-2.3.0.0
@@ -59,11 +58,8 @@ extra-deps:
 # stan dependencies not found in the stackage snapshot
 - stan-0.1.0.2
 - clay-0.14.0
-- colourista-0.1.0.2
 - dir-traverse-0.2.3.0
 - extensions-0.1.0.0
-- relude-1.2.1.0
-- slist-0.2.1.0
 - tomland-1.3.3.2
 - trial-0.0.0.0
 - trial-optparse-applicative-0.0.0.0

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -44,7 +44,7 @@ ghc-options:
 allow-newer: true
 
 extra-deps:
-- floskell-0.10.7
+- floskell-0.11.1
 - hiedb-0.4.4.0
 - hie-bios-0.13.1
 - implicit-hie-0.1.4.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,7 +43,7 @@ ghc-options:
 allow-newer: true
 
 extra-deps:
-- floskell-0.10.8
+- floskell-0.11.1
 - retrie-1.2.2
 - hiedb-0.4.4.0
 - implicit-hie-0.1.4.0


### PR DESCRIPTION
Closes: #3927 

`hls-floskell-plugin` updated to `floskell` 0.11.* . The reason is that `floskell` 0.11.* supports `aeson` 2.2.* : https://hackage.haskell.org/package/floskell-0.11.0

There is a small change required in `plugins/hls-floskell-plugin/src/Ide/Plugin/Floskell.hs`. The easy change breaks compatibility with `floskell` 0.10. So I have bumped the version of `hls-floskell-plugin` from `2.5.0.0` to `2.5.1.0`.

`haskell-language-server` 2.5.0.0 is pinned to `hls-floskell-plugin` 2.5.0.0 exactly. This PR changes the bound on `hls-floskell-plugin` to `2.5.*`.

- This could be a revision to `haskell-language-server` 2.5.0.0
- or a fix version, `haskell-language-server` 2.5.0.1.
  - I believe `haskell-language-server` 2.5.0.1 is compatible with both:
    - `hls-floskell-plugin` 2.5.0.0 and `floskell` 0.10.*
      - first test
    - `hls-floskell-plugin` 2.5.1.0 and `floskell` 0.11.*
      - second test
    
What do you think?

_I suppose this PR should target the tag `2.5.0.0`_ https://github.com/haskell/haskell-language-server/tree/2.5.0.0 instead of `master`

-----------

**First test**
`git reset` to `master`. Apply only the change to `haskell-language-server.cabal`. Build `haskell-language-server` 2.5.0.1 and all other packages.

This builds successfully:
```
cabal build --constraint 'floskell == 0.10.*' --enable-tests
```

**Second test**
In this PR, this builds successfully:
```
cabal build --constraint 'floskell == 0.11.*' --enable-tests
```


These tests were run in the `nix develop` shell.