### PR TITLE
Add performace diff benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -156,7 +156,7 @@ jobs:
     - name: Display results
       run: |
         column -s, -t < bench-results/unprofiled/${{ matrix.example }}/results.csv | tee bench-results/unprofiled/${{ matrix.example }}/results.txt
-        column -s, -t < bench-results/unprofiled/${{ matrix.example }}/results.csv | tee bench-results/unprofiled/${{ matrix.example }}/resultDiff.txt
+        column -s, -t < bench-results/unprofiled/${{ matrix.example }}/resultDiff.csv | tee bench-results/unprofiled/${{ matrix.example }}/resultDiff.txt
 
     - name: tar benchmarking artifacts
       run:  find bench-results -name "*.csv" -or -name "*.svg" -or -name "*.html" | xargs tar -czf benchmark-artifacts.tar.gz

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -156,6 +156,8 @@ jobs:
     - name: Display results
       run: |
         column -s, -t < bench-results/unprofiled/${{ matrix.example }}/results.csv | tee bench-results/unprofiled/${{ matrix.example }}/results.txt
+        echo
+        echo "Performance Diff(comparing to its previous Version):"
         column -s, -t < bench-results/unprofiled/${{ matrix.example }}/resultDiff.csv | tee bench-results/unprofiled/${{ matrix.example }}/resultDiff.txt
 
     - name: tar benchmarking artifacts

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -156,6 +156,7 @@ jobs:
     - name: Display results
       run: |
         column -s, -t < bench-results/unprofiled/${{ matrix.example }}/results.csv | tee bench-results/unprofiled/${{ matrix.example }}/results.txt
+        column -s, -t < bench-results/unprofiled/${{ matrix.example }}/results.csv | tee bench-results/unprofiled/${{ matrix.example }}/resultDiff.txt
 
     - name: tar benchmarking artifacts
       run:  find bench-results -name "*.csv" -or -name "*.svg" -or -name "*.html" | xargs tar -czf benchmark-artifacts.tar.gz

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -163,7 +163,7 @@ createBuildSystem config = do
 
   buildRules build hlsBuildRules
   benchRules build (MkBenchRules (askOracle $ GetSamples ()) benchHls warmupHls "haskell-language-server" (parallelism configStatic))
-  addGeParentOracle
+  addGetParentOracle
   csvRules build
   svgRules build
   heapProfileRules build

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -163,6 +163,7 @@ createBuildSystem config = do
 
   buildRules build hlsBuildRules
   benchRules build (MkBenchRules (askOracle $ GetSamples ()) benchHls warmupHls "haskell-language-server" (parallelism configStatic))
+  addGeParentOracle
   csvRules build
   svgRules build
   heapProfileRules build

