### PR TITLE
add back withLongTimeout to CradleTests

### DIFF
--- a/ghcide/test/exe/CradleTests.hs
+++ b/ghcide/test/exe/CradleTests.hs
@@ -125,7 +125,7 @@ multiTestName :: FilePath -> String -> String
 multiTestName dir name = "simple-" ++ dir ++ "-" ++ name
 
 simpleMultiTest :: FilePath -> TestTree
-simpleMultiTest variant = testCase (multiTestName variant "test") $ runWithExtraFiles variant $ \dir -> do
+simpleMultiTest variant = testCase (multiTestName variant "test") $ withLongTimeout $ runWithExtraFiles variant $ \dir -> do
     let aPath = dir </> "a/A.hs"
         bPath = dir </> "b/B.hs"
     adoc <- openDoc aPath "haskell"


### PR DESCRIPTION
In previous migrate of `CradleTests`, removal of `withLongTimeout` seems to be causing trouble to windows.
Add it back fix that.