### PR TITLE
Update contact info in docs

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -4,10 +4,8 @@ The Haskell tooling dream is near, we need your help!
 
 ## How to contact the haskell ide team
 
+- Join the [haskell-language-server channel](https://matrix.to/#/#haskell-language-server:matrix.org) in [matrix](https://matrix.org/).
 - Join [our IRC channel](https://web.libera.chat/?channels=#haskell-language-server) at `#haskell-language-server` on [`libera`](https://libera.chat/).
-- Follow the [Haskell IDE team twitter account](https://twitter.com/IdeHaskell) for updates and help.
-- Join the [#haskell-tooling channel](https://discord.com/channels/280033776820813825/505370075402862594/808027763868827659) in the Functional Programming discord server. You can join the server via [this invitation](https://discord.gg/9spEdTNGrD).
-- Join the [haskell-tooling channel](https://matrix.to/#/#haskell-tooling:matrix.org) in [matrix](https://matrix.org/).
 - Visit [the project GitHub repo](https://github.com/haskell/haskell-language-server) to view the source code, or open issues or pull requests.
 
 ## Building

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -4,8 +4,8 @@ The Haskell tooling dream is near, we need your help!
 
 ## How to contact the haskell ide team
 
-- Join the [haskell-language-server channel](https://matrix.to/#/#haskell-language-server:matrix.org) in [matrix](https://matrix.org/).
-- Join [our IRC channel](https://web.libera.chat/?channels=#haskell-language-server) at `#haskell-language-server` on [`libera`](https://libera.chat/).
+- Join the [haskell-language-server channel](https://matrix.to/#/#haskell-language-server:matrix.org) in [matrix](https://matrix.org/) (primary communication channel).
+- Join [our IRC channel](https://web.libera.chat/?channels=#haskell-language-server) at `#haskell-language-server` on [`libera`](https://libera.chat/) (secondary communication channel - all messages in this IRC channel are automatically bridged to the Matrix channel).
 - Visit [the project GitHub repo](https://github.com/haskell/haskell-language-server) to view the source code, or open issues or pull requests.
 
 ## Building


### PR DESCRIPTION
- don't mention discord (can't find any haskell-tooling channel in there, maybe I'm just searching incorrectly)?
- replace the generic haskell-tooling matrix with haskell-language-server which seems more appropriate for hls documentation
- move IRC down in the list to incentivize people to join matrix as first option (I'm ok with deleting IRC as @michaelpj suggested, just waiting for some feedback). EDIT got feedback from geekosaur that he's maintaining the irc bridge, so I'd just keep it for now.