### PR TITLE
Remove unused dependencies in hls-refactor-plugin

### DIFF
--- a/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
+++ b/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
@@ -66,7 +66,6 @@ library
     ViewPatterns
   hs-source-dirs:   src
   build-depends:
-    , aeson
     , base                  >=4.12 && <5
     , ghc
     , bytestring
@@ -116,25 +115,17 @@ test-suite tests
     , lens
     , lsp-types
     , text
-    , aeson
     , hls-plugin-api
     , parser-combinators
     , data-default
     , extra
-    , text-rope
-    , containers
-    -- ghc is included to enable the MIN_VERSION_ghc macro
-    , ghc
     , ghcide
     , ghcide-test-utils
     , shake
     , hls-plugin-api
     , lsp-test
-    , network-uri
     , directory
-    , async
     , regex-tdfa
-    , tasty-rerun
     , tasty-hunit
     , tasty-expected-failure
     , tasty

--- a/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
+++ b/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
@@ -21,7 +21,11 @@ source-repository head
     type:     git
     location: https://github.com/haskell/haskell-language-server.git
 
+common warnings
+    ghc-options: -Wall -Wunused-packages
+
 library
+  import: warnings
   -- Plugins that need exactprint have not been updated for 9.8 yet
   if impl(ghc >= 9.8)
     buildable: False
@@ -93,10 +97,11 @@ library
     -- FIXME: Only needed to workaround for qualified imports in GHC 9.4
     , regex-applicative
     , parser-combinators
-  ghc-options: -Wall -Wno-name-shadowing
+  ghc-options: -Wno-name-shadowing
   default-language: Haskell2010
 
 test-suite tests
+  import: warnings
   if impl(ghc >= 9.8)
     buildable: False
   else

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -2388,7 +2388,7 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "f = 1"
                ])
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
     [ (DiagnosticSeverity_Warning, (3, 4), "Defaulting the type variable") ]
 #else
     [ (DiagnosticSeverity_Warning, (3, 4), "Defaulting the following constraint") ]
@@ -2409,7 +2409,7 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , "    let x = 3"
                , "    in x"
                ])
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
     [ (DiagnosticSeverity_Warning, (4, 12), "Defaulting the type variable") ]
 #else
     [ (DiagnosticSeverity_Warning, (4, 12), "Defaulting the following constraint") ]
@@ -2431,7 +2431,7 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , "    let x = let y = 5 in y"
                , "    in x"
                ])
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
     [ (DiagnosticSeverity_Warning, (4, 20), "Defaulting the type variable") ]
 #else
     [ (DiagnosticSeverity_Warning, (4, 20), "Defaulting the following constraint") ]
@@ -2454,7 +2454,7 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "f = seq \"debug\" traceShow \"debug\""
                ])
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
     [ (DiagnosticSeverity_Warning, (6, 8), "Defaulting the type variable")
     , (DiagnosticSeverity_Warning, (6, 16), "Defaulting the type variable")
     ]
@@ -2482,7 +2482,7 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "f a = traceShow \"debug\" a"
                ])
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
     [ (DiagnosticSeverity_Warning, (6, 6), "Defaulting the type variable") ]
 #else
     [ (DiagnosticSeverity_Warning, (6, 6), "Defaulting the following constraint") ]
@@ -2506,7 +2506,7 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "f = seq (\"debug\" :: [Char]) (seq (\"debug\" :: [Char]) (traceShow \"debug\"))"
                ])
-#if MIN_VERSION_ghc(9,4,0)
+#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
     [ (DiagnosticSeverity_Warning, (6, 54), "Defaulting the type variable") ]
 #else
     [ (DiagnosticSeverity_Warning, (6, 54), "Defaulting the following constraint") ]

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -3,9 +3,7 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE ImplicitParams        #-}
 {-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiWayIf            #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PatternSynonyms       #-}
@@ -2388,11 +2386,9 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "f = 1"
                ])
-#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
-    [ (DiagnosticSeverity_Warning, (3, 4), "Defaulting the type variable") ]
-#else
-    [ (DiagnosticSeverity_Warning, (3, 4), "Defaulting the following constraint") ]
-#endif
+    (if ghcVersion >= GHC94
+      then [ (DiagnosticSeverity_Warning, (3, 4), "Defaulting the type variable") ]
+      else [ (DiagnosticSeverity_Warning, (3, 4), "Defaulting the following constraint") ])
     "Add type annotation ‘Integer’ to ‘1’"
     (T.unlines [ "{-# OPTIONS_GHC -Wtype-defaults #-}"
                , "module A (f) where"
@@ -2409,11 +2405,9 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , "    let x = 3"
                , "    in x"
                ])
