### PR TITLE
Fix -Wall and -Wunused-packages in stan plugin

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -676,17 +676,13 @@ library hls-stan-plugin
   hs-source-dirs:     plugins/hls-stan-plugin/src
   build-depends:
       base
-    , containers
-    , data-default
     , deepseq
     , hashable
     , hie-compat
     , hls-plugin-api
-    , ghc
     , ghcide
     , lsp-types
     , text
-    , transformers
     , unordered-containers
     , stan >= 0.1.2.0
     , trial
@@ -711,9 +707,7 @@ test-suite hls-stan-plugin-tests
   hs-source-dirs:   plugins/hls-stan-plugin/test
   main-is:          Main.hs
   build-depends:
-      aeson
     , base
-    , containers
     , filepath
     , haskell-language-server:hls-stan-plugin
     , hls-plugin-api

--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -80,9 +80,6 @@ stripModifiers = go ""
         Nothing    -> txt
         Just index -> T.drop (index + 1) txt
 
-renderId :: Id a -> T.Text
-renderId (Id t) = "Id = " <> t
-
 instance Pretty Log where
   pretty = \case
     LogShake log -> pretty log
@@ -136,12 +133,11 @@ rules recorder plId = do
                           }
 
               (configTrial, useDefConfig, env) <- liftIO $ getStanConfig stanArgs isLoud
-              seTomlFiles <- liftIO $ usedTomlFiles useDefConfig (stanArgsConfigFile stanArgs)
-              logWith recorder Debug (LogDebugStanConfigResult seTomlFiles configTrial)
+              tomlsUsedByStan <- liftIO $ usedTomlFiles useDefConfig (stanArgsConfigFile stanArgs)
+              logWith recorder Debug (LogDebugStanConfigResult tomlsUsedByStan configTrial)
 
               -- If envVar is set to 'False', stan will ignore all local and global .stan.toml files
               logWith recorder Debug (LogDebugStanEnvVars env)
-              seTomlFiles <- liftIO $ usedTomlFiles useDefConfig (stanArgsConfigFile stanArgs)
 
               -- Note that Stan works in terms of relative paths, but the HIE come in as absolute. Without
               -- making its path relative, the file name(s) won't line up with the associated Map keys.


### PR DESCRIPTION
This PR is part of larger effort where I try to reduce the amount of compiler warnings across all packages.