### PR TITLE
Actually enable pedantic flag in ci flags job

### DIFF
--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -76,10 +76,10 @@ jobs:
       - name: Configue non-default flags for all components
         run: |
           cabal configure \
-              --constraint "hls-graph +embed-files +stm-stats" \
+              --constraint "haskell-language-server +pedantic" \
+              --constraint "hls-graph +embed-files +pedantic +stm-stats" \
               --constraint "ghcide +ekg +executable +test-exe" \
-              --constraint "hls-plugin-api -use-fingertree" \
-              --constraint "all +pedantic"
+              --constraint "hls-plugin-api +pedantic -use-fingertree"
           cat cabal.project.local
 
       - name: Build everything with non-default flags

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -94,7 +94,6 @@
     - Main
     - Experiments
     - Development.Benchmark.Rules
-    - Development.IDE.Plugin.CodeAction
     - Development.IDE.Plugin.Completions
     - Development.IDE.Plugin.CodeAction.ExactPrint
     - Development.IDE.Spans.Documentation

--- a/ghcide/exe/Main.hs
+++ b/ghcide/exe/Main.hs
@@ -6,14 +6,11 @@ module Main(main) where
 
 import           Arguments                                (Arguments (..),
                                                            getArguments)
-import           Control.Monad.Extra                      (unless)
 import           Control.Monad.IO.Class                   (liftIO)
 import           Data.Default                             (def)
 import           Data.Function                            ((&))
 import           Data.Version                             (showVersion)
 import           Development.GitRev                       (gitHash)
-import           Development.IDE                          (action)
-import           Development.IDE.Core.OfInterest          (kick)
 import           Development.IDE.Core.Rules               (mainRule)
 import qualified Development.IDE.Core.Rules               as Rules
 import           Development.IDE.Core.Tracing             (withTelemetryRecorder)

--- a/ghcide/test/exe/DiagnosticTests.hs
+++ b/ghcide/test/exe/DiagnosticTests.hs
@@ -36,10 +36,8 @@ import           Control.Monad.Extra             (whenJust)
 import           Data.Default                    (def)
 import           Development.IDE.Plugin.Test     (WaitForIdeRuleResult (..))
 import           System.Time.Extra
-import           Test.Hls                        (runSessionWithServer',
-                                                  runSessionWithServerInTmpDirCont,
-                                                  waitForProgressBegin,
-                                                  waitForTypecheck)
+import           Test.Hls                        (runSessionWithServerInTmpDirCont,
+                                                  waitForProgressBegin)
 import           Test.Hls.FileSystem             (directCradle, file, text,
                                                   toAbsFp)
 import           Test.Tasty

