### PR TITLE
Drop Legacy Logger from Codebase

### DIFF
--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -41,11 +41,8 @@ import qualified Data.Text                          as T
 import qualified Data.Text.IO                       as T
 import           Development.IDE.LSP.LanguageServer (runLanguageServer)
 import qualified Development.IDE.Main               as Main
-import           GHC.Stack.Types                    (emptyCallStack)
-import           Ide.Logger                         (Doc, Logger (Logger),
-                                                     Pretty (pretty),
-                                                     Recorder (logger_),
-                                                     WithPriority (WithPriority),
+import           Ide.Logger                         (Doc, Pretty (pretty),
+                                                     Recorder, WithPriority,
                                                      cmapWithPrio,
                                                      makeDefaultStderrRecorder)
 import           Ide.Plugin.Config                  (Config)
@@ -272,9 +269,7 @@ newtype ErrorLSPM c a = ErrorLSPM { unErrorLSPM :: (LspM c) a }
 -- to shut down the LSP.
 launchErrorLSP :: Recorder (WithPriority (Doc ())) -> T.Text -> IO ()
 launchErrorLSP recorder errorMsg = do
-  let logger = Logger $ \p m -> logger_ recorder (WithPriority p emptyCallStack (pretty m))
-
-  let defaultArguments = Main.defaultArguments (cmapWithPrio pretty recorder) logger (IdePlugins [])
+  let defaultArguments = Main.defaultArguments (cmapWithPrio pretty recorder) (IdePlugins [])
 
   inH <- Main.argsHandleIn defaultArguments
 

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -42,10 +42,11 @@ import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options            (IdeTesting (..))
 import           GHC.TypeLits                             (KnownSymbol)
 import           Ide.Logger                               (Pretty (pretty),
+                                                           Priority (..),
                                                            Recorder,
                                                            WithPriority,
                                                            cmapWithPrio,
-                                                           logDebug)
+                                                           logWith)
 import qualified Language.LSP.Protocol.Message            as LSP
 import qualified Language.LSP.Server                      as LSP
 
@@ -110,16 +111,16 @@ addFileOfInterest state f v = do
         pure (new, (prev, new))
     when (prev /= Just v) $ do
         join $ atomically $ recordDirtyKeys (shakeExtras state) IsFileOfInterest [f]
-        logDebug (ideLogger state) $
-            "Set files of interest to: " <> T.pack (show files)
+        logWith (ideLogger state) Debug $
+            LogSetFilesOfInterest (HashMap.toList files)
 
 deleteFileOfInterest :: IdeState -> NormalizedFilePath -> IO ()
 deleteFileOfInterest state f = do
     OfInterestVar var <- getIdeGlobalState state
     files <- modifyVar' var $ HashMap.delete f
     join $ atomically $ recordDirtyKeys (shakeExtras state) IsFileOfInterest [f]
-    logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show files)
-
+    logWith (ideLogger state) Debug $
+        LogSetFilesOfInterest (HashMap.toList files)
 scheduleGarbageCollection :: IdeState -> IO ()
 scheduleGarbageCollection state = do
     GarbageCollectVar var <- getIdeGlobalState state

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -41,6 +41,8 @@ import           Development.IDE.Spans.Common
 import           Development.IDE.Spans.LocalBindings
 import           Development.IDE.Types.Diagnostics
 import           GHC.Serialized                               (Serialized)
+import           Ide.Logger                                   (Pretty (..),
+                                                               viaShow)
 import           Language.LSP.Protocol.Types                  (Int32,
                                                                NormalizedFilePath)
 
@@ -339,6 +341,9 @@ data FileOfInterestStatus
   deriving (Eq, Show, Typeable, Generic)
 instance Hashable FileOfInterestStatus
 instance NFData   FileOfInterestStatus
+
+instance Pretty FileOfInterestStatus where
+    pretty = viaShow
 
 data IsFileOfInterestResult = NotFOI | IsFOI FileOfInterestStatus
   deriving (Eq, Show, Typeable, Generic)

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -22,8 +22,7 @@ import           Development.IDE.Core.FileExists  (fileExistsRules)
 import           Development.IDE.Core.OfInterest  hiding (Log, LogShake)
 import           Development.IDE.Graph
 import           Development.IDE.Types.Options    (IdeOptions (..))
