### PR TITLE
Shorter file names completion

### DIFF
--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Paths.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Paths.hs
@@ -51,14 +51,20 @@ data PathCompletionInfo = PathCompletionInfo
   if wasn't present in the original path.
 
   Fix for the issue #3774
-   
-  Examples of path splitting:
-  ""            -> ("", "") instead of ("./","")
-  "./"          -> ("./", "")
-  "dir"         -> ("", "dir") instead of ("./","dir")
-  "./dir"       -> ("./", "dir")
-  "dir1/dir2"   -> ("dir1/","dir2")
-  "./dir1/dir2" -> ("./dir1/","dir2")
+  Examples:
+
+  >>> splitFileNameNoTrailingSlash ""
+  ("", "")
+  >>> splitFileNameNoTrailingSlash "./"
+  ("./", "")
+  >>> splitFileNameNoTrailingSlash "dir"
+  ("", "dir")
+  >>> splitFileNameNoTrailingSlash "./dir"
+  ("./", "dir")
+  >>> splitFileNameNoTrailingSlash "dir1/dir2"
+  ("dir1/","dir2")
+  >>> splitFileNameNoTrailingSlash "./dir1/dir2"
+  ("./dir1/","dir2")
 -}
 splitFileNameNoTrailingSlash :: FilePath -> (String, String)
 splitFileNameNoTrailingSlash prefix = rmTrailingSlash ("./" `List.isPrefixOf` prefix) (Posix.splitFileName prefix)
@@ -85,7 +91,7 @@ pathCompletionInfoFromCabalPrefixInfo srcDir prefInfo =
     }
   where
     prefix = T.unpack $ completionPrefix prefInfo
-    (queryDirectory', pathSegment') = splitFileNameNoTrailingSlash prefix             
+    (queryDirectory', pathSegment') = splitFileNameNoTrailingSlash prefix
 
 -- | Extracts the source directories of the library stanza.
 sourceDirsExtractionLibrary :: Maybe StanzaName -> GenericPackageDescription -> [FilePath]

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Paths.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Paths.hs
@@ -1,6 +1,7 @@
 module Ide.Plugin.Cabal.Completion.Completer.Paths where
 
 import qualified Data.List                         as List