--- a/ghcide/test/exe/TestUtils.hs
+++ b/ghcide/test/exe/TestUtils.hs
@@ -1,46 +1,37 @@
-
 {-# LANGUAGE GADTs #-}
 
 module TestUtils where
 
-import           Control.Applicative.Combinators
 import           Control.Concurrent.Async
-import           Control.Exception               (bracket_, finally)
-import           Control.Lens                    ((.~))
-import qualified Control.Lens                    as Lens
-import qualified Control.Lens.Extras             as Lens
-import           Control.Monad
+import           Control.Exception              (bracket_, finally)
 import           Data.Foldable
-import           Data.Function                   ((&))
 import           Data.Maybe
-import           Development.IDE.GHC.Compat      (GhcVersion (..), ghcVersion)
-import qualified Development.IDE.Main            as IDE
-import           Development.IDE.Test            (configureCheckProject,
-                                                  expectNoMoreDiagnostics)
+import           Development.IDE.GHC.Compat     (GhcVersion (..), ghcVersion)
+import qualified Development.IDE.Main           as IDE
+import           Development.IDE.Test           (configureCheckProject,
+                                                 expectNoMoreDiagnostics)
 import           Development.IDE.Test.Runfiles
 import           Development.IDE.Types.Location
-import           Development.Shake               (getDirectoryFilesIO)
-import           Ide.Logger                      (Recorder, WithPriority,
-                                                  cmapWithPrio)
-import qualified Language.LSP.Protocol.Lens      as L
-import           Language.LSP.Protocol.Message
-import           Language.LSP.Protocol.Types     hiding
-                                                 (SemanticTokenAbsolute (..),
-                                                  SemanticTokenRelative (..),
-                                                  SemanticTokensEdit (..),
-                                                  mkRange)
+import           Development.Shake              (getDirectoryFilesIO)
+import           Ide.Logger                     (Recorder, WithPriority,
+                                                 cmapWithPrio)
+import           Language.LSP.Protocol.Types    hiding
+                                                (SemanticTokenAbsolute (..),
+                                                 SemanticTokenRelative (..),
+                                                 SemanticTokensEdit (..),
+                                                 mkRange)
 import           Language.LSP.Test
 import           System.Directory
-import           System.Environment.Blank        (getEnv, setEnv, unsetEnv)
+import           System.Environment.Blank       (getEnv, setEnv, unsetEnv)
 import           System.FilePath
-import           System.Info.Extra               (isMac, isWindows)
+import           System.Info.Extra              (isMac, isWindows)
 import qualified System.IO.Extra
-import           System.Process.Extra            (createPipe)
+import           System.Process.Extra           (createPipe)
 import           Test.Tasty
 import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.HUnit
 
-import           Config                          (lspTestCaps)
+import           Config                         (lspTestCaps)
 import           LogType
 
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -340,6 +340,8 @@ test-suite hls-class-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
   if !flag(class)
     buildable: False
+  if impl(ghc >= 9.8)
+    ghc-options: -Wwarn=x-partial
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-class-plugin/test
   main-is:          Main.hs
@@ -1183,6 +1185,8 @@ test-suite hls-change-type-signature-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
   if !flag(changeTypeSignature)
     buildable: False
+  if impl(ghc >= 9.8)
+    ghc-options: -Wwarn=x-partial
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-change-type-signature-plugin/test
   main-is:          Main.hs

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1680,25 +1680,23 @@ test-suite hls-refactor-plugin-tests
   ghc-options:      -O0
   build-depends:
     , base
+    , data-default
+    , directory
+    , extra
     , filepath
+    , ghcide:ghcide
     , haskell-language-server:hls-refactor-plugin
     , hls-test-utils      == 2.8.0.0
     , lens
-    , lsp-types
-    , text
-    , hls-plugin-api
-    , parser-combinators
-    , data-default
-    , extra
-    , ghcide:ghcide
-    , shake
-    , hls-plugin-api
     , lsp-test
-    , directory
+    , lsp-types
+    , parser-combinators
     , regex-tdfa
-    , tasty-hunit
-    , tasty-expected-failure
+    , shake
     , tasty
+    , tasty-expected-failure
+    , tasty-hunit
+    , text
 
 -----------------------------
 -- semantic tokens plugin
@@ -1767,19 +1765,17 @@ test-suite hls-semantic-tokens-plugin-tests
     , aeson
     , base
     , containers
+    , data-default
     , filepath
+    , ghcide                == 2.8.0.0
     , haskell-language-server:hls-semantic-tokens-plugin
-    , hls-test-utils              == 2.8.0.0
-    , hls-plugin-api
+    , hls-plugin-api        == 2.8.0.0
+    , hls-test-utils        == 2.8.0.0
     , lens
     , lsp
-    , text-rope
     , lsp-test
     , text
-    , data-default
-    , ghcide                == 2.8.0.0
-    , hls-plugin-api        == 2.8.0.0
-    , data-default
+    , text-rope
 
 -----------------------------
 -- notes plugin

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -44,7 +44,10 @@ common defaults
   default-extensions: ExplicitNamespaces
 
 common test-defaults
-  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  if impl(ghc >= 9.8)
+    -- We allow using partial functions in tests
+    ghc-options: -Wno-x-partial
 
 -- Default warnings in HLS
 common warnings
@@ -340,8 +343,6 @@ test-suite hls-class-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
   if !flag(class)
     buildable: False
-  if impl(ghc >= 9.8)
-    ghc-options: -Wwarn=x-partial
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-class-plugin/test
   main-is:          Main.hs
@@ -1185,8 +1186,6 @@ test-suite hls-change-type-signature-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
   if !flag(changeTypeSignature)
     buildable: False
-  if impl(ghc >= 9.8)
-    ghc-options: -Wwarn=x-partial
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-change-type-signature-plugin/test
   main-is:          Main.hs

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -57,7 +57,11 @@ library
     , temporary
     , text
 
-  ghc-options:      -Wall -Wunused-packages -Wno-name-shadowing
+  ghc-options:
+    -Wall
+    -Wunused-packages
+    -Wno-name-shadowing
+    -Wno-unticked-promoted-constructors
 
   if flag(pedantic)
     ghc-options: -Werror

--- a/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/Literals.hs
+++ b/plugins/hls-alternate-number-format-plugin/src/Ide/Plugin/Literals.hs
@@ -9,9 +9,10 @@ module Ide.Plugin.Literals (
 
 import           Data.Maybe                    (maybeToList)
 import           Data.Text                     (Text)
-import qualified Data.Text                     as T
 #if __GLASGOW_HASKELL__ >= 908
 import qualified Data.Text.Encoding            as T
+#else
+import qualified Data.Text                     as T
 #endif
 import           Development.IDE.GHC.Compat    hiding (getSrcSpan)
 import           Development.IDE.Graph.Classes (NFData (rnf))

--- a/plugins/hls-change-type-signature-plugin/test/Main.hs
+++ b/plugins/hls-change-type-signature-plugin/test/Main.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 908
-{-# OPTIONS_GHC -Wwarn=x-partial #-}
-#endif
-
 module Main where
 
 import           Control.Monad                  (void)

--- a/plugins/hls-change-type-signature-plugin/test/Main.hs
+++ b/plugins/hls-change-type-signature-plugin/test/Main.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wwarn=x-partial #-}
+#endif
+
 module Main where
 
 import           Control.Monad                  (void)

--- a/plugins/hls-class-plugin/test/Main.hs
+++ b/plugins/hls-class-plugin/test/Main.hs
@@ -1,10 +1,6 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
-#if __GLASGOW_HASKELL__ >= 908
-{-# OPTIONS_GHC -Wwarn=x-partial #-}
-#endif
 
 module Main
   ( main

--- a/plugins/hls-class-plugin/test/Main.hs
+++ b/plugins/hls-class-plugin/test/Main.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wwarn=x-partial #-}
+#endif
 
 module Main
   ( main

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Parse/Comments.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Parse/Comments.hs
@@ -57,7 +57,7 @@ We build parsers combining the following three kinds of them:
 -}
 
 -- | Line parser
-type LineParser a = forall m. Monad m => ParsecT Void String m a
+type LineParser a = forall m. ParsecT Void String m a
 
 -- | Line comment group parser
 type LineGroupParser = Parsec Void [(Range, RawLineComment)]

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -1085,12 +1085,14 @@ suggestImportDisambiguation df (Just txt) ps fileContents diag@Diagnostic {..}
                         _                 -> False
                     ]
                 ++ [HideOthers restImports | not (null restImports)]
-            ] ++ [ ( renderUniquify mode T.empty symbol True
-              , disambiguateSymbol ps fileContents diag symbol mode
-              ) | local
-                , (m,ms) <- take 1 targetsWithRestImports
-                , let mode = HideOthers (m:ms)
-            ]
+            ] ++ case targetsWithRestImports of
+                    (m,ms):_ | local ->
+                        let mode = HideOthers (m:ms)
+                        in [( renderUniquify mode T.empty symbol True
+                            , disambiguateSymbol ps fileContents diag symbol mode
+                            )]
+                    _ -> []
+
         renderUniquify HideOthers {} modName symbol local =
             "Use " <> (if local then "local definition" else modName) <> " for " <> symbol <> ", hiding other imports"
         renderUniquify (ToQualified _ qual) _ symbol _ =

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -1087,8 +1087,9 @@ suggestImportDisambiguation df (Just txt) ps fileContents diag@Diagnostic {..}
                 ++ [HideOthers restImports | not (null restImports)]
             ] ++ [ ( renderUniquify mode T.empty symbol True
               , disambiguateSymbol ps fileContents diag symbol mode
-              ) | local, not (null targetsWithRestImports)
-                , let mode = HideOthers (uncurry (:) (head targetsWithRestImports))
+              ) | local
+                , (m,ms) <- take 1 targetsWithRestImports
+                , let mode = HideOthers (m:ms)
             ]
         renderUniquify HideOthers {} modName symbol local =
             "Use " <> (if local then "local definition" else modName) <> " for " <> symbol <> ", hiding other imports"


### PR DESCRIPTION
As found in https://github.com/haskell/haskell-language-server/pull/4223 we're not actually enabling pedantic in CI at all.
This enables it for all cabal projects for which most warnings have been fixed so far (not yet for ghcide).