--- a/bench/README.md
+++ b/bench/README.md
@@ -54,6 +54,9 @@ Targets:
   - bench-results/*/*/*/results.csv
   - bench-results/*/*/results.csv
   - bench-results/*/results.csv
+  - bench-results/*/*/*/resultDiff.csv
+  - bench-results/*/*/resultDiff.csv
+  - bench-results/*/resultDiff.csv
   - bench-results/*/*/*/*.svg
   - bench-results/*/*/*/*.diff.svg
   - bench-results/*/*/*.svg

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -418,7 +418,7 @@ csvRules build = do
     let resultsPrev = tail allResultsPrev
     let resultsCur = tail allResultsCur
     let resultDiff = zipWith convertToDiffResults resultsCur resultsPrev
-    writeFileChanged out $ unlines $ show out2 : head allResultsCur : resultDiff
+    writeFileChanged out $ unlines $ head allResultsCur : resultDiff
   -- aggregate all configurations for an experiment
   priority 3 $ build -/- "*/*/*/results.csv" %> genConfig "results.csv"
     "Configuration" (map confName <$> askOracle (GetConfigurations ()))

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -391,7 +391,7 @@ parseMaxResidencyAndAllocations input =
 
 
 --------------------------------------------------------------------------------
-addGeParentOracle = void $ addOracle $ \(GetParent name) -> findPrev name <$> askOracle (GetVersions ())
+addGetParentOracle = void $ addOracle $ \(GetParent name) -> findPrev name <$> askOracle (GetVersions ())
 -- | Rules to aggregate the CSV output of individual experiments
 csvRules :: forall example . RuleResultForExample example => FilePattern -> Rules ()
 csvRules build = do

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -48,6 +48,7 @@ module Development.Benchmark.Rules
   (
       buildRules, MkBuildRules(..), OutputFolder, ProjectRoot,
       benchRules, MkBenchRules(..), BenchProject(..), ProfilingMode(..),
+      addGeParentOracle,
       csvRules,
       svgRules,
       heapProfileRules,
@@ -77,11 +78,13 @@ import           Data.Aeson                                (FromJSON (..),
 import           Data.Aeson.Lens                           (AsJSON (_JSON),
                                                             _Object, _String)
 import           Data.ByteString.Lazy                      (ByteString)
-import           Data.Char                                 (isDigit)
-import           Data.List                                 (find, isInfixOf,
+import           Data.Char                                 (isAlpha, isDigit)
+import           Data.List                                 (find, intercalate,
+                                                            isInfixOf,
+                                                            isSuffixOf,
                                                             stripPrefix,
                                                             transpose)
-import           Data.List.Extra                           (lower)
+import           Data.List.Extra                           (lower, splitOn)
 import           Data.Maybe                                (fromMaybe)
 import           Data.String                               (fromString)
 import           Data.Text                                 (Text)
@@ -186,6 +189,8 @@ phonyRules prefix executableName prof buildFolder examples = do
         exampleTargets <- forM examples $ \ex ->
             allTargetsForExample prof buildFolder ex
         need $ (buildFolder </> profilingPath prof </> "results.csv")
+             : concat exampleTargets
+        need $ (buildFolder </> profilingPath prof </> "resultDiff.csv")
              : concat exampleTargets
     phony (prefix <> "all-binaries") $ need =<< allBinaries buildFolder executableName
 --------------------------------------------------------------------------------
@@ -384,69 +389,89 @@ parseMaxResidencyAndAllocations input =
 
 
 --------------------------------------------------------------------------------
-
+addGeParentOracle = void $ addOracle $ \(GetParent name) -> findPrev name <$> askOracle (GetVersions ())
 -- | Rules to aggregate the CSV output of individual experiments
 csvRules :: forall example . RuleResultForExample example => FilePattern -> Rules ()
 csvRules build = do
+  let genConfig resultName prefixName prefixOracles out = do
+        configurations <- prefixOracles
+        let allResultFiles = [takeDirectory out </> c </> resultName | c <- configurations ]
+        allResults <- traverse readFileLines allResultFiles
+        let header = head $ head allResults
+            results = map tail allResults
+            header' = prefixName <> ", " <> header
+            results' = zipWith (\v -> map (\l -> v <> ", " <> l)) configurations results
+        writeFileChanged out $ unlines $ header' : interleave results'
   -- build results for every experiment*example
-  build -/- "*/*/*/*/results.csv" %> \out -> do
+  priority 1 $ build -/- "*/*/*/*/results.csv" %> \out -> do
       experiments <- askOracle $ GetExperiments ()
-
       let allResultFiles = [takeDirectory out </> escaped (escapeExperiment e) <.> "csv" | e <- experiments]
       allResults <- traverse readFileLines allResultFiles
-
       let header = head $ head allResults
           results = map tail allResults
       writeFileChanged out $ unlines $ header : concat results
-
+  priority 2 $ build -/- "*/*/*/*/resultDiff.csv" %> \out -> do
+    let out2@[b, flav, example, ver, conf, exp_] = splitDirectories out
+    prev <- fmap T.unpack $ askOracle $ GetParent $ T.pack ver
+    allResultsCur <- readFileLines $ joinPath [b ,flav, example, ver, conf] </> "results.csv"
+    allResultsPrev <- readFileLines $ joinPath [b ,flav, example, prev, conf] </> "results.csv"
+    let resultsPrev = tail allResultsPrev
+    let resultsCur = tail allResultsCur
+    let resultDiff = zipWith convertToDiffResults resultsCur resultsPrev
+    writeFileChanged out $ unlines $ show out2 : head allResultsCur : resultDiff
   -- aggregate all configurations for an experiment
-  build -/- "*/*/*/results.csv" %> \out -> do
-    configurations <- map confName <$> askOracle (GetConfigurations ())
-    let allResultFiles = [takeDirectory out </> c </> "results.csv" | c <- configurations ]
-
-    allResults <- traverse readFileLines allResultFiles
-
-    let header = head $ head allResults
-        results = map tail allResults
-        header' = "configuration, " <> header
-        results' = zipWith (\v -> map (\l -> v <> ", " <> l)) configurations results
-
-    writeFileChanged out $ unlines $ header' : interleave results'
-
+  priority 3 $ build -/- "*/*/*/results.csv" %> genConfig "results.csv"
+    "Configuration" (map confName <$> askOracle (GetConfigurations ()))
+  priority 3 $ build -/- "*/*/*/resultDiff.csv" %> genConfig "resultDiff.csv"
+    "Configuration" (map confName <$> askOracle (GetConfigurations ()))
   -- aggregate all experiments for an example
