### PR TITLE
Fix references to old CPP names in tests, update tests

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1889,6 +1889,10 @@ test-suite func-test
                     , warnings
                     , pedantic
                     , refactor
+                    , eval
+                    , fourmolu
+                    , ormolu
+                    , floskell
   type:               exitcode-stdio-1.0
   build-tool-depends:
     haskell-language-server:haskell-language-server,

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1889,10 +1889,6 @@ test-suite func-test
                     , warnings
                     , pedantic
                     , refactor
-                    , eval
-                    , fourmolu
-                    , ormolu
-                    , floskell
   type:               exitcode-stdio-1.0
   build-tool-depends:
     haskell-language-server:haskell-language-server,

--- a/plugins/hls-eval-plugin/test/cabal.project
+++ b/plugins/hls-eval-plugin/test/cabal.project
@@ -1,3 +1,3 @@
 packages:
   testdata/
-  info-util/
+  testdata/info-util/

--- a/test/functional/Progress.hs
+++ b/test/functional/Progress.hs
@@ -37,7 +37,7 @@ tests =
 
               (codeLensResponse, activeProgressTokens) <- expectProgressMessagesTill
                 (responseForId SMethod_TextDocumentCodeLens lspId)
-                ["Setting up testdata (for T1.hs)", "Processing", "Indexing"]
+                ["Setting up testdata (for T1.hs)", "Processing"]
                 []
 
               -- this is a test so exceptions result in fails

--- a/test/functional/Progress.hs
+++ b/test/functional/Progress.hs
@@ -59,7 +59,7 @@ tests =
                 void configurationRequest
                 setHlsConfig (formatLspConfig "ormolu")
                 doc <- openDoc "Format.hs" "haskell"
-                expectProgressMessages ["Setting up testdata (for Format.hs)", "Processing", "Indexing"] []
+                expectProgressMessages ["Setting up format (for Format.hs)", "Processing", "Indexing"] []
                 _ <- sendRequest SMethod_TextDocumentFormatting $ DocumentFormattingParams Nothing doc (FormattingOptions 2 True Nothing Nothing Nothing)
                 expectProgressMessages ["Formatting Format.hs"] []
         , requiresFourmoluPlugin $ testCase "fourmolu plugin sends progress notifications" $ do
@@ -67,7 +67,7 @@ tests =
                 void configurationRequest
                 setHlsConfig (formatLspConfig "fourmolu")
                 doc <- openDoc "Format.hs" "haskell"
-                expectProgressMessages ["Setting up testdata (for Format.hs)", "Processing", "Indexing"] []
+                expectProgressMessages ["Setting up format (for Format.hs)", "Processing", "Indexing"] []
                 _ <- sendRequest SMethod_TextDocumentFormatting $ DocumentFormattingParams Nothing doc (FormattingOptions 2 True Nothing Nothing Nothing)
                 expectProgressMessages ["Formatting Format.hs"] []
         ]

--- a/test/utils/Test/Hls/Flags.hs
+++ b/test/utils/Test/Hls/Flags.hs
@@ -10,7 +10,7 @@ import           Test.Hls (TestTree, ignoreTestBecause)
 
 -- | Disable test unless the eval flag is set
 requiresEvalPlugin            :: TestTree -> TestTree
-#if eval
+#if hls_eval
 requiresEvalPlugin            = id
 #else
 requiresEvalPlugin            = ignoreTestBecause "Eval plugin disabled"
@@ -19,7 +19,7 @@ requiresEvalPlugin            = ignoreTestBecause "Eval plugin disabled"
 -- * Formatters
 -- | Disable test unless the floskell flag is set
 requiresFloskellPlugin        :: TestTree -> TestTree
-#if floskell
+#if hls_floskell
 requiresFloskellPlugin        = id
 #else
 requiresFloskellPlugin        = ignoreTestBecause "Floskell plugin disabled"
@@ -27,7 +27,7 @@ requiresFloskellPlugin        = ignoreTestBecause "Floskell plugin disabled"
 
 -- | Disable test unless the fourmolu flag is set
 requiresFourmoluPlugin        :: TestTree -> TestTree
-#if fourmolu
+#if hls_fourmolu
 requiresFourmoluPlugin        = id
 #else
 requiresFourmoluPlugin        = ignoreTestBecause "Fourmolu plugin disabled"
@@ -35,7 +35,7 @@ requiresFourmoluPlugin        = ignoreTestBecause "Fourmolu plugin disabled"
 
 -- | Disable test unless the ormolu flag is set
 requiresOrmoluPlugin          :: TestTree -> TestTree
-#if ormolu
+#if hls_ormolu
 requiresOrmoluPlugin          = id
 #else
 requiresOrmoluPlugin          = ignoreTestBecause "Ormolu plugin disabled"


### PR DESCRIPTION
Picks up where https://github.com/haskell/haskell-language-server/pull/4129 left off + includes test fixes.
One of the fixed tests seems to be flaky so might require some stabilization..