### PR TITLE
Disable caching job with ghc 9.2 on windows

### DIFF
--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -50,7 +50,6 @@ env:
   cabalBuild: "v2-build --keep-going"
 
 jobs:
-
   pre_job:
     runs-on: ubuntu-latest
     outputs:
@@ -90,13 +89,17 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        exclude:
+          # We disable this this combo in test.yml due to long path issues, so we also need to disable it here
+          - os: windows-latest
+            ghc: "9.2"
     steps:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup-build
         with:
           ghc: ${{ matrix.ghc }}
-          os:  ${{ runner.os }}
+          os: ${{ runner.os }}
 
       # Download sources for feeding build sources cache
       # Fetching from github cache is faster than doing it from hackage


### PR DESCRIPTION
Not sure if this is desirable, but @michaelpj recently disabled tests for this combination (see [PR](https://github.com/haskell/haskell-language-server/pull/3976/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R81-R83))  and said something like this would be needed to prevent failures of caching job on master.

