### PR TITLE
Prepare release 2.6.0.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,12 +21,18 @@ build_task:
     GITHUB_WORKSPACE: ${CIRRUS_WORKING_DIR}
     CABAL_CACHE_NONFATAL: "yes"
   matrix:
-    - name: build-ghc-9.2.5
+    - name: build-ghc-9.2.8
       env:
-        GHC_VERSION: 9.2.5
-    - name: build-ghc-9.2.7
+        GHC_VERSION: 9.2.8
+    - name: build-ghc-9.4.8
       env:
-        GHC_VERSION: 9.2.7
+        GHC_VERSION: 9.4.8
+    - name: build-ghc-9.6.4
+      env:
+        GHC_VERSION: 9.6.4
+    - name: build-ghc-9.8.1
+      env:
+        GHC_VERSION: 9.8.1
   install_script: pkg install -y hs-cabal-install git bash misc/compat10x misc/compat11x misc/compat12x gmake patchelf tree gmp libiconv
   script:
     - tzsetup Etc/GMT
@@ -40,8 +46,10 @@ build_task:
 bindist_task:
   name: bindist
   depends_on:
-    - build-ghc-9.2.5
-    - build-ghc-9.2.7
+    - build-ghc-9.2.8
+    - build-ghc-9.4.8
+    - build-ghc-9.6.4
+    - build-ghc-9.8.1
   timeout_in: 120m
   only_if: $CIRRUS_TAG != ''
   env:
@@ -56,13 +64,21 @@ bindist_task:
     - tzsetup Etc/GMT
     - adjkerntz -a
 
-    - curl -o binaries-9.2.5.tar.xz -L https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build-ghc-9.2.5/binaries/out.tar.xz
-    - tar xvf binaries-9.2.5.tar.xz
-    - rm -f binaries-9.2.5.tar.xz
+    - curl -o binaries-9.2.8.tar.xz -L https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build-ghc-9.2.8/binaries/out.tar.xz
+    - tar xvf binaries-9.2.8.tar.xz
+    - rm -f binaries-9.2.8.tar.xz
 
-    - curl -o binaries-9.2.7.tar.xz -L https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build-ghc-9.2.7/binaries/out.tar.xz
-    - tar xvf binaries-9.2.7.tar.xz
-    - rm -f binaries-9.2.7.tar.xz
+    - curl -o binaries-9.4.8.tar.xz -L https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build-ghc-9.4.8/binaries/out.tar.xz
+    - tar xvf binaries-9.4.8.tar.xz
+    - rm -f binaries-9.4.8.tar.xz
+
+    - curl -o binaries-9.6.4.tar.xz -L https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build-ghc-9.6.4/binaries/out.tar.xz
+    - tar xvf binaries-9.6.4.tar.xz
+    - rm -f binaries-9.6.4.tar.xz
+
+    - curl -o binaries-9.8.1.tar.xz -L https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/build-ghc-9.8.1/binaries/out.tar.xz
+    - tar xvf binaries-9.8.1.tar.xz
+    - rm -f binaries-9.8.1.tar.xz
 
     - bash .github/scripts/bindist.sh
   bindist_artifacts:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -156,7 +156,7 @@ jobs:
       run:  find bench-results -name "*.csv" -or -name "*.svg" -or -name "*.html" | xargs tar -czf benchmark-artifacts.tar.gz
 
     - name: Archive benchmarking artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4444
       with:
         name: bench-results-${{ matrix.example }}-${{ runner.os }}-${{ matrix.ghc }}
         path: benchmark-artifacts.tar.gz

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -95,14 +95,14 @@ jobs:
         tar -czf cabal.tar.gz *
 
     - name: Upload workspace
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: workspace-${{ matrix.ghc }}-${{ matrix.os }}
         retention-days: 1
         path: workspace.tar.gz
 
     - name: Upload .cabal
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: cabal-home-${{ matrix.ghc }}-${{ matrix.os }}
         retention-days: 1
@@ -128,13 +128,13 @@ jobs:
         enable-stack: false
 
     - name: Download cabal home
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: cabal-home-${{ matrix.ghc }}-${{ matrix.os }}
         path: .
 
     - name: Download workspace
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: workspace-${{ matrix.ghc }}-${{ matrix.os }}
         path: .
@@ -156,7 +156,7 @@ jobs:
       run:  find bench-results -name "*.csv" -or -name "*.svg" -or -name "*.html" | xargs tar -czf benchmark-artifacts.tar.gz
 
     - name: Archive benchmarking artifacts
-      uses: actions/upload-artifact@v4444
+      uses: actions/upload-artifact@v3
       with:
         name: bench-results-${{ matrix.example }}-${{ runner.os }}-${{ matrix.ghc }}
         path: benchmark-artifacts.tar.gz
@@ -166,7 +166,7 @@ jobs:
       run: find bench-results -name "*.log" -or -name "*.hp" | xargs tar -czf benchmark-logs.tar.gz
 
     - name: Archive benchmark logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: bench-logs-${{ matrix.example }}-${{ runner.os }}-${{ matrix.ghc }}
         path: benchmark-logs.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,7 +183,7 @@ jobs:
 
       - if: always()
         name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           retention-days: 2
@@ -244,7 +244,7 @@ jobs:
 
       - if: always()
         name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           retention-days: 2
@@ -288,7 +288,7 @@ jobs:
 
       - if: always()
         name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           retention-days: 2
@@ -335,7 +335,7 @@ jobs:
 
       - if: always()
         name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           retention-days: 2
@@ -388,7 +388,7 @@ jobs:
 
       - if: always()
         name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           retention-days: 2
@@ -485,7 +485,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifacts-${{ matrix.ARTIFACT }}
           path: ./
@@ -502,7 +502,7 @@ jobs:
           ARTIFACT: ${{ matrix.ARTIFACT }}
 
       - name: Upload bindist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           name: bindists-${{ matrix.ARTIFACT }}
@@ -537,7 +537,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifacts-arm
           path: ./
