### PR TITLE
CI: enable pedantic for each cabal package separately

### DIFF
--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -76,10 +76,11 @@ jobs:
       - name: Configue non-default flags for all components
         run: |
           cabal configure \
-              --constraint "hls-graph +embed-files +stm-stats" \
-              --constraint "ghcide +ekg +executable +test-exe" \
-              --constraint "hls-plugin-api -use-fingertree" \
-              --constraint "all +pedantic"
+              --constraint "haskell-language-server +pedantic" \
+              --constraint "hls-graph +embed-files +pedantic +stm-stats" \
+              --constraint "hls-test-utils +embed-files +pedantic +stm-stats" \
+              --constraint "ghcide +ekg +executable +pedantic +test-exe" \
+              --constraint "hls-plugin-api +pedantic -use-fingertree"
           cat cabal.project.local
 
       - name: Build everything with non-default flags


### PR DESCRIPTION
It seems that the original "all +pedantic" doesn't enable pedantic flag for everything 
If you run `cabal configure --constraint "all +pedantic"` followed by 

```bash
cabal build -v2   #among other things verbosity level 2 outputs "Flags chosen: ... pedantic=False... " for each target
# or 
cabal build -v2 all
# or 
cabal build -v2 <specific-component>
```
you' won't see any pedantic=True anywhere.
Doing it on per-cabal-file basis seems to work fine (and leads to desirable CI failures).