### PR TITLE
enable ThreadId for when testing

### DIFF
--- a/hls-plugin-api/src/Ide/Logger.hs
+++ b/hls-plugin-api/src/Ide/Logger.hs
@@ -27,6 +27,7 @@ module Ide.Logger
   , module PrettyPrinterModule
   , renderStrict
   , toCologActionWithPrio
+  , defaultLoggingColumns
   ) where
 
 import           Colog.Core                    (LogAction (..), Severity,

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -94,9 +94,9 @@ import           Ide.Logger                         (Pretty (pretty),
                                                      Priority (..), Recorder,
                                                      WithPriority (WithPriority, priority),
                                                      cfilter, cmapWithPrio,
+                                                     defaultLoggingColumns,
                                                      logWith,
                                                      makeDefaultStderrRecorder,
-                                                     defaultLoggingColumns,
                                                      (<+>))
 import           Ide.Types
 import           Language.LSP.Protocol.Capabilities

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -348,7 +348,7 @@ pluginTestRecorder = do
 -- See 'runSessionWithServer'' for details.
 initialiseTestRecorder :: Pretty a => [String] -> IO (Recorder (WithPriority a))
 initialiseTestRecorder envVars = do
-    docWithPriorityRecorder <- makeDefaultStderrRecorder (Just [ThreadIdColumn])
+    docWithPriorityRecorder <- makeDefaultStderrRecorder (Just $ [ThreadIdColumn] <> defaultLoggingColumns)
     -- There are potentially multiple environment variables that enable this logger
     definedEnvVars <- forM envVars (\var -> fromMaybe "0" <$> lookupEnv var)
     let logStdErr = any (/= "0") definedEnvVars

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -349,7 +349,7 @@ pluginTestRecorder = do
 -- See 'runSessionWithServer'' for details.
 initialiseTestRecorder :: Pretty a => [String] -> IO (Recorder (WithPriority a))
 initialiseTestRecorder envVars = do
-    docWithPriorityRecorder <- makeDefaultStderrRecorder (Just $ [ThreadIdColumn] <> defaultLoggingColumns)
+    docWithPriorityRecorder <- makeDefaultStderrRecorder (Just $ ThreadIdColumn : defaultLoggingColumns)
     -- There are potentially multiple environment variables that enable this logger
     definedEnvVars <- forM envVars (\var -> fromMaybe "0" <$> lookupEnv var)
     let logStdErr = any (/= "0") definedEnvVars

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -80,7 +80,7 @@ import           Data.Proxy                         (Proxy (Proxy))
 import qualified Data.Text                          as T
 import qualified Data.Text.Lazy                     as TL
 import qualified Data.Text.Lazy.Encoding            as TL
-import           Development.IDE                    (IdeState)
+import           Development.IDE                    (IdeState, LoggingColumn (ThreadIdColumn))
 import           Development.IDE.Main               hiding (Log)
 import qualified Development.IDE.Main               as Ghcide
 import qualified Development.IDE.Main               as IDEMain

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -348,7 +348,7 @@ pluginTestRecorder = do
 -- See 'runSessionWithServer'' for details.
 initialiseTestRecorder :: Pretty a => [String] -> IO (Recorder (WithPriority a))
 initialiseTestRecorder envVars = do
-    docWithPriorityRecorder <- makeDefaultStderrRecorder Nothing
+    docWithPriorityRecorder <- makeDefaultStderrRecorder (Just [ThreadIdColumn])
     -- There are potentially multiple environment variables that enable this logger
     definedEnvVars <- forM envVars (\var -> fromMaybe "0" <$> lookupEnv var)
     let logStdErr = any (/= "0") definedEnvVars

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -96,6 +96,7 @@ import           Ide.Logger                         (Pretty (pretty),
                                                      cfilter, cmapWithPrio,
                                                      logWith,
                                                      makeDefaultStderrRecorder,
+                                                     defaultLoggingColumns,
                                                      (<+>))
 import           Ide.Types
 import           Language.LSP.Protocol.Capabilities


### PR DESCRIPTION
It seems we do have it already, I enable it for default when testing.