### PR TITLE
Various 9.8 compat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
         name: Test hls-stan-plugin
         run: cabal test hls-stan-plugin --test-options="$TEST_OPTS" || cabal test hls-stan-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && !startsWith(matrix.ghc,'9.8')
+      - if: matrix.test
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
         name: Test hls-rename-plugin test suite
         run: cabal test hls-rename-plugin --test-options="$TEST_OPTS" || cabal test hls-rename-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && !startsWith(matrix.ghc,'9.8')
+      - if: matrix.test 
         name: Test hls-hlint-plugin test suite
         run: cabal test hls-hlint-plugin --test-options="$TEST_OPTS" || cabal test hls-hlint-plugin --test-options="$TEST_OPTS"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,7 @@ jobs:
         name: Test hls-refactor-plugin
         run: cabal test hls-refactor-plugin --test-options="$TEST_OPTS" || cabal test hls-refactor-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && matrix.ghc != '9.6' && !startsWith(matrix.ghc,'9.8')
+      - if: matrix.test 
         name: Test hls-floskell-plugin
         run: cabal test hls-floskell-plugin --test-options="$TEST_OPTS" || cabal test hls-floskell-plugin --test-options="$TEST_OPTS"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,11 +167,11 @@ jobs:
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS" || cabal test hls-stylish-haskell-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && !startsWith(matrix.ghc,'9.8')
+      - if: matrix.test 
         name: Test hls-ormolu-plugin
         run: cabal test hls-ormolu-plugin --test-options="$TEST_OPTS" || cabal test hls-ormolu-plugin --test-options="$TEST_OPTS"
 
-      - if: matrix.test && !startsWith(matrix.ghc,'9.8')
+      - if: matrix.test 
         name: Test hls-fourmolu-plugin
         run: cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS" || cabal test hls-fourmolu-plugin --test-options="$TEST_OPTS"
 

--- a/cabal.project
+++ b/cabal.project
@@ -36,7 +36,7 @@ packages:
          ./plugins/hls-overloaded-record-dot-plugin
          ./plugins/hls-semantic-tokens-plugin
 
-index-state: 2024-01-19T00:00:00Z
+index-state: 2024-01-20T00:00:00Z
 
 tests: True
 test-show-details: direct

--- a/cabal.project
+++ b/cabal.project
@@ -36,7 +36,7 @@ packages:
          ./plugins/hls-overloaded-record-dot-plugin
          ./plugins/hls-semantic-tokens-plugin
 
-index-state: 2024-01-20T00:00:00Z
+index-state: 2024-01-21T00:00:00Z
 
 tests: True
 test-show-details: direct

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -59,7 +59,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-qualify-imported-names-plugin` | 2    |                          |
 | `hls-ormolu-plugin`                 | 2    |                          |
 | `hls-rename-plugin`                 | 2    |                          |
-| `hls-stylish-haskell-plugin`        | 2    | 9.8                      |
+| `hls-stylish-haskell-plugin`        | 2    |                          |
 | `hls-overloaded-record-dot-plugin`  | 2    |                          |
 | `hls-semantic-tokens-plugin`        | 2    |                          |
 | `hls-floskell-plugin`               | 3    | 9.8                      |

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -62,7 +62,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-stylish-haskell-plugin`        | 2    |                          |
 | `hls-overloaded-record-dot-plugin`  | 2    |                          |
 | `hls-semantic-tokens-plugin`        | 2    |                          |
