### PR TITLE
Upgrade to latest lsp / lsp-types / lsp-test

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,7 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-index-state: 2024-04-23T12:00:00Z
+index-state: 2024-04-30T10:44:19Z
 
 tests: True
 test-show-details: direct
@@ -41,11 +41,3 @@ constraints:
   -- We want to be able to benefit from the performance optimisations
   -- in the future, thus: TODO: remove this flag.
   bitvec -simd
-
-source-repository-package
-  type:git
-  location: https://github.com/haskell/lsp
-  tag: b3c18fe44124eedd1ce9138321e753b08784ddba
-  subdir: lsp
-  subdir: lsp-test
-  subdir: lsp-types

--- a/cabal.project
+++ b/cabal.project
@@ -45,7 +45,7 @@ constraints:
 source-repository-package
   type:git
   location: https://github.com/haskell/lsp
-  tag: 1e5940b4c85d53f01831bca487f3cd0a9466d3de
+  tag: b3c18fe44124eedd1ce9138321e753b08784ddba
   subdir: lsp
   subdir: lsp-test
   subdir: lsp-types

--- a/cabal.project
+++ b/cabal.project
@@ -41,3 +41,11 @@ constraints:
   -- We want to be able to benefit from the performance optimisations
   -- in the future, thus: TODO: remove this flag.
   bitvec -simd
+
+source-repository-package
+  type:git
+  location: https://github.com/haskell/lsp
+  tag: 1e5940b4c85d53f01831bca487f3cd0a9466d3de
+  subdir: lsp
+  subdir: lsp-test
+  subdir: lsp-types

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -86,8 +86,8 @@ library
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5
     , lens
     , list-t
-    , lsp                          ^>=2.4.0.0
-    , lsp-types                    ^>=2.1.0.0
+    , lsp                          ^>=2.5.0.0
+    , lsp-types                    ^>=2.2.0.0
     , mtl
     , opentelemetry                >=0.6.1
     , optparse-applicative

--- a/ghcide/src/Development/IDE/Core/PositionMapping.hs
+++ b/ghcide/src/Development/IDE/Core/PositionMapping.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedLabels #-}
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 module Development.IDE.Core.PositionMapping
@@ -25,6 +24,7 @@ module Development.IDE.Core.PositionMapping
   ) where
 
 import           Control.DeepSeq
+import           Control.Lens                ((^.))
 import           Control.Monad
 import           Data.Algorithm.Diff
 import           Data.Bifunctor
@@ -32,6 +32,7 @@ import           Data.List
 import           Data.Row
 import qualified Data.Text                   as T
 import qualified Data.Vector.Unboxed         as V
