### PR TITLE
Integrate stylish-haskell into hls executable with ghc 9.8

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-index-state: 2024-02-25T00:00:00Z
+index-state: 2024-03-09T08:17:00Z
 
 tests: True
 test-show-details: direct

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1433,7 +1433,7 @@ library hls-stylish-haskell-plugin
     , hls-plugin-api   == 2.7.0.0
     , lsp-types
     , mtl
-    , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14.2 || ^>=0.14.6
+    , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14
     , text
 
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1416,7 +1416,7 @@ flag stylishHaskell
   manual:      True
 
 common stylishHaskell
-  if flag(stylishHaskell) && (impl(ghc < 9.8.0) || flag(ignore-plugins-ghc-bounds))
+  if flag(stylishHaskell)
     build-depends: haskell-language-server:hls-stylish-haskell-plugin
     cpp-options: -Dhls_stylishHaskell
 
@@ -1433,7 +1433,7 @@ library hls-stylish-haskell-plugin
     , hls-plugin-api   == 2.7.0.0
     , lsp-types
     , mtl
-    , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14.2
+    , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14.2 || ^>=0.14.6
     , text
 
 


### PR DESCRIPTION
The version of stylish-haskell where @michaelpj added support for ghc 9.8 is on hackage:
https://hackage.haskell.org/package/stylish-haskell-0.14.6.0/changelog
Let's enable it in hls! 