### PR TITLE
Use Set.member instead of Foldable.elem

### DIFF
--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -155,7 +155,7 @@ setupLSP  recorder getHieDbLoc userHandlers getIdeState clientMsgVar = do
           -- We want to avoid that the list of cancelled requests
           -- keeps growing if we receive cancellations for requests
           -- that do not exist or have already been processed.
-          when (reqId `elem` queued) $
+          when (reqId `Set.member` queued) $
               modifyTVar cancelledRequests (Set.insert reqId)
   let clearReqId reqId = atomically $ do
           modifyTVar pendingRequests (Set.delete reqId)

--- a/ghcide/src/Development/IDE/Types/Exports.hs
+++ b/ghcide/src/Development/IDE/Types/Exports.hs
@@ -207,7 +207,7 @@ identInfoToKeyVal identInfo =
 
 buildModuleExportMap:: [(ModuleName, HashSet IdentInfo)] -> ModuleNameEnv (HashSet IdentInfo)
 buildModuleExportMap exportsMap = do
-  let lst = concatMap (Set.toList. snd) exportsMap
+  let lst = concatMap (Set.toList . snd) exportsMap
   let lstThree = map identInfoToKeyVal lst
   sortAndGroup lstThree
 
@@ -223,4 +223,4 @@ extractModuleExports modIFace = do
   (modName, functionSet)
 
 sortAndGroup :: [(ModuleName, IdentInfo)] -> ModuleNameEnv (HashSet IdentInfo)
-sortAndGroup assocs = listToUFM_C (<>) [(k, Set.fromList [v]) | (k, v) <- assocs]
+sortAndGroup assocs = listToUFM_C (<>) [(k, Set.singleton v) | (k, v) <- assocs]

--- a/ghcide/test/src/Development/IDE/Test.hs
+++ b/ghcide/test/src/Development/IDE/Test.hs
@@ -175,7 +175,7 @@ expectCurrentDiagnostics doc expected = do
 
 checkDiagnosticsForDoc :: HasCallStack => TextDocumentIdentifier -> [(DiagnosticSeverity, Cursor, T.Text)] -> [Diagnostic] -> Session ()
 checkDiagnosticsForDoc TextDocumentIdentifier {_uri} expected obtained = do
-    let expected' = Map.fromList [(nuri, map (\(ds, c, t) -> (ds, c, t, Nothing)) expected)]
+    let expected' = Map.singleton nuri (map (\(ds, c, t) -> (ds, c, t, Nothing)) expected)
         nuri = toNormalizedUri _uri
     expectDiagnosticsWithTags' (return (_uri, obtained)) expected'
 

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/AlternateNumberFormat.hs
@@ -112,7 +112,7 @@ codeActionHandler state pId (CodeActionParams _ _ docId currRange _) = do
         mkWorkspaceEdit :: NormalizedFilePath -> [TextEdit] -> WorkspaceEdit
         mkWorkspaceEdit nfp edits = WorkspaceEdit changes Nothing Nothing
             where
-                changes = Just $ Map.fromList [(filePathToUri $ fromNormalizedFilePath nfp, edits)]
+                changes = Just $ Map.singleton (filePathToUri $ fromNormalizedFilePath nfp) edits
 
 mkCodeActionTitle :: Literal -> AlternateFormat -> [GhcExtension] -> Text
 mkCodeActionTitle lit (alt, ext) ghcExts

--- a/plugins/hls-code-range-plugin/src/Ide/Plugin/CodeRange/ASTPreProcess.hs
+++ b/plugins/hls-code-range-plugin/src/Ide/Plugin/CodeRange/ASTPreProcess.hs
@@ -174,7 +174,7 @@ isIdentADef outerSpan (span, detail) =
     && isDef
   where
     isDef :: Bool
-    isDef = any isContextInfoDef . toList . identInfo $ detail
+    isDef = any isContextInfoDef $ identInfo detail
 
     -- Determines if the 'ContextInfo' represents a variable/function definition
     isContextInfoDef :: ContextInfo -> Bool

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/CodeLens.hs
@@ -228,7 +228,7 @@ runEvalCmd plId st mtoken EvalParams{..} =
                         evalGhcEnv final_hscEnv $ do
                             runTests evalCfg (st, fp) tests
 