-  build -/- "*/*/results.csv" %> \out -> do
-    versions <- map (T.unpack . humanName) <$> askOracle (GetVersions ())
-    let allResultFiles = [takeDirectory out </> v </> "results.csv" | v <- versions]
-
-    allResults <- traverse readFileLines allResultFiles
-
-    let header = head $ head allResults
-        results = map tail allResults
-        header' = "version, " <> header
-        results' = zipWith (\v -> map (\l -> v <> ", " <> l)) versions results
-
-    writeFileChanged out $ unlines $ header' : interleave results'
-
+  priority 4 $ build -/- "*/*/results.csv" %> genConfig "results.csv"
+        "Version" (map (T.unpack . humanName) <$> askOracle (GetVersions ()))
+  priority 4 $ build -/- "*/*/resultDiff.csv" %> genConfig "resultDiff.csv"
+        "Version" (map (T.unpack . humanName) <$> askOracle (GetVersions ()))
   -- aggregate all examples
-  build -/- "*/results.csv" %> \out -> do
-    examples <- map (getExampleName @example) <$> askOracle (GetExamples ())
-    let allResultFiles = [takeDirectory out </> e </> "results.csv" | e <- examples]
+  priority 5 $ build -/- "*/results.csv" %> genConfig "results.csv"
+        "Example" (map getExampleName <$> askOracle (GetExamples ()))
+  priority 5 $ build -/- "*/resultDiff.csv" %> genConfig "resultDiff.csv"
+        "Example" (map getExampleName <$> askOracle (GetExamples ()))
 
-    allResults <- traverse readFileLines allResultFiles
+convertToDiffResults :: String -> String -> String
+convertToDiffResults line baseLine = intercalate "," diffResults
+        where items = parseLine line
+              baseItems = parseLine baseLine
+              diffItems = zipWith diffItem items baseItems
+              diffResults = map showItemDiffResult diffItems
 
-    let header = head $ head allResults
-        results = map tail allResults
-        header' = "example, " <> header
-        results' = zipWith (\e -> map (\l -> e <> ", " <> l)) examples results
+showItemDiffResult ::  (Item, Maybe Double) -> String
+showItemDiffResult (ItemString x, _) = x
+showItemDiffResult (_, Nothing)      = "Nah"
+showItemDiffResult (Mem x, Just y)   = printf "%.2f" (y * 100 - 100) <> "%"
+showItemDiffResult (Time x, Just y)  = printf "%.2f" (y * 100 - 100) <> "%"
 
-    writeFileChanged out $ unlines $ header' : concat results'
+diffItem :: Item -> Item -> (Item, Maybe Double)
+diffItem (Mem x) (Mem y) = (Mem x, Just $ fromIntegral x / fromIntegral y)
+diffItem (Time x) (Time y) = (Time x, if y == 0 then Nothing else Just $ x / y)
+diffItem (ItemString x) (ItemString y) = (ItemString x, Nothing)
+diffItem _ _ = (ItemString "no match", Nothing)
+
+data Item = Mem Int | Time Double | ItemString String
+  deriving (Show)
+
+-- split on ','
+parseLine :: String -> [Item]
+parseLine = map f . splitOn ","
+  where
+    f x
+      | "MB" `isSuffixOf` x = Mem $ read $ reverse $ drop 2 $ reverse x
+      --   is is double
+      | any isAlpha x = ItemString x
+      | otherwise = Time $ read x
 
 --------------------------------------------------------------------------------
 
 -- | Rules to produce charts for the GC stats
 svgRules :: FilePattern -> Rules ()
 svgRules build = do
-  void $ addOracle $ \(GetParent name) -> findPrev name <$> askOracle (GetVersions ())
   -- chart GC stats for an experiment on a given revision
   priority 1 $
     build -/- "*/*/*/*/*.svg" %> \out -> do

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -147,7 +147,9 @@ allTargetsForExample prof baseFolder ex = do
     configurations <- askOracle $ GetConfigurations ()
     let buildFolder = baseFolder </> profilingPath prof
     return $
-        [buildFolder </> getExampleName ex </> "results.csv"]
+        [
+            buildFolder </> getExampleName ex </> "results.csv"
+            , buildFolder </> getExampleName ex </> "resultDiff.csv"]
         ++ [ buildFolder </> getExampleName ex </> escaped (escapeExperiment e) <.> "svg"
              | e <- experiments
            ]

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -459,7 +459,6 @@ diffItem _ _ = (ItemString "no match", Nothing)
 data Item = Mem Int | Time Double | ItemString String
   deriving (Show)
 
