### PR TITLE
Refactor delayedProgressReporting lsp progress api

### DIFF
--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -138,7 +138,7 @@ delayedProgressReporting before after (Just lspEnv) optProgressStyle = do
             -- a "noticable amount of time" (we often expect a thread kill to arrive before the sleep finishes)
             liftIO $ sleep before
             cancelProgress <- newBarrier
-            LSP.runLspT lspEnv $ withProgress "Processing" Nothing Cancellable $ \update ->
+            async $ LSP.runLspT lspEnv $ withProgress "Processing" Nothing Cancellable $ \update ->
                 race (liftIO $ waitBarrier cancelProgress) (loop update 0)
             return cancelProgress
             where

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -77,7 +77,7 @@ updateState start (Event KickStarted)   NotStarted  = pure $ Running start
 updateState start (Event KickStarted)   (Running a) = join a $> Running start
 updateState _     (Event KickCompleted) (Running a) = join a $> NotStarted
 updateState _     (Event KickCompleted) st          = pure st
-updateState _     StopProgress          (Running a) = join a $> Stopped
+updateState _     StopProgress          (Running a) = a $> Stopped
 updateState _     StopProgress          st          = pure st
 
 -- | Data structure to track progress across the project
@@ -144,7 +144,7 @@ delayedProgressReporting before after (Just lspEnv) optProgressStyle = do
                 b <- liftIO newBarrier
                 LSP.sendRequest SMethod_WindowWorkDoneProgressCreate
                     LSP.WorkDoneProgressCreateParams { _token = u } $ liftIO . signalBarrier b
-                return $ async $ do
+                liftIO $ async $ do
                     ready <- waitBarrier b
                     LSP.runLspT lspEnv $ withProgress "Processing" (Just u) Cancellable $ \update -> loopUntil cancelProgress update 0
             return (Control.Concurrent.Strict.putMVar cancelProgress ())

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -79,7 +79,7 @@ updateState start (Event KickStarted)   NotStarted  = pure $ Running start
 updateState start (Event KickStarted)   (Running a) = join a $> Running start
 updateState _     (Event KickCompleted) (Running a) = join a $> NotStarted
 updateState _     (Event KickCompleted) st          = pure st
-updateState _     StopProgress          (Running a) = a $> Stopped
+updateState _     StopProgress          (Running a) = join a $> Stopped
 updateState _     StopProgress          st          = pure st
 
 -- | Data structure to track progress across the project

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -79,7 +79,7 @@ updateState start (Event KickStarted)   NotStarted  = pure $ Running start
 updateState start (Event KickStarted)   (Running a) = signalBarrier a () $> Running start
 updateState _     (Event KickCompleted) (Running a) = signalBarrier a () $> NotStarted
 updateState _     (Event KickCompleted) st          = pure st
-updateState _     StopProgress          (Running a) = putMVar a () $> Stopped
+updateState _     StopProgress          (Running a) = signalBarrier a () $> Stopped
 updateState _     StopProgress          st          = pure st
 
 -- | Data structure to track progress across the project


### PR DESCRIPTION
It seems we have not been using lsp progress helper api any where.
Refactor `delayedProgressReporting` to use lsp progress api. 
It is an easy target, we can see see how it works out here.
cc @michaelpj 