### PR TITLE
POC: push plugin enablement into plugin components

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1370,19 +1370,18 @@ flag fourmolu
   default:     True
   manual:      True
 
-common fourmolu
-  if flag(fourmolu)
-    build-depends: haskell-language-server:hls-fourmolu-plugin
-    cpp-options: -Dhls_fourmolu
-
 library hls-fourmolu-plugin
   import:           defaults, pedantic, warnings
   exposed-modules:  Ide.Plugin.Fourmolu
   hs-source-dirs:   plugins/hls-fourmolu-plugin/src
+
+  if flag(fourmolu)
+    build-depends: fourmolu        ^>= 0.14 || ^>= 0.15
+    cpp-options: -Dhls_fourmolu
+
   build-depends:
     , base            >=4.12 && <5
     , filepath
-    , fourmolu        ^>= 0.14 || ^>= 0.15
     , ghc-boot-th
     , ghcide          == 2.7.0.0
     , hls-plugin-api  == 2.7.0.0
@@ -1393,12 +1392,16 @@ library hls-fourmolu-plugin
     , text
     , transformers
 
-
 test-suite hls-fourmolu-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
   type:             exitcode-stdio-1.0
+
+  if !flag(fourmolu)
+    buildable: False
+
   hs-source-dirs:   plugins/hls-fourmolu-plugin/test
   main-is:          Main.hs
+
   build-tool-depends:
     fourmolu:fourmolu
   build-depends:
@@ -1770,7 +1773,6 @@ library
                   , explicitFixity
                   , explicitFields
                   , floskell
-                  , fourmolu
                   , ormolu
                   , stylishHaskell
                   , refactor
@@ -1797,6 +1799,7 @@ library
     , ghc
     , ghcide                == 2.7.0.0
     , githash               >=0.1.6.1
+    , haskell-language-server:{hls-fourmolu-plugin}
     , hie-bios
     , hls-plugin-api        == 2.7.0.0
     , optparse-applicative

--- a/src/HlsPlugins.hs
+++ b/src/HlsPlugins.hs
@@ -103,9 +103,7 @@ import qualified Ide.Plugin.Notes                  as Notes
 import qualified Ide.Plugin.Floskell               as Floskell
 #endif
 
-#if hls_fourmolu
 import qualified Ide.Plugin.Fourmolu               as Fourmolu
-#endif
 
 #if hls_cabalfmt
 import qualified Ide.Plugin.CabalFmt               as CabalFmt
@@ -161,9 +159,7 @@ idePlugins recorder = pluginDescToIdePlugins allPlugins
 #if hls_floskell
       Floskell.descriptor "floskell" :
 #endif
-#if hls_fourmolu
       let pId = "fourmolu" in Fourmolu.descriptor (pluginRecorder pId) pId:
-#endif
 #if hls_cabalfmt
       let pId = "cabal-fmt" in CabalFmt.descriptor (pluginRecorder pId) pId:
 #endif

--- a/test/utils/Test/Hls/Flags.hs
+++ b/test/utils/Test/Hls/Flags.hs
@@ -10,7 +10,7 @@ import           Test.Hls (TestTree, ignoreTestBecause)
 
 -- | Disable test unless the eval flag is set
 requiresEvalPlugin            :: TestTree -> TestTree
-#if eval
+#if hls_eval
 requiresEvalPlugin            = id
 #else
 requiresEvalPlugin            = ignoreTestBecause "Eval plugin disabled"
@@ -19,7 +19,7 @@ requiresEvalPlugin            = ignoreTestBecause "Eval plugin disabled"
 -- * Formatters
 -- | Disable test unless the floskell flag is set
 requiresFloskellPlugin        :: TestTree -> TestTree
-#if floskell
+#if hls_floskell
 requiresFloskellPlugin        = id
 #else
 requiresFloskellPlugin        = ignoreTestBecause "Floskell plugin disabled"
@@ -27,7 +27,7 @@ requiresFloskellPlugin        = ignoreTestBecause "Floskell plugin disabled"
 
 -- | Disable test unless the fourmolu flag is set
 requiresFourmoluPlugin        :: TestTree -> TestTree
-#if fourmolu
+#if hls_fourmolu
 requiresFourmoluPlugin        = id
 #else
 requiresFourmoluPlugin        = ignoreTestBecause "Fourmolu plugin disabled"
@@ -35,7 +35,7 @@ requiresFourmoluPlugin        = ignoreTestBecause "Fourmolu plugin disabled"
 
 -- | Disable test unless the ormolu flag is set
 requiresOrmoluPlugin          :: TestTree -> TestTree
-#if ormolu
+#if hls_ormolu
 requiresOrmoluPlugin          = id
 #else
 requiresOrmoluPlugin          = ignoreTestBecause "Ormolu plugin disabled"


### PR DESCRIPTION
This implements a version of what I describe in [this comment] on the `fourmolu` plugin as a POC. The goal here is that:
- CPP moves to plugin components, rather than the integration point
- Plugin components always export a plugin descriptor, it just might provide nothing and say it is disabled
   - This can be helpful for our users, to tell them that things are disabled
- Plugin components always build, even if the flag is turned off
   - This is useful since cabal actually always tries to solve for all the buildable components, pulling in unwanted dependencies. This way that will happen, but it will be fine. (An alternative would be to just mark them as not buildable in this situation)
- Plugin _tests_ are not buildable if the flag is off.
    - We could try and make them always buildable, and just have no tests, but that seems worse?

I haven't tried to make "being disabled" a first-class status or anything, a disabled plugin is just a plugin with no handlers and a description that calls that out. Maybe that's a mistake? I'm not sure.