### PR TITLE
Document cabal diagnostic options

### DIFF
--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -114,6 +114,9 @@ descriptor recorder plId =
                   deleteFileOfInterest recorder ide file
                   restartCabalShakeSession (shakeExtras ide) vfs file "(closed)"
           ]
+    , pluginConfigDescriptor = defaultConfigDescriptor
+      { configHasDiagnostics = True
+      }
     }
  where
   log' = logWith recorder

--- a/test/testdata/schema/ghc92/default-config.golden.json
+++ b/test/testdata/schema/ghc92/default-config.golden.json
@@ -9,7 +9,8 @@
         },
         "cabal": {
             "codeActionsOn": true,
-            "completionOn": true
+            "completionOn": true,
+            "diagnosticsOn": true
         },
         "callHierarchy": {
             "globalOn": true

--- a/test/testdata/schema/ghc92/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc92/vscode-extension-schema.golden.json
@@ -17,6 +17,12 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.cabal.diagnosticsOn": {
+        "default": true,
+        "description": "Enables cabal diagnostics",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.callHierarchy.globalOn": {
         "default": true,
         "description": "Enables callHierarchy plugin",

--- a/test/testdata/schema/ghc94/default-config.golden.json
+++ b/test/testdata/schema/ghc94/default-config.golden.json
@@ -9,7 +9,8 @@
         },
         "cabal": {
             "codeActionsOn": true,
-            "completionOn": true
+            "completionOn": true,
+            "diagnosticsOn": true
         },
         "callHierarchy": {
             "globalOn": true

--- a/test/testdata/schema/ghc94/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc94/vscode-extension-schema.golden.json
@@ -17,6 +17,12 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.cabal.diagnosticsOn": {
+        "default": true,
+        "description": "Enables cabal diagnostics",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.callHierarchy.globalOn": {
         "default": true,
         "description": "Enables callHierarchy plugin",

--- a/test/testdata/schema/ghc96/default-config.golden.json
+++ b/test/testdata/schema/ghc96/default-config.golden.json
@@ -9,7 +9,8 @@
         },
         "cabal": {
             "codeActionsOn": true,
-            "completionOn": true
+            "completionOn": true,
+            "diagnosticsOn": true
         },
         "callHierarchy": {
             "globalOn": true

--- a/test/testdata/schema/ghc96/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc96/vscode-extension-schema.golden.json
@@ -17,6 +17,12 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.cabal.diagnosticsOn": {
+        "default": true,
+        "description": "Enables cabal diagnostics",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.callHierarchy.globalOn": {
         "default": true,
         "description": "Enables callHierarchy plugin",

--- a/test/testdata/schema/ghc98/default-config.golden.json
+++ b/test/testdata/schema/ghc98/default-config.golden.json
@@ -9,7 +9,8 @@
         },
         "cabal": {
             "codeActionsOn": true,
-            "completionOn": true
+            "completionOn": true,
+            "diagnosticsOn": true
         },
         "callHierarchy": {
             "globalOn": true

--- a/test/testdata/schema/ghc98/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc98/vscode-extension-schema.golden.json
@@ -17,6 +17,12 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.cabal.diagnosticsOn": {
+        "default": true,
+        "description": "Enables cabal diagnostics",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.callHierarchy.globalOn": {
         "default": true,
         "description": "Enables callHierarchy plugin",


### PR DESCRIPTION
I missed that, and preemptively added the options in https://github.com/haskell/vscode-haskell/pull/1032 and https://github.com/haskell/vscode-haskell/pull/1031