-            let workspaceEditsMap = Map.fromList [(_uri, addFinalReturn mdlText edits)]
+            let workspaceEditsMap = Map.singleton _uri (addFinalReturn mdlText edits)
             let workspaceEdits = WorkspaceEdit (Just workspaceEditsMap) Nothing Nothing
 
             return workspaceEdits

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -232,7 +232,7 @@ resolveWTextEdit ideState (RefineAll uri) = do
   pure $ mkWorkspaceEdit uri edits pm
 mkWorkspaceEdit :: Uri -> [ImportEdit] -> PositionMapping -> WorkspaceEdit
 mkWorkspaceEdit uri edits pm =
-      WorkspaceEdit {_changes = Just $ Map.fromList [(uri, mapMaybe toWEdit edits)]
+      WorkspaceEdit {_changes = Just $ Map.singleton uri  (mapMaybe toWEdit edits)
                     , _documentChanges = Nothing
                     , _changeAnnotations = Nothing}
   where toWEdit ImportEdit{ieRange, ieText} =

--- a/plugins/hls-qualify-imported-names-plugin/src/Ide/Plugin/QualifyImportedNames.hs
+++ b/plugins/hls-qualify-imported-names-plugin/src/Ide/Plugin/QualifyImportedNames.hs
@@ -17,6 +17,7 @@ import           Data.List                        (sortOn)
 import qualified Data.List                        as List
 import qualified Data.Map.Strict                  as Map
 import           Data.Maybe                       (fromMaybe, isJust, mapMaybe)
+import qualified Data.Set                         as Set
 import           Data.Text                        (Text)
 import qualified Data.Text                        as Text
 import           Development.IDE                  (spanContainsRange)
@@ -164,7 +165,7 @@ refMapToUsedIdentifiers = DList.toList . Map.foldlWithKey' folder DList.empty
     getUsedIdentifier identifier span IdentifierDetails {..}
       | Just identifierSpan <- realSrcSpanToIdentifierSpan span
       , Right name <- identifier
-      , Use `elem` identInfo = Just $ UsedIdentifier name identifierSpan
+      , Use `Set.member` identInfo = Just $ UsedIdentifier name identifierSpan
       | otherwise = Nothing
 
 updateColOffset :: Int -> Int -> Int -> Int

--- a/plugins/hls-retrie-plugin/test/Main.hs
+++ b/plugins/hls-retrie-plugin/test/Main.hs
@@ -74,7 +74,7 @@ codeActionTitle _                         = Nothing
 
 goldenWithRetrie :: TestName -> FilePath -> (TextDocumentIdentifier -> Session ()) -> TestTree
 goldenWithRetrie title path act =
-    goldenWithHaskellDoc (def { plugins = M.fromList [("retrie", def)] }) testPlugins title testDataDir path "expected" "hs" act
+    goldenWithHaskellDoc (def { plugins = M.singleton "retrie" def }) testPlugins title testDataDir path "expected" "hs" act
 
 runWithRetrie :: Session a -> IO a
 runWithRetrie = runSessionWithServer def testPlugins testDataDir

--- a/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
+++ b/plugins/hls-stan-plugin/src/Ide/Plugin/Stan.hs
@@ -148,7 +148,7 @@ rules recorder plId = do
                   FiascoL es -> do
                       logWith recorder Development.IDE.Warning (LogWarnConf es)
                       -- If we can't read the config file, default to using all inspections:
-                      let allInspections = HM.fromList [(relativeHsFilePath, inspectionsIds)]
+                      let allInspections = HM.singleton relativeHsFilePath inspectionsIds
                       pure (allInspections, [])
                   ResultL _warnings stanConfig -> do
                       -- HashMap of *relative* file paths to info about enabled checks for those file paths.


### PR DESCRIPTION
`Set.member` is generally more efficient because it can use Ord constraint unlike `Foldable.elem` which can only use Eq class and has to traverse the whole thing if the element is not present.

using Set/Map.singleton is less important but I still find it useful because it reduces visual noise.

