### PR TITLE
stack CI: switch to offic. haskell images, bump to lts-22.9 (ghc 9.6.4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/build
   docker:
-    - image: alanz/haskell-hie-ci
+    - image: haskell:9.6.4-slim-buster
   resource_class: large
   steps:
     - checkout
@@ -80,7 +80,7 @@ jobs:
       - STACK_FILE: "stack-lts21.yaml"
     <<: *defaults
 
-  stackage-nightly:
+  stackage-lts22:
     environment:
       - STACK_FILE: "stack.yaml"
     <<: *defaults
@@ -91,4 +91,4 @@ workflows:
   multiple-ghcs:
     jobs:
       - stackage-lts21
-      - stackage-nightly
+      - stackage-lts22

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ defaults: &defaults
           echo "export SKIP_CI=$SKIP_CI" >> $BASH_ENV
 
     - run:
-        name: Build (we need the exe for tests)
-        # need j1, else ghc-lib-parser triggers OOM
+        name: Build
         command: |
           if [[ -z "$SKIP_CI" ]]; then
             stack -j4 --stack-yaml=${STACK_FILE} install --system-ghc --no-terminal
@@ -54,7 +53,7 @@ defaults: &defaults
 
     - save_cache:
         key: v4-stack-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
-        paths: &cache_paths
+        paths:
           - ~/.stack
 
 version: 2
@@ -66,7 +65,7 @@ jobs:
       - STACK_FILE: "stack-lts21.yaml"
     <<: *defaults
 
-  stackage-lts22:
+  stackage-nightly:
     docker:
       - image: haskell:9.6.4-slim-buster
     environment:
@@ -78,4 +77,4 @@ workflows:
   multiple-ghcs:
     jobs:
       - stackage-lts21
-      - stackage-lts22
+      - stackage-nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
 defaults: &defaults
   working_directory: ~/build
-  docker:
-    - image: haskell:9.6.4-slim-buster
   resource_class: large
   steps:
     - checkout
@@ -34,25 +32,11 @@ defaults: &defaults
           echo "export SKIP_CI=$SKIP_CI" >> $BASH_ENV
 
     - run:
-        name: Stack upgrade
-        command: |
-          if [[ -z "$SKIP_CI" ]]; then
-            stack upgrade
-          fi
-
-    - run:
-        name: Stack setup
-        command: |
-          if [[ -z "$SKIP_CI" ]]; then
-            stack -j4 --stack-yaml=${STACK_FILE} setup
-          fi
-
-    - run:
         name: Build (we need the exe for tests)
         # need j1, else ghc-lib-parser triggers OOM
         command: |
           if [[ -z "$SKIP_CI" ]]; then
-            stack -j4 --stack-yaml=${STACK_FILE} install --no-terminal
+            stack -j4 --stack-yaml=${STACK_FILE} install --system-ghc --no-terminal
           fi
         no_output_timeout: 30m
 
@@ -60,7 +44,7 @@ defaults: &defaults
         name: Build Testsuite without running it
         command: |
           if [[ -z "$SKIP_CI" ]]; then
-            stack -j4 --stack-yaml=${STACK_FILE} build --test --no-run-tests --no-terminal
+            stack -j4 --stack-yaml=${STACK_FILE} build --system-ghc --test --no-run-tests --no-terminal
           fi
         no_output_timeout: 30m
 
@@ -76,15 +60,18 @@ defaults: &defaults
 version: 2
 jobs:
   stackage-lts21:
+    docker:
+      - image: haskell:9.4.8-slim-buster
     environment:
       - STACK_FILE: "stack-lts21.yaml"
     <<: *defaults
 
   stackage-lts22:
+    docker:
+      - image: haskell:9.6.4-slim-buster
     environment:
       - STACK_FILE: "stack.yaml"
     <<: *defaults
-
 
 workflows:
   version: 2

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.25 # ghc-9.4
+resolver: lts-21.25 # ghc-9.4.8
 
 packages:
   - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-07-10 # ghc-9.6.2
+resolver: lts-22.9 # ghc-9.6.4
 
 packages:
   - .
@@ -20,25 +20,15 @@ extra-deps:
 - retrie-1.2.2
 - hiedb-0.5.0.1
 - implicit-hie-0.1.4.0
-- hie-bios-0.13.1
 - lsp-2.4.0.0
 - lsp-test-0.17.0.0
 - lsp-types-2.1.1.0
-- attoparsec-aeson-2.1.0.0
-- hw-fingertree-0.1.2.1
-- integer-conversion-0.1.0.1
 - monad-dijkstra-0.1.1.4
-- hw-prim-0.6.3.2
-- optparse-applicative-0.17.1.0
 
 # stan and friends
 - stan-0.1.2.0
-- clay-0.14.0
-- colourista-0.1.0.2
 - dir-traverse-0.2.3.0
 - extensions-0.1.0.1
-- relude-1.2.1.0
-- slist-0.2.1.0
 - tomland-1.3.3.2
 - trial-0.0.0.0
 - trial-optparse-applicative-0.0.0.0


### PR DESCRIPTION
Motivation:
this week I saw several instances of stack CI jobs failing with errors ala "failed to download stack binaries from fpcomplete servers".

I propose we switch to official haskell images which have latest stack preinstalled so we can avoid this class of failures altogether.

