### PR TITLE
hls-cabal-plugin: refactor context search to use `readFields`

### DIFF
--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -11,6 +11,7 @@ module Development.IDE.Plugin.Completions.Logic (
 , getCompletions
 , fromIdentInfo
 , getCompletionPrefix
+, getCompletionPrefixFromRope
 ) where
 
 import           Control.Applicative
@@ -897,7 +898,10 @@ mergeListsBy cmp all_lists = merge_lists all_lists
 
 -- |From the given cursor position, gets the prefix module or record for autocompletion
 getCompletionPrefix :: Position -> VFS.VirtualFile -> PosPrefixInfo
-getCompletionPrefix pos@(Position l c) (VFS.VirtualFile _ _ ropetext) =
+getCompletionPrefix pos (VFS.VirtualFile _ _ ropetext) = getCompletionPrefixFromRope pos ropetext
+
+getCompletionPrefixFromRope :: Position -> Rope.Rope -> PosPrefixInfo
+getCompletionPrefixFromRope pos@(Position l c) ropetext =
       fromMaybe (PosPrefixInfo "" "" "" pos) $ do -- Maybe monad
         let headMaybe = listToMaybe
             lastMaybe = headMaybe . reverse

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -241,6 +241,7 @@ library hls-cabal-plugin
     Ide.Plugin.Cabal.Completion.Data
     Ide.Plugin.Cabal.Completion.Types
     Ide.Plugin.Cabal.LicenseSuggest
+    Ide.Plugin.Cabal.Orphans
     Ide.Plugin.Cabal.Parse
 
 

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -49,6 +49,7 @@ library
     , lsp
     , lsp-test                ^>=0.17
     , lsp-types               ^>=2.2
+    , neat-interpolation
     , safe-exceptions
     , tasty
     , tasty-expected-failure
@@ -57,6 +58,7 @@ library
     , tasty-rerun
     , temporary
     , text
+    , text-rope
 
   ghc-options:
     -Wall

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -34,6 +34,8 @@ module Test.Hls
     runSessionWithServer,
     runSessionWithServerInTmpDir,
     runSessionWithTestConfig,
+    -- * Running parameterised tests for a set of test configurations
+    parameterisedCursorTest,
     -- * Helpful re-exports
     PluginDescriptor,
     IdeState,
@@ -64,74 +66,76 @@ module Test.Hls
 where
 
 import           Control.Applicative.Combinators
-import           Control.Concurrent.Async           (async, cancel, wait)
+import           Control.Concurrent.Async                 (async, cancel, wait)
 import           Control.Concurrent.Extra
 import           Control.Exception.Safe
-import           Control.Lens.Extras                (is)
-import           Control.Monad                      (guard, unless, void)
-import           Control.Monad.Extra                (forM)
+import           Control.Lens.Extras                      (is)
+import           Control.Monad                            (guard, unless, void)
+import           Control.Monad.Extra                      (forM)
 import           Control.Monad.IO.Class