-import           Ide.Logger                       as Logger (Logger,
-                                                             Pretty (pretty),
+import           Ide.Logger                       as Logger (Pretty (pretty),
                                                              Priority (Debug),
                                                              Recorder,
                                                              WithPriority,
@@ -63,14 +62,13 @@ initialise :: Recorder (WithPriority Log)
            -> IdePlugins IdeState
            -> Rules ()
            -> Maybe (LSP.LanguageContextEnv Config)
-           -> Logger
            -> Debouncer LSP.NormalizedUri
            -> IdeOptions
            -> WithHieDb
            -> IndexQueue
            -> Monitoring
            -> IO IdeState
-initialise recorder defaultConfig plugins mainRule lspEnv logger debouncer options withHieDb hiedbChan metrics = do
+initialise recorder defaultConfig plugins mainRule lspEnv debouncer options withHieDb hiedbChan metrics = do
     shakeProfiling <- do
         let fromConf = optShakeProfiling options
         fromEnv <- lookupEnv "GHCIDE_BUILD_PROFILING"
@@ -80,7 +78,6 @@ initialise recorder defaultConfig plugins mainRule lspEnv logger debouncer optio
         lspEnv
         defaultConfig
         plugins
-        logger
         debouncer
         shakeProfiling
         (optReportProgress options)

--- a/ghcide/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/ghcide/src/Development/IDE/LSP/HoverDefinition.hs
@@ -4,9 +4,9 @@
 
 -- | Display information on hover.
 module Development.IDE.LSP.HoverDefinition
-    (
+    ( Log(..)
     -- * For haskell-language-server
-    hover
+    , hover
     , gotoDefinition
     , gotoTypeDefinition
     , documentHighlight
@@ -18,8 +18,9 @@ import           Control.Monad.Except           (ExceptT)
 import           Control.Monad.IO.Class
 import           Data.Maybe                     (fromMaybe)
 import           Development.IDE.Core.Actions
-import           Development.IDE.Core.Rules
-import           Development.IDE.Core.Shake
+import qualified Development.IDE.Core.Rules     as Shake
+import           Development.IDE.Core.Shake     (IdeAction, IdeState (..),
+                                                 ideLogger, runIdeAction)
 import           Development.IDE.Types.Location
 import           Ide.Logger
 import           Ide.Plugin.Error
@@ -30,26 +31,37 @@ import qualified Language.LSP.Server            as LSP
 
 import qualified Data.Text                      as T
 
-gotoDefinition :: IdeState -> TextDocumentPositionParams -> ExceptT PluginError (LSP.LspM c) (MessageResult Method_TextDocumentDefinition)
-hover          :: IdeState -> TextDocumentPositionParams -> ExceptT PluginError (LSP.LspM c) (Hover |? Null)
-gotoTypeDefinition :: IdeState -> TextDocumentPositionParams -> ExceptT PluginError (LSP.LspM c) (MessageResult Method_TextDocumentTypeDefinition)
-documentHighlight :: IdeState -> TextDocumentPositionParams -> ExceptT PluginError (LSP.LspM c) ([DocumentHighlight] |? Null)
+
+data Log
+  = LogWorkspaceSymbolRequest !T.Text
+  | LogRequest !T.Text !Position !NormalizedFilePath
+  deriving (Show)
+
+instance Pretty Log where
+  pretty = \case
+    LogWorkspaceSymbolRequest query -> "Workspace symbols request:" <+> pretty query
+    LogRequest label pos nfp ->
+      pretty label <+> "request at position" <+> pretty (showPosition pos) <+>
+        "in file:" <+> pretty (fromNormalizedFilePath nfp)
+
+gotoDefinition     :: Recorder (WithPriority Log) -> IdeState -> TextDocumentPositionParams -> ExceptT PluginError (LSP.LspM c) (MessageResult Method_TextDocumentDefinition)
+hover              :: Recorder (WithPriority Log) -> IdeState -> TextDocumentPositionParams -> ExceptT PluginError (LSP.LspM c) (Hover |? Null)
+gotoTypeDefinition :: Recorder (WithPriority Log) -> IdeState -> TextDocumentPositionParams -> ExceptT PluginError (LSP.LspM c) (MessageResult Method_TextDocumentTypeDefinition)
+documentHighlight  :: Recorder (WithPriority Log) -> IdeState -> TextDocumentPositionParams -> ExceptT PluginError (LSP.LspM c) ([DocumentHighlight] |? Null)
 gotoDefinition = request "Definition" getDefinition (InR $ InR Null) (InL . Definition. InR)
 gotoTypeDefinition = request "TypeDefinition" getTypeDefinition (InR $ InR Null) (InL . Definition. InR)
 hover          = request "Hover"      getAtPoint     (InR Null)     foundHover
 documentHighlight = request "DocumentHighlight" highlightAtPoint (InR Null) InL
 
-references :: PluginMethodHandler IdeState Method_TextDocumentReferences
-references ide _ (ReferenceParams (TextDocumentIdentifier uri) pos _ _ _) = do
+references :: Recorder (WithPriority Log) -> PluginMethodHandler IdeState Method_TextDocumentReferences
+references recorder ide _ (ReferenceParams (TextDocumentIdentifier uri) pos _ _ _) = do
   nfp <- getNormalizedFilePathE uri
-  liftIO $ logDebug (ideLogger ide) $
-        "References request at position " <> T.pack (showPosition pos) <>
-        " in file: " <> T.pack (show nfp)
-  InL <$> (liftIO $ runAction "references" ide $ refsAtPoint nfp pos)
+  liftIO $ logWith recorder Debug $ LogRequest "References" pos nfp
+  InL <$> (liftIO $ Shake.runAction "references" ide $ refsAtPoint nfp pos)
 
-wsSymbols :: PluginMethodHandler IdeState Method_WorkspaceSymbol
-wsSymbols ide _ (WorkspaceSymbolParams _ _ query) = liftIO $ do
-  logDebug (ideLogger ide) $ "Workspace symbols request: " <> query
+wsSymbols :: Recorder (WithPriority Log) -> PluginMethodHandler IdeState Method_WorkspaceSymbol
+wsSymbols recorder ide _ (WorkspaceSymbolParams _ _ query) = liftIO $ do
+  logWith recorder Debug $ LogWorkspaceSymbolRequest query
   runIdeAction "WorkspaceSymbols" (shakeExtras ide) $ InL . fromMaybe [] <$> workspaceSymbols query
 
 foundHover :: (Maybe Range, [T.Text]) -> Hover |? Null
@@ -62,19 +74,18 @@ request
   -> (NormalizedFilePath -> Position -> IdeAction (Maybe a))
   -> b
   -> (a -> b)
+  -> Recorder (WithPriority Log)
   -> IdeState
   -> TextDocumentPositionParams
   -> ExceptT PluginError (LSP.LspM c) b
-request label getResults notFound found ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = liftIO $ do
+request label getResults notFound found recorder ide (TextDocumentPositionParams (TextDocumentIdentifier uri) pos) = liftIO $ do
     mbResult <- case uriToFilePath' uri of
-        Just path -> logAndRunRequest label getResults ide pos path
+        Just path -> logAndRunRequest recorder label getResults ide pos path
         Nothing   -> pure Nothing
     pure $ maybe notFound found mbResult
 
-logAndRunRequest :: T.Text -> (NormalizedFilePath -> Position -> IdeAction b) -> IdeState -> Position -> String -> IO b
-logAndRunRequest label getResults ide pos path = do
+logAndRunRequest :: Recorder (WithPriority Log) -> T.Text -> (NormalizedFilePath -> Position -> IdeAction b) -> IdeState -> Position -> String -> IO b
+logAndRunRequest recorder label getResults ide pos path = do
   let filePath = toNormalizedFilePath' path
-  logDebug (ideLogger ide) $
-    label <> " request at position " <> T.pack (showPosition pos) <>
-    " in file: " <> T.pack path
+  logWith recorder Debug $ LogRequest label pos filePath
   runIdeAction (T.unpack label) (shakeExtras ide) (getResults filePath pos)

--- a/ghcide/src/Development/IDE/Plugin/HLS/GhcIde.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS/GhcIde.hs
@@ -9,7 +9,7 @@ module Development.IDE.Plugin.HLS.GhcIde
   ) where
 import           Control.Monad.IO.Class
 import           Development.IDE
-import           Development.IDE.LSP.HoverDefinition
+import qualified Development.IDE.LSP.HoverDefinition as Hover
 import qualified Development.IDE.LSP.Notifications   as Notifications
 import           Development.IDE.LSP.Outline
 import qualified Development.IDE.Plugin.Completions  as Completions
@@ -23,6 +23,7 @@ data Log
   = LogNotifications Notifications.Log
   | LogCompletions Completions.Log
   | LogTypeLenses TypeLenses.Log
+  | LogHover Hover.Log
   deriving Show
 
 instance Pretty Log where
@@ -30,10 +31,11 @@ instance Pretty Log where
     LogNotifications msg -> pretty msg
     LogCompletions msg   -> pretty msg
     LogTypeLenses msg    -> pretty msg
+    LogHover msg         -> pretty msg
 
 descriptors :: Recorder (WithPriority Log) -> [PluginDescriptor IdeState]
 descriptors recorder =
-  [ descriptor "ghcide-hover-and-symbols",
+  [ descriptor (cmapWithPrio LogHover recorder) "ghcide-hover-and-symbols",
     Completions.descriptor (cmapWithPrio LogCompletions recorder) "ghcide-completions",
     TypeLenses.descriptor (cmapWithPrio LogTypeLenses recorder) "ghcide-type-lenses",
     Notifications.descriptor (cmapWithPrio LogNotifications recorder) "ghcide-core"
@@ -41,18 +43,18 @@ descriptors recorder =
 
 -- ---------------------------------------------------------------------
 
-descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId desc)
-  { pluginHandlers = mkPluginHandler SMethod_TextDocumentHover hover'
+descriptor :: Recorder (WithPriority Hover.Log) -> PluginId -> PluginDescriptor IdeState
+descriptor recorder plId = (defaultPluginDescriptor plId desc)
+  { pluginHandlers = mkPluginHandler SMethod_TextDocumentHover (hover' recorder)
                   <> mkPluginHandler SMethod_TextDocumentDocumentSymbol moduleOutline
                   <> mkPluginHandler SMethod_TextDocumentDefinition (\ide _ DefinitionParams{..} ->
-                      gotoDefinition ide TextDocumentPositionParams{..})
+                      Hover.gotoDefinition recorder ide TextDocumentPositionParams{..})
                   <> mkPluginHandler SMethod_TextDocumentTypeDefinition (\ide _ TypeDefinitionParams{..} ->
-                      gotoTypeDefinition ide TextDocumentPositionParams{..})
+                      Hover.gotoTypeDefinition recorder ide TextDocumentPositionParams{..})
                   <> mkPluginHandler SMethod_TextDocumentDocumentHighlight (\ide _ DocumentHighlightParams{..} ->
-                      documentHighlight ide TextDocumentPositionParams{..})
-                  <> mkPluginHandler SMethod_TextDocumentReferences references
-                  <> mkPluginHandler SMethod_WorkspaceSymbol wsSymbols,
+                      Hover.documentHighlight recorder ide TextDocumentPositionParams{..})
+                  <> mkPluginHandler SMethod_TextDocumentReferences (Hover.references recorder)
+                  <> mkPluginHandler SMethod_WorkspaceSymbol (Hover.wsSymbols recorder),
 
     pluginConfigDescriptor = defaultConfigDescriptor
   }
@@ -61,7 +63,6 @@ descriptor plId = (defaultPluginDescriptor plId desc)
 
 -- ---------------------------------------------------------------------
 
-hover' :: PluginMethodHandler IdeState Method_TextDocumentHover
-hover' ideState _ HoverParams{..} = do
-    liftIO $ logDebug (ideLogger ideState) "GhcIde.hover entered (ideLogger)" -- AZ
-    hover ideState TextDocumentPositionParams{..}
+hover' :: Recorder (WithPriority Hover.Log) -> PluginMethodHandler IdeState Method_TextDocumentHover
+hover' recorder ideState _ HoverParams{..} =
+    Hover.hover recorder ideState TextDocumentPositionParams{..}

--- a/ghcide/test/exe/Main.hs
+++ b/ghcide/test/exe/Main.hs
@@ -30,62 +30,55 @@
 
 module Main (main) where
 -- import Test.QuickCheck.Instances ()
-import           Data.Function                            ((&))
-import           Ide.Logger             (Logger (Logger),
-                                                           LoggingColumn (DataColumn, PriorityColumn),
-                                                           Pretty (pretty),
-                                                           Priority (Debug),
-                                                           Recorder (Recorder, logger_),
-                                                           WithPriority (WithPriority, priority),
-                                                           cfilter,
-                                                           cmapWithPrio,
-                                                           makeDefaultStderrRecorder)
-import           GHC.Stack                                (emptyCallStack)
+import           Data.Function                ((&))
 import qualified HieDbRetry
+import           Ide.Logger                   (LoggingColumn (DataColumn, PriorityColumn),
+                                               Pretty (pretty),
+                                               Priority (Debug),
+                                               WithPriority (WithPriority, priority),
+                                               cfilter, cmapWithPrio,
+                                               makeDefaultStderrRecorder)
 import           Test.Tasty
 import           Test.Tasty.Ingredients.Rerun
 
-import LogType ()
-import OpenCloseTest
-import InitializeResponseTests
-import CompletionTests
-import CPPTests
-import DiagnosticTests
-import CodeLensTests
-import OutlineTests
-import HighlightTests
-import FindDefinitionAndHoverTests
-import PluginSimpleTests
-import PreprocessorTests
-import THTests
-import SymlinkTests
-import SafeTests
-import UnitTests
-import HaddockTests
-import PositionMappingTests
-import WatchedFileTests
-import CradleTests
-import DependentFileTest
-import NonLspCommandLine
-import IfaceTests
-import BootTests
-import RootUriTests
-import AsyncTests
-import ClientSettingsTests
-import ReferenceTests
-import GarbageCollectionTests
-import ExceptionTests
+import           AsyncTests
+import           BootTests
+import           ClientSettingsTests
+import           CodeLensTests
+import           CompletionTests
+import           CPPTests
+import           CradleTests
+import           DependentFileTest
+import           DiagnosticTests
+import           ExceptionTests
+import           FindDefinitionAndHoverTests
+import           GarbageCollectionTests
+import           HaddockTests
+import           HighlightTests
+import           IfaceTests
+import           InitializeResponseTests
+import           LogType                      ()
+import           NonLspCommandLine
+import           OpenCloseTest
+import           OutlineTests
+import           PluginSimpleTests
+import           PositionMappingTests
+import           PreprocessorTests
+import           ReferenceTests
+import           RootUriTests
+import           SafeTests
+import           SymlinkTests
+import           THTests
+import           UnitTests
+import           WatchedFileTests
 
 main :: IO ()
 main = do
   docWithPriorityRecorder <- makeDefaultStderrRecorder (Just [PriorityColumn, DataColumn])
 
-  let docWithFilteredPriorityRecorder@Recorder{ logger_ } =
+  let docWithFilteredPriorityRecorder =
         docWithPriorityRecorder
         & cfilter (\WithPriority{ priority } -> priority >= Debug)
-
-  -- exists so old-style logging works. intended to be phased out
-  let logger = Logger $ \p m -> logger_ (WithPriority p emptyCallStack (pretty m))
 
   let recorder = docWithFilteredPriorityRecorder
                & cmapWithPrio pretty
@@ -106,7 +99,7 @@ main = do
     , THTests.tests
     , SymlinkTests.tests
     , SafeTests.tests
-    , UnitTests.tests recorder logger
+    , UnitTests.tests recorder
     , HaddockTests.tests
     , PositionMappingTests.tests
     , WatchedFileTests.tests
@@ -121,5 +114,5 @@ main = do
     , ReferenceTests.tests
     , GarbageCollectionTests.tests
     , HieDbRetry.tests
-    , ExceptionTests.tests recorder logger
+    , ExceptionTests.tests recorder
     ]

--- a/ghcide/test/exe/UnitTests.hs
+++ b/ghcide/test/exe/UnitTests.hs
@@ -14,8 +14,8 @@ import qualified Development.IDE.Plugin.HLS.GhcIde as Ghcide
 import qualified Development.IDE.Types.Diagnostics as Diagnostics
 import           Development.IDE.Types.Location
 import qualified FuzzySearch
-import           Ide.Logger                        (Logger, Recorder,
-                                                    WithPriority, cmapWithPrio)
+import           Ide.Logger                        (Recorder, WithPriority,
+                                                    cmapWithPrio)
 import           Ide.PluginUtils                   (pluginDescToIdePlugins)
 import           Ide.Types
 import           Language.LSP.Protocol.Message
@@ -36,8 +36,8 @@ import           Test.Tasty.HUnit
 import           TestUtils
 import           Text.Printf                       (printf)
 
-tests :: Recorder (WithPriority Log) -> Logger -> TestTree
-tests recorder logger = do
+tests :: Recorder (WithPriority Log) -> TestTree
+tests recorder = do
   testGroup "Unit"
      [ testCase "empty file path does NOT work with the empty String literal" $
          uriToFilePath' (fromNormalizedUri $ filePathToUri' "") @?= Just "."
@@ -82,7 +82,7 @@ tests recorder logger = do
                 ] ++ Ghcide.descriptors (cmapWithPrio LogGhcIde recorder)
             priorityPluginDescriptor i = (defaultPluginDescriptor (fromString $ show i) ""){pluginPriority = i}
 
-        testIde recorder (IDE.testing (cmapWithPrio LogIDEMain recorder) logger plugins) $ do
+        testIde recorder (IDE.testing (cmapWithPrio LogIDEMain recorder) plugins) $ do
             _ <- createDoc "A.hs" "haskell" "module A where"
             waitForProgressDone
             actualOrder <- liftIO $ reverse <$> readIORef orderRef

--- a/hls-plugin-api/src/Ide/Logger.hs
+++ b/hls-plugin-api/src/Ide/Logger.hs
@@ -10,10 +10,7 @@
 -- framework they want to.
 module Ide.Logger
   ( Priority(..)
-  , Logger(..)
   , Recorder(..)
-  , logError, logWarning, logInfo, logDebug
-  , noLogging
   , WithPriority(..)
   , logWith
   , cmap
@@ -80,32 +77,6 @@ data Priority
       -- should be investigated.
     | Error -- ^ Such log messages must never occur in expected usage.
     deriving (Eq, Show, Read, Ord, Enum, Bounded)
-
--- | Note that this is logging actions _of the program_, not of the user.
---   You shouldn't call warning/error if the user has caused an error, only
---   if our code has gone wrong and is itself erroneous (e.g. we threw an exception).
-newtype Logger = Logger {logPriority :: Priority -> T.Text -> IO ()}
-
-instance Semigroup Logger where
-    l1 <> l2 = Logger $ \p t -> logPriority l1 p t >> logPriority l2 p t
-
-instance Monoid Logger where
-    mempty = Logger $ \_ _ -> pure ()
-
-logError :: Logger -> T.Text -> IO ()
-logError x = logPriority x Error
-
-logWarning :: Logger -> T.Text -> IO ()
-logWarning x = logPriority x Warning
-
-logInfo :: Logger -> T.Text -> IO ()
-logInfo x = logPriority x Info
-
-logDebug :: Logger -> T.Text -> IO ()
-logDebug x = logPriority x Debug
-
-noLogging :: Logger
-noLogging = Logger $ \_ _ -> return ()
 
 data WithPriority a = WithPriority { priority :: Priority, callStack_ :: CallStack, payload :: a } deriving Functor
 

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval.hs
@@ -8,16 +8,15 @@ Eval Plugin entry point.
 -}
 module Ide.Plugin.Eval (
     descriptor,
-    Log(..)
+    Eval.Log(..)
     ) where
 
 import           Development.IDE               (IdeState)
-import           Ide.Logger                    (Pretty (pretty), Recorder,
-                                                WithPriority, cmapWithPrio)
+import           Ide.Logger                    (Recorder, WithPriority)
 import qualified Ide.Plugin.Eval.CodeLens      as CL
 import           Ide.Plugin.Eval.Config
 import           Ide.Plugin.Eval.Rules         (rules)
-import qualified Ide.Plugin.Eval.Rules         as EvalRules
+import qualified Ide.Plugin.Eval.Types         as Eval
 import           Ide.Types                     (ConfigDescriptor (..),
                                                 PluginDescriptor (..), PluginId,
                                                 defaultConfigDescriptor,
@@ -25,19 +24,13 @@ import           Ide.Types                     (ConfigDescriptor (..),
                                                 mkCustomConfig, mkPluginHandler)
 import           Language.LSP.Protocol.Message
 
-newtype Log = LogEvalRules EvalRules.Log deriving Show
-
-instance Pretty Log where
-  pretty = \case
-    LogEvalRules log -> pretty log
-
 -- |Plugin descriptor
-descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
+descriptor :: Recorder (WithPriority Eval.Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
     (defaultPluginDescriptor plId "Provies a code lens to evaluate expressions in doctest comments")
-        { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeLens CL.codeLens
-        , pluginCommands = [CL.evalCommand plId]
-        , pluginRules = rules (cmapWithPrio LogEvalRules recorder)
+        { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeLens (CL.codeLens recorder)
+        , pluginCommands = [CL.evalCommand recorder plId]
+        , pluginRules = rules recorder
         , pluginConfigDescriptor = defaultConfigDescriptor
                                    { configCustomConfig = mkCustomConfig properties
                                    }

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Rules.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Rules.hs
@@ -33,22 +33,15 @@ import           Development.IDE.Core.Shake           (IsIdeGlobal,
                                                        addIdeGlobal,
                                                        getIdeGlobalAction,
                                                        getIdeGlobalState)
-import qualified Development.IDE.Core.Shake           as Shake
 import           Development.IDE.GHC.Compat
 import qualified Development.IDE.GHC.Compat           as SrcLoc
 import qualified Development.IDE.GHC.Compat.Util      as FastString
 import           Development.IDE.Graph                (alwaysRerun)
 import           GHC.Parser.Annotation
-import           Ide.Logger                           (Pretty (pretty),
-                                                       Recorder, WithPriority,
+import           Ide.Logger                           (Recorder, WithPriority,
                                                        cmapWithPrio)
 import           Ide.Plugin.Eval.Types
 
-newtype Log = LogShake Shake.Log deriving Show
-
-instance Pretty Log where
-  pretty = \case
-    LogShake shakeLog -> pretty shakeLog
 
 rules :: Recorder (WithPriority Log) -> Rules ()
 rules recorder = do

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
@@ -1,12 +1,16 @@
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wwarn #-}
 
 module Ide.Plugin.Eval.Types
-    ( locate,
+    ( Log(..),
+      locate,
       locate0,
       Test (..),
       isProperty,
@@ -30,17 +34,75 @@ module Ide.Plugin.Eval.Types
       nullComments)
 where
 
-import           Control.DeepSeq               (deepseq)
-import           Data.Aeson                    (FromJSON, ToJSON)
-import           Data.List                     (partition)
-import           Data.List.NonEmpty            (NonEmpty)
-import           Data.Map.Strict               (Map)
-import           Data.String                   (IsString (..))
-import           Development.IDE               (Range, RuleResult)
+import           Control.Arrow                   ((>>>))
+import           Control.DeepSeq                 (deepseq)
+import           Control.Lens
+import           Data.Aeson                      (FromJSON, ToJSON)
+import           Data.List                       (partition)
+import           Data.List.NonEmpty              (NonEmpty)
+import           Data.Map.Strict                 (Map)
+import           Data.String                     (IsString (..))
+import qualified Data.Text                       as T
+import           Development.IDE                 (Range, RuleResult)
+import qualified Development.IDE.Core.Shake      as Shake
+import qualified Development.IDE.GHC.Compat.Core as Core
 import           Development.IDE.Graph.Classes
-import           GHC.Generics                  (Generic)
-import           Language.LSP.Protocol.Types   (TextDocumentIdentifier)
-import qualified Text.Megaparsec               as P
+import           GHC.Generics                    (Generic)
+import           Ide.Logger
+import           Ide.Plugin.Eval.GHC             (showDynFlags)
+import           Ide.Plugin.Eval.Util
+import           Language.LSP.Protocol.Types     (TextDocumentIdentifier,
+                                                  TextEdit)
+import qualified System.Time.Extra               as Extra
+import qualified Text.Megaparsec                 as P
+
+data Log
+    = LogShake Shake.Log
+    | LogCodeLensFp FilePath
+    | LogCodeLensComments Comments
+    | LogExecutionTime T.Text Extra.Seconds
+    | LogTests !Int !Int !Int !Int
+    | LogRunTestResults [T.Text]
+    | LogRunTestEdits TextEdit
+    | LogEvalFlags [String]
+    | LogEvalPreSetDynFlags Core.DynFlags
+    | LogEvalParsedFlags
+        (Either
+            Core.GhcException
+            (Core.DynFlags, [Core.Located String], DynFlagsParsingWarnings))
+    | LogEvalPostSetDynFlags Core.DynFlags
+    | LogEvalStmtStart String
+    | LogEvalStmtResult (Maybe [T.Text])
+    | LogEvalImport String
+    | LogEvalDeclaration String
+
+instance Pretty Log where
+    pretty = \case
+        LogShake shakeLog -> pretty shakeLog
+        LogCodeLensFp fp -> "fp" <+> pretty fp
+        LogCodeLensComments comments -> "comments" <+> viaShow comments
+        LogExecutionTime lbl duration -> pretty lbl <> ":" <+> pretty (Extra.showDuration duration)
+        LogTests nTests nNonSetupSections nSetupSections nLenses -> "Tests" <+> fillSep
+            [ pretty nTests
+            , "tests in"
+            , pretty nNonSetupSections
+            , "sections"
+            , pretty nSetupSections
+            , "setups"
+            , pretty nLenses
+            , "lenses."
+            ]
+        LogRunTestResults results ->  "TEST RESULTS" <+> viaShow results
+        LogRunTestEdits edits -> "TEST EDIT" <+> viaShow edits
+        LogEvalFlags flags -> "{:SET" <+> pretty flags
+        LogEvalPreSetDynFlags dynFlags -> "pre set" <+> pretty (showDynFlags dynFlags)
+        LogEvalParsedFlags eans -> "parsed flags" <+> viaShow (eans
+              <&> (_1 %~ showDynFlags >>> _3 %~ prettyWarnings))
+        LogEvalPostSetDynFlags dynFlags -> "post set" <+> pretty (showDynFlags dynFlags)
+        LogEvalStmtStart stmt -> "{STMT" <+> pretty stmt
+        LogEvalStmtResult result -> "STMT}" <+> pretty result
+        LogEvalImport stmt -> "{IMPORT" <+> pretty stmt
+        LogEvalDeclaration stmt -> "{DECL" <+> pretty stmt
 
 -- | A thing with a location attached.
 data Located l a = Located {location :: l, located :: a}

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# OPTIONS_GHC -Wno-orphans -Wno-unused-imports #-}
+{-# LANGUAGE RecordWildCards           #-}
 
 -- |Debug utilities
 module Ide.Plugin.Eval.Util (
@@ -8,7 +9,8 @@ module Ide.Plugin.Eval.Util (
     isLiterate,
     response',
     gStrictTry,
-    logWith,
+    DynFlagsParsingWarnings,
+    prettyWarnings,
 ) where
 
 import           Control.Exception                     (SomeException, evaluate,
@@ -22,9 +24,11 @@ import           Data.Aeson                            (Value)
 import           Data.Bifunctor                        (second)
 import           Data.String                           (IsString (fromString))
 import qualified Data.Text                             as T
-import           Development.IDE                       (IdeState, Priority (..),
-                                                        ideLogger, logPriority)
+import           Development.IDE                       (IdeState,
+                                                        printOutputable)
 import qualified Development.IDE.Core.PluginUtils      as PluginUtils
+import qualified Development.IDE.GHC.Compat.Core       as Core
+import qualified Development.IDE.GHC.Compat.Core       as SrcLoc
 import           Development.IDE.GHC.Compat.Outputable
 import           Development.IDE.GHC.Compat.Util       (MonadCatch, bagToList,
                                                         catch)
@@ -38,35 +42,15 @@ import           Language.LSP.Protocol.Message
 import           Language.LSP.Protocol.Types
 import           Language.LSP.Server
 import           System.FilePath                       (takeExtension)
+import qualified System.Time.Extra                     as Extra
 import           System.Time.Extra                     (duration, showDuration)
 import           UnliftIO.Exception                    (catchAny)
 
-timed :: MonadIO m => (t -> String -> m a) -> t -> m b -> m b
+timed :: MonadIO m => (t -> Extra.Seconds -> m a) -> t -> m b -> m b
 timed out name op = do
     (secs, r) <- duration op
-    _ <- out name (showDuration secs)
+    _ <- out name secs
     return r
-
--- | Log using hie logger, reports source position of logging statement
-logWith :: (HasCallStack, MonadIO m, Show a1, Show a2) => IdeState -> a1 -> a2 -> m ()
-logWith state key val =
-    liftIO . logPriority (ideLogger state) logLevel $
-        T.unwords
-            [T.pack logWithPos, asT key, asT val]
-  where
-    logWithPos =
-        let stk = toList callStack
-            pr pos = concat [srcLocFile pos, ":", show . srcLocStartLine $ pos, ":", show . srcLocStartCol $ pos]
-         in case stk of
-              []    -> ""
-              (x:_) -> pr $ snd x
-
-    asT :: Show a => a -> T.Text
-    asT = T.pack . show
-
--- | Set to Info to see extensive debug info in hie log, set to Debug in production
-logLevel :: Priority
-logLevel = Debug -- Info
 
 isLiterate :: FilePath -> Bool
 isLiterate x = takeExtension x `elem` [".lhs", ".lhs-boot"]
@@ -109,3 +93,20 @@ showErr e =
     _ ->
 #endif
       return . show $ e
+
+#if MIN_VERSION_ghc(9,8,0)
+type DynFlagsParsingWarnings = Messages DriverMessage
+
+prettyWarnings :: DynFlagsParsingWarnings -> String
+prettyWarnings = printWithoutUniques . pprMessages (defaultDiagnosticOpts @DriverMessage)
+#else
+type DynFlagsParsingWarnings = [Core.Warn]
+
+prettyWarnings :: DynFlagsParsingWarnings -> String
+prettyWarnings = unlines . map prettyWarn
+
+prettyWarn :: Core.Warn -> String
+prettyWarn Core.Warn{..} =
+    T.unpack (printOutputable $ SrcLoc.getLoc warnMsg) <> ": warning:\n"
+    <> "    " <> SrcLoc.unLoc warnMsg
+#endif

--- a/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
+++ b/plugins/hls-retrie-plugin/src/Ide/Plugin/Retrie.hs
@@ -11,7 +11,7 @@
 
 {-# OPTIONS -Wno-orphans #-}
 
-module Ide.Plugin.Retrie (descriptor) where
+module Ide.Plugin.Retrie (descriptor, Log) where
 
 import           Control.Concurrent.STM               (readTVarIO)
 import           Control.Exception.Safe               (Exception (..),
@@ -135,11 +135,18 @@ import           System.Directory                     (makeAbsolute)
 import           GHC.Types.PkgQual
 #endif
 
-descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId =
+data Log
+  = LogParsingModule FilePath
+
+instance Pretty Log where
+  pretty = \case
+    LogParsingModule fp -> "Parsing module:" <+> pretty fp
+
+descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
+descriptor recorder plId =
   (defaultPluginDescriptor plId "Provides code actions to inline Haskell definitions")
     { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeAction provider,
-      pluginCommands = [retrieCommand, retrieInlineThisCommand]
+      pluginCommands = [retrieCommand recorder, retrieInlineThisCommand recorder]
     }
 
 retrieCommandId :: CommandId
@@ -148,14 +155,14 @@ retrieCommandId = "retrieCommand"
 retrieInlineThisCommandId :: CommandId
 retrieInlineThisCommandId = "retrieInlineThisCommand"
 
-retrieCommand :: PluginCommand IdeState
-retrieCommand =
-  PluginCommand retrieCommandId "run the refactoring" runRetrieCmd
+retrieCommand :: Recorder (WithPriority Log) -> PluginCommand IdeState
+retrieCommand recorder =
+  PluginCommand retrieCommandId "run the refactoring" (runRetrieCmd recorder)
 
-retrieInlineThisCommand :: PluginCommand IdeState
-retrieInlineThisCommand =
+retrieInlineThisCommand :: Recorder (WithPriority Log) -> PluginCommand IdeState
+retrieInlineThisCommand recorder =
   PluginCommand retrieInlineThisCommandId "inline function call"
-     runRetrieInlineThisCmd
+    (runRetrieInlineThisCmd recorder)
 
 -- | Parameters for the runRetrie PluginCommand.
 data RunRetrieParams = RunRetrieParams
@@ -166,8 +173,8 @@ data RunRetrieParams = RunRetrieParams
   }
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
-runRetrieCmd :: CommandFunction IdeState RunRetrieParams
-runRetrieCmd state token RunRetrieParams{originatingFile = uri, ..} = ExceptT $
+runRetrieCmd :: Recorder (WithPriority Log) ->  CommandFunction IdeState RunRetrieParams
+runRetrieCmd recorder state token RunRetrieParams{originatingFile = uri, ..} = ExceptT $
   withIndefiniteProgress description token Cancellable $ \_updater -> do
     _ <- runExceptT $ do
         nfp <- getNormalizedFilePathE uri
@@ -179,6 +186,7 @@ runRetrieCmd state token RunRetrieParams{originatingFile = uri, ..} = ExceptT $
         let importRewrites = concatMap (extractImports ms binds) rewrites
         (errors, edits) <- liftIO $
             callRetrie
+                recorder
                 state
                 (hscEnv session)
                 (map Right rewrites <> map Left importRewrites)
@@ -201,8 +209,8 @@ data RunRetrieInlineThisParams = RunRetrieInlineThisParams
   }
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
-runRetrieInlineThisCmd :: CommandFunction IdeState RunRetrieInlineThisParams
-runRetrieInlineThisCmd state _token RunRetrieInlineThisParams{..} = do
+runRetrieInlineThisCmd :: Recorder (WithPriority Log) -> CommandFunction IdeState RunRetrieInlineThisParams
+runRetrieInlineThisCmd recorder state _token RunRetrieInlineThisParams{..} = do
     nfp <- getNormalizedFilePathE $ getLocationUri inlineIntoThisLocation
     nfpSource <- getNormalizedFilePathE $ getLocationUri inlineFromThisLocation
     -- What we do here:
@@ -219,7 +227,7 @@ runRetrieInlineThisCmd state _token RunRetrieInlineThisParams{..} = do
     when (null inlineRewrite) $ throwError $ PluginInternalError "Empty rewrite"
     (session, _) <- runActionE "retrie" state $
       useWithStaleE GhcSessionDeps nfp
-    (fixityEnv, cpp) <- liftIO $ getCPPmodule state (hscEnv session) $ fromNormalizedFilePath nfp
+    (fixityEnv, cpp) <- liftIO $ getCPPmodule recorder state (hscEnv session) $ fromNormalizedFilePath nfp
     result <- liftIO $ try @_ @SomeException $
         runRetrie fixityEnv (applyWithUpdate myContextUpdater inlineRewrite) cpp
     case result of
@@ -506,13 +514,14 @@ instance Show CallRetrieError where
 instance Exception CallRetrieError
 
 callRetrie ::
+  Recorder (WithPriority Log) ->
   IdeState ->
   HscEnv ->
   [Either ImportSpec RewriteSpec] ->
   NormalizedFilePath ->
   Bool ->
   IO ([CallRetrieError], WorkspaceEdit)
-callRetrie state session rewrites origin restrictToOriginatingFile = do
+callRetrie recorder state session rewrites origin restrictToOriginatingFile = do
   knownFiles <- toKnownFiles . unhashed <$> readTVarIO (knownTargetsVar $ shakeExtras state)
   let
       -- TODO cover all workspaceFolders
@@ -540,7 +549,7 @@ callRetrie state session rewrites origin restrictToOriginatingFile = do
   targets <- getTargetFiles retrieOptions (getGroundTerms retrie)
 
   results <- forM targets $ \t -> runExceptT $ do
-    (fixityEnv, cpp) <- ExceptT $ try $ getCPPmodule state session t
+    (fixityEnv, cpp) <- ExceptT $ try $ getCPPmodule recorder state session t
     -- TODO add the imports to the resulting edits
     (_user, _ast, change@(Change _replacements _imports)) <-
       lift $ runRetrie fixityEnv retrie cpp
@@ -751,8 +760,8 @@ reuseParsedModule state f = do
         (fixities, pm') <- fixFixities state f (fixAnns pm)
         return (fixities, pm')
 
-getCPPmodule :: IdeState -> HscEnv -> FilePath -> IO (FixityEnv, CPP AnnotatedModule)
-getCPPmodule state session t = do
+getCPPmodule :: Recorder (WithPriority Log) -> IdeState -> HscEnv -> FilePath -> IO (FixityEnv, CPP AnnotatedModule)
+getCPPmodule recorder state session t = do
     nt <- toNormalizedFilePath' <$> makeAbsolute t
     let getParsedModule f contents = do
           modSummary <- msrModSummary <$>
@@ -762,7 +771,7 @@ getCPPmodule state session t = do
                   { ms_hspp_buf =
                       Just (stringToStringBuffer contents)
                   }
-          logPriority (ideLogger state) Info $ T.pack $ "Parsing module: " <> t
+          logWith recorder Info $ LogParsingModule t
           parsed <- evalGhcEnv session (GHCGHC.parseModule ms')
               `catch` \e -> throwIO (GHCParseError nt (show @SomeException e))
           (fixities, parsed) <- fixFixities state f (fixAnns parsed)

--- a/plugins/hls-stylish-haskell-plugin/src/Ide/Plugin/StylishHaskell.hs
+++ b/plugins/hls-stylish-haskell-plugin/src/Ide/Plugin/StylishHaskell.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE CPP               #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
 module Ide.Plugin.StylishHaskell
   ( descriptor
   , provider
+  , Log
   )
 where
 
@@ -26,9 +28,17 @@ import           Language.LSP.Protocol.Types      as LSP
 import           System.Directory
 import           System.FilePath
 
-descriptor :: PluginId -> PluginDescriptor IdeState
-descriptor plId = (defaultPluginDescriptor plId desc)
-  { pluginHandlers = mkFormattingHandlers provider
+data Log
+  = LogLanguageExtensionFromDynFlags
+
+instance Pretty Log where
+  pretty = \case
+    LogLanguageExtensionFromDynFlags -> "stylish-haskell uses the language extensions from DynFlags"
+
+
+descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
+descriptor recorder plId = (defaultPluginDescriptor plId desc)
+  { pluginHandlers = mkFormattingHandlers (provider recorder)
   }
   where
     desc = "Provides formatting of Haskell files via stylish-haskell. Built with stylish-haskell-" <> VERSION_stylish_haskell
@@ -36,8 +46,8 @@ descriptor plId = (defaultPluginDescriptor plId desc)
 -- | Formatter provider of stylish-haskell.
 -- Formats the given source in either a given Range or the whole Document.
 -- If the provider fails an error is returned that can be displayed to the user.
-provider :: FormattingHandler IdeState
-provider ide _token typ contents fp _opts = do
+provider :: Recorder (WithPriority Log) -> FormattingHandler IdeState
+provider recorder ide _token typ contents fp _opts = do
   (msrModSummary -> ms_hspp_opts -> dyn) <- runActionE "stylish-haskell" ide $ useE GetModSummary fp
   let file = fromNormalizedFilePath fp
   config <- liftIO $ loadConfigFrom file
@@ -53,7 +63,7 @@ provider ide _token typ contents fp _opts = do
     getMergedConfig dyn config
       | null (configLanguageExtensions config)
       = do
-          logInfo (ideLogger ide) "stylish-haskell uses the language extensions from DynFlags"
+          logWith recorder Info LogLanguageExtensionFromDynFlags
           pure
             $ config
               { configLanguageExtensions = getExtensions dyn }

--- a/plugins/hls-stylish-haskell-plugin/test/Main.hs
+++ b/plugins/hls-stylish-haskell-plugin/test/Main.hs
@@ -10,8 +10,8 @@ import           Test.Hls
 main :: IO ()
 main = defaultTestRunner tests
 
-stylishHaskellPlugin :: PluginTestDescriptor ()
-stylishHaskellPlugin = mkPluginTestDescriptor' StylishHaskell.descriptor "stylishHaskell"
+stylishHaskellPlugin :: PluginTestDescriptor StylishHaskell.Log
+stylishHaskellPlugin = mkPluginTestDescriptor StylishHaskell.descriptor "stylishHaskell"
 
 tests :: TestTree
 tests = testGroup "stylish-haskell"

--- a/src/HlsPlugins.hs
+++ b/src/HlsPlugins.hs
@@ -178,13 +178,13 @@ idePlugins recorder = pluginDescToIdePlugins allPlugins
       let pId = "ormolu" in Ormolu.descriptor (pluginRecorder pId) pId :
 #endif
 #if hls_stylishHaskell
-      StylishHaskell.descriptor "stylish-haskell" :
+      let pId = "stylish-haskell" in StylishHaskell.descriptor (pluginRecorder pId) pId :
 #endif
 #if hls_rename
       let pId = "rename" in Rename.descriptor (pluginRecorder pId) pId:
 #endif
 #if hls_retrie
-      Retrie.descriptor "retrie" :
+      let pId = "retrie" in Retrie.descriptor (pluginRecorder pId) pId :
 #endif
 #if hls_callHierarchy
       CallHierarchy.descriptor "callHierarchy" :

--- a/src/Ide/Main.hs
+++ b/src/Ide/Main.hs
@@ -12,18 +12,18 @@ import           Control.Monad.Extra
 import qualified Data.Aeson.Encode.Pretty      as A
 import           Data.Coerce                   (coerce)
 import           Data.Default
+import           Data.Function                 ((&))
 import           Data.List                     (sortOn)
 import           Data.Text                     (Text)
 import qualified Data.Text                     as T
 import           Data.Text.Lazy.Encoding       (decodeUtf8)
 import qualified Data.Text.Lazy.IO             as LT
 import           Development.IDE.Core.Rules    hiding (Log, logToPriority)
-import           Development.IDE.Core.Tracing  (withTelemetryLogger)
+import           Development.IDE.Core.Tracing  (withTelemetryRecorder)
 import           Development.IDE.Main          (isLSP)
 import qualified Development.IDE.Main          as IDEMain
 import qualified Development.IDE.Session       as Session
 import qualified Development.IDE.Types.Options as Ghcide
-import           GHC.Stack                     (emptyCallStack)
 import qualified HIE.Bios.Environment          as HieBios
 import           HIE.Bios.Types                hiding (Log)
 import qualified HIE.Bios.Types                as HieBios
@@ -121,7 +121,7 @@ defaultMain recorder args idePlugins = do
 -- ---------------------------------------------------------------------
 
 runLspMode :: Recorder (WithPriority Log) -> GhcideArguments -> IdePlugins IdeState -> IO ()
-runLspMode recorder ghcideArgs@GhcideArguments{..} idePlugins = withTelemetryLogger $ \telemetryLogger -> do
+runLspMode recorder ghcideArgs@GhcideArguments{..} idePlugins = withTelemetryRecorder $ \telemetryRecorder' -> do
     let log = logWith recorder
     whenJust argsCwd IO.setCurrentDirectory
     dir <- IO.getCurrentDirectory
@@ -130,14 +130,13 @@ runLspMode recorder ghcideArgs@GhcideArguments{..} idePlugins = withTelemetryLog
     when (isLSP argsCommand) $ do
         log Info $ LogLspStart ghcideArgs (map pluginId $ ipMap idePlugins)
 
-    -- exists so old-style logging works. intended to be phased out
-    let logger = Logger $ \p m -> logger_ recorder (WithPriority p emptyCallStack $ LogOther m)
-        args = (if argsTesting then IDEMain.testing else IDEMain.defaultArguments)
-                    (cmapWithPrio LogIDEMain recorder) logger idePlugins
+    let args = (if argsTesting then IDEMain.testing else IDEMain.defaultArguments)
+                    (cmapWithPrio LogIDEMain recorder) idePlugins
 
-    IDEMain.defaultMain (cmapWithPrio LogIDEMain recorder) args
+    let telemetryRecorder = telemetryRecorder' & cmapWithPrio pretty
+
+    IDEMain.defaultMain (cmapWithPrio LogIDEMain $ recorder <> telemetryRecorder) args
       { IDEMain.argCommand = argsCommand
-      , IDEMain.argsLogger = pure logger <> pure telemetryLogger
       , IDEMain.argsThreads = if argsThreads == 0 then Nothing else Just $ fromIntegral argsThreads
       , IDEMain.argsIdeOptions = \config sessionLoader ->
         let defOptions = IDEMain.argsIdeOptions args config sessionLoader


### PR DESCRIPTION
Move ghcide completely to colog-logging style.
Move plugins that were relying on `ideLogger` to colog style logging.
Move opentelemetry to colog-logging style.

This allows us to drop legacy code and unify the logging experience in
HLS.

We add a bunch of new Log constructors at various locations that aim to
be identical to their previous `Logger` statements.

Just a bit of busy work. It started out as migrating `ekg` to colog style logging. ~~Now only the telemetry logger uses `Logger`.~~ Fixed.