### PR TITLE
Rename hls-graph's paths file to align with its module name

### DIFF
--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -65,9 +65,9 @@ library
     Development.IDE.Graph.KeyMap
     Development.IDE.Graph.KeySet
     Development.IDE.Graph.Rule
-    Paths_hls_graph
+    PathsHlsGraph
 
-  autogen-modules:    Paths_hls_graph
+  autogen-modules:    PathsHlsGraph
   hs-source-dirs:     src
   build-depends:
     , aeson

--- a/hls-graph/src/Development/IDE/Graph/Internal/Paths.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Paths.hs
@@ -6,7 +6,7 @@ module Development.IDE.Graph.Internal.Paths (readDataFileHTML) where
 #ifndef FILE_EMBED
 import           Control.Exception    (SomeException (SomeException), catch)
 import           Control.Monad        (filterM)
-import           Paths_hls_graph
+import           PathsHlsGraph
 import           System.Directory     (doesFileExist, getCurrentDirectory)
 import           System.Environment   (getExecutablePath)
 import           System.FilePath      (takeDirectory, (</>))

--- a/hls-graph/src/PathsHlsGraph.hs
+++ b/hls-graph/src/PathsHlsGraph.hs
@@ -1,6 +1,6 @@
 -- | Fake cabal module for local building
 
-module Paths_hls_graph(getDataDir, version) where
+module PathsHlsGraph(getDataDir, version) where
 
 import           Data.Version.Extra
 


### PR DESCRIPTION
At first, it comes to me as the cabal 3.12 prerelease having trouble identifiying this file in multi repl mode.
Error like saying the file is not in `*.cabal`.

But then, I do feel like it is a good idea we just rename the file properly. So the module name and the file name aligns