### PR TITLE
Update comment in refactor tests

### DIFF
--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -667,7 +667,7 @@ typeWildCardActionTests = testGroup "type wildcard actions"
         , "func x y = x + y"
         ]
         [ if ghcVersion >= GHC98
-          then "func :: a -> a -> a" -- 9.8 has a different suggestion
+          then "func :: a -> a -> a" -- since 9.8 GHC no longer does type defaulting (see https://gitlab.haskell.org/ghc/ghc/-/issues/24522)
           else "func :: Integer -> Integer -> Integer"
         , "func x y = x + y"
         ]
@@ -697,7 +697,7 @@ typeWildCardActionTests = testGroup "type wildcard actions"
         , "func x y = x + y"
         ]
         [ if ghcVersion >= GHC98
-          then "func::a -> a -> a" -- 9.8 has a different suggestion
+          then "func::a -> a -> a" -- since 9.8 GHC no longer does type defaulting (see https://gitlab.haskell.org/ghc/ghc/-/issues/24522)
           else "func::Integer -> Integer -> Integer"
         , "func x y = x + y"
         ]


### PR DESCRIPTION
I guess that's about as much as we can do with https://github.com/haskell/haskell-language-server/issues/4134
The code action still works, it just suggests not-defaulted types.

Another possible alternative to consider would be to simplify the test by switching to something not-typeclass-polymorphic (e.g. use && instead of + to remove the conditional in test).