-#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
-    [ (DiagnosticSeverity_Warning, (4, 12), "Defaulting the type variable") ]
-#else
-    [ (DiagnosticSeverity_Warning, (4, 12), "Defaulting the following constraint") ]
-#endif
+    (if ghcVersion >= GHC94
+      then [ (DiagnosticSeverity_Warning, (4, 12), "Defaulting the type variable") ]
+      else [ (DiagnosticSeverity_Warning, (4, 12), "Defaulting the following constraint") ])
     "Add type annotation ‘Integer’ to ‘3’"
     (T.unlines [ "{-# OPTIONS_GHC -Wtype-defaults #-}"
                , "module A where"
@@ -2431,11 +2425,9 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , "    let x = let y = 5 in y"
                , "    in x"
                ])
-#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
-    [ (DiagnosticSeverity_Warning, (4, 20), "Defaulting the type variable") ]
-#else
-    [ (DiagnosticSeverity_Warning, (4, 20), "Defaulting the following constraint") ]
-#endif
+    (if ghcVersion >= GHC94
+      then [ (DiagnosticSeverity_Warning, (4, 20), "Defaulting the type variable") ]
+      else [ (DiagnosticSeverity_Warning, (4, 20), "Defaulting the following constraint") ])
     "Add type annotation ‘Integer’ to ‘5’"
     (T.unlines [ "{-# OPTIONS_GHC -Wtype-defaults #-}"
                , "module A where"
@@ -2454,15 +2446,15 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "f = seq \"debug\" traceShow \"debug\""
                ])
-#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
-    [ (DiagnosticSeverity_Warning, (6, 8), "Defaulting the type variable")
-    , (DiagnosticSeverity_Warning, (6, 16), "Defaulting the type variable")
-    ]
-#else
-    [ (DiagnosticSeverity_Warning, (6, 8), "Defaulting the following constraint")
-    , (DiagnosticSeverity_Warning, (6, 16), "Defaulting the following constraint")
-    ]
-#endif
+    (if ghcVersion >= GHC94
+      then
+        [ (DiagnosticSeverity_Warning, (6, 8), "Defaulting the type variable")
+        , (DiagnosticSeverity_Warning, (6, 16), "Defaulting the type variable")
+        ]
+      else
+        [ (DiagnosticSeverity_Warning, (6, 8), "Defaulting the following constraint")
+        , (DiagnosticSeverity_Warning, (6, 16), "Defaulting the following constraint")
+        ])
     ("Add type annotation ‘" <> listOfChar <> "’ to ‘\"debug\"’")
     (T.unlines [ "{-# OPTIONS_GHC -Wtype-defaults #-}"
                , "{-# LANGUAGE OverloadedStrings #-}"
@@ -2482,11 +2474,9 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "f a = traceShow \"debug\" a"
                ])
-#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
-    [ (DiagnosticSeverity_Warning, (6, 6), "Defaulting the type variable") ]
-#else
-    [ (DiagnosticSeverity_Warning, (6, 6), "Defaulting the following constraint") ]
-#endif
+    (if ghcVersion >= GHC94
+      then [ (DiagnosticSeverity_Warning, (6, 6), "Defaulting the type variable") ]
+      else [ (DiagnosticSeverity_Warning, (6, 6), "Defaulting the following constraint") ])
     ("Add type annotation ‘" <> listOfChar <> "’ to ‘\"debug\"’")
     (T.unlines [ "{-# OPTIONS_GHC -Wtype-defaults #-}"
                , "{-# LANGUAGE OverloadedStrings #-}"
@@ -2506,11 +2496,9 @@ addTypeAnnotationsToLiteralsTest = testGroup "add type annotations to literals t
                , ""
                , "f = seq (\"debug\" :: [Char]) (seq (\"debug\" :: [Char]) (traceShow \"debug\"))"
                ])
-#if MIN_VERSION_GLASGOW_HASKELL(9,4,0,0)
-    [ (DiagnosticSeverity_Warning, (6, 54), "Defaulting the type variable") ]
-#else
-    [ (DiagnosticSeverity_Warning, (6, 54), "Defaulting the following constraint") ]
-#endif
+    (if ghcVersion >= GHC94
+      then [ (DiagnosticSeverity_Warning, (6, 54), "Defaulting the type variable") ]
+      else [ (DiagnosticSeverity_Warning, (6, 54), "Defaulting the following constraint") ])
     ("Add type annotation ‘" <> listOfChar <> "’ to ‘\"debug\"’")
     (T.unlines [ "{-# OPTIONS_GHC -Wtype-defaults #-}"
                , "{-# LANGUAGE OverloadedStrings #-}"


### PR DESCRIPTION
I'd like to do general cleanup of unused dependencies (stuff reported by `-Wunused-packages`).

This PR starts by just doing this for one plugin and checking that people agree with the approach to removing unused ghc  (direct - I know that most plugins actually do depend on GHC transitively) dependency.

If you find such initiative useful, I can continue with other plugins.