### PR TITLE
Enable stylish-haskell with ghc 9.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,8 +165,7 @@ jobs:
         name: Test hls-stan-plugin
         run: cabal test hls-stan-plugin-tests || cabal test hls-stan-plugin-tests
 
-      # TODO enable when it supports 9.10
-      - if: matrix.test && matrix.ghc != '9.10'
+      - if: matrix.test
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin-tests || cabal test hls-stylish-haskell-plugin-tests
 

--- a/cabal.project
+++ b/cabal.project
@@ -45,3 +45,8 @@ constraints:
 if impl(ghc >= 9.9)
   -- https://github.com/haskell/haskell-language-server/issues/4324
   benchmarks: False
+
+  source-repository-package
+    type:git
+    location: https://github.com/jhrcek/stylish-haskell.git
+    tag: 6223f45f4fbf36e52781c8661bd8de6842855958

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1563,14 +1563,13 @@ flag stylishHaskell
   manual:      True
 
 common stylishHaskell
-  if flag(stylishHaskell) && impl(ghc < 9.10)
+  if flag(stylishHaskell)
     build-depends: haskell-language-server:hls-stylish-haskell-plugin
     cpp-options: -Dhls_stylishHaskell
 
 library hls-stylish-haskell-plugin
   import:           defaults, pedantic, warnings
-  -- https://github.com/haskell/stylish-haskell/issues/479
-  if !(flag(stylishHaskell) && impl(ghc < 9.10))
+  if !flag(stylishHaskell)
     buildable: False
   exposed-modules:  Ide.Plugin.StylishHaskell
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/src
@@ -1589,7 +1588,7 @@ library hls-stylish-haskell-plugin
 
 test-suite hls-stylish-haskell-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !(flag(stylishHaskell) && impl(ghc < 9.10))
+  if !flag(stylishHaskell)
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/test


### PR DESCRIPTION
Blocked on https://github.com/haskell/stylish-haskell/pull/480 which in turn is blocked on ghc 9.10 becoming available in stackage snapshot..