### PR TITLE
Display instances on hover for type and data constructors

### DIFF
--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -316,7 +316,10 @@ atPoint IdeOptions{} (HAR _ hf _ _ (kind :: HieKind hietype)) (DKMap dm km) env 
                 instancesForName :: IO (Maybe [ClsInst])
                 instancesForName = runMaybeT $ do
                     typ <- MaybeT . pure $ lookupNameEnv km n >>= tyThingAsDataType
-                    liftIO $ evalGhcEnv env $ getInstancesForType typ
+                    clsInst <- liftIO $ evalGhcEnv env $ getInstancesForType typ
+                    -- Avoid creating an empty wrapped section if no instances are found
+                    guard $ not $ null clsInst
+                    return clsInst
 
                 -- | Gets the datatype `Type` corresponding to a TyThing, if it repressents a datatype or
                 -- a data constructor.


### PR DESCRIPTION
An attempt to implement the requested enhancement in https://github.com/haskell/haskell-language-server/issues/3098

It displays the list of typeclass instances a type has when requesting hover information.
It should work on type constructors as well as the data constructors, using the related type.

It is added as a new section at the end of the hover information.

Here is an example of how it looks when hovering on `Maybe` or `Just` or `Nothing`
![maybe_instances](https://github.com/haskell/haskell-language-server/assets/74479846/60e6326b-15a8-4991-a26b-1b1f50cdf004)

It seems to also be scope aware, if I import new instances then they will be added to the list. For example if I install `hashable` and `import Data.Hashable` with the `Hashable` instance for `Int` and hover on `Int` I get an additional
![hashable_int](https://github.com/haskell/haskell-language-server/assets/74479846/65752572-656a-4706-9eab-87540a12ff38)
which is pretty cool.
