### PR TITLE
update `hiedb` dependency

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -78,7 +78,7 @@ library
     , hashable
     , hie-bios                     ==0.13.1
     , hie-compat                   ^>=0.3.0.0
-    , hiedb                        >=0.4.4    && <0.4.5
+    , hiedb                        >=0.4.4    && <0.6
     , hls-graph                    == 2.5.0.0
     , hls-plugin-api               == 2.5.0.0
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,7 @@ allow-newer: true
 extra-deps:
 - floskell-0.11.1
 - retrie-1.2.2
-- hiedb-0.4.4.0
+- hiedb-0.5.0.1
 - implicit-hie-0.1.4.0
 - hie-bios-0.13.1
 - lsp-2.3.0.0


### PR DESCRIPTION
Oddly this fails:
```
cabal build ./ghcide --constraint 'hiedb==0.5.*'
```

It seems it cannot find `hiedb` 0.5.0.0 or 0.5.0.1. These were uploaded to Hackage in the last few days.
```
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] trying: ghcide-2.5.0.0 (user goal)
[__1] next goal: hiedb (dependency of ghcide)
[__1] rejecting: hiedb-0.4.4.0, hiedb-0.4.3.0, hiedb-0.4.2.0, hiedb-0.4.1.0,
hiedb-0.4.0.0, hiedb-0.3.0.1, hiedb-0.3.0.0, hiedb-0.2.0.0, hiedb-0.1.0.0
(constraint from command line flag requires >=0.5 && <0.6)
[__1] fail (backjumping, conflict set: ghcide, hiedb)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: ghcide, hiedb
```

I believe my Cabal package index is up-to-date. `cabal update` worked.

https://hackage.haskell.org/package/hiedb-0.5.0.1

closes: https://github.com/haskell/haskell-language-server/issues/3945