### PR TITLE
FindImports: ThisPkg means some home unit, not "this" unit

### DIFF
--- a/ghcide/test/data/multi-unit/b-1.0.0-inplace
+++ b/ghcide/test/data/multi-unit/b-1.0.0-inplace
@@ -16,4 +16,5 @@ a-1.0.0-inplace
 -package
 base
 -XHaskell98
+-XPackageImports
 B

--- a/ghcide/test/data/multi-unit/b/B.hs
+++ b/ghcide/test/data/multi-unit/b/B.hs
@@ -1,3 +1,3 @@
 module B(module B) where
-import A
+import "a" A
 qux = foo


### PR DESCRIPTION
This bug prevents package imports from working within a multi unit session.