@@ -553,7 +553,7 @@ jobs:
           args: bash .github/scripts/bindist.sh
 
       - name: Upload bindist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           name: bindists-arm
@@ -576,7 +576,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifacts-mac-x86_64
           path: ./
@@ -591,7 +591,7 @@ jobs:
           bash .github/scripts/bindist.sh
 
       - name: Upload bindist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           name: bindists-mac-x86_64
@@ -614,7 +614,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifacts-mac-aarch64
           path: ./
@@ -635,7 +635,7 @@ jobs:
           bash .github/scripts/bindist.sh
 
       - name: Upload bindist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           name: bindists-mac-aarch64
@@ -666,7 +666,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifacts-win
           path: ./out
@@ -679,7 +679,7 @@ jobs:
         shell: pwsh
 
       - name: Upload bindist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           name: bindists-win
@@ -780,7 +780,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: bindists-${{ matrix.ARTIFACT }}
           path: ./out
@@ -816,7 +816,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: bindists-arm
           path: ./out

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.8.1", "9.6.3", "9.4.8", "9.2.8"]
+        ghc: ["9.8.1", "9.6.4", "9.4.8", "9.2.8"]
         platform: [ { image: "debian:9"
                     , installCmd: "sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && sed -i /-updates/d /etc/apt/sources.list && apt-get update && apt-get install -y"
                     , toolRequirements: "libnuma-dev zlib1g-dev libgmp-dev libgmp10 libssl-dev liblzma-dev libbz2-dev git wget lsb-release software-properties-common gnupg2 apt-transport-https gcc autoconf automake build-essential curl ghc gzip libffi-dev libncurses-dev libncurses5 libtinfo5 patchelf"
@@ -136,7 +136,7 @@ jobs:
               , ARTIFACT: "x86_64-linux-unknown"
               , ADD_CABAL_ARGS: "--enable-split-sections"
               }
-          - ghc: 9.6.3
+          - ghc: 9.6.4
             platform:
               { image: "rockylinux:8"
               , installCmd: "yum -y install epel-release && yum install -y --allowerasing"
@@ -213,7 +213,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: ["9.8.1", "9.6.3", "9.4.8", "9.2.8" ]
+        ghc: ["9.8.1", "9.6.4", "9.4.8", "9.2.8" ]
     steps:
       - uses: docker://arm64v8/ubuntu:focal
         name: Cleanup (aarch64 linux)
@@ -273,7 +273,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.8.1", "9.6.3", "9.4.8", "9.2.8"]
+        ghc: ["9.8.1", "9.6.4", "9.4.8", "9.2.8"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -318,7 +318,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.8.1", "9.6.3", "9.4.8", "9.2.8"]
+        ghc: ["9.8.1", "9.6.4", "9.4.8", "9.2.8"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -363,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.8.1", "9.6.3", "9.4.8", "9.2.8"]
+        ghc: ["9.8.1", "9.6.4", "9.4.8", "9.2.8"]
     steps:
       - name: install windows deps
         shell: pwsh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -510,7 +510,7 @@ jobs:
             ./out/*.tar.xz
             ./out/plan.json/*
 
-      - uses: geekyeggo/delete-artifact@v4
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: artifacts-${{ matrix.ARTIFACT }}
 
@@ -561,7 +561,7 @@ jobs:
             ./out/*.tar.xz
             ./out/plan.json/*
 
-      - uses: geekyeggo/delete-artifact@v4
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: artifacts-arm
 
@@ -599,7 +599,7 @@ jobs:
             ./out/*.tar.xz
             ./out/plan.json/*
 
-      - uses: geekyeggo/delete-artifact@v4
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: artifacts-mac-x86_64
 
@@ -643,7 +643,7 @@ jobs:
             ./out/*.tar.xz
             ./out/plan.json/*
 
-      - uses: geekyeggo/delete-artifact@v4
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: artifacts-mac-aarch64
 
@@ -687,7 +687,7 @@ jobs:
             ./out/*.zip
             ./out/plan.json/*
 
-      - uses: geekyeggo/delete-artifact@v4
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: artifacts-win
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,87 @@
 # Changelog for haskell-language-server
 
+## 2.6.0.0
+
+- Bindists for GHC 9.6.4
+- A new semantic tokens plugin (#3892, @soulomoon).
+- Improvements to multiple home unit support with GHC 9.4. Using cabal 3.11+ will
+  load proper multiple home unit sessions by default, fixing a lot of issues with
+  loading and reloading projects that have more than one component (#3462, @wz1000).
+- Removed implicit-hie, resulting in better behaviour for projects without cradles.
+- Don't produce diagnostics for disabled plugins (#3941, @fendor).
+- Many other bug fixes.
+
+### Pull Requests
+
+- fix: semantic token omitting record field in `{-# LANGUAGE DuplicateRecordFields  #-}` #3950
+  ([#3951](https://github.com/haskell/haskell-language-server/pull/3951)) by @soulomoon
+- Properties API: Remove unsafe coerce in favor of type class based method in 
+  ([#3947](https://github.com/haskell/haskell-language-server/pull/3947)) by @soulomoon
+- Bump to hiedb 0.5.0.0 to fix #3542
+  ([#3943](https://github.com/haskell/haskell-language-server/pull/3943)) by @wz1000
+- Don't produce diagnostics if plugin is turned off
+  ([#3941](https://github.com/haskell/haskell-language-server/pull/3941)) by @fendor
+- add config  for semantic-tokens-plugin for mapping from hs token type to LSP default token type
+  ([#3940](https://github.com/haskell/haskell-language-server/pull/3940)) by @soulomoon
+- add doc and ci test for semantic tokens
+  ([#3938](https://github.com/haskell/haskell-language-server/pull/3938)) by @soulomoon
+- update Floskell to 0.11.*
+  ([#3933](https://github.com/haskell/haskell-language-server/pull/3933)) by @peterbecich
+- Remove some people from CODEOWNERS
+  ([#3930](https://github.com/haskell/haskell-language-server/pull/3930)) by @michaelpj
+- Adapt to minor API change for 9.6.4 compatibility
+  ([#3929](https://github.com/haskell/haskell-language-server/pull/3929)) by @wz1000
+- Fix multi unit session when some packages have reexported modules.
+  ([#3928](https://github.com/haskell/haskell-language-server/pull/3928)) by @wz1000
+- Switch to haskell-actions/setup since haskell/actions is deprecated
+  ([#3926](https://github.com/haskell/haskell-language-server/pull/3926)) by @fendor
+- Make vscode-extension-schema honour default values
+  ([#3925](https://github.com/haskell/haskell-language-server/pull/3925)) by @fendor
+- Add golden tests for public configs
+  ([#3922](https://github.com/haskell/haskell-language-server/pull/3922)) by @fendor
+- Bump geekyeggo/delete-artifact from 2 to 4
+  ([#3921](https://github.com/haskell/haskell-language-server/pull/3921)) by @dependabot[bot]
+- Fix positionMapping in stale data
+  ([#3920](https://github.com/haskell/haskell-language-server/pull/3920)) by @soulomoon
+- Disable stan plugin by default
+  ([#3917](https://github.com/haskell/haskell-language-server/pull/3917)) by @fendor
+- Use stan config files for stan plugin (#3904)
+  ([#3914](https://github.com/haskell/haskell-language-server/pull/3914)) by @0rphee
+- Bump both upload and download artifact
+  ([#3913](https://github.com/haskell/haskell-language-server/pull/3913)) by @michaelpj
+- Update ghc-version-support.md for 2.5.0
+  ([#3909](https://github.com/haskell/haskell-language-server/pull/3909)) by @lehmacdj
+- Give plugins descriptions, include versions of key dependencies 
+  ([#3903](https://github.com/haskell/haskell-language-server/pull/3903)) by @michaelpj
+- Remove some buildability blockers that aren't needed
+  ([#3899](https://github.com/haskell/haskell-language-server/pull/3899)) by @michaelpj
+- Bump actions/setup-python from 4 to 5
+  ([#3895](https://github.com/haskell/haskell-language-server/pull/3895)) by @dependabot[bot]
+- Update index-state to get latest stan version
+  ([#3894](https://github.com/haskell/haskell-language-server/pull/3894)) by @0rphee
+- Generate FileTarget for all possible targetLocations
+  ([#3893](https://github.com/haskell/haskell-language-server/pull/3893)) by @fendor
+- Implement semantic tokens plugin to support semantic highlighting(textDocument/semanticTokens/full)
+  ([#3892](https://github.com/haskell/haskell-language-server/pull/3892)) by @soulomoon
+- session-loader: Set working directory on GHC 9.4+
+  ([#3891](https://github.com/haskell/haskell-language-server/pull/3891)) by @wz1000
+- Demote home unit closure errors to warnings.
+  ([#3890](https://github.com/haskell/haskell-language-server/pull/3890)) by @wz1000
+- Bump cachix/install-nix-action from 23 to 24
+  ([#3889](https://github.com/haskell/haskell-language-server/pull/3889)) by @dependabot[bot]
+- Bump cachix/cachix-action from 12 to 13
+  ([#3888](https://github.com/haskell/haskell-language-server/pull/3888)) by @dependabot[bot]
+- Add more docs for implicit discovery
+  ([#3887](https://github.com/haskell/haskell-language-server/pull/3887)) by @fendor
+- Prepare release 2.5.0.0
+  ([#3879](https://github.com/haskell/haskell-language-server/pull/3879)) by @wz1000
+- Improve no plugin messages
+  ([#3864](https://github.com/haskell/haskell-language-server/pull/3864)) by @joyfulmantis
+- Add support for multi unit argument syntax
+  ([#3462](https://github.com/haskell/haskell-language-server/pull/3462)) by @wz1000
+- Fix completion for qualified import
+  ([#2838](https://github.com/haskell/haskell-language-server/pull/2838)) by @xsebek
+
 ## 2.5.0.0
 
 - Bindists for GHC 9.4.8

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 - Bindists for GHC 9.6.4
 - A new semantic tokens plugin (#3892, @soulomoon).
-- Improvements to multiple home unit support with GHC 9.4. Using cabal 3.11+ will
+- Improvements to multiple home unit support with GHC 9.4. When HLS is used with cabal 3.11+ it will
   load proper multiple home unit sessions by default, fixing a lot of issues with
   loading and reloading projects that have more than one component (#3462, @wz1000).
 - Removed implicit-hie, resulting in better behaviour for projects without cradles.

--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -18,7 +18,8 @@ Support status (see the support policy below for more details):
 | GHC version  | Last supporting HLS version                                                          | Support status                                                              |
 |--------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | 9.8.1        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | initial support                                                             |
-| 9.6.3        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
+| 9.6.4        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
+| 9.6.3        | [2.5.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.5.0.0)   | full support                                                                |
 | 9.6.2        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |
 | 9.6.1        | [2.0.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.0.0.0)   | deprecated                                                                  |
 | 9.4.8        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |

--- a/ghcide-bench/ghcide-bench.cabal
+++ b/ghcide-bench/ghcide-bench.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide-bench
-version:            2.5.0.0
+version:            2.6.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             The Haskell IDE team

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.0
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            2.5.0.0
+version:            2.6.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -79,8 +79,8 @@ library
     , hie-bios                     ==0.13.1
     , hie-compat                   ^>=0.3.0.0
     , hiedb                        ^>= 0.5.0.1
-    , hls-graph                    == 2.5.0.0
-    , hls-plugin-api               == 2.5.0.0
+    , hls-graph                    == 2.6.0.0
+    , hls-plugin-api               == 2.6.0.0
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5
     , lens
     , list-t

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.0
 category:           Development
 name:               haskell-language-server
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -208,139 +208,139 @@ flag cabalfmt
 
 common cabalfmt
   if flag(cabalfmt)
-    build-depends: hls-cabal-fmt-plugin == 2.5.0.0
+    build-depends: hls-cabal-fmt-plugin == 2.6.0.0
     cpp-options: -Dhls_cabalfmt
 
 common cabal
   if flag(cabal)
-    build-depends: hls-cabal-plugin == 2.5.0.0
+    build-depends: hls-cabal-plugin == 2.6.0.0
     cpp-options: -Dhls_cabal
 
 common class
   if flag(class) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-class-plugin == 2.5.0.0
+    build-depends: hls-class-plugin == 2.6.0.0
     cpp-options: -Dhls_class
 
 common callHierarchy
   if flag(callHierarchy)
-    build-depends: hls-call-hierarchy-plugin == 2.5.0.0
+    build-depends: hls-call-hierarchy-plugin == 2.6.0.0
     cpp-options: -Dhls_callHierarchy
 
 common eval
   if flag(eval)
-    build-depends: hls-eval-plugin == 2.5.0.0
+    build-depends: hls-eval-plugin == 2.6.0.0
     cpp-options: -Dhls_eval
 
 common importLens
   if flag(importLens)
-    build-depends: hls-explicit-imports-plugin == 2.5.0.0
+    build-depends: hls-explicit-imports-plugin == 2.6.0.0
     cpp-options: -Dhls_importLens
 
 common rename
   if flag(rename) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-rename-plugin == 2.5.0.0
+    build-depends: hls-rename-plugin == 2.6.0.0
     cpp-options: -Dhls_rename
 
 common retrie
   if flag(retrie) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-retrie-plugin == 2.5.0.0
+    build-depends: hls-retrie-plugin == 2.6.0.0
     cpp-options: -Dhls_retrie
 
 common hlint
   if flag(hlint) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-hlint-plugin == 2.5.0.0
+    build-depends: hls-hlint-plugin == 2.6.0.0
     cpp-options: -Dhls_hlint
 
 common stan
   if flag(stan) && (impl(ghc > 8.8.1) && impl(ghc <= 9.2.3) || impl(ghc >= 9.4.0) && impl(ghc < 9.10.0))
-    build-depends: hls-stan-plugin == 2.5.0.0
+    build-depends: hls-stan-plugin == 2.6.0.0
     cpp-options: -Dhls_stan
 
 common moduleName
   if flag(moduleName)
-    build-depends: hls-module-name-plugin == 2.5.0.0
+    build-depends: hls-module-name-plugin == 2.6.0.0
     cpp-options: -Dhls_moduleName
 
 common pragmas
   if flag(pragmas)
-    build-depends: hls-pragmas-plugin == 2.5.0.0
+    build-depends: hls-pragmas-plugin == 2.6.0.0
     cpp-options: -Dhls_pragmas
 
 common splice
   if flag(splice) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-splice-plugin == 2.5.0.0
+    build-depends: hls-splice-plugin == 2.6.0.0
     cpp-options: -Dhls_splice
 
 common alternateNumberFormat
   if flag(alternateNumberFormat)
-    build-depends: hls-alternate-number-format-plugin == 2.5.0.0
+    build-depends: hls-alternate-number-format-plugin == 2.6.0.0
     cpp-options: -Dhls_alternateNumberFormat
 
 common qualifyImportedNames
   if flag(qualifyImportedNames)
-    build-depends: hls-qualify-imported-names-plugin == 2.5.0.0
+    build-depends: hls-qualify-imported-names-plugin == 2.6.0.0
     cpp-options: -Dhls_qualifyImportedNames
 
 common codeRange
   if flag(codeRange)
-    build-depends: hls-code-range-plugin == 2.5.0.0
+    build-depends: hls-code-range-plugin == 2.6.0.0
     cpp-options: -Dhls_codeRange
 
 common changeTypeSignature
   if flag(changeTypeSignature)
-    build-depends: hls-change-type-signature-plugin == 2.5.0.0
+    build-depends: hls-change-type-signature-plugin == 2.6.0.0
     cpp-options: -Dhls_changeTypeSignature
 
 common gadt
   if flag(gadt) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-gadt-plugin == 2.5.0.0
+    build-depends: hls-gadt-plugin == 2.6.0.0
     cpp-options: -Dhls_gadt
 
 common explicitFixity
   if flag(explicitFixity)
-    build-depends: hls-explicit-fixity-plugin == 2.5.0.0
+    build-depends: hls-explicit-fixity-plugin == 2.6.0.0
     cpp-options: -DexplicitFixity
 
 common explicitFields
   if flag(explicitFields)
-    build-depends: hls-explicit-record-fields-plugin == 2.5.0.0
+    build-depends: hls-explicit-record-fields-plugin == 2.6.0.0
     cpp-options: -DexplicitFields
 
 common overloadedRecordDot
   if flag(overloadedRecordDot) && (impl(ghc >= 9.2.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-overloaded-record-dot-plugin == 2.5.0.0
+    build-depends: hls-overloaded-record-dot-plugin == 2.6.0.0
     cpp-options: -Dhls_overloaded_record_dot
 
 -- formatters
 
 common floskell
   if flag(floskell) && (impl(ghc < 9.7) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-floskell-plugin == 2.5.0.0
+    build-depends: hls-floskell-plugin == 2.6.0.0
     cpp-options: -Dhls_floskell
 
 common fourmolu
   if flag(fourmolu)
-    build-depends: hls-fourmolu-plugin == 2.5.0.0
+    build-depends: hls-fourmolu-plugin == 2.6.0.0
     cpp-options: -Dhls_fourmolu
 
 common ormolu
   if flag(ormolu)
-    build-depends: hls-ormolu-plugin == 2.5.0.0
+    build-depends: hls-ormolu-plugin == 2.6.0.0
     cpp-options: -Dhls_ormolu
 
 common stylishHaskell
   if flag(stylishHaskell) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-stylish-haskell-plugin == 2.5.0.0
+    build-depends: hls-stylish-haskell-plugin == 2.6.0.0
     cpp-options: -Dhls_stylishHaskell
 
 common refactor
   if flag(refactor) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
-    build-depends: hls-refactor-plugin == 2.5.0.0
+    build-depends: hls-refactor-plugin == 2.6.0.0
     cpp-options: -Dhls_refactor
 
 common semanticTokens
   if flag(semanticTokens)
-    build-depends: hls-semantic-tokens-plugin == 2.5.0.0
+    build-depends: hls-semantic-tokens-plugin == 2.6.0.0
     cpp-options: -Dhls_semanticTokens
 
 
@@ -395,12 +395,12 @@ library
     , cryptohash-sha1
     , data-default
     , ghc
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , githash               >=0.1.6.1
     , lsp                   >= 2.3.0.0
     , hie-bios
     , hiedb
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , optparse-applicative
     , optparse-simple
     , process
@@ -538,7 +538,7 @@ test-suite func-test
     , lens-aeson
     , ghcide
     , ghcide-test-utils
-    , hls-test-utils == 2.5.0.0
+    , hls-test-utils == 2.6.0.0
     , lsp-types
     , aeson
     , hls-plugin-api

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-graph
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       2.5.0.0
+version:       2.6.0.0
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -60,7 +60,7 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             == 2.5.0.0
+    , hls-graph             == 2.6.0.0
     , lens
     , lens-aeson
     , lsp                   ^>=2.3

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       2.5.0.0
+version:       2.6.0.0
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -42,9 +42,9 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  == 2.5.0.0
+    , ghcide                  == 2.6.0.0
     , hls-graph
-    , hls-plugin-api          == 2.5.0.0
+    , hls-plugin-api          == 2.6.0.0
     , lens
     , lsp                     ^>=2.3
     , lsp-test                ^>=0.16

--- a/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
+++ b/plugins/hls-alternate-number-format-plugin/hls-alternate-number-format-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-alternate-number-format-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Provide Alternate Number Formats plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -31,10 +31,10 @@ library
     , base                 >=4.12 && < 5
     , containers
     , extra
-    , ghcide               == 2.5.0.0
+    , ghcide               == 2.6.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       == 2.5.0.0
+    , hls-plugin-api       == 2.6.0.0
     , hie-compat
     , lens
     , lsp                  ^>=2.3.0.0
@@ -62,7 +62,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-alternate-number-format-plugin
-    , hls-test-utils       == 2.5.0.0
+    , hls-test-utils       == 2.6.0.0
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
+++ b/plugins/hls-cabal-fmt-plugin/hls-cabal-fmt-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-cabal-fmt-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Integration with the cabal-fmt code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -33,8 +33,8 @@ library
     , base            >=4.12 && <5
     , directory
     , filepath
-    , ghcide          == 2.5.0.0
-    , hls-plugin-api  == 2.5.0.0
+    , ghcide          == 2.6.0.0
+    , hls-plugin-api  == 2.6.0.0
     , lens
     , lsp-types
     , mtl
@@ -56,7 +56,7 @@ test-suite tests
     , directory
     , filepath
     , hls-cabal-fmt-plugin
-    , hls-test-utils        == 2.5.0.0
+    , hls-test-utils        == 2.6.0.0
 
   if flag(isolateTests)
     build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.6

--- a/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
+++ b/plugins/hls-cabal-plugin/hls-cabal-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-cabal-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Cabal integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -49,10 +49,10 @@ library
     , directory
     , filepath
     , extra                 >=1.7.4
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hashable
-    , hls-plugin-api        == 2.5.0.0
-    , hls-graph             == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
+    , hls-graph             == 2.6.0.0
     , lens
     , lsp                   ^>=2.3
     , lsp-types             ^>=2.1
@@ -84,7 +84,7 @@ test-suite tests
     , filepath
     , ghcide
     , hls-cabal-plugin
-    , hls-test-utils    == 2.5.0.0
+    , hls-test-utils    == 2.6.0.0
     , lens
     , lsp
     , lsp-types

--- a/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
+++ b/plugins/hls-call-hierarchy-plugin/hls-call-hierarchy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-call-hierarchy-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Call hierarchy plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-call-hierarchy-plugin#readme>
@@ -33,9 +33,9 @@ library
     , base                  >=4.12 && <5
     , containers
     , extra
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hiedb
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp                    >=2.3
     , sqlite-simple
@@ -58,7 +58,7 @@ test-suite tests
     , extra
     , filepath
     , hls-call-hierarchy-plugin
-    , hls-test-utils              == 2.5.0.0
+    , hls-test-utils              == 2.6.0.0
     , ghcide-test-utils
     , lens
     , lsp

--- a/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
+++ b/plugins/hls-change-type-signature-plugin/hls-change-type-signature-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-change-type-signature-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Change a declarations type signature with a Code Action
 description:
   Please see the README on GitHub at <https://github.com/haskell/plugins/hls-change-type-signature-plugin/README.md>
@@ -27,8 +27,8 @@ library
   hs-source-dirs:   src
   build-depends:
     , base             >=4.12 && < 5
-    , ghcide           == 2.5.0.0
-    , hls-plugin-api   == 2.5.0.0
+    , ghcide           == 2.6.0.0
+    , hls-plugin-api   == 2.6.0.0
     , lsp-types
     , regex-tdfa
     , syb
@@ -59,7 +59,7 @@ test-suite tests
     , base                 >=4.12 && < 5
     , filepath
     , hls-change-type-signature-plugin
-    , hls-test-utils       == 2.5.0.0
+    , hls-test-utils       == 2.6.0.0
     , lsp
     , QuickCheck
     , regex-tdfa

--- a/plugins/hls-class-plugin/hls-class-plugin.cabal
+++ b/plugins/hls-class-plugin/hls-class-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-class-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:
   Class/instance management plugin for Haskell Language Server
 
@@ -44,10 +44,10 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide          == 2.5.0.0
+    , ghcide          == 2.6.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api  == 2.5.0.0
+    , hls-plugin-api  == 2.6.0.0
     , lens
     , lsp
     , mtl
@@ -84,7 +84,7 @@ test-suite tests
     , ghcide
     , hls-class-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.5.0.0
+    , hls-test-utils     == 2.6.0.0
     , lens
     , lsp-types
     , row-types

--- a/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
+++ b/plugins/hls-code-range-plugin/hls-code-range-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-code-range-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:
   HLS Plugin to support smart selection range and Folding range
 
@@ -37,9 +37,9 @@ library
     , containers
     , deepseq
     , extra
-    , ghcide           == 2.5.0.0
+    , ghcide           == 2.6.0.0
     , hashable
-    , hls-plugin-api   == 2.5.0.0
+    , hls-plugin-api   == 2.6.0.0
     , lens
     , lsp
     , mtl
@@ -62,10 +62,10 @@ test-suite tests
     , bytestring
     , containers
     , filepath
-    , ghcide                     == 2.5.0.0
+    , ghcide                     == 2.6.0.0
     , hls-code-range-plugin
     , hls-plugin-api
-    , hls-test-utils             == 2.5.0.0
+    , hls-test-utils             == 2.6.0.0
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-eval-plugin/hls-eval-plugin.cabal
+++ b/plugins/hls-eval-plugin/hls-eval-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-eval-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Eval plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -67,10 +67,10 @@ library
     , ghc
     , ghc-boot-th
     , ghc-paths
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hashable
     , hls-graph
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp
     , lsp-types
@@ -112,7 +112,7 @@ test-suite tests
     , filepath
     , hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   == 2.5.0.0
+    , hls-test-utils   == 2.6.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
+++ b/plugins/hls-explicit-fixity-plugin/hls-explicit-fixity-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-explicit-fixity-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Show fixity explicitly while hovering
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-explicit-fixity-plugin#readme>
@@ -29,9 +29,9 @@ library
     , deepseq
     , extra
     , ghc
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hashable
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lsp                   >=2.3
     , text
     , transformers
@@ -53,5 +53,5 @@ test-suite tests
     , base
     , filepath
     , hls-explicit-fixity-plugin
-    , hls-test-utils              == 2.5.0.0
+    , hls-test-utils              == 2.6.0.0
     , text

--- a/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
+++ b/plugins/hls-explicit-imports-plugin/hls-explicit-imports-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-explicit-imports-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Explicit imports plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -37,9 +37,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hls-graph
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp
     , mtl

--- a/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
+++ b/plugins/hls-explicit-record-fields-plugin/hls-explicit-record-fields-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-explicit-record-fields-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Explicit record fields plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -35,8 +35,8 @@ library
     build-depends:
       , base                  >=4.12 && <5
       , ghc
-      , ghcide                == 2.5.0.0
-      , hls-plugin-api        == 2.5.0.0
+      , ghcide                == 2.6.0.0
+      , hls-plugin-api        == 2.6.0.0
       , lsp
       , lens
       , hls-graph

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-floskell-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Integration with the Floskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,8 +29,8 @@ library
   build-depends:
     , base            >=4.12 && <5
     , floskell        ^>=0.11.0
-    , ghcide          == 2.5.0.0
-    , hls-plugin-api  == 2.5.0.0
+    , ghcide          == 2.6.0.0
+    , hls-plugin-api  == 2.6.0.0
     , lsp-types       ^>=2.1
     , mtl
     , text
@@ -50,4 +50,4 @@ test-suite tests
     , base
     , filepath
     , hls-floskell-plugin
-    , hls-test-utils       == 2.5.0.0
+    , hls-test-utils       == 2.6.0.0

--- a/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
+++ b/plugins/hls-fourmolu-plugin/hls-fourmolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-fourmolu-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Integration with the Fourmolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,8 +32,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          == 2.5.0.0
-    , hls-plugin-api  == 2.5.0.0
+    , ghcide          == 2.6.0.0
+    , hls-plugin-api  == 2.6.0.0
     , lens
     , lsp
     , mtl
@@ -66,5 +66,5 @@ test-suite tests
     , filepath
     , hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       == 2.5.0.0
+    , hls-test-utils       == 2.6.0.0
     , lsp-test

--- a/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
+++ b/plugins/hls-gadt-plugin/hls-gadt-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-gadt-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Convert to GADT syntax plugin
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-gadt-plugin#readme>
@@ -35,10 +35,10 @@ library
     , containers
     , extra
     , ghc
-    , ghcide                 == 2.5.0.0
+    , ghcide                 == 2.6.0.0
     , ghc-boot-th
     , ghc-exactprint
-    , hls-plugin-api         == 2.5.0.0
+    , hls-plugin-api         == 2.6.0.0
     , hls-refactor-plugin
     , lens
     , lsp                    >=2.3
@@ -68,7 +68,7 @@ test-suite tests
     , base
     , filepath
     , hls-gadt-plugin
-    , hls-test-utils              == 2.5.0.0
+    , hls-test-utils              == 2.6.0.0
     , lens
     , lsp
     , lsp-test

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-hlint-plugin
-version:       2.5.0.0
+version:       2.6.0.0
 synopsis:      Hlint integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -50,10 +50,10 @@ library
     , extra
     , filepath
     , ghc-exactprint        >=0.6.3.4
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hashable
     , hlint                 >= 3.5 && < 3.7
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp
     , mtl
@@ -98,7 +98,7 @@ test-suite tests
     , filepath
     , hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.5.0.0
+    , hls-test-utils      == 2.6.0.0
     , lens
     , lsp-types
     , row-types

--- a/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
+++ b/plugins/hls-module-name-plugin/hls-module-name-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-module-name-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Module name plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -32,8 +32,8 @@ library
     , containers
     , directory
     , filepath
-    , ghcide                == 2.5.0.0
-    , hls-plugin-api        == 2.5.0.0
+    , ghcide                == 2.6.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lsp
     , text
     , transformers
@@ -51,4 +51,4 @@ test-suite tests
     , base
     , filepath
     , hls-module-name-plugin
-    , hls-test-utils          == 2.5.0.0
+    , hls-test-utils          == 2.6.0.0

--- a/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
+++ b/plugins/hls-ormolu-plugin/hls-ormolu-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-ormolu-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Integration with the Ormolu code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -31,8 +31,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide          == 2.5.0.0
-    , hls-plugin-api  == 2.5.0.0
+    , ghcide          == 2.6.0.0
+    , hls-plugin-api  == 2.6.0.0
     , lens
     , lsp
     , mtl
@@ -58,7 +58,7 @@ test-suite tests
     , filepath
     , hls-ormolu-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.5.0.0
+    , hls-test-utils     == 2.6.0.0
     , lsp-types
     , text
     , ormolu

--- a/plugins/hls-overloaded-record-dot-plugin/hls-overloaded-record-dot-plugin.cabal
+++ b/plugins/hls-overloaded-record-dot-plugin/hls-overloaded-record-dot-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-overloaded-record-dot-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Overloaded record dot plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>

--- a/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
+++ b/plugins/hls-pragmas-plugin/hls-pragmas-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-pragmas-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Pragmas plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -29,8 +29,8 @@ library
     , extra
     , fuzzy
     , ghc
-    , ghcide                == 2.5.0.0
-    , hls-plugin-api        == 2.5.0.0
+    , ghcide                == 2.6.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp
     , text
@@ -51,7 +51,7 @@ test-suite tests
     , base
     , filepath
     , hls-pragmas-plugin
-    , hls-test-utils      == 2.5.0.0
+    , hls-test-utils      == 2.6.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
+++ b/plugins/hls-qualify-imported-names-plugin/hls-qualify-imported-names-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-qualify-imported-names-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           A Haskell Language Server plugin that qualifies imported names
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -30,9 +30,9 @@ library
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hls-graph
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp
     , text
@@ -56,4 +56,4 @@ test-suite tests
     , text
     , filepath
     , hls-qualify-imported-names-plugin
-    , hls-test-utils             == 2.5.0.0
+    , hls-test-utils             == 2.6.0.0

--- a/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
+++ b/plugins/hls-refactor-plugin/hls-refactor-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hls-refactor-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Exactprint refactorings for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -73,8 +73,8 @@ library
     , ghc-boot
     , regex-tdfa
     , text-rope
-    , ghcide                == 2.5.0.0
-    , hls-plugin-api        == 2.5.0.0
+    , ghcide                == 2.6.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lsp
     , text
     , transformers
@@ -112,7 +112,7 @@ test-suite tests
     , base
     , filepath
     , hls-refactor-plugin
-    , hls-test-utils      == 2.5.0.0
+    , hls-test-utils      == 2.6.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-rename-plugin/hls-rename-plugin.cabal
+++ b/plugins/hls-rename-plugin/hls-rename-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-rename-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Rename plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -34,11 +34,11 @@ library
     , extra
     , ghc
     , ghc-exactprint
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hashable
     , hiedb
     , hie-compat
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , hls-refactor-plugin
     , lens
     , lsp
@@ -69,4 +69,4 @@ test-suite tests
     , filepath
     , hls-plugin-api
     , hls-rename-plugin
-    , hls-test-utils             == 2.5.0.0
+    , hls-test-utils             == 2.6.0.0

--- a/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
+++ b/plugins/hls-retrie-plugin/hls-retrie-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hls-retrie-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Retrie integration plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -37,9 +37,9 @@ library
     , directory
     , extra
     , ghc
-    , ghcide                == 2.5.0.0
+    , ghcide                == 2.6.0.0
     , hashable
-    , hls-plugin-api        == 2.5.0.0
+    , hls-plugin-api        == 2.6.0.0
     , hls-refactor-plugin
     , lens
     , lsp
@@ -77,5 +77,5 @@ test-suite tests
     , hls-plugin-api
     , hls-refactor-plugin
     , hls-retrie-plugin
-    , hls-test-utils             == 2.5.0.0
+    , hls-test-utils             == 2.6.0.0
     , text

--- a/plugins/hls-semantic-tokens-plugin/hls-semantic-tokens-plugin.cabal
+++ b/plugins/hls-semantic-tokens-plugin/hls-semantic-tokens-plugin.cabal
@@ -35,7 +35,7 @@ library
   hs-source-dirs:     src
   build-depends:
     , aeson
-    , base
+    , base                  >=4.12 && <5
     , containers
     , extra
     , hiedb

--- a/plugins/hls-semantic-tokens-plugin/hls-semantic-tokens-plugin.cabal
+++ b/plugins/hls-semantic-tokens-plugin/hls-semantic-tokens-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-semantic-tokens-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Call hierarchy plugin for Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-call-hierarchy-plugin#readme>
@@ -40,8 +40,8 @@ library
     , extra
     , hiedb
     , mtl                   >= 2.2
-    , ghcide                == 2.5.0.0
-    , hls-plugin-api        == 2.5.0.0
+    , ghcide                == 2.6.0.0
+    , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp                    >=2.3
     , sqlite-simple
@@ -52,7 +52,7 @@ library
     , syb
     , array
     , deepseq
-    , hls-graph == 2.5.0.0
+    , hls-graph == 2.6.0.0
     , template-haskell
     , data-default
 
@@ -74,7 +74,7 @@ test-suite tests
     , extra
     , filepath
     , hls-semantic-tokens-plugin
-    , hls-test-utils              == 2.5.0.0
+    , hls-test-utils              == 2.6.0.0
     , ghcide-test-utils
     , hls-plugin-api
     , lens
@@ -85,7 +85,7 @@ test-suite tests
     , text
     , data-default
     , bytestring
-    , ghcide                == 2.5.0.0
-    , hls-plugin-api        == 2.5.0.0
+    , ghcide                == 2.6.0.0
+    , hls-plugin-api        == 2.6.0.0
     , template-haskell
     , data-default

--- a/plugins/hls-splice-plugin/hls-splice-plugin.cabal
+++ b/plugins/hls-splice-plugin/hls-splice-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-splice-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:
   HLS Plugin to expand TemplateHaskell Splices and QuasiQuotes
 
@@ -47,8 +47,8 @@ library
     , foldl
     , ghc
     , ghc-exactprint
-    , ghcide                == 2.5.0.0
-    , hls-plugin-api        == 2.5.0.0
+    , ghcide                == 2.6.0.0
+    , hls-plugin-api        == 2.6.0.0
     , hls-refactor-plugin
     , lens
     , lsp
@@ -79,6 +79,6 @@ test-suite tests
     , base
     , filepath
     , hls-splice-plugin
-    , hls-test-utils == 2.5.0.0
+    , hls-test-utils == 2.6.0.0
     , text
     , row-types

--- a/plugins/hls-stan-plugin/hls-stan-plugin.cabal
+++ b/plugins/hls-stan-plugin/hls-stan-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-stan-plugin
-version:       2.5.0.0
+version:       2.6.0.0
 synopsis:      Stan integration plugin with Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -77,7 +77,7 @@ test-suite test
     , filepath
     , hls-stan-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.5.0.0
+    , hls-test-utils      == 2.6.0.0
     , lens
     , lsp-types
     , text

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-stylish-haskell-plugin
-version:            2.5.0.0
+version:            2.6.0.0
 synopsis:           Integration with the Stylish Haskell code formatter
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -33,8 +33,8 @@ library
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide           == 2.5.0.0
-    , hls-plugin-api   == 2.5.0.0
+    , ghcide           == 2.6.0.0
+    , hls-plugin-api   == 2.6.0.0
     , lsp-types
     , mtl
     , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14.2
@@ -56,4 +56,4 @@ test-suite tests
     , base
     , filepath
     , hls-stylish-haskell-plugin
-    , hls-test-utils              == 2.5.0.0
+    , hls-test-utils              == 2.6.0.0


### PR DESCRIPTION
- [x] check ghcup supports new GHC releases if any
- [x] set the supported GHCs in workflow file `.github/workflows/release.yaml`
  - There is currently a list of GHC versions for each major platform. Search for `ghc: [` to find all lists.
  - Look for `TODO:` to find locations that require extra care for GHC versions.
- [x] check all plugins still work if release includes code changes
- [x] bump package versions in all `*.cabal` files (same version as hls)
  - HLS uses lockstep versioning. The core packages and all plugins use the same version number, and only support exactly this version.
    - Exceptions:
      - `hie-compat` requires no automatic version bump.
      - `shake-bench` is an internal testing tool, not exposed to the outside world. Thus, no version bump required for releases.
  - For updating cabal files, the following script can be used:
    - ```sh
      # Update all `version:` fields
      sed -ri "s/^version:( +)2.2.0.0/version:\12.3.0.0/" **/*.cabal
      # Update all constraints expected to be in the form `== <version>`.
      # We usually don't force an exact version, so this is relatively unambiguous.
      # We could introduce some more ad-hoc parsing, if there is still ambiguity.
      sed -ri "s/== 2.2.0.0/== 2.3.0.0/" **/*.cabal
      ```
    - It still requires manual verification and review
- [x] generate and update changelog
  - Generate a ChangeLog via `./GenChangelogs.hs <api-key> <tag>`
    - `<tag>` is the git tag you want to generate the ChangeLog from.
    - `<api-key>` is a github access key: https://github.com/settings/tokens
- [x] create release branch as `wip/<version>`
  - `git switch -c wip/<version>`
- [x] create release tag as `<version>`
  - `git tag <version>`
- [x] trigger release pipeline by pushing the tag
  - this creates a draft release
  - `git push <remote> <version>`
- [x] run `sh scripts/release/download-gh-artifacts.sh <version> <your-gpg-email>`
  - downloads artifacts to `gh-release-artifacts/haskell-language-server-<version>/`
  - also downloads FreeBSD bindist from circle CI
  - adds signatures
- [x] upload artifacts to downloads.haskell.org from `gh-release-artifacts/haskell-language-server-<version>/`
  - You require sftp access, contact wz1000, bgamari or chreekat
  - `cd gh-release-artifacts/haskell-language-server-<version>`
  - `SIGNING_KEY=... ../../release/upload.sh upload`
    - Your SIGNING_KEY can be obtained with `gpg --list-secret-keys --keyid-format=long`
  - Afterwards, the artifacts are available at: `https://downloads.haskell.org/~hls/haskell-language-server-<version>/`
  - Run `SIGNING_KEY=... ../../release/upload.sh purge_all` to remove CDN caches
- [x] create PR to [ghcup-metadata](https://github.com/haskell/ghcup-metadata)
  - [ ] update `ghcup-0.0.7.yaml` and `ghcup-vanilla-0.0.7.yaml`
    - can use `sh scripts/release/create-yaml-snippet.sh <version>` to generate a snippet that can be manually inserted into the yaml files
  - [ ] update `hls-metadata-0.0.1.json`
    - utilize `cabal run ghcup-gen -- generate-hls-ghcs -f ghcup-0.0.7.yaml --format json --stdout` in the root of ghcup-metadata repository
  - Be sure to mark the correct latest version and add the 'recommended' tag to the latest release.
- [x] get sign-off on release
  - from wz1000, michealpj, maerwald and fendor
- [x] publish release on github
- [x] upload hackage packages
  - requires credentials
- [ ] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
- [ ] Supported tools table needs to be updated:
  - https://www.haskell.org/ghcup/install/#supported-platforms
  - https://github.com/haskell/ghcup-hs/blob/master/docs/install.md#supported-platforms
  - https://github.com/haskell/ghcup-metadata/blob/44c6e2b5d0fcae15abeffff03e87544edf76dd7a/ghcup-gen/Main.hs#L67
- [ ] post release on discourse and reddit
- [ ] merge release PR to master or forward port relevant changes
