### PR TITLE
refactor plugin: fix regex for extracting import suggestions

### DIFF
--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -931,9 +931,9 @@ suggestExtendImport exportsMap (L _ HsModule {hsmodImports}) Diagnostic{_range=_
     | Just [binding, mod, srcspan] <-
       matchRegexUnifySpaces _message
 #if MIN_VERSION_ghc(9,7,0)
-      "Add ‘([^’]*)’ to the import list in the import of ‘([^’]*)’ *\\(at (.*)\\)."
+      "Add ‘([^’]*)’ to the import list in the import of ‘([^’]*)’ *\\(at (.*)\\)\\."
 #else
-      "Perhaps you want to add ‘([^’]*)’ to the import list in the import of ‘([^’]*)’ *\\((.*)\\)."
+      "Perhaps you want to add ‘([^’]*)’ to the import list in the import of ‘([^’]*)’ *\\((.*)\\)\\."
 #endif
     = suggestions hsmodImports binding mod srcspan
     | Just (binding, mod_srcspan) <-

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -1275,7 +1275,8 @@ extendImportTests = testGroup "extend import actions"
                     , "b :: A"
                     , "b = ConstructorFoo"
                     ])
-        , testSession "extend single line import in presence of extra perens" $ template
+        , brokenForGHC92 "On GHC 9.2, the error doesn't contain \"perhaps you want ...\" part from which import suggestion can be extracted." $
+          testSession "extend single line import in presence of extra parens" $ template
             []
             ("Main.hs", T.unlines
                     [ "import Data.Monoid (First)"
@@ -3749,3 +3750,6 @@ withTempDir f = System.IO.Extra.withTempDir $ \dir ->
 
 brokenForGHC94 :: String -> TestTree -> TestTree
 brokenForGHC94 = knownBrokenForGhcVersions [GHC94]
+
+brokenForGHC92 :: String -> TestTree -> TestTree
+brokenForGHC92 = knownBrokenForGhcVersions [GHC92]

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -1275,6 +1275,20 @@ extendImportTests = testGroup "extend import actions"
                     , "b :: A"
                     , "b = ConstructorFoo"
                     ])
+        , testSession "extend single line import in presence of extra perens" $ template
+            []
+            ("Main.hs", T.unlines
+                    [ "import Data.Monoid (First)"
+                    , "f = (First Nothing) <> mempty" -- parens tripped up the regex extracting import suggestions
+                    ])
+            (Range (Position 1 6) (Position 1 7))
+            [ "Add First(..) to the import list of Data.Monoid"
+            , "Add First(First) to the import list of Data.Monoid"
+            ]
+            (T.unlines
+                    [ "import Data.Monoid (First (..))"
+                    , "f = (First Nothing) <> mempty"
+                    ])
         , brokenForGHC94 "On GHC 9.4, the error messages with -fdefer-type-errors don't have necessary imported target srcspan info." $
           testSession "extend single line qualified import with value" $ template
             [("ModuleA.hs", T.unlines


### PR DESCRIPTION
Fixes https://github.com/haskell/haskell-language-server/issues/4079

The problem was that the original regex was mistakenly using `.` as a regex metacharacter, whereas the GHC error  contains a literal `.`

In cases where GHC error contains further `)`'s this led to 3rd match group (which is used to extract srcspan) to contain too much stuff, leading to errors described in the issue.

If the tests pass, would you still recommend adding a test case for this or is it ok like this?