-import           Data.Aeson                         (Result (Success),
-                                                     Value (Null), fromJSON,
-                                                     toJSON)
-import qualified Data.Aeson                         as A
-import           Data.ByteString.Lazy               (ByteString)
-import           Data.Default                       (Default, def)
-import qualified Data.Map                           as M
-import           Data.Maybe                         (fromMaybe)
-import           Data.Proxy                         (Proxy (Proxy))
-import qualified Data.Text                          as T
-import qualified Data.Text.Lazy                     as TL
-import qualified Data.Text.Lazy.Encoding            as TL
-import           Development.IDE                    (IdeState,
-                                                     LoggingColumn (ThreadIdColumn),
-                                                     defaultLayoutOptions,
-                                                     layoutPretty, renderStrict)
-import qualified Development.IDE.LSP.Notifications  as Notifications
-import           Development.IDE.Main               hiding (Log)
-import qualified Development.IDE.Main               as IDEMain
-import           Development.IDE.Plugin.Test        (TestRequest (GetBuildKeysBuilt, WaitForIdeRule, WaitForShakeQueue),
-                                                     WaitForIdeRuleResult (ideResultSuccess))
-import qualified Development.IDE.Plugin.Test        as Test
+import           Data.Aeson                               (Result (Success),
+                                                           Value (Null),
+                                                           fromJSON, toJSON)
+import qualified Data.Aeson                               as A
+import           Data.ByteString.Lazy                     (ByteString)
+import           Data.Default                             (Default, def)
+import qualified Data.Map                                 as M
+import           Data.Maybe                               (fromMaybe)
+import           Data.Proxy                               (Proxy (Proxy))
+import qualified Data.Text                                as T
+import qualified Data.Text.Lazy                           as TL
+import qualified Data.Text.Lazy.Encoding                  as TL
+import           Development.IDE                          (IdeState,
+                                                           LoggingColumn (ThreadIdColumn),
+                                                           defaultLayoutOptions,
+                                                           layoutPretty,
+                                                           renderStrict)
+import           Development.IDE.Main                     hiding (Log)
+import qualified Development.IDE.Main                     as IDEMain
+import           Development.IDE.Plugin.Completions.Types (PosPrefixInfo)
+import           Development.IDE.Plugin.Test              (TestRequest (GetBuildKeysBuilt, WaitForIdeRule, WaitForShakeQueue),
+                                                           WaitForIdeRuleResult (ideResultSuccess))
+import qualified Development.IDE.Plugin.Test              as Test
 import           Development.IDE.Types.Options
 import           GHC.IO.Handle
 import           GHC.TypeLits
-import           Ide.Logger                         (Pretty (pretty),
-                                                     Priority (..), Recorder,
-                                                     WithPriority (WithPriority, priority),
-                                                     cfilter, cmapWithPrio,
-                                                     defaultLoggingColumns,
-                                                     logWith,
-                                                     makeDefaultStderrRecorder,
-                                                     (<+>))
-import qualified Ide.Logger                         as Logger
-import           Ide.Plugin.Properties              ((&))
-import           Ide.PluginUtils                    (idePluginsToPluginDesc,
-                                                     pluginDescToIdePlugins)
+import           Ide.Logger                               (Pretty (pretty),
+                                                           Priority (..),
+                                                           Recorder,
+                                                           WithPriority (WithPriority, priority),
+                                                           cfilter,
+                                                           cmapWithPrio,
+                                                           defaultLoggingColumns,
+                                                           logWith,
+                                                           makeDefaultStderrRecorder,
+                                                           (<+>))
+import qualified Ide.Logger                               as Logger
+import           Ide.PluginUtils                          (idePluginsToPluginDesc,
+                                                           pluginDescToIdePlugins)
 import           Ide.Types
 import           Language.LSP.Protocol.Capabilities
 import           Language.LSP.Protocol.Message
-import qualified Language.LSP.Protocol.Message      as LSP
-import           Language.LSP.Protocol.Types        hiding (Null)
-import qualified Language.LSP.Server                as LSP
+import qualified Language.LSP.Protocol.Message            as LSP
+import           Language.LSP.Protocol.Types              hiding (Null)
+import qualified Language.LSP.Server                      as LSP
 import           Language.LSP.Test
-import           Prelude                            hiding (log)
-import           System.Directory                   (canonicalizePath,
-                                                     createDirectoryIfMissing,
-                                                     getCurrentDirectory,
-                                                     getTemporaryDirectory,
-                                                     makeAbsolute,
-                                                     setCurrentDirectory)
-import           System.Environment                 (lookupEnv, setEnv)
+import           Prelude                                  hiding (log)
+import           System.Directory                         (canonicalizePath,
+                                                           createDirectoryIfMissing,
+                                                           getCurrentDirectory,
+                                                           getTemporaryDirectory,
+                                                           makeAbsolute,
+                                                           setCurrentDirectory)
+import           System.Environment                       (lookupEnv, setEnv)
 import           System.FilePath
