### PR TITLE
Remove unused and outdated CHANGELOG files

### DIFF
--- a/plugins/hls-cabal-plugin/CHANGELOG.md
+++ b/plugins/hls-cabal-plugin/CHANGELOG.md
@@ -1,6 +1,0 @@
-# Revision history for hls-cabal-plugin
-
-## 0.1.0.0 -- YYYY-mm-dd
-
-* Provide Diagnostics on parse errors and warnings for .cabal files
-* Provide CodeAction for the common SPDX License mistake "BSD3" instead of "BSD-3-Clause"

--- a/plugins/hls-explicit-record-fields-plugin/CHANGELOG.md
+++ b/plugins/hls-explicit-record-fields-plugin/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Revision history for hls-explicit-record-fields-plugin
-
-## 1.0.0.0 -- YYYY-mm-dd
-
-* First version. Released on an unsuspecting world.

--- a/plugins/hls-floskell-plugin/CHANGELOG.md
+++ b/plugins/hls-floskell-plugin/CHANGELOG.md
@@ -1,4 +1,0 @@
-# Revision history for hls-floskell-plugin
-
-## 2.5.1.0 -- 2024-01-05
-Updates Floskell dependency to 0.11.*, which supports Aeson 2.2.*

--- a/plugins/hls-overloaded-record-dot-plugin/CHANGELOG.md
+++ b/plugins/hls-overloaded-record-dot-plugin/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Revision history for hls-overloaded-record-dot-plugin
-
-## 1.0.0.0 -- 2023-04-16
-
-* First version. 

--- a/plugins/hls-retrie-plugin/changelog.md
+++ b/plugins/hls-retrie-plugin/changelog.md
@@ -1,2 +1,0 @@
-### 0.1.1.0 (2021-02-..)
-* Fix bug in Retrieve "fold/unfold in local file" commands (#1202)


### PR DESCRIPTION
The CHANGELOG files in plugins are neither up-to-date nor can they even be displayed in Hackage (since plugins are all internal libraries and Hackage). I also don't think they are displayed in flora.

Thus, delete them, so users aren't confused why the ChangeLogs contain barely any information.


Thanks to @Kleidukos, who kindly told me that we had CHANGELOGs :)