### PR TITLE
Exit with non-zero exitcode if wrapper fails to launch

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -48,6 +48,8 @@ test_all_hls() {
             fi
         fi
     done
+    # install the recommended GHC version so the wrapper can launch HLS
+    ghcup install ghc --set recommended
     "$bindir/haskell-language-server-wrapper${ext}" typecheck "${test_module}" || fail "failed to typecheck with HLS wrapper"
 }
 

--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -99,8 +99,10 @@ main = do
             Left err -> do
               T.hPutStrLn stderr (prettyError err NoShorten)
               case args of
-                Ghcide _ -> launchErrorLSP recorder (prettyError err Shorten)
-                _        -> pure ()
+                Ghcide (GhcideArguments { argsCommand = Main.LSP }) ->
+                    launchErrorLSP recorder (prettyError err Shorten)
+
+                _ -> exitFailure
 
 launchHaskellLanguageServer :: Recorder (WithPriority (Doc ())) -> Arguments -> IO (Either WrapperSetupError ())
 launchHaskellLanguageServer recorder parsedArgs = do


### PR DESCRIPTION
As reported by https://github.com/haskell/haskell-language-server/pull/3748#discussion_r1508794998, the tests are not run correctly, since there is no GHC installed. We install the recommended GHC version to make sure one (hopefully) supported GHC version is installed for running the wrapper test.

Further, if setup fails, HLS-wrapper launches an LSP server that allows users to restart the server once they have fixed potential setup issues. That's only desired if we are indeed launching as an LSP server. Thus, we exit with a non-zero exit code if setup fails and we are not launching in LSP mode.