-import           System.IO.Extra                    (newTempDirWithin)
-import           System.IO.Unsafe                   (unsafePerformIO)
-import           System.Process.Extra               (createPipe)
+import           System.IO.Extra                          (newTempDirWithin)
+import           System.IO.Unsafe                         (unsafePerformIO)
+import           System.Process.Extra                     (createPipe)
 import           System.Time.Extra
-import qualified Test.Hls.FileSystem                as FS
+import qualified Test.Hls.FileSystem                      as FS
 import           Test.Hls.FileSystem
 import           Test.Hls.Util
-import           Test.Tasty                         hiding (Timeout)
+import           Test.Tasty                               hiding (Timeout)
 import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
@@ -328,6 +332,56 @@ goldenWithDocInTmpDir languageKind config plugin title tree path desc ext act =
     act doc
     documentContents doc
 
+-- | A parameterised test is similar to a normal test case but allows to run
+-- the same test case multiple times with different inputs.
+-- A 'parameterisedCursorTest' allows to define a test case based on an input file
+-- that specifies one or many cursor positions via the identification value '^'.
+--
+-- For example:
+--
+-- @
+--  parameterisedCursorTest "Cursor Test" [trimming|
+--       foo = 2
+--        ^
+--       bar = 3
+--       baz = foo + bar
+--         ^
+--       |]
+--       ["foo", "baz"]
+--       (\input cursor -> findFunctionNameUnderCursor input cursor)
+-- @
+--
+-- Assuming a fitting implementation for 'findFunctionNameUnderCursor'.
+--
+-- This test definition will run the test case 'findFunctionNameUnderCursor' for
+-- each cursor position, each in its own isolated 'testCase'.
+-- Cursor positions are identified via the character '^', which points to the
+-- above line as the actual cursor position.
+-- Lines containing '^' characters, are removed from the final text, that is
+-- passed to the testing function.
+--
+-- TODO: Many Haskell and Cabal source may contain '^' characters for good reasons.
+-- We likely need a way to change the character for certain test cases in the future.
+--
+-- The quasi quoter 'trimming' is very helpful to define such tests, as it additionally
+-- allows to interpolate haskell values and functions. We reexport this quasi quoter
+-- for easier usage.
+parameterisedCursorTest :: (Show a, Eq a) => String -> T.Text -> [a] -> (T.Text -> PosPrefixInfo -> IO a) -> TestTree
+parameterisedCursorTest title content expectations act
+  | lenPrefs /= lenExpected = error $ "parameterisedCursorTest: Expected " <> show lenExpected <> " cursors but found: " <> show lenPrefs
+  | otherwise = testGroup title $
+      map singleTest testCaseSpec
+  where
+    lenPrefs = length prefInfos
+    lenExpected = length expectations
+    (cleanText, prefInfos) = extractCursorPositions content
+
+    testCaseSpec = zip [1 ::Int ..] (zip expectations prefInfos)
+
+    singleTest (n, (expected, info)) = testCase (title <> " " <> show n) $ do
+      actual <- act cleanText info
+      assertEqual (mkParameterisedLabel info) expected actual
+
 -- ------------------------------------------------------------
 -- Helper function for initialising plugins under test
 -- ------------------------------------------------------------
@@ -429,6 +483,7 @@ initializeTestRecorder envVars = do
 -- ------------------------------------------------------------
 -- Run an HLS server testing a specific plugin
 -- ------------------------------------------------------------
