### PR TITLE
update hlint to 3.8 and prevent linting on testdata dir

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: 'Installing'
       uses: rwe/actions-hlint-setup@v1
       with:
-        version: '3.6.1'
+        version: '3.8.0'
 
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2
       with:
-        hlint-bin: "hlint --git -j4 --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
+        hlint-bin: "hlint --version && hlint --git -j4 --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
         fail-on: error
         path: .
 

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2
       with:
-        hlint-bin: "hlint --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
+        hlint-bin: "hlint --with-group=extra --ignore-glob=**/testdata/** --ignore-glob=**/test/data/**"
         fail-on: error
         path: .
 

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2
       with:
-        hlint-bin: "hlint --git --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
+        hlint-bin: "hlint --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
         fail-on: error
         path: .
 

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2
       with:
-        hlint-bin: "hlint --with-group=extra"
+        hlint-bin: "hlint --git -j4 --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
         fail-on: error
         path: .
 

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: 'Installing'
       uses: rwe/actions-hlint-setup@v1
       with:
-        version: '3.8.0'
+        version: '3.8'
 
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2
       with:
-        hlint-bin: "hlint --git -j4 --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
+        hlint-bin: "hlint --git --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
         fail-on: error
         path: .
 

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: 'Checking code'
       uses: rwe/actions-hlint-run@v2
       with:
-        hlint-bin: "hlint --version && hlint --git -j4 --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
+        hlint-bin: "hlint --git -j4 --with-group=extra --ignore-glob='**/testdata/**' --ignore-glob='**/test/data/**'"
         fail-on: error
         path: .
 

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -5,10 +5,6 @@
 # To run HLint do:
 # $ hlint --git -j4
 
-# Ignore all lints in testdata directories, as they are distracting.
-- ignore: { "within": '**/testdata/**' }
-- ignore: { "within": '**/test/data/**' }
-
 # Warnings currently triggered by our code
 - ignore: {name: "Use <$>"}
 - ignore: {name: "Use :"}


### PR DESCRIPTION
This is a following up of #3901

I dig a bit into hlint. 
1. We can only ignore-glob in commandline. config file missing the options for ignore glob.
2. hlint 3.8 can ignore files more correctly.