### PR TITLE
Run ExceptionTests in temporary directory

### DIFF
--- a/ghcide/test/exe/ExceptionTests.hs
+++ b/ghcide/test/exe/ExceptionTests.hs
@@ -55,7 +55,7 @@ tests recorder logger = do
               (view L.result -> lens) <- request SMethod_TextDocumentCodeLens (CodeLensParams Nothing Nothing doc)
               case lens of
                 Left (ResponseError {_code = InR ErrorCodes_InternalError, _message}) ->
-                  liftIO $ assertBool "We caught an error, but it wasn't ours!"
+                    liftIO $ assertBool "We caught an error, but it wasn't ours!"
                           (T.isInfixOf "divide by zero" _message && T.isInfixOf (coerce pluginId) _message)
                 _ -> liftIO $ assertFailure $ show lens
 

--- a/ghcide/test/exe/TestUtils.hs
+++ b/ghcide/test/exe/TestUtils.hs
@@ -307,11 +307,12 @@ testIde recorder arguments session = do
     cwd <- getCurrentDirectory
     (hInRead, hInWrite) <- createPipe
     (hOutRead, hOutWrite) <- createPipe
-    let projDir = "."
+
     let server = IDE.defaultMain (cmapWithPrio LogIDEMain recorder) arguments
             { IDE.argsHandleIn = pure hInRead
             , IDE.argsHandleOut = pure hOutWrite
             }
 
-    flip finally (setCurrentDirectory cwd) $ withAsync server $ \_ ->
-        runSessionWithHandles hInWrite hOutRead config lspTestCaps projDir session
+    withTempDir $ \dir -> do
+        flip finally (setCurrentDirectory cwd) $ withAsync server $ \_ ->
+            runSessionWithHandles hInWrite hOutRead config lspTestCaps dir session

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -470,6 +470,7 @@ setupTestEnvironment = do
   createDirectoryIfMissing True testCacheDir
   setEnv "XDG_CACHE_HOME" testCacheDir
   pure testRoot
+
 goldenWithHaskellDocFormatter
   :: Pretty b
   => Config


### PR DESCRIPTION
Fixes #4036

The tests weren't strictly speaking incorrect, as they were testing what they aim to, but using the cabal directory of ghcide is not correct.