### PR TITLE
Bump haskell-actions/setup to get GHC 9.6.4 in CI

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -31,7 +31,7 @@ runs:
         sudo chown -R $USER /usr/local/.ghcup
       shell: bash
 
-    - uses: haskell-actions/setup@v2.6.0
+    - uses: haskell-actions/setup@v2.6.1
       id: HaskEnvSetup
       with:
         ghc-version  : ${{ inputs.ghc   }}


### PR DESCRIPTION
Was confused about why I keep seing `-w ghc-9.6.3` in CI when we're supposed to be on 9.6.4.
This explains it: https://github.com/haskell-actions/setup/releases/tag/v2.6.1