### PR TITLE
Bump to hiedb 0.6.0.0

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -87,7 +87,7 @@ library
     , hashable
     , hie-bios                     ==0.13.1
     , hie-compat                   ^>=0.3.0.0
-    , hiedb                        ^>= 0.5.0.1
+    , hiedb                        ^>= 0.6.0.0
     , hls-graph                    == 2.6.0.0
     , hls-plugin-api               == 2.6.0.0
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -305,7 +305,7 @@ library hls-call-hierarchy-plugin
     , containers
     , extra
     , ghcide                == 2.6.0.0
-    , hiedb
+    , hiedb                 ^>= 0.6.0.0
     , hls-plugin-api        == 2.6.0.0
     , lens
     , lsp                    >=2.4
@@ -488,7 +488,7 @@ library hls-rename-plugin
     , containers
     , ghcide                == 2.6.0.0
     , hashable
-    , hiedb
+    , hiedb                 ^>= 0.6.0.0
     , hie-compat
     , hls-plugin-api        == 2.6.0.0
     , haskell-language-server:hls-refactor-plugin

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -18,7 +18,7 @@ allow-newer: true
 
 extra-deps:
 - floskell-0.11.1
-- hiedb-0.5.0.1
+- hiedb-0.6.0.0
 - hie-bios-0.13.1
 - implicit-hie-0.1.4.0
 - monad-dijkstra-0.1.1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ allow-newer: true
 extra-deps:
 - floskell-0.11.1
 - retrie-1.2.2
-- hiedb-0.5.0.1
+- hiedb-0.6.0.0
 - implicit-hie-0.1.4.0
 - lsp-2.4.0.0
 - lsp-test-0.17.0.0


### PR DESCRIPTION
The main appeal of this bump is that it fixes the [issue](https://github.com/wz1000/HieDb/issues/61) with duplicate typeref indexing, making indexing noticably faster (>2x) and resulting hiedb sqlite files smaller (~7x on our work codebase) which likely also improves the speed of querying.