### PR TITLE
Cleanup conditional build logic pertaining to pre 9.2 GHCs

### DIFF
--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -75,9 +75,7 @@ jobs:
       - name: Build `ghcide` with flags
         run: cabal v2-build ghcide --flags="ghc-patched-unboxed-bytecode test-exe executable bench-exe ekg"
 
-      # wingman fails with flags on 9.0, so this can be removed when that's gone
-      - if: matrix.ghc != '9.0'
-        name: Build with pedantic (-WError)
+      - name: Build with pedantic (-WError)
         run: cabal v2-build --flags="pedantic"
 
   flags_post_job:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,7 +236,7 @@ jobs:
         name: Test hls-retrie-plugin test suite
         run: cabal test hls-retrie-plugin --test-options="$TEST_OPTS" || cabal test hls-retrie-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.0'
+      - if: matrix.test
         name: Test hls-overloaded-record-dot-plugin test suite
         run: cabal test hls-overloaded-record-dot-plugin --test-options="$TEST_OPTS" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test hls-overloaded-record-dot-plugin --test-options="$TEST_OPTS"
 

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -232,12 +232,7 @@ library
       -Wwarn=duplicate-exports -Wwarn=dodgy-exports
       -Wwarn=incomplete-patterns -Wwarn=overlapping-patterns
       -Wwarn=incomplete-record-updates
-
-  -- ambiguous-fields is only understood by GHC >= 9.2, so we only disable it
-  -- then. The above comment goes for here too -- this should be understood to
-  -- be temporary until we can remove these warnings.
-  if (impl(ghc >=9.2) && flag(pedantic))
-    ghc-options: -Wwarn=ambiguous-fields
+      -Wwarn=ambiguous-fields
 
   if flag(ekg)
     build-depends:
@@ -269,7 +264,7 @@ executable ghcide
   hs-source-dirs:     exe
   ghc-options:
     -threaded -Wall -Wincomplete-uni-patterns -Wno-name-shadowing
-    -rtsopts "-with-rtsopts=-I0 -A128M -T"
+    -rtsopts "-with-rtsopts=-I0 -A128M -T" -Wunused-packages
 
   -- allow user RTS overrides
   -- disable idle GC
@@ -318,9 +313,6 @@ executable ghcide
 
     cpp-options:   -DMONITORING_EKG
 
-  if impl(ghc >=9)
-    ghc-options: -Wunused-packages
-
 test-suite ghcide-tests
   type:               exitcode-stdio-1.0
   default-language:   Haskell2010
@@ -340,6 +332,13 @@ test-suite ghcide-tests
     , extra
     , filepath
     , fuzzy
+  --------------------------------------------------------------
+  -- The MIN_VERSION_ghc macro relies on MIN_VERSION pragmas
+  -- which require depending on ghc. So the tests need to depend
+  -- on ghc if they need to use MIN_VERSION_ghc. Maybe a
+  -- better solution can be found, but this is a quick solution
+  -- which works for now.
+  --------------------------------------------------------------
     , ghc
     , ghcide
     , hls-plugin-api
@@ -367,18 +366,6 @@ test-suite ghcide-tests
     , text
     , text-rope
     , unordered-containers
-
-  --------------------------------------------------------------
-  -- The MIN_VERSION_ghc macro relies on MIN_VERSION pragmas
-  -- which require depending on ghc. So the tests need to depend
-  -- on ghc if they need to use MIN_VERSION_ghc. Maybe a
-  -- better solution can be found, but this is a quick solution
-  -- which works for now.
-  --------------------------------------------------------------
-  if impl(ghc <9.2)
-    build-depends:
-      , record-dot-preprocessor
-      , record-hasfield
 
   if impl(ghc <9.3)
     build-depends: ghc-typelits-knownnat

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -263,8 +263,8 @@ executable ghcide
   default-language:   Haskell2010
   hs-source-dirs:     exe
   ghc-options:
-    -threaded -Wall -Wincomplete-uni-patterns -Wno-name-shadowing
-    -rtsopts "-with-rtsopts=-I0 -A128M -T" -Wunused-packages
+    -threaded -Wall -Wincomplete-uni-patterns -Wno-name-shadowing -Wunused-packages
+    -rtsopts "-with-rtsopts=-I0 -A128M -T"
 
   -- allow user RTS overrides
   -- disable idle GC

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -307,7 +307,7 @@ common explicitFields
     cpp-options: -DexplicitFields
 
 common overloadedRecordDot
