### PR TITLE
benchmarks: switch from deprecated haskell/actions/setup to haskell-actions/setup

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -121,7 +121,7 @@ jobs:
         example: ['cabal', 'lsp-types']
 
     steps:
-    - uses: haskell/actions/setup@v2.4.7
+    - uses: haskell-actions/setup@v2.6.1
       with:
         ghc-version  : ${{ matrix.ghc   }}
         cabal-version: ${{ matrix.cabal }}


### PR DESCRIPTION
![Screenshot from 2024-02-12 11-02-47](https://github.com/haskell/haskell-language-server/assets/2716069/ba3f0af4-cc15-4232-8ca7-919020cc1ef8)
