### PR TITLE
eval: more robust way to extract comments from ParsedModule

### DIFF
--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -112,6 +112,7 @@ tests =
   , goldenWithEval ":kind treats a multilined result properly" "T25" "hs"
   , goldenWithEvalAndFs "local imports" (FS.directProjectMulti ["T26.hs", "Util.hs"]) "T26" "hs"
   , goldenWithEval "Preserves one empty comment line after prompt" "T27" "hs"
+  , goldenWithEval "Evaluate comment after multiline function definition" "T28" "hs"
   , goldenWithEval "Multi line comments" "TMulti" "hs"
   , goldenWithEval "Multi line comments, with the last test line ends without newline" "TEndingMulti" "hs"
   , goldenWithEval "Evaluate expressions in Plain comments in both single line and multi line format" "TPlainComment" "hs"

--- a/plugins/hls-eval-plugin/test/testdata/T28.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T28.expected.hs
@@ -1,0 +1,7 @@
+module T28 where
+
+f True = True
+f False = False
+
+-- >>> 1+1
+-- 2

--- a/plugins/hls-eval-plugin/test/testdata/T28.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T28.hs
@@ -1,0 +1,6 @@
+module T28 where
+
+f True = True
+f False = False
+
+-- >>> 1+1


### PR DESCRIPTION
Fixes https://github.com/haskell/haskell-language-server/issues/3500 and https://github.com/haskell/haskell-language-server/issues/3312

The problem in those issues can be illustrated by this simpler reproducer.
![Peek 2024-03-03 13-47](https://github.com/haskell/haskell-language-server/assets/2716069/81d43e16-5da2-49e8-a3da-a04ac5bfc4c1)
The issue is that the "end of line comment" is associated with the 2nd match group of function definition (confirmed this by compiling with `-ddump-parsed-ast -dkeep-comments`), which was part of AST  that eval plugin was ignoring when extracting comments, thus it didn't create "Evaluate..." code lens.


By using `biplate` combinator from lens we can more simply extract all occurrences of LEpaComment from the parsed source, wherever they might be.