+import           Data.List.Extra                   (dropPrefix)
 import qualified Data.Text                         as T
 import           Distribution.PackageDescription   (Benchmark (..),
                                                     BuildInfo (..),
@@ -15,8 +16,6 @@ import           Distribution.Utils.Path           (getSymbolicPath)
 import           Ide.Plugin.Cabal.Completion.Types
 import qualified System.FilePath                   as FP
 import qualified System.FilePath.Posix             as Posix
-import Data.List.Extra (dropPrefix)
-import Data.List (isPrefixOf)
 
 
 {- | Information used to query and build path completions.
@@ -62,7 +61,7 @@ data PathCompletionInfo = PathCompletionInfo
   "./dir1/dir2" -> ("./dir1/","dir2")
 -}
 splitFileNameNoTrailingSlash :: FilePath -> (String, String)
-splitFileNameNoTrailingSlash prefix = rmTrailingSlash ("./" `isPrefixOf` prefix) (Posix.splitFileName prefix)
+splitFileNameNoTrailingSlash prefix = rmTrailingSlash ("./" `List.isPrefixOf` prefix) (Posix.splitFileName prefix)
   where rmTrailingSlash hadTrailingSlash (queryDirectory', pathSegment')
                     | hadTrailingSlash = (queryDirectory', pathSegment')
                     | otherwise        = ("./" `dropPrefix` queryDirectory', pathSegment')

--- a/plugins/hls-cabal-plugin/test/Completer.hs
+++ b/plugins/hls-cabal-plugin/test/Completer.hs
@@ -165,15 +165,15 @@ directoryCompleterTests :: TestTree
 directoryCompleterTests =
   testGroup
     "Directory Completer Tests"
-    [ testCase "Current Directory" $ do
+    [ testCase "Current Directory - no leading ./ by default" $ do
         completions <- completeDirectory "" filePathComplTestDir
-        completions @?== ["./dir1/", "./dir2/"],
+        completions @?== ["dir1/", "dir2/"],
       testCase "Current Directory - alternative writing" $ do
         completions <- completeDirectory "./" filePathComplTestDir
         completions @?== ["./dir1/", "./dir2/"],
       testCase "Current Directory - incomplete directory path written" $ do
         completions <- completeDirectory "di" filePathComplTestDir
-        completions @?== ["./dir1/", "./dir2/"],
+        completions @?== ["dir1/", "dir2/"],
       testCase "Current Directory - incomplete filepath written" $ do
         completions <- completeDirectory "te" filePathComplTestDir
         completions @?== [],

--- a/plugins/hls-cabal-plugin/test/Completer.hs
+++ b/plugins/hls-cabal-plugin/test/Completer.hs
@@ -55,8 +55,8 @@ basicCompleterTests =
         doc <- openDoc "main-is.cabal" "cabal"
         compls <- getCompletions doc (Position 10 12)
         let complTexts = getTextEditTexts compls
-        liftIO $ assertBool "suggests f2" $ "./f2.hs" `elem` complTexts
-        liftIO $ assertBool "does not suggest" $ "./Content.hs" `notElem` complTexts
+        liftIO $ assertBool "suggests f2" $ "f2.hs" `elem` complTexts
+        liftIO $ assertBool "does not suggest" $ "Content.hs" `notElem` complTexts
     ]
     where
       getTextEditTexts :: [CompletionItem] -> [T.Text]
@@ -66,21 +66,21 @@ fileCompleterTests :: TestTree
 fileCompleterTests =
   testGroup
     "File Completer Tests"
-    [ testCase "Current Directory" $ do
+    [ testCase "Current Directory - no leading ./ by default" $ do
         completions <- completeFilePath "" filePathComplTestDir
-        completions @?== ["./.hidden", "./Content.hs", "./dir1/", "./dir2/", "./textfile.txt", "./main-is.cabal"],
+        completions @?== [".hidden", "Content.hs", "dir1/", "dir2/", "textfile.txt", "main-is.cabal"],
       testCase "Current Directory - alternative writing" $ do
         completions <- completeFilePath "./" filePathComplTestDir
         completions @?== ["./.hidden", "./Content.hs", "./dir1/", "./dir2/", "./textfile.txt", "./main-is.cabal"],
       testCase "Current Directory - hidden file start" $ do
         completions <- completeFilePath "." filePathComplTestDir
-        completions @?== ["./Content.hs", "./.hidden", "./textfile.txt", "./main-is.cabal"],
+        completions @?== ["Content.hs", ".hidden", "textfile.txt", "main-is.cabal"],
       testCase "Current Directory - incomplete directory path written" $ do
         completions <- completeFilePath "di" filePathComplTestDir
-        completions @?== ["./dir1/", "./dir2/"],
+        completions @?== ["dir1/", "dir2/"],
       testCase "Current Directory - incomplete filepath written" $ do
         completions <- completeFilePath "te" filePathComplTestDir
-        completions @?== ["./Content.hs", "./textfile.txt"],
+        completions @?== ["Content.hs", "textfile.txt"],
       testCase "Subdirectory" $ do
         completions <- completeFilePath "dir1/" filePathComplTestDir
         completions @?== ["dir1/f1.txt", "dir1/f2.hs"],

--- a/plugins/hls-cabal-plugin/test/Context.hs
+++ b/plugins/hls-cabal-plugin/test/Context.hs
@@ -31,12 +31,12 @@ pathCompletionInfoFromCompletionContextTests :: TestTree
 pathCompletionInfoFromCompletionContextTests =
     testGroup
         "Completion Info to Completion Context Tests"
-        [ testCase "Current Directory" $ do
+        [ testCase "Current Directory - no leading ./ by default" $ do
             let complInfo = pathCompletionInfoFromCabalPrefixInfo "" $ simpleCabalPrefixInfoFromFp "" testDataDir
-            queryDirectory complInfo @?= "./"
+            queryDirectory complInfo @?= ""
         , testCase "Current Directory - partly written next" $ do
             let complInfo = pathCompletionInfoFromCabalPrefixInfo "" $ simpleCabalPrefixInfoFromFp "di" testDataDir
-            queryDirectory complInfo @?= "./"
+            queryDirectory complInfo @?= ""
             pathSegment complInfo @?= "di"
         , testCase "Current Directory - alternative writing" $ do
             let complInfo = pathCompletionInfoFromCabalPrefixInfo "" $ simpleCabalPrefixInfoFromFp "./" testDataDir


### PR DESCRIPTION
Fix for the issue #3774

To solve it I have created a wrapper of the `Posix.splitFileName` function.
The function by default [tends to add unnecessary trailing slash](https://hackage.haskell.org/package/filepath-1.5.2.0/docs/System-FilePath-Posix.html#g:4) 

