### PR TITLE
Allow users to specify whether to use `cabal`'s multi-repl feature

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-index-state: 2024-03-09T08:17:00Z
+index-state: 2024-04-23T12:00:00Z
 
 tests: True
 test-show-details: direct

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -78,7 +78,7 @@ library
     , Glob
     , haddock-library              >=1.8      && <1.12
     , hashable
-    , hie-bios                     ==0.13.1
+    , hie-bios                     ^>=0.14.0
     , hie-compat                   ^>=0.3.0.0
     , hiedb                        ^>= 0.6.0.0
     , hls-graph                    == 2.7.0.0

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -822,7 +822,7 @@ test-suite hls-stan-plugin-tests
     , lens
     , lsp-types
     , text
- default-extensions:
+  default-extensions:
     OverloadedStrings
 
 -----------------------------

--- a/hls-plugin-api/src/Ide/Plugin/Config.hs
+++ b/hls-plugin-api/src/Ide/Plugin/Config.hs
@@ -42,6 +42,7 @@ parseConfig idePlugins defValue = A.withObject "settings" $ \o ->
     <*> o .:? "formattingProvider"                      .!= formattingProvider defValue
     <*> o .:? "cabalFormattingProvider"                 .!= cabalFormattingProvider defValue
     <*> o .:? "maxCompletions"                          .!= maxCompletions defValue
+    <*> o .:? "sessionLoading"                          .!= sessionLoading defValue
     <*> A.explicitParseFieldMaybe (parsePlugins idePlugins) o "plugin" .!= plugins defValue
 
 -- | Parse the 'PluginConfig'.

--- a/stack-lts21.yaml
+++ b/stack-lts21.yaml
@@ -18,7 +18,7 @@ allow-newer: true
 extra-deps:
 - floskell-0.11.1
 - hiedb-0.6.0.0
-- hie-bios-0.13.1
+- hie-bios-0.14.0
 - implicit-hie-0.1.4.0
 - monad-dijkstra-0.1.1.3
 - retrie-1.2.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,6 +18,7 @@ extra-deps:
 - floskell-0.11.1
 - retrie-1.2.2
 - hiedb-0.6.0.0
+- hie-bios-0.14.0
 - implicit-hie-0.1.4.0
 - lsp-2.4.0.0
 - lsp-test-0.17.0.0

--- a/test/testdata/schema/ghc92/default-config.golden.json
+++ b/test/testdata/schema/ghc92/default-config.golden.json
@@ -148,5 +148,6 @@
         "splice": {
             "globalOn": true
         }
-    }
+    },
+    "sessionLoading": "singleComponent"
 }

--- a/test/testdata/schema/ghc94/default-config.golden.json
+++ b/test/testdata/schema/ghc94/default-config.golden.json
@@ -151,5 +151,6 @@
         "stan": {
             "globalOn": false
         }
-    }
+    },
+    "sessionLoading": "singleComponent"
 }

--- a/test/testdata/schema/ghc96/default-config.golden.json
+++ b/test/testdata/schema/ghc96/default-config.golden.json
@@ -151,5 +151,6 @@
         "stan": {
             "globalOn": false
         }
-    }
+    },
+    "sessionLoading": "singleComponent"
 }

--- a/test/testdata/schema/ghc98/default-config.golden.json
+++ b/test/testdata/schema/ghc98/default-config.golden.json
@@ -151,5 +151,6 @@
         "stan": {
             "globalOn": false
         }
-    }
+    },
+    "sessionLoading": "singleComponent"
 }


### PR DESCRIPTION
We add an option to `Config` that allows clients to specify how HLS should load components.

The three options are:

* SessionLoadSingleComponent: Always load only a single component when a new component is discovered.
* SessionLoadMultipleComponents: Always allow the cradle to load multiple components at once. This might not be always possible, e.g., if the tool doesn't support multiple components loading. The cradle can decide how to handle these situations.
* SessionAuto: Leave the decision to the individual cradle type. Some cradles have good support for loading multiple components, while others do not. So use multiple components loading for tools, such as cabal, and force single component loading for tools that do not support multiple components, such as stack.

This allows users to opt-out of `cabal` `multi-repl` whenever they want and vice versa.

Closes #4178 

Depends on https://github.com/haskell/hie-bios/pull/433

Sibling PR for vscode-haskell: https://github.com/haskell/vscode-haskell/pull/1077