### PR TITLE
Improve isolation of build artefacts of test runs

### DIFF
--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -46,6 +46,7 @@ library
     , lens
     , lsp-test                ^>=0.17
     , lsp-types               ^>=2.1
+    , safe-exceptions
     , tasty
     , tasty-expected-failure
     , tasty-golden


### PR DESCRIPTION
Even though we copy test files into temporary directories, we used to reuse the same cache directory for build artefacts, hiedb and compilation artefacts. While there is practially no chance this causes any issues for the test runs themselves, it litters the cache directory with a lot of files. So, we create one main directory in the temporary directory, and generate all caches and in there. This makes it trivial to delete all test caches, without risking deleting the cache that is still used.