### PR TITLE
Make hlint plugin buildable with ghc 9.8

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -36,7 +36,7 @@ packages:
          ./plugins/hls-overloaded-record-dot-plugin
          ./plugins/hls-semantic-tokens-plugin
 
-index-state: 2024-01-17T16:04:21Z
+index-state: 2024-01-20T18:17:36Z
 
 tests: True
 test-show-details: direct

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -30,11 +30,6 @@ flag pedantic
   manual:      True
 
 library
-  -- Plugins that need exactprint have not been updated for 9.8 yet
-  if impl(ghc >= 9.8)
-    buildable: False
-  else
-    buildable: True
   exposed-modules:    Ide.Plugin.Hlint
   hs-source-dirs:     src
   build-depends:
@@ -52,7 +47,7 @@ library
     , ghc-exactprint        >=0.6.3.4
     , ghcide                == 2.6.0.0
     , hashable
-    , hlint                 >= 3.5 && < 3.7
+    , hlint                 >= 3.5 && < 3.9
     , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp
@@ -82,10 +77,6 @@ library
     TypeOperators
 
 test-suite tests
-  if impl(ghc >= 9.8)
-    buildable: False
-  else
-    buildable: True
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test


### PR DESCRIPTION
[hlint](https://hackage.haskell.org/package/hlint) 3.8 with support for ghc 9.8 was released to hackage today.