### PR TITLE
Use -fno-show-error-context from GHC 9.8

### DIFF
--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -1232,6 +1232,9 @@ setOptions cfp (ComponentOptions theOpts compRoot _) dflags rootDir = do
               Just wdir -> compRoot </> wdir
         let dflags''' =
               setWorkingDirectory root $
+#if MIN_VERSION_ghc(9,8,0)
+              setNoShowErrorContext $
+#endif
               disableWarningsAsErrors $
               -- disabled, generated directly by ghcide instead
               flip gopt_unset Opt_WriteInterface $
@@ -1252,6 +1255,12 @@ setOptions cfp (ComponentOptions theOpts compRoot _) dflags rootDir = do
         -- is done later in newComponentCache
         final_flags <- liftIO $ wrapPackageSetupException $ Compat.oldInitUnits dflags'''
         return (final_flags, targets)
+
+#if MIN_VERSION_ghc(9,8,0)
+setNoShowErrorContext :: DynFlags -> DynFlags
+setNoShowErrorContext df =
+    gopt_unset df Opt_ShowErrorContext
+#endif
 
 setIgnoreInterfacePragmas :: DynFlags -> DynFlags
 setIgnoreInterfacePragmas df =


### PR DESCRIPTION
Resolves #4281

Before the change, with GHC 9.8.1, this is how error messages look in Visual Studio Code:

<img width="725" alt="Screenshot 2024-06-08 at 20 47 34" src="https://github.com/haskell/haskell-language-server/assets/1685489/390b6108-3306-49e5-b5ea-df92e92fb3ca">

After the change, this is how it looks now:

<img width="706" alt="Screenshot 2024-06-08 at 20 50 33" src="https://github.com/haskell/haskell-language-server/assets/1685489/0a301246-f5a8-41ed-bbf7-ea3caa5d60d8">