-| `hls-floskell-plugin`               | 3    | 9.8                      |
+| `hls-floskell-plugin`               | 3    |                          |
 | `hls-stan-plugin`                   | 3    | 9.2.(4-8)                |
 | `hls-retrie-plugin`                 | 3    |                          |
 | `hls-splice-plugin`                 | 3    |                          |

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -54,7 +54,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-explicit-record-fields-plugin` | 2    |                          |
 | `hls-fourmolu-plugin`               | 2    |                          |
 | `hls-gadt-plugin`                   | 2    |                          |
-| `hls-hlint-plugin`                  | 2    | 9.8                      |
+| `hls-hlint-plugin`                  | 2    |                          |
 | `hls-module-name-plugin`            | 2    |                          |
 | `hls-qualify-imported-names-plugin` | 2    |                          |
 | `hls-ormolu-plugin`                 | 2    |                          |

--- a/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
+++ b/plugins/hls-floskell-plugin/hls-floskell-plugin.cabal
@@ -21,9 +21,6 @@ source-repository head
     location: https://github.com/haskell/haskell-language-server.git
 
 library
-  -- floskell does not support GHC 9.8 yet
-  if impl(ghc >= 9.7)
-    buildable: False
   exposed-modules:  Ide.Plugin.Floskell
   hs-source-dirs:   src
   build-depends:
@@ -39,8 +36,6 @@ library
   default-language: Haskell2010
 
 test-suite tests
-  if impl(ghc >= 9.7)
-    buildable: False
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test

--- a/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
+++ b/plugins/hls-hlint-plugin/hls-hlint-plugin.cabal
@@ -30,11 +30,6 @@ flag pedantic
   manual:      True
 
 library
-  -- Plugins that need exactprint have not been updated for 9.8 yet
-  if impl(ghc >= 9.8)
-    buildable: False
-  else
-    buildable: True
   exposed-modules:    Ide.Plugin.Hlint
   hs-source-dirs:     src
   build-depends:
@@ -52,7 +47,7 @@ library
     , ghc-exactprint        >=0.6.3.4
     , ghcide                == 2.6.0.0
     , hashable
-    , hlint                 >= 3.5 && < 3.7
+    , hlint                 >= 3.5 && < 3.9
     , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp
@@ -82,10 +77,6 @@ library
     TypeOperators
 
 test-suite tests
-  if impl(ghc >= 9.8)
-    buildable: False
-  else
-    buildable: True
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -202,13 +202,8 @@ suggestionsTests =
         doc <- openDoc "IgnoreAnnHlint.hs" "haskell"
         expectNoMoreDiagnostics 3 doc "hlint"
 
-    , knownBrokenForGhcVersions [GHC92, GHC94, GHC96] "apply-refact has different behavior on v0.10" $
-      testCase "apply-refact preserve regular comments" $ runHlintSession "" $ do
+    , testCase "apply-refact preserve regular comments" $ runHlintSession "" $ do
         testRefactor "Comments.hs" "Redundant bracket" expectedComments
-
-    , onlyRunForGhcVersions [GHC92, GHC94, GHC96] "only run test for apply-refact-0.10" $
-      testCase "apply-refact preserve regular comments" $ runHlintSession "" $ do
-        testRefactor "Comments.hs" "Redundant bracket" expectedComments'
 
     , testCase "[#2290] apply all hints works with a trailing comment" $ runHlintSession "" $ do
         testRefactor "TwoHintsAndComment.hs" "Apply all hints" expectedComments2
@@ -275,15 +270,7 @@ suggestionsTests =
                              , "g = 2"
                              , "#endif", ""
                              ]
-        expectedComments =   [ "-- comment before header"
-                             , "module Comments where", ""
-                             , "{-# standalone annotation #-}", ""
-                             , "-- standalone comment", ""
-                             , "-- | haddock comment"
-                             , "f = {- inline comment -}{- inline comment inside refactored code -} 1 -- ending comment", ""
-                             , "-- final comment"
-                             ]
-        expectedComments' =  [ "-- comment before header"
+        expectedComments =  [ "-- comment before header"
                              , "module Comments where", ""
                              , "{-# standalone annotation #-}", ""
                              , "-- standalone comment", ""

--- a/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
+++ b/plugins/hls-stylish-haskell-plugin/hls-stylish-haskell-plugin.cabal
@@ -20,11 +20,6 @@ source-repository head
     location: https://github.com/haskell/haskell-language-server.git
 
 library
-  -- Plugins that need exactprint have not been updated for 9.8 yet
-  if impl(ghc >= 9.8)
-    buildable: False
-  else
-    buildable: True
   exposed-modules:  Ide.Plugin.StylishHaskell
   hs-source-dirs:   src
   build-depends:
@@ -43,10 +38,6 @@ library
   default-language: Haskell2010
 
 test-suite tests
-  if impl(ghc >= 9.8)
-    buildable: False
-  else
-    buildable: True
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   hs-source-dirs:   test


### PR DESCRIPTION
- New stylish-haskell release supports 9.8
- Ormolu and fourmolu were updated but the test matrix hadn't been
- New version of floskell supports 9.8
- New version of hlint supports 9.8, small test wrangling required

9.8 support shaped up a lot in the last few days!