### PR TITLE
Improve handling of nonsense rename attempts

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -508,6 +508,7 @@ library hls-rename-plugin
     , mtl
     , mod
     , syb
+    , row-types
     , text
     , transformers
     , unordered-containers

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -526,6 +526,9 @@ test-suite hls-rename-plugin-tests
     , hls-plugin-api
     , haskell-language-server:hls-rename-plugin
     , hls-test-utils             == 2.7.0.0
+    , lens
+    , lsp-types
+    , text
 
 -----------------------------
 -- retrie plugin

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -475,6 +475,9 @@ instance PluginMethod Request Method_CodeLensResolve where
 instance PluginMethod Request Method_TextDocumentRename where
   handlesRequest = pluginEnabledWithFeature plcRenameOn
 
+instance PluginMethod Request Method_TextDocumentPrepareRename where
+  handlesRequest = pluginEnabledWithFeature plcRenameOn
+
 instance PluginMethod Request Method_TextDocumentHover where
   handlesRequest = pluginEnabledWithFeature plcHoverOn
 
@@ -599,7 +602,7 @@ class PluginMethod Request m => PluginRequestMethod (m :: Method ClientToServer 
 ---
 instance PluginRequestMethod Method_TextDocumentCodeAction where
   combineResponses _method _config (ClientCapabilities _ textDocCaps _ _ _ _) (CodeActionParams _ _ _ _ context) resps =
-      InL $ fmap compat $ filter wasRequested $ concat $ mapMaybe nullToMaybe $ toList resps
+      InL $ fmap compat $ concatMap (filter wasRequested) $ mapMaybe nullToMaybe $ toList resps
     where
       compat :: (Command |? CodeAction) -> (Command |? CodeAction)
       compat x@(InL _) = x
@@ -656,6 +659,10 @@ instance PluginRequestMethod Method_CodeLensResolve where
     combineResponses _ _ _ _ (x :| _) = x
 
 instance PluginRequestMethod Method_TextDocumentRename where
+
+instance PluginRequestMethod Method_TextDocumentPrepareRename where
+    -- TODO more intelligent combining?
+    combineResponses _ _ _ _ (x :| _) = x
 
 instance PluginRequestMethod Method_TextDocumentHover where
   combineResponses _ _ _ _ (mapMaybe nullToMaybe . toList -> hs :: [Hover]) =

--- a/plugins/hls-rename-plugin/test/testdata/Comment.expected.hs
+++ b/plugins/hls-rename-plugin/test/testdata/Comment.expected.hs
@@ -1,0 +1,1 @@
+{- IShouldNotBeRenaemable -}

--- a/plugins/hls-rename-plugin/test/testdata/Comment.hs
+++ b/plugins/hls-rename-plugin/test/testdata/Comment.hs
@@ -1,0 +1,1 @@
+{- IShouldNotBeRenaemable -}


### PR DESCRIPTION
First step towards improving behavior when renaming unsupported things (e.g. keywords or words within comments).
Instead of throwing plugin error (reporte here https://github.com/haskell/haskell-language-server/issues/3915)
we detect that there is no Name to rename under cursor and throw less scary looking Invalid Param warning.

Behavior after this PR:

![Peek 2024-03-02 08-30](https://github.com/haskell/haskell-language-server/assets/2716069/97460d17-fcd3-4d09-b12d-02ce1b866643)

EDIT: Actually in the end I included @michaelpj's suggestion to implement [Prepare Rename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareRename) handler that "prefilters" invalid requests on the client and doesn't even allow creating rename request for them.