--- split on ','
 parseLine :: String -> [Item]
 parseLine = map f . splitOn ","
   where

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -464,7 +464,7 @@ parseLine = map f . splitOn ","
   where
     f x
       | "MB" `isSuffixOf` x = Mem $ read $ reverse $ drop 2 $ reverse x
-      --   is is double
+      --   is it double
       | any isAlpha x = ItemString x
       | otherwise = Time $ read x
 


### PR DESCRIPTION
add something like this in benchmark result to easily view the performance diffferent like what we did for the svg.
```
Configuration, name, success, samples, startup, setup, userT, delayedT, 1stBuildT, avgPerRespT, totalT, rulesBuilt, rulesChanged, rulesVisited, rulesTotal, ruleEdges, ghcRebuilds, maxResidency, allocatedBytes
All, edit-header, True,0.00%,2.21%,Nah,-98.75%,Nah,67.50%, NaN,67.50%,-1.89%,-1.81%,-1.80%,-1.24%,0.39%,1650.00%,169.44%,49.89%
All, edit, True,0.00%,0.56%,Nah,3.66%,Nah,3.66%, NaN,3.66%,1.10%,1.10%,1.10%,0.00%,0.00%,0.00%,72.22%,-0.18%
All, hover, True,0.00%,0.57%,Nah,-43.57%,Nah,-43.57%, NaN,-43.57%,0.13%,0.13%,0.13%,1.07%,-0.39%,-94.29%,-61.50%,-33.32%
All, semanticTokens, True,0.00%,1.10%,Nah,2.22%,Nah,2.22%, NaN,2.22%,0.00%,0.00%,0.00%,0.00%,0.00%,0.00%,90.43%,0.46%
All, hover after edit, True,0.00%,5.88%,Nah,-1.22%,Nah,-1.22%, NaN,-1.22%,-1.55%,-1.55%,-1.55%,0.00%,0.00%,0.00%,118.07%,0.71%
All, getDefinition, True,0.00%,1.11%,Nah,8.57%,Nah,7.04%, NaN,7.04%,-0.71%,-0.71%,-0.71%,0.00%,0.00%,0.00%,33.33%,1.06%
All, getDefinition after edit, True,0.00%,-1.68%,Nah,10.53%,Nah,9.09%, NaN,9.09%,2.45%,2.45%,2.45%,0.00%,0.00%,0.00%,37.14%,-1.01%
All, completions, True,0.00%,0.56%,Nah,5.68%,Nah,5.68%, NaN,5.68%,0.31%,0.31%,0.31%,0.00%,0.00%,0.00%,0.00%,-0.48%
All, completions after edit, True,0.00%,9.20%,Nah,-3.03%,Nah,-3.03%, NaN,-3.03%,-1.37%,-1.37%,-1.37%,0.00%,0.00%,0.00%,-25.25%,0.54%
All, code actions, True,0.00%,-6.67%,Nah,-18.28%,0.00%,-18.09%, NaN,-18.09%,0.48%,0.48%,0.48%,0.04%,0.00%,0.00%,98.89%,-0.95%
All, code actions after edit, True,0.00%,-2.13%,Nah,-9.18%,Nah,-9.18%, NaN,-9.18%,-2.67%,-2.67%,-2.67%,0.00%,0.00%,0.00%,79.25%,0.37%
All, code actions after cradle edit, False,0.00%,2.30%,Nah,Nah,Nah,Nah, NaN,23.77%,-0.42%,-0.46%,-0.33%,-1.05%,0.39%,1650.00%,119.44%,44.27%
All, documentSymbols after edit, True,0.00%,-13.40%,Nah,50.00%,-47.48%,-44.14%, NaN,-44.14%,1.91%,1.91%,1.90%,1.07%,-0.39%,-94.29%,-17.37%,-32.40%
All, hole fit suggestions, True,0.00%,0.00%,Nah,1.15%,Nah,1.15%, NaN,1.15%,-0.93%,-0.93%,-0.93%,0.00%,0.00%,0.00%,101.92%,0.49%
All, eval execute single-line code lens, True,0.00%,-1.63%,Nah,-15.02%,Nah,-15.02%, NaN,-15.02%,10.00%,0.00%,12.29%,0.00%,0.00%,0.00%,0.88%,0.58%
All, eval execute multi-line code lens, True,0.00%,-1.60%,Nah,1.98%,Nah,1.98%, NaN,1.98%,0.00%,0.00%,-0.30%,0.00%,0.00%,0.00%,-0.84%,0.11%

```