-  if flag(overloadedRecordDot) && (impl(ghc >= 9.2.0) || flag(ignore-plugins-ghc-bounds))
+  if flag(overloadedRecordDot)
     build-depends: hls-overloaded-record-dot-plugin == 2.6.0.0
     cpp-options: -Dhls_overloaded_record_dot
 

--- a/hie-compat/hie-compat.cabal
+++ b/hie-compat/hie-compat.cabal
@@ -35,8 +35,6 @@ library
     Compat.HieDebug
     Compat.HieUtils
 
-  if (impl(ghc >= 9.0) && impl(ghc < 9.1))
-    hs-source-dirs: src-ghc90 src-reexport-ghc9
   if (impl(ghc >= 9.2) && impl(ghc < 9.3))
     hs-source-dirs: src-ghc92 src-reexport-ghc9
   if (impl(ghc >= 9.4))

--- a/hie-compat/src-ghc90/Compat/HieAst.hs
+++ b/hie-compat/src-ghc90/Compat/HieAst.hs
@@ -1,3 +1,0 @@
-module Compat.HieAst ( enrichHie ) where
-
-import           GHC.Iface.Ext.Ast   (enrichHie)

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -44,6 +44,7 @@ library
     , deepseq
     , extra
     , ghc
+    , ghc-exactprint  >= 1.5
     , ghcide          == 2.6.0.0
     , ghc-boot-th
     , hls-graph
@@ -53,11 +54,6 @@ library
     , mtl
     , text
     , transformers
-
-  if impl(ghc >=9.2.1)
-    build-depends: ghc-exactprint >= 1.5
-  else
-    build-depends: ghc-exactprint >= 0.6.4 && <1.1
 
   default-language:   Haskell2010
   default-extensions:

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -42,9 +42,6 @@ library
     , text
     , transformers
 
-  -- fourmolu 0.9.0 fails to build on Windows CI for reasons unknown
-  if os(windows) && impl(ghc < 9.4)
-     build-depends: fourmolu > 0.9.0.0 || < 0.9.0.0
   default-language: Haskell2010
 
 test-suite tests

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     , base            >=4.12 && <5
     , filepath
-    , fourmolu ^>= 0.14
+    , fourmolu        ^>= 0.14
     , ghc
     , ghc-boot-th
     , ghcide          == 2.6.0.0

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -30,6 +30,7 @@ library
   build-depends:
     , base            >=4.12 && <5
     , filepath
+    , fourmolu ^>= 0.14
     , ghc
     , ghc-boot-th
     , ghcide          == 2.6.0.0
@@ -41,13 +42,8 @@ library
     , text
     , transformers
 
-  if impl(ghc >= 9.0) && impl(ghc < 9.2)
-    build-depends: fourmolu ^>= 0.11
-  else 
-    build-depends: fourmolu ^>= 0.14
-
   -- fourmolu 0.9.0 fails to build on Windows CI for reasons unknown
-  if impl(ghc >= 9.2) && os(windows) && impl(ghc < 9.4)
+  if os(windows) && impl(ghc < 9.4)
      build-depends: fourmolu > 0.9.0.0 || < 0.9.0.0
   default-language: Haskell2010
 

--- a/plugins/hls-overloaded-record-dot-plugin/hls-overloaded-record-dot-plugin.cabal
+++ b/plugins/hls-overloaded-record-dot-plugin/hls-overloaded-record-dot-plugin.cabal
@@ -23,10 +23,6 @@ common warnings
 
 library
     import:           warnings
-    if impl(ghc < 9.2)
-      buildable: False
-    else
-      buildable: True
     exposed-modules:  Ide.Plugin.OverloadedRecordDot
     build-depends:
       , base                  >=4.16 && <5
@@ -48,10 +44,6 @@ library
 
 test-suite tests
     import:           warnings
-    if impl(ghc < 9.2)
-      buildable: False
-    else
-      buildable: True
     default-language: GHC2021
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test


### PR DESCRIPTION
Since we're supporting GHCs 9.2+ we can assume that impl(ghc >= 9.2) will be true going forward.