+import qualified Language.LSP.Protocol.Lens  as L
 import           Language.LSP.Protocol.Types (Position (Position),
                                               Range (Range),
                                               TextDocumentContentChangeEvent (TextDocumentContentChangeEvent),
@@ -131,8 +132,8 @@ addOldDelta delta (PositionMapping pm) = PositionMapping (composeDelta pm delta)
 -- that was what was done with lsp* 1.6 packages
 applyChange :: PositionDelta -> TextDocumentContentChangeEvent -> PositionDelta
 applyChange PositionDelta{..} (TextDocumentContentChangeEvent (InL x)) = PositionDelta
-    { toDelta = toCurrent (x .! #range) (x .! #text) <=< toDelta
-    , fromDelta = fromDelta <=< fromCurrent (x .! #range) (x .! #text)
+    { toDelta = toCurrent (x ^. L.range) (x ^. L.text) <=< toDelta
+    , fromDelta = fromDelta <=< fromCurrent (x ^. L.range) (x ^. L.text)
     }
 applyChange posMapping _ = posMapping
 

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiWayIf            #-}
-{-# LANGUAGE OverloadedLabels      #-}
 
 -- Mostly taken from "haskell-ide-engine"
 module Development.IDE.Plugin.Completions.Logic (
@@ -530,7 +529,7 @@ toggleSnippets ClientCapabilities {_textDocument} CompletionsConfig{..} =
   removeSnippetsWhen (not $ enableSnippets && supported)
   where
     supported =
-      Just True == (_textDocument >>= _completion >>= view L.completionItem >>= (\x -> x .! #snippetSupport))
+      Just True == (_textDocument >>= _completion >>= view L.completionItem >>= view L.snippetSupport)
 
 toggleAutoExtend :: CompletionsConfig -> CompItem -> CompItem
 toggleAutoExtend CompletionsConfig{enableAutoExtend=False} x = x {additionalTextEdits = Nothing}

--- a/ghcide/test/exe/CompletionTests.hs
+++ b/ghcide/test/exe/CompletionTests.hs
@@ -15,7 +15,6 @@ import           Control.Monad.IO.Class         (liftIO)
 import           Data.Default
 import           Data.List.Extra
 import           Data.Maybe
-import           Data.Row
 import qualified Data.Text                      as T
 import           Development.IDE.GHC.Compat     (GhcVersion (..), ghcVersion)
 import           Development.IDE.Types.Location
@@ -205,7 +204,7 @@ localCompletionTests = [
         doc <- createDoc "A.hs" "haskell" $ src "AAA"
         void $ waitForTypecheck doc
         let editA rhs =
-                changeDoc doc [TextDocumentContentChangeEvent . InR . (.==) #text $ src rhs]
+                changeDoc doc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $ src rhs]
         editA "AAAA"
         void $ waitForTypecheck doc
         editA "AAAAA"

--- a/ghcide/test/exe/DependentFileTest.hs
+++ b/ghcide/test/exe/DependentFileTest.hs
@@ -1,12 +1,10 @@
 
-{-# LANGUAGE GADTs            #-}
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE GADTs #-}
 
 module DependentFileTest (tests) where
 
 import           Config
 import           Control.Monad.IO.Class         (liftIO)
-import           Data.Row
 import qualified Data.Text                      as T
 import           Development.IDE.Test           (expectDiagnostics)
 import           Development.IDE.Types.Location
@@ -52,8 +50,10 @@ tests = testGroup "addDependentFile"
             [FileEvent (filePathToUri "dep-file.txt") FileChangeType_Changed ]
 
         -- Modifying Baz will now trigger Foo to be rebuilt as well
-        let change = TextDocumentContentChangeEvent $ InL $ #range .== Range (Position 2 0) (Position 2 6)
-                                                         .+ #rangeLength .== Nothing
-                                                         .+ #text .== "f = ()"
+        let change = TextDocumentContentChangeEvent $ InL TextDocumentContentChangePartial
+                { _range = Range (Position 2 0) (Position 2 6)
+                , _rangeLength = Nothing
+                , _text = "f = ()"
+                }
         changeDoc doc [change]
         expectDiagnostics [("Foo.hs", [])]

--- a/ghcide/test/exe/DiagnosticTests.hs
+++ b/ghcide/test/exe/DiagnosticTests.hs
@@ -517,7 +517,7 @@ tests = testGroup "diagnostics"
               }
 
         ,TextDocumentContentChangeEvent $ InL TextDocumentContentChangePartial
-              { _range = Range p' p'
+              { _range = Range p p'
               , _rangeLength = Nothing
               , _text = ""
               }

--- a/ghcide/test/exe/GarbageCollectionTests.hs
+++ b/ghcide/test/exe/GarbageCollectionTests.hs
@@ -1,10 +1,6 @@
-
-{-# LANGUAGE OverloadedLabels #-}
-
 module GarbageCollectionTests (tests) where
 
 import           Control.Monad.IO.Class      (liftIO)
-import           Data.Row
 import qualified Data.Set                    as Set
 import qualified Data.Text                   as T
 import           Development.IDE.Test        (expectCurrentDiagnostics,
@@ -15,7 +11,6 @@ import           Language.LSP.Protocol.Types hiding (SemanticTokenAbsolute (..),
                                               SemanticTokensEdit (..), mkRange)
 import           Language.LSP.Test
 import           System.FilePath
--- import Test.QuickCheck.Instances ()
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           TestUtils
@@ -74,14 +69,14 @@ tests = testGroup "garbage collection"
                         , "a = ()"
                         ]
             doc <- generateGarbage "A" dir
-            changeDoc doc [TextDocumentContentChangeEvent . InR . (.==) #text $ edit]
+            changeDoc doc [TextDocumentContentChangeEvent . InR $ TextDocumentContentChangeWholeDocument edit]
             builds <- waitForTypecheck doc
             liftIO $ assertBool "it still builds" builds
             expectCurrentDiagnostics doc [(DiagnosticSeverity_Error, (2,4), "Couldn't match expected type")]
         ]
   ]
   where
-    isExpected k = any (`T.isPrefixOf` k) ["GhcSessionIO"]
+    isExpected k = "GhcSessionIO" `T.isPrefixOf` k
 
     generateGarbage :: String -> FilePath -> Session TextDocumentIdentifier
     generateGarbage modName dir = do

--- a/ghcide/test/exe/IfaceTests.hs
+++ b/ghcide/test/exe/IfaceTests.hs
@@ -1,10 +1,6 @@
-
-{-# LANGUAGE OverloadedLabels #-}
-
 module IfaceTests (tests) where
 
 import           Control.Monad.IO.Class        (liftIO)
-import           Data.Row
 import qualified Data.Text                     as T
 import           Development.IDE.GHC.Util
 import           Development.IDE.Test          (configureCheckProject,
@@ -52,7 +48,7 @@ ifaceTHTest = testCase "iface-th-test" $ runWithExtraFiles "TH" $ \dir -> do
     liftIO $ writeFileUTF8 aPath (unlines $ init (lines $ T.unpack aSource) ++ ["th_a = [d| a = False|]"])
 
     -- Check that the change propagates to C
-    changeDoc cdoc [TextDocumentContentChangeEvent . InR . (.==) #text $ cSource]
+    changeDoc cdoc [TextDocumentContentChangeEvent . InR $ TextDocumentContentChangeWholeDocument cSource]
     expectDiagnostics
       [("THC.hs", [(DiagnosticSeverity_Error, (4, 4), "Couldn't match expected type '()' with actual type 'Bool'")])
       ,("THB.hs", [(DiagnosticSeverity_Warning, (4,1), "Top-level binding")])]
@@ -72,7 +68,9 @@ ifaceErrorTest = testCase "iface-error-test-1" $ runWithExtraFiles "recomp" $ \d
       [("P.hs", [(DiagnosticSeverity_Warning,(4,0), "Top-level binding")])] -- So what we know P has been loaded
 
     -- Change y from Int to B
-    changeDoc bdoc [TextDocumentContentChangeEvent . InR . (.==) #text $ T.unlines ["module B where", "y :: Bool", "y = undefined"]]
+    changeDoc bdoc [ TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $
+                        T.unlines [ "module B where", "y :: Bool", "y = undefined"]
+                   ]
     -- save so that we can that the error propagates to A
     sendNotification SMethod_TextDocumentDidSave (DidSaveTextDocumentParams bdoc Nothing)
 
@@ -90,7 +88,7 @@ ifaceErrorTest = testCase "iface-error-test-1" $ runWithExtraFiles "recomp" $ \d
     expectDiagnostics
       [("P.hs", [(DiagnosticSeverity_Warning,(4,0), "Top-level binding")])
       ]
-    changeDoc pdoc [TextDocumentContentChangeEvent . InR . (.==) #text $ pSource <> "\nfoo = y :: Bool" ]
+    changeDoc pdoc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $ pSource <> "\nfoo = y :: Bool" ]
     -- Now in P we have
     -- bar = x :: Int
     -- foo = y :: Bool
@@ -119,10 +117,11 @@ ifaceErrorTest2 = testCase "iface-error-test-2" $ runWithExtraFiles "recomp" $ \
       [("P.hs", [(DiagnosticSeverity_Warning,(4,0), "Top-level binding")])] -- So that we know P has been loaded
 
     -- Change y from Int to B
-    changeDoc bdoc [TextDocumentContentChangeEvent . InR . (.==) #text $ T.unlines ["module B where", "y :: Bool", "y = undefined"]]
+    changeDoc bdoc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $
+        T.unlines ["module B where", "y :: Bool", "y = undefined"]]
 
     -- Add a new definition to P
-    changeDoc pdoc [TextDocumentContentChangeEvent . InR . (.==) #text $ pSource <> "\nfoo = y :: Bool" ]
+    changeDoc pdoc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $ pSource <> "\nfoo = y :: Bool" ]
     -- Now in P we have
     -- bar = x :: Int
     -- foo = y :: Bool
@@ -149,7 +148,7 @@ ifaceErrorTest3 = testCase "iface-error-test-3" $ runWithExtraFiles "recomp" $ \
     bdoc <- createDoc bPath "haskell" bSource
 
     -- Change y from Int to B
-    changeDoc bdoc [TextDocumentContentChangeEvent . InR . (.==) #text $ T.unlines ["module B where", "y :: Bool", "y = undefined"]]
+    changeDoc bdoc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $ T.unlines ["module B where", "y :: Bool", "y = undefined"]]
 
     -- P should not typecheck, as there are no last valid artifacts for A
     _pdoc <- createDoc pPath "haskell" pSource

--- a/ghcide/test/exe/InitializeResponseTests.hs
+++ b/ghcide/test/exe/InitializeResponseTests.hs
@@ -1,12 +1,10 @@
 
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE DataKinds #-}
 
 module InitializeResponseTests (tests) where
 
 import           Control.Monad
 import           Data.List.Extra
-import           Data.Row
 import qualified Data.Text                         as T
 import           Development.IDE.Plugin.TypeLenses (typeLensCommandId)
 import qualified Language.LSP.Protocol.Lens        as L
@@ -55,8 +53,13 @@ tests = withResource acquire release tests where
     , chk "NO color"                   (^. L.colorProvider) Nothing
     , chk "NO folding range"          _foldingRangeProvider Nothing
     , che "   execute command"      _executeCommandProvider [typeLensCommandId, blockCommandId]
-    , chk "   workspace"                   (^. L.workspace) (Just $ #workspaceFolders .== Just WorkspaceFoldersServerCapabilities{_supported = Just True, _changeNotifications = Just ( InR True )}
-                                                                 .+ #fileOperations   .== Nothing)
+    , chk "   workspace"                   (^. L.workspace) (Just $ WorkspaceOptions
+                                                                      { _workspaceFolders = Just WorkspaceFoldersServerCapabilities
+                                                                           { _supported = Just True
+                                                                           , _changeNotifications = Just (InR True)
+                                                                           }
+                                                                      , _fileOperations = Nothing
+                                                                      })
     , chk "NO experimental"             (^. L.experimental) Nothing
     ] where
 

--- a/ghcide/test/exe/THTests.hs
+++ b/ghcide/test/exe/THTests.hs
@@ -1,10 +1,7 @@
 
-{-# LANGUAGE OverloadedLabels #-}
-
 module THTests (tests) where
 
 import           Control.Monad.IO.Class      (liftIO)
-import           Data.Row
 import qualified Data.Text                   as T
 import           Development.IDE.GHC.Util
 import           Development.IDE.Test        (expectCurrentDiagnostics,
@@ -142,9 +139,9 @@ thReloadingTest unboxed = testCase name $ runWithExtraFiles dir $ \dir -> do
 
     -- Change th from () to Bool
     let aSource' = T.unlines $ init (T.lines aSource) ++ ["th_a = [d| a = False|]"]
-    changeDoc adoc [TextDocumentContentChangeEvent . InR . (.==) #text $ aSource']
+    changeDoc adoc [TextDocumentContentChangeEvent . InR $ TextDocumentContentChangeWholeDocument aSource']
     -- generate an artificial warning to avoid timing out if the TH change does not propagate
-    changeDoc cdoc [TextDocumentContentChangeEvent . InR . (.==) #text $ cSource <> "\nfoo=()"]
+    changeDoc cdoc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $ cSource <> "\nfoo=()"]
 
     -- Check that the change propagates to C
     expectDiagnostics
@@ -176,11 +173,11 @@ thLinkingTest unboxed = testCase name $ runWithExtraFiles dir $ \dir -> do
     expectDiagnostics [("THB.hs", [(DiagnosticSeverity_Warning, (4,1), "Top-level binding")])]
 
     let aSource' = T.unlines $ init (init (T.lines aSource)) ++ ["th :: DecsQ", "th = [d| a = False|]"]
-    changeDoc adoc [TextDocumentContentChangeEvent . InR . (.==) #text $ aSource']
+    changeDoc adoc [TextDocumentContentChangeEvent . InR $ TextDocumentContentChangeWholeDocument aSource']
 
     -- modify b too
     let bSource' = T.unlines $ init (T.lines bSource) ++ ["$th"]
-    changeDoc bdoc [TextDocumentContentChangeEvent . InR . (.==) #text $ bSource']
+    changeDoc bdoc [TextDocumentContentChangeEvent . InR $ TextDocumentContentChangeWholeDocument bSource']
     waitForProgressBegin
     waitForAllProgressDone
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -255,8 +255,8 @@ library hls-cabal-plugin
     , hls-plugin-api        == 2.7.0.0
     , hls-graph             == 2.7.0.0
     , lens
-    , lsp                   ^>=2.4
-    , lsp-types             ^>=2.1
+    , lsp                   ^>=2.5
+    , lsp-types             ^>=2.2
     , regex-tdfa            ^>=1.3.1
     , stm
     , text
@@ -387,7 +387,7 @@ library hls-call-hierarchy-plugin
     , hiedb                 ^>= 0.6.0.0
     , hls-plugin-api        == 2.7.0.0
     , lens
-    , lsp                    >=2.4
+    , lsp                    >=2.5
     , sqlite-simple
     , text
 
@@ -1001,7 +1001,7 @@ library hls-alternate-number-format-plugin
     , hls-graph
     , hls-plugin-api       == 2.7.0.0
     , lens
-    , lsp                  ^>=2.4
+    , lsp                  ^>=2.5
     , mtl
     , regex-tdfa
     , syb
@@ -1231,7 +1231,7 @@ library hls-gadt-plugin
     , hls-plugin-api         == 2.7.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
-    , lsp                    >=2.4
+    , lsp                    >=2.5
     , mtl
     , text
     , transformers
@@ -1280,7 +1280,7 @@ library hls-explicit-fixity-plugin
     , ghcide                == 2.7.0.0
     , hashable
     , hls-plugin-api        == 2.7.0.0
-    , lsp                   >=2.4
+    , lsp                   >=2.5
     , text
 
   default-extensions: DataKinds
@@ -1423,7 +1423,7 @@ library hls-floskell-plugin
     , floskell        ^>=0.11.0
     , ghcide          == 2.7.0.0
     , hls-plugin-api  == 2.7.0.0
-    , lsp-types       ^>=2.1
+    , lsp-types       ^>=2.2
     , mtl
     , text
 
@@ -1737,7 +1737,7 @@ library hls-semantic-tokens-plugin
     , ghcide                == 2.7.0.0
     , hls-plugin-api        == 2.7.0.0
     , lens
-    , lsp                    >=2.4
+    , lsp                    >=2.5
     , text
     , transformers
     , bytestring
@@ -1808,7 +1808,7 @@ library hls-notes-plugin
     , hls-graph == 2.7.0.0
     , hls-plugin-api == 2.7.0.0
     , lens
-    , lsp >=2.4
+    , lsp >=2.5
     , mtl >= 2.2
     , regex-tdfa >= 1.3.1
     , text
@@ -2117,7 +2117,7 @@ test-suite ghcide-tests
     , lens
     , list-t
     , lsp
-    , lsp-test                ^>=0.17.0.0
+    , lsp-test                ^>=0.17.0.1
     , lsp-types
     , monoid-subclasses
     , mtl

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -609,7 +609,6 @@ test-suite hls-rename-plugin-tests
     , hls-test-utils             == 2.7.0.0
     , lens
     , lsp-types
-    , row-types
     , text
 
 -----------------------------
@@ -2126,7 +2125,6 @@ test-suite ghcide-tests
     , QuickCheck
     , random
     , regex-tdfa              ^>=1.3.1
-    , row-types
     , shake
     , sqlite-simple
     , stm

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -290,7 +290,6 @@ test-suite hls-cabal-plugin-tests
     , text
     , text-rope
     , transformers
-    , row-types
 
 -----------------------------
 -- class plugin
@@ -352,7 +351,6 @@ test-suite hls-class-plugin-tests
     , hls-test-utils     == 2.7.0.0
     , lens
     , lsp-types
-    , row-types
     , text
 
 -----------------------------
@@ -498,7 +496,6 @@ test-suite hls-eval-plugin-tests
     , lens
     , lsp-types
     , text
-    , row-types
 
 -----------------------------
 -- import lens plugin
@@ -553,7 +550,6 @@ test-suite hls-explicit-imports-plugin-tests
     , hls-test-utils   == 2.7.0.0
     , lens
     , lsp-types
-    , row-types
     , text
 
 -----------------------------
@@ -591,7 +587,6 @@ library hls-rename-plugin
     , mtl
     , mod
     , syb
-    , row-types
     , text
     , transformers
     , unordered-containers
@@ -759,7 +754,6 @@ test-suite hls-hlint-plugin-tests
     , hls-test-utils      == 2.7.0.0
     , lens
     , lsp-types
-    , row-types
     , text
 
 -----------------------------
@@ -977,7 +971,6 @@ test-suite hls-splice-plugin-tests
     , haskell-language-server:hls-splice-plugin
     , hls-test-utils == 2.7.0.0
     , text
-    , row-types
 
 -----------------------------
 -- alternate number format plugin
@@ -1787,7 +1780,6 @@ test-suite hls-semantic-tokens-plugin-tests
     , ghcide                == 2.7.0.0
     , hls-plugin-api        == 2.7.0.0
     , data-default
-    , row-types
 
 -----------------------------
 -- notes plugin

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -76,7 +76,6 @@ library
     , optparse-applicative
     , prettyprinter
     , regex-tdfa            >=1.3.1.0
-    , row-types
     , stm
     , text
     , time

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -69,7 +69,7 @@ library
     , hls-graph             == 2.7.0.0
     , lens
     , lens-aeson
-    , lsp                   ^>=2.4
+    , lsp                   ^>=2.5
     , megaparsec            >=9.0
     , mtl
     , opentelemetry         >=0.4

--- a/hls-plugin-api/src/Ide/Plugin/Resolve.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Resolve.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE LambdaCase               #-}
-{-# LANGUAGE OverloadedLabels         #-}
 {-# LANGUAGE OverloadedStrings        #-}
 {-| This module currently includes helper functions to provide fallback support
 to code actions that use resolve in HLS. The difference between the two
@@ -26,7 +25,6 @@ import           Control.Monad.Trans.Except    (ExceptT (..))
 
 import qualified Data.Aeson                    as A
 import           Data.Maybe                    (catMaybes)
-import           Data.Row                      ((.!))
 import qualified Data.Text                     as T
 import           GHC.Generics                  (Generic)
 import           Ide.Logger
@@ -190,7 +188,7 @@ supportsCodeActionResolve :: ClientCapabilities -> Bool
 supportsCodeActionResolve caps =
     caps ^? L.textDocument . _Just . L.codeAction . _Just . L.dataSupport . _Just == Just True
     && case caps ^? L.textDocument . _Just . L.codeAction . _Just . L.resolveSupport . _Just of
-        Just row -> "edit" `elem` row .! #properties
+        Just ClientCodeActionResolveOptions{_properties} -> "edit" `elem` _properties
         _        -> False
 
 internalError :: T.Text -> PluginError

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -56,7 +56,7 @@ library
     , tasty-rerun
     , temporary
     , text
-    , row-types
+
   ghc-options:      -Wall -Wunused-packages
 
   if flag(pedantic)

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -47,7 +47,7 @@ library
     , hls-plugin-api          == 2.7.0.0
     , lens
     , lsp-test                ^>=0.17
-    , lsp-types               ^>=2.1
+    , lsp-types               ^>=2.2
     , safe-exceptions
     , tasty
     , tasty-expected-failure

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -167,7 +167,7 @@ goldenWithHaskellDoc
   -> FilePath
   -> (TextDocumentIdentifier -> Session ())
   -> TestTree
-goldenWithHaskellDoc = goldenWithDoc "haskell"
+goldenWithHaskellDoc = goldenWithDoc LanguageKind_Haskell
 
 goldenWithHaskellDocInTmpDir
   :: Pretty b
@@ -180,7 +180,7 @@ goldenWithHaskellDocInTmpDir
   -> FilePath
   -> (TextDocumentIdentifier -> Session ())
   -> TestTree
-goldenWithHaskellDocInTmpDir = goldenWithDocInTmpDir "haskell"
+goldenWithHaskellDocInTmpDir = goldenWithDocInTmpDir LanguageKind_Haskell
 
 goldenWithHaskellAndCaps
   :: Pretty b
@@ -237,11 +237,11 @@ goldenWithCabalDoc
   -> FilePath
   -> (TextDocumentIdentifier -> Session ())
   -> TestTree
-goldenWithCabalDoc = goldenWithDoc "cabal"
+goldenWithCabalDoc = goldenWithDoc (LanguageKind_Custom "cabal")
 
 goldenWithDoc
   :: Pretty b
-  => T.Text
+  => LanguageKind
   -> Config
   -> PluginTestDescriptor b
   -> TestName
@@ -251,19 +251,19 @@ goldenWithDoc
   -> FilePath
   -> (TextDocumentIdentifier -> Session ())
   -> TestTree
-goldenWithDoc fileType config plugin title testDataDir path desc ext act =
+goldenWithDoc languageKind config plugin title testDataDir path desc ext act =
   goldenGitDiff title (testDataDir </> path <.> desc <.> ext)
   $ runSessionWithServer config plugin testDataDir
   $ TL.encodeUtf8 . TL.fromStrict
   <$> do
-    doc <- openDoc (path <.> ext) fileType
+    doc <- openDoc (path <.> ext) languageKind
     void waitForBuildQueue
     act doc
     documentContents doc
 
 goldenWithDocInTmpDir
   :: Pretty b
-  => T.Text
+  => LanguageKind
   -> Config
   -> PluginTestDescriptor b
   -> TestName
@@ -273,12 +273,12 @@ goldenWithDocInTmpDir
   -> FilePath
   -> (TextDocumentIdentifier -> Session ())
   -> TestTree
-goldenWithDocInTmpDir fileType config plugin title tree path desc ext act =
+goldenWithDocInTmpDir languageKind config plugin title tree path desc ext act =
   goldenGitDiff title (vftOriginalRoot tree </> path <.> desc <.> ext)
   $ runSessionWithServerInTmpDir config plugin tree
   $ TL.encodeUtf8 . TL.fromStrict
   <$> do
-    doc <- openDoc (path <.> ext) fileType
+    doc <- openDoc (path <.> ext) languageKind
     void waitForBuildQueue
     act doc
     documentContents doc

--- a/hls-test-utils/src/Test/Hls/Util.hs
+++ b/hls-test-utils/src/Test/Hls/Util.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE OverloadedLabels      #-}
 {-# LANGUAGE OverloadedStrings     #-}
 module Test.Hls.Util
   (  -- * Test Capabilities
@@ -58,7 +57,6 @@ import           Data.Bool                       (bool)
 import           Data.Default
 import           Data.List.Extra                 (find)
 import           Data.Proxy
-import           Data.Row
 import qualified Data.Set                        as Set
 import qualified Data.Text                       as T
 import           Development.IDE                 (GhcVersion (..), ghcVersion)
@@ -89,11 +87,11 @@ codeActionSupportCaps = def & L.textDocument ?~ textDocumentCaps
   where
     textDocumentCaps = def { _codeAction = Just codeActionCaps }
     codeActionCaps = CodeActionClientCapabilities (Just True) (Just literalSupport) (Just True) Nothing Nothing Nothing Nothing
-    literalSupport = #codeActionKind .==  (#valueSet .== [])
+    literalSupport = ClientCodeActionLiteralOptions (ClientCodeActionKindOptions [])
 
 codeActionResolveCaps :: ClientCapabilities
 codeActionResolveCaps = Test.fullCaps
-                          & (L.textDocument . _Just . L.codeAction . _Just . L.resolveSupport . _Just) .~ (#properties .== ["edit"])
+                          & (L.textDocument . _Just . L.codeAction . _Just . L.resolveSupport . _Just) .~ ClientCodeActionResolveOptions {_properties= ["edit"]}
                           & (L.textDocument . _Just . L.codeAction . _Just . L.dataSupport . _Just) .~ True
 
 codeActionNoResolveCaps :: ClientCapabilities

--- a/plugins/hls-cabal-plugin/test/Main.hs
+++ b/plugins/hls-cabal-plugin/test/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE OverloadedLabels         #-}
 {-# LANGUAGE OverloadedStrings        #-}
 
 module Main (
@@ -12,7 +11,6 @@ import           Control.Lens                    ((^.))
 import           Control.Monad                   (guard)
 import qualified Data.ByteString                 as BS
 import           Data.Either                     (isRight)
-import           Data.Row
 import qualified Data.Text                       as T
 import qualified Data.Text                       as Text
 import           Ide.Plugin.Cabal.LicenseSuggest (licenseErrorSuggestion)
@@ -117,13 +115,11 @@ pluginTests =
                     changeDoc
                         cabalDoc
                         [ TextDocumentContentChangeEvent $
-                            InL $
-                                #range
-                                    .== theRange
-                                    .+ #rangeLength
-                                    .== Nothing
-                                    .+ #text
-                                    .== "MIT3"
+                            InL TextDocumentContentChangePartial
+                                { _range = theRange
+                                , _rangeLength = Nothing
+                                , _text = "MIT3"
+                                }
                         ]
                     cabalDiags <- waitForDiagnosticsFrom cabalDoc
                     unknownLicenseDiag <- liftIO $ inspectDiagnostic cabalDiags ["Unknown SPDX license identifier: 'MIT3'"]

--- a/plugins/hls-class-plugin/test/Main.hs
+++ b/plugins/hls-class-plugin/test/Main.hs
@@ -13,7 +13,6 @@ import           Control.Lens                  (Prism', prism', view, (^.),
 import           Control.Monad                 (void)
 import           Data.Foldable                 (find)
 import           Data.Maybe
-import           Data.Row                      ((.==))
 import qualified Data.Text                     as T
 import qualified Ide.Plugin.Class              as Class
 import qualified Language.LSP.Protocol.Lens    as L
@@ -86,7 +85,7 @@ codeActionTests = testGroup
 
     -- Change the doc to ensure the version is not 0
     changeDoc doc
-        [ TextDocumentContentChangeEvent . InR . (.==) #text $
+        [ TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $
             T.unlines ["module Version where", "data A a = A a", "instance Functor A where"]
         ]
     ver2 <- (^. L.version) <$> getVersionedDoc doc

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultiWayIf        #-}
-{-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE ViewPatterns      #-}
@@ -15,7 +14,6 @@ import           Data.Aeson.Types           (Pair, Result (Success))
 import           Data.List                  (isInfixOf)
 import           Data.List.Extra            (nubOrdOn)
 import qualified Data.Map                   as Map
-import           Data.Row
 import qualified Data.Text                  as T
 import           Ide.Plugin.Config          (Config)
 import qualified Ide.Plugin.Config          as Plugin
@@ -303,7 +301,7 @@ evalInFile fp e expected = runSessionWithServerInTmpDir def evalPlugin (mkFs $ F
   doc <- openDoc fp "haskell"
   origin <- documentContents doc
   let withEval = origin <> e
-  changeDoc doc [TextDocumentContentChangeEvent . InR . (.==) #text $ withEval]
+  changeDoc doc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $ withEval]
   executeLensesBackwards doc
   result <- fmap T.strip . T.stripPrefix withEval <$> documentContents doc
   liftIO $ result @?= Just (T.strip expected)

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 module Main
@@ -12,7 +11,6 @@ import           Data.Functor               (void)
 import           Data.List                  (find)
 import qualified Data.Map                   as Map
 import           Data.Maybe                 (fromJust, isJust)
-import           Data.Row                   ((.+), (.==))
 import qualified Data.Text                  as T
 import           Ide.Plugin.Config          (Config (..))
 import qualified Ide.Plugin.Config          as Plugin
@@ -139,16 +137,22 @@ suggestionsTests =
         doc <- openDoc "Base.hs" "haskell"
         testHlintDiagnostics doc
 
-        let change = TextDocumentContentChangeEvent $ InL $ #range .== Range (Position 1 8) (Position 1 12)
-                                                         .+ #rangeLength .== Nothing
-                                                         .+ #text .== "x"
+        let change = TextDocumentContentChangeEvent $ InL
+              TextDocumentContentChangePartial
+                { _range = Range (Position 1 8) (Position 1 12)
+                , _rangeLength = Nothing
+                , _text = "x"
+                }
+
         changeDoc doc [change]
         expectNoMoreDiagnostics 3 doc "hlint"
 
-        let change' = TextDocumentContentChangeEvent $ InL $ #range .== Range (Position 1 8) (Position 1 12)
-                                                          .+ #rangeLength .== Nothing
-                                                          .+ #text .== "id x"
-
+        let change' = TextDocumentContentChangeEvent $ InL
+              TextDocumentContentChangePartial
+                { _range = Range (Position 1 8) (Position 1 12)
+                , _rangeLength = Nothing
+                , _text = "id x"
+                }
         changeDoc doc [change']
         testHlintDiagnostics doc
 

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -25,7 +25,6 @@ import           Data.List.NonEmpty                    (NonEmpty ((:|)),
 import qualified Data.Map                              as M
 import           Data.Maybe
 import           Data.Mod.Word
-import           Data.Row
 import qualified Data.Set                              as S
 import qualified Data.Text                             as T
 import           Development.IDE                       (Recorder, WithPriority,
@@ -77,7 +76,7 @@ prepareRenameProvider state _pluginId (PrepareRenameParams (TextDocumentIdentifi
     -- In particular it allows some cases through (e.g. cross-module renames),
     -- so that the full rename handler can give more informative error about them.
     let renameValid = not $ null namesUnderCursor
-    pure $ InL $ PrepareRenameResult $ InR $ InR $ #defaultBehavior .== renameValid
+    pure $ InL $ PrepareRenameResult $ InR $ InR $ PrepareRenameDefaultBehavior renameValid
 
 renameProvider :: PluginMethodHandler IdeState Method_TextDocumentRename
 renameProvider state pluginId (RenameParams _prog (TextDocumentIdentifier uri) pos newNameText) = do

--- a/plugins/hls-rename-plugin/test/Main.hs
+++ b/plugins/hls-rename-plugin/test/Main.hs
@@ -1,12 +1,11 @@
-{-# LANGUAGE OverloadedLabels  #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE OverloadedStrings        #-}
 
 module Main (main) where
 
 import           Control.Lens               ((^.))
 import           Data.Aeson
 import qualified Data.Map                   as M
-import           Data.Row                   ((.+), (.==))
 import           Data.Text                  (Text, pack)
 import           Ide.Plugin.Config
 import qualified Ide.Plugin.Rename          as Rename
@@ -81,9 +80,11 @@ tests = testGroup "Rename"
         expectNoMoreDiagnostics 3 doc "typecheck"
 
         -- Update the document so it doesn't compile
-        let change = TextDocumentContentChangeEvent $ InL $ #range .== Range (Position 2 13) (Position 2 17)
-                                                         .+ #rangeLength .== Nothing
-                                                         .+ #text .== "A"
+        let change = TextDocumentContentChangeEvent $ InL TextDocumentContentChangePartial
+              { _range = Range (Position 2 13) (Position 2 17)
+              , _rangeLength = Nothing
+              , _text = "A"
+              }
         changeDoc doc [change]
         diags@(tcDiag : _) <- waitForDiagnosticsFrom doc
 
@@ -101,9 +102,11 @@ tests = testGroup "Rename"
           renameErr ^. L.message @?= "rename: Rule Failed: GetHieAst"
 
         -- Update the document so it compiles
-        let change' = TextDocumentContentChangeEvent $ InL $ #range .== Range (Position 2 13) (Position 2 14)
-                                                          .+ #rangeLength .== Nothing
-                                                          .+ #text .== "Int"
+        let change' = TextDocumentContentChangeEvent $  InL TextDocumentContentChangePartial
+              { _range = Range (Position 2 13) (Position 2 14)
+              , _rangeLength = Nothing
+              , _text = "Int"
+              }
         changeDoc doc [change']
         expectNoMoreDiagnostics 3 doc "typecheck"
 

--- a/plugins/hls-semantic-tokens-plugin/test/SemanticTokensTest.hs
+++ b/plugins/hls-semantic-tokens-plugin/test/SemanticTokensTest.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE OverloadedLabels  #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE OverloadedStrings        #-}
 
 import           Control.Lens                       ((^.), (^?))
 import           Control.Monad.IO.Class             (liftIO)
@@ -177,7 +177,7 @@ semanticTokensConfigTest =
 
 semanticTokensFullDeltaTests :: TestTree
 semanticTokensFullDeltaTests =
-  testGroup "semanticTokensFullDeltaTests" $
+  testGroup "semanticTokensFullDeltaTests"
     [ testCase "null delta since unchanged" $ do
         let file1 = "TModuleA.hs"
         let expectDelta = InR (InL (SemanticTokensDelta (Just "1") []))
@@ -197,12 +197,11 @@ semanticTokensFullDeltaTests =
           _ <- waitForAction "TypeCheck" doc1
           _ <- Test.getSemanticTokens doc1
           -- open the file and append a line to it
-          let change =
-                TextDocumentContentChangeEvent $
-                  InL $
-                    #range .== Range (Position 4 0) (Position 4 6)
-                      .+ #rangeLength .== Nothing
-                      .+ #text .== "foo = 1"
+          let change = TextDocumentContentChangeEvent $ InL TextDocumentContentChangePartial
+                { _range = Range (Position 4 0) (Position 4 6)
+                , _rangeLength = Nothing
+                , _text = "foo = 1"
+                }
           changeDoc doc1 [change]
           _ <- waitForAction "TypeCheck" doc1
           delta <- getSemanticTokensFullDelta doc1 "0"
@@ -216,12 +215,11 @@ semanticTokensFullDeltaTests =
           _ <- waitForAction "TypeCheck" doc1
           _ <- Test.getSemanticTokens doc1
           -- open the file and append a line to it
-          let change =
-                TextDocumentContentChangeEvent $
-                  InL $
-                    #range .== Range (Position 2 0) (Position 2 28)
-                      .+ #rangeLength .== Nothing
-                      .+ #text .== Text.replicate 28 " "
+          let change = TextDocumentContentChangeEvent $ InL TextDocumentContentChangePartial
+                { _range = Range (Position 2 0) (Position 2 28)
+                , _rangeLength = Nothing
+                , _text = Text.replicate 28 " "
+                }
           changeDoc doc1 [change]
           _ <- waitForAction "TypeCheck" doc1
           delta <- getSemanticTokensFullDelta doc1 "0"

--- a/plugins/hls-semantic-tokens-plugin/test/SemanticTokensTest.hs
+++ b/plugins/hls-semantic-tokens-plugin/test/SemanticTokensTest.hs
@@ -9,8 +9,6 @@ import qualified Data.Aeson.KeyMap                  as KV
 import           Data.Default
 import           Data.Functor                       (void)
 import           Data.Map.Strict                    as Map hiding (map)
-import           Data.Row                           ((.==))
-import           Data.Row.Records                   ((.+))
 import           Data.String                        (fromString)
 import           Data.Text                          hiding (length, map,
                                                      unlines)

--- a/plugins/hls-splice-plugin/test/Main.hs
+++ b/plugins/hls-splice-plugin/test/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedLabels      #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ViewPatterns          #-}
 module Main
@@ -8,7 +7,6 @@ module Main
 
 import           Control.Monad           (void)
 import           Data.List               (find)
-import           Data.Row
 import           Data.Text               (Text)
 import qualified Data.Text               as T
 import qualified Data.Text.IO            as T
@@ -93,9 +91,10 @@ goldenTestWithEdit fp expect tc line col =
      waitForAllProgressDone
      alt <- liftIO $ T.readFile (fp <.> "error.hs")
      void $ applyEdit doc $ TextEdit theRange alt
-     changeDoc doc [TextDocumentContentChangeEvent $ InL $ #range .== theRange
-                                                        .+ #rangeLength .== Nothing
-                                                        .+ #text .== alt]
+     changeDoc doc [TextDocumentContentChangeEvent $ InL
+        TextDocumentContentChangePartial {_range = theRange, _rangeLength = Nothing, _text = alt}
+        ]
+
      void waitForDiagnostics
      -- wait for the entire build to finish
      void waitForBuildQueue

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -23,15 +23,9 @@ extra-deps:
 - monad-dijkstra-0.1.1.3
 - retrie-1.2.2
 - stylish-haskell-0.14.4.0
-# TODO switch to hackage release when new version published
-# - lsp-2.4.0.0
-# - lsp-test-0.17.0.0
-# - lsp-types-2.1.1.0
-- url: https://github.com/haskell/lsp/archive/b3c18fe44124eedd1ce9138321e753b08784ddba.tar.gz
-  subdirs:
-    - lsp
-    - lsp-types
-    - lsp-test
+- lsp-2.5.0.0
+- lsp-test-0.17.0.1
+- lsp-types-2.2.0.0
 
 # stan dependencies not found in the stackage snapshot
 - stan-0.1.2.0

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -23,9 +23,15 @@ extra-deps:
 - monad-dijkstra-0.1.1.3
 - retrie-1.2.2
 - stylish-haskell-0.14.4.0
-- lsp-2.4.0.0
-- lsp-test-0.17.0.0
-- lsp-types-2.1.1.0
+# TODO switch to hackage release when new version published
+# - lsp-2.4.0.0
+# - lsp-test-0.17.0.0
+# - lsp-types-2.1.1.0
+- url: https://github.com/haskell/lsp/archive/b3c18fe44124eedd1ce9138321e753b08784ddba.tar.gz
+  subdirs:
+    - lsp
+    - lsp-types
+    - lsp-test
 
 # stan dependencies not found in the stackage snapshot
 - stan-0.1.2.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,15 +20,9 @@ extra-deps:
 - hiedb-0.6.0.0
 - hie-bios-0.14.0
 - implicit-hie-0.1.4.0
-# TODO switch to hackage release when new version published
-# - lsp-2.4.0.0
-# - lsp-test-0.17.0.0
-# - lsp-types-2.1.1.0
-- url: https://github.com/haskell/lsp/archive/b3c18fe44124eedd1ce9138321e753b08784ddba.tar.gz
-  subdirs:
-    - lsp
-    - lsp-types
-    - lsp-test
+- lsp-2.5.0.0
+- lsp-test-0.17.0.1
+- lsp-types-2.2.0.0
 - monad-dijkstra-0.1.1.4
 
 # stan and friends

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,9 +20,15 @@ extra-deps:
 - hiedb-0.6.0.0
 - hie-bios-0.14.0
 - implicit-hie-0.1.4.0
-- lsp-2.4.0.0
-- lsp-test-0.17.0.0
-- lsp-types-2.1.1.0
+# TODO switch to hackage release when new version published
+# - lsp-2.4.0.0
+# - lsp-test-0.17.0.0
+# - lsp-types-2.1.1.0
+- url: https://github.com/haskell/lsp/archive/b3c18fe44124eedd1ce9138321e753b08784ddba.tar.gz
+  subdirs:
+    - lsp
+    - lsp-types
+    - lsp-test
 - monad-dijkstra-0.1.1.4
 
 # stan and friends


### PR DESCRIPTION
~New version of lsp* has not been released yet, but I upgraded hls codebase to master version to be able to test https://github.com/haskell/lsp/pull/566~

UPDATE: we're not going to merge the "disable progress messages" PR in lsp repo,
but this PR can still be used because it contains all the fixes to breaking changes in lsp repo.