+
 runSessionWithServerInTmpDir :: Pretty b => Config -> PluginTestDescriptor b -> VirtualFileTree -> Session a -> IO a
 runSessionWithServerInTmpDir config plugin tree act =
     runSessionWithTestConfig def

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Diagnostics.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Diagnostics.hs
@@ -4,6 +4,7 @@ module Ide.Plugin.Cabal.Diagnostics
 ( errorDiagnostic
 , warningDiagnostic
 , positionFromCabalPosition
+, fatalParseErrorDiagnostic
   -- * Re-exports
 , FileDiagnostic
 , Diagnostic(..)
@@ -14,7 +15,7 @@ import qualified Data.Text                   as T
 import           Development.IDE             (FileDiagnostic,
                                               ShowDiagnostic (ShowDiag))
 import           Distribution.Fields         (showPError, showPWarning)
-import qualified Ide.Plugin.Cabal.Parse      as Lib
+import qualified Distribution.Parsec         as Syntax
 import           Ide.PluginUtils             (extendNextLine)
 import           Language.LSP.Protocol.Types (Diagnostic (..),
                                               DiagnosticSeverity (..),
@@ -23,16 +24,21 @@ import           Language.LSP.Protocol.Types (Diagnostic (..),
                                               Range (Range),
                                               fromNormalizedFilePath)
 
+-- | Produce a diagnostic for a fatal Cabal parser error.
+fatalParseErrorDiagnostic :: NormalizedFilePath -> T.Text -> FileDiagnostic
+fatalParseErrorDiagnostic fp msg =
+  mkDiag fp "cabal" DiagnosticSeverity_Error (toBeginningOfNextLine Syntax.zeroPos) msg
+
 -- | Produce a diagnostic from a Cabal parser error
-errorDiagnostic :: NormalizedFilePath -> Lib.PError -> FileDiagnostic
-errorDiagnostic fp err@(Lib.PError pos _) =
+errorDiagnostic :: NormalizedFilePath -> Syntax.PError -> FileDiagnostic
+errorDiagnostic fp err@(Syntax.PError pos _) =
   mkDiag fp "cabal" DiagnosticSeverity_Error (toBeginningOfNextLine pos) msg
   where
     msg = T.pack $ showPError (fromNormalizedFilePath fp) err
 
 -- | Produce a diagnostic from a Cabal parser warning
-warningDiagnostic :: NormalizedFilePath -> Lib.PWarning -> FileDiagnostic
-warningDiagnostic fp warning@(Lib.PWarning _ pos _) =
+warningDiagnostic :: NormalizedFilePath -> Syntax.PWarning -> FileDiagnostic
+warningDiagnostic fp warning@(Syntax.PWarning _ pos _) =
   mkDiag fp "cabal" DiagnosticSeverity_Warning (toBeginningOfNextLine pos) msg
   where
     msg = T.pack $ showPWarning (fromNormalizedFilePath fp) warning
@@ -41,7 +47,7 @@ warningDiagnostic fp warning@(Lib.PWarning _ pos _) =
 -- only a single source code 'Lib.Position'.
 -- We define the range to be _from_ this position
 -- _to_ the first column of the next line.
-toBeginningOfNextLine :: Lib.Position -> Range
+toBeginningOfNextLine :: Syntax.Position -> Range
 toBeginningOfNextLine cabalPos = extendNextLine $ Range pos pos
    where
     pos = positionFromCabalPosition cabalPos
@@ -53,8 +59,8 @@ toBeginningOfNextLine cabalPos = extendNextLine $ Range pos pos
 --
 -- >>> positionFromCabalPosition $ Lib.Position 1 1
 -- Position 0 0
-positionFromCabalPosition :: Lib.Position -> Position
-positionFromCabalPosition (Lib.Position line column) = Position (fromIntegral line') (fromIntegral col')
+positionFromCabalPosition :: Syntax.Position -> Position
+positionFromCabalPosition (Syntax.Position line column) = Position (fromIntegral line') (fromIntegral col')
   where
     -- LSP is zero-based, Cabal is one-based
     line' = line-1

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Orphans.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Orphans.hs
@@ -1,0 +1,24 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Ide.Plugin.Cabal.Orphans where
+import           Control.DeepSeq
+import           Distribution.Fields.Field
+import           Distribution.Parsec.Position
+
+-- ----------------------------------------------------------------
+-- Cabal-syntax orphan instances we need sometimes
+-- ----------------------------------------------------------------
+
+instance NFData (Field Position) where
+    rnf (Field name fieldLines) = rnf name `seq` rnf fieldLines
+    rnf (Section name sectionArgs fields) =  rnf name `seq` rnf sectionArgs `seq` rnf fields
+
+instance NFData (Name Position) where
+    rnf (Name ann fName) = rnf ann `seq` rnf fName
+
+instance NFData (FieldLine Position) where
+    rnf (FieldLine ann bs) = rnf ann `seq` rnf bs
+
+instance NFData (SectionArg Position) where
+    rnf (SecArgName ann bs)  = rnf ann `seq` rnf bs
+    rnf (SecArgStr ann bs)   = rnf ann `seq` rnf bs
+    rnf (SecArgOther ann bs) = rnf ann `seq` rnf bs

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Parse.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Parse.hs
@@ -1,13 +1,7 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Ide.Plugin.Cabal.Parse
 ( parseCabalFileContents
-  -- * Re-exports
-, FilePath
-, NonEmpty(..)
-, PWarning(..)
-, Version
-, PError(..)
-, Position(..)
-, GenericPackageDescription(..)
+, readCabalFields
 ) where
 
 import qualified Data.ByteString                              as BS
@@ -16,12 +10,31 @@ import           Distribution.Fields                          (PError (..),
                                                                PWarning (..))
 import           Distribution.Fields.ParseResult              (runParseResult)
 import           Distribution.PackageDescription.Parsec       (parseGenericPackageDescription)
-import           Distribution.Parsec.Position                 (Position (..))
 import           Distribution.Types.GenericPackageDescription (GenericPackageDescription (..))
 import           Distribution.Types.Version                   (Version)
+import qualified Ide.Plugin.Cabal.Diagnostics                 as Diagnostics
+
+import qualified Data.Text                                    as T
+import           Development.IDE
+import qualified Distribution.Fields.Parser                   as Syntax
+import qualified Distribution.Parsec.Position                 as Syntax
+
 
 parseCabalFileContents
   :: BS.ByteString -- ^ UTF-8 encoded bytestring
   -> IO ([PWarning], Either (Maybe Version, NonEmpty PError) GenericPackageDescription)
 parseCabalFileContents bs =
   pure $ runParseResult (parseGenericPackageDescription bs)
+
+readCabalFields ::
+  NormalizedFilePath ->
+  BS.ByteString ->
+  Either FileDiagnostic [Syntax.Field Syntax.Position]
+readCabalFields file contents  = do
+  case Syntax.readFields' contents of
+    Left parseError ->
+      Left $ Diagnostics.fatalParseErrorDiagnostic file
+           $ "Failed to parse cabal file: " <> T.pack (show parseError)
+    Right (fields, _warnings) -> do
+      -- we don't want to double report diagnostics, all diagnostics are produced by 'ParseCabalFile'.
+      Right fields

--- a/plugins/hls-cabal-plugin/test/Completer.hs
+++ b/plugins/hls-cabal-plugin/test/Completer.hs
@@ -9,6 +9,7 @@ import qualified Data.ByteString                                as ByteString
 import           Data.Maybe                                     (mapMaybe)
 import qualified Data.Text                                      as T
 import qualified Development.IDE.Plugin.Completions.Types       as Ghcide
+import           Distribution.PackageDescription                (GenericPackageDescription)
 import           Distribution.PackageDescription.Parsec         (parseGenericPackageDescriptionMaybe)
 import           Ide.Plugin.Cabal.Completion.Completer.FilePath
 import           Ide.Plugin.Cabal.Completion.Completer.Module
@@ -17,7 +18,6 @@ import           Ide.Plugin.Cabal.Completion.Completer.Types    (CompleterData (
 import           Ide.Plugin.Cabal.Completion.Completions
 import           Ide.Plugin.Cabal.Completion.Types              (CabalPrefixInfo (..),
                                                                  StanzaName)
-import           Ide.Plugin.Cabal.Parse                         (GenericPackageDescription)
 import qualified Language.LSP.Protocol.Lens                     as L
 import           System.FilePath
 import           Test.Hls

--- a/plugins/hls-cabal-plugin/test/Context.hs
+++ b/plugins/hls-cabal-plugin/test/Context.hs
@@ -1,18 +1,20 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE LambdaCase               #-}
 {-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE QuasiQuotes              #-}
 
 module Context where
 
-import           Control.Monad.Trans.Maybe                   (runMaybeT)
 import qualified Data.Text                                   as T
-import qualified Data.Text.Utf16.Rope.Mixed                  as Rope
+import qualified Data.Text.Encoding                          as Text
+import           Development.IDE.Plugin.Completions.Types    (PosPrefixInfo (..))
 import           Ide.Plugin.Cabal
 import           Ide.Plugin.Cabal.Completion.Completer.Paths
 import           Ide.Plugin.Cabal.Completion.Completions
 import           Ide.Plugin.Cabal.Completion.Types           (Context,
                                                               FieldContext (KeyWord, None),
                                                               StanzaContext (Stanza, TopLevel))
+import qualified Ide.Plugin.Cabal.Parse                      as Parse
 import           Test.Hls
 import           Utils                                       as T
 
@@ -22,7 +24,7 @@ cabalPlugin = mkPluginTestDescriptor descriptor "cabal context"
 contextTests :: TestTree
 contextTests =
     testGroup
-        "Context Tests "
+        "Context Tests"
         [ pathCompletionInfoFromCompletionContextTests
         , getContextTests
         ]
@@ -58,39 +60,39 @@ pathCompletionInfoFromCompletionContextTests =
 getContextTests :: TestTree
 getContextTests =
     testGroup
-        "Context Tests"
+        "Context Tests Real"
         [ testCase "Empty File - Start" $ do
             -- for a completely empty file, the context needs to
             -- be top level without a specified keyword
-            ctx <- callGetContext (Position 0 0) "" [""]
+            ctx <- callGetContext (Position 0 0) "" ""
             ctx @?= (TopLevel, None)
         , testCase "Cabal version keyword - no value, no space after :" $ do
             -- on a file, where the keyword is already written
             -- the context should still be toplevel but the keyword should be recognized
-            ctx <- callGetContext (Position 0 14) "" ["cabal-version:"]
+            ctx <- callGetContext (Position 0 14) "" "cabal-version:\n"
             ctx @?= (TopLevel, KeyWord "cabal-version:")
         , testCase "Cabal version keyword - cursor in keyword" $ do
             -- on a file, where the keyword is already written
             -- but the cursor is in the middle of the keyword,
             -- we are not in a keyword context
-            ctx <- callGetContext (Position 0 5) "cabal" ["cabal-version:"]
+            ctx <- callGetContext (Position 0 5) "cabal" "cabal-version:\n"
             ctx @?= (TopLevel, None)
         , testCase "Cabal version keyword - no value, many spaces" $ do
             -- on a file, where the "cabal-version:" keyword is already written
             -- the context should still be top level but the keyword should be recognized
-            ctx <- callGetContext (Position 0 45) "" ["cabal-version:" <> T.replicate 50 " "]
+            ctx <- callGetContext (Position 0 45) "" ("cabal-version:" <> T.replicate 50 " " <> "\n")
             ctx @?= (TopLevel, KeyWord "cabal-version:")
         , testCase "Cabal version keyword - keyword partly written" $ do
             -- in the first line of the file, if the keyword
             -- has not been written completely, the keyword context
             -- should still be None
-            ctx <- callGetContext (Position 0 5) "cabal" ["cabal"]
+            ctx <- callGetContext (Position 0 5) "cabal" "cabal"
             ctx @?= (TopLevel, None)
         , testCase "Cabal version keyword - value partly written" $ do
             -- in the first line of the file, if the keyword
             -- has not been written completely, the keyword context
             -- should still be None
-            ctx <- callGetContext (Position 0 17) "1." ["cabal-version: 1."]
+            ctx <- callGetContext (Position 0 17) "1." "cabal-version: 1."
             ctx @?= (TopLevel, KeyWord "cabal-version:")
         , testCase "Inside Stanza - no keyword" $ do
             -- on a file, where the library stanza has been defined
@@ -102,14 +104,15 @@ getContextTests =
             -- has been defined, the keyword and stanza should be recognized
             ctx <- callGetContext (Position 4 21) "" libraryStanzaData
             ctx @?= (Stanza "library" Nothing, KeyWord "build-depends:")
-        , expectFailBecause "While not valid, it is not that important to make the code more complicated for this" $
-            testCase "Cabal version keyword - no value, next line" $ do
-                -- if the cabal version keyword has been written but without a value,
-                -- in the next line we still should be in top level context with no keyword
-                -- since the cabal version keyword and value pair need to be in the same line
-                ctx <- callGetContext (Position 1 2) "" ["cabal-version:", ""]
-                ctx @?= (TopLevel, None)
-        , testCase "Non-cabal-version keyword - no value, next line indentented position" $ do
+        , testCase "Cabal version keyword - no value, next line" $ do
+            -- if the cabal version keyword has been written but without a value,
+            -- in the next line we still should be in top level context with no keyword
+            -- since the cabal version keyword and value pair need to be in the same line.
+            -- However, that's too much work to implement for virtually no benefit, so we
+            -- test here the status-quo is satisfied.
+            ctx <- callGetContext (Position 1 2) "" "cabal-version:\n\n"
+            ctx @?= (TopLevel, KeyWord "cabal-version:")
+        , testCase "Non-cabal-version keyword - no value, next line indented position" $ do
             -- if a keyword, other than the cabal version keyword has been written
             -- with no value, in the next line we still should be in top level keyword context
             -- of the keyword with no value, since its value may be written in the next line
@@ -153,46 +156,124 @@ getContextTests =
             ctx @?= (TopLevel, KeyWord "name:")
         , testCase "Named Stanza" $ do
             ctx <- callGetContext (Position 2 18) "" executableStanzaData
-            ctx @?= (Stanza "executable" (Just "exeName"), None)
+            ctx @?= (TopLevel, None)
+        , testCase "Multi line, finds context in same line" $ do
+            ctx <- callGetContext (Position 5 18) "" multiLineOptsData
+            ctx @?= (Stanza "library" Nothing, KeyWord "build-depends:")
+        , testCase "Multi line, in the middle of option" $ do
+            ctx <- callGetContext (Position 6 11) "" multiLineOptsData
+            ctx @?= (Stanza "library" Nothing, KeyWord "build-depends:")
+        , testCase "Multi line, finds context in between lines" $ do
+            ctx <- callGetContext (Position 7 8) "" multiLineOptsData
+            ctx @?= (Stanza "library" Nothing, KeyWord "build-depends:")
+        , testCase "Multi line, finds context in between lines, start if line" $ do
+            ctx <- callGetContext (Position 7 0) "" multiLineOptsData
+            ctx @?= (TopLevel, None)
+        , testCase "Multi line, end of option" $ do
+            ctx <- callGetContext (Position 8 14) "" multiLineOptsData
+            ctx @?= (Stanza "library" Nothing, KeyWord "build-depends:")
+        , parameterisedCursorTest "Contexts in large testfile" multiPositionTestData
+            [ (TopLevel, None)
+            , (TopLevel, KeyWord "cabal-version:")
+            , (TopLevel, None)
+            , (TopLevel, KeyWord "description:")
+            , (TopLevel, KeyWord "extra-source-files:")
+            , (TopLevel, None)
+            -- this might not be what we want, maybe add another Context
+            , (TopLevel, None)
+            -- this might not be what we want, maybe add another Context
+            , (TopLevel, None)
+            , (Stanza "source-repository" (Just "head"), None)
+            , (Stanza "source-repository" (Just "head"), KeyWord "type:")
+            , (Stanza "source-repository" (Just "head"), KeyWord "type:")
+            , (Stanza "source-repository" (Just "head"), KeyWord "type:")
+            , (Stanza "source-repository" (Just "head"), None)
+            ]
+            $ \fileContent posPrefInfo ->
+                callGetContext (cursorPos posPrefInfo) (prefixText posPrefInfo) fileContent
         ]
   where
-    callGetContext :: Position -> T.Text -> [T.Text] -> IO Context
+    callGetContext :: Position -> T.Text -> T.Text -> IO Context
     callGetContext pos pref ls = do
-        runMaybeT (getContext mempty (simpleCabalPrefixInfoFromPos pos pref) (Rope.fromText $ T.unlines ls))
-            >>= \case
-                Nothing -> assertFailure "Context must be found"
-                Just ctx -> pure ctx
+        case Parse.readCabalFields "not-real" (Text.encodeUtf8 ls) of
+            Left err -> fail $ show err
+            Right fields -> do
+                getContext mempty (simpleCabalPrefixInfoFromPos pos pref) fields
 
 -- ------------------------------------------------------------------------
 -- Test Data
 -- ------------------------------------------------------------------------
 
-libraryStanzaData :: [T.Text]
-libraryStanzaData =
-    [ "cabal-version:      3.0"
-    , "name:               simple-cabal"
-    , "library "
-    , "    default-language: Haskell98"
-    , "    build-depends:    "
-    , "           "
-    , "ma  "
-    ]
+libraryStanzaData :: T.Text
+libraryStanzaData = [trimming|
+cabal-version:      3.0
+name:               simple-cabal
+library
+    default-language: Haskell98
+    build-depends:
 
-executableStanzaData :: [T.Text]
-executableStanzaData =
-    [ "cabal-version:      3.0"
-    , "name:               simple-cabal"
-    , "executable exeName"
-    , "    default-language: Haskell2010"
-    , "    hs-source-dirs: test/preprocessor"
-    ]
+ma
+|]
 
-topLevelData :: [T.Text]
-topLevelData =
-    [ "cabal-version:      3.0"
-    , "name:"
-    , ""
-    , ""
-    , ""
-    , "          eee"
-    ]
+executableStanzaData :: T.Text
+executableStanzaData = [trimming|
+cabal-version:      3.0
+name:               simple-cabal
+executable exeName
+    default-language: Haskell2010
+    hs-source-dirs: test/preprocessor
+|]
+
+topLevelData :: T.Text
+topLevelData = [trimming|
+cabal-version:      3.0
+name:
+
+
+
+          eee
+|]
+
+multiLineOptsData :: T.Text
+multiLineOptsData = [trimming|
+cabal-version:      3.0
+name:
+
+
+library
+    build-depends:
+        base,
+
+        text ,
+|]
+
+multiPositionTestData :: T.Text
+multiPositionTestData = [trimming|
+cabal-version:      3.4
+       ^             ^
+category:           Development
+^
+name:               haskell-language-server
+description:
+  Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
+    ^
+extra-source-files:
+  README.md
+  ChangeLog.md
+  test/testdata/**/*.project
+  test/testdata/**/*.cabal
+  test/testdata/**/*.yaml
+  test/testdata/**/*.hs
+  test/testdata/**/*.json
+    ^
+  -- These globs should only match test/testdata
+  plugins/**/*.project
+
+source-repository head
+     ^              ^   ^
+  type:     git
+    ^    ^    ^  ^
+  location: https://github.com/haskell/haskell-language-server
+
+  ^
+|]


### PR DESCRIPTION
Replace the more brittle parser with cabal's `readFields`.

Ready for review :)