### PR TITLE
Formalize the ProgressReporting Type

### DIFF
--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -71,7 +71,8 @@ import           Data.Tuple.Extra                       (dupe)
 import           Debug.Trace
 import           Development.IDE.Core.FileStore         (resetInterfaceStore)
 import           Development.IDE.Core.Preprocessor
-import           Development.IDE.Core.ProgressReporting (ProgressReporting (..))
+import           Development.IDE.Core.ProgressReporting (ProgressReporting (..),
+                                                         progressReportingNoTrace, progressUpdate)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
 import           Development.IDE.Core.Tracing           (withTrace)

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -71,8 +71,7 @@ import           Data.Tuple.Extra                       (dupe)
 import           Debug.Trace
 import           Development.IDE.Core.FileStore         (resetInterfaceStore)
 import           Development.IDE.Core.Preprocessor
-import           Development.IDE.Core.ProgressReporting (ProgressReporting (..),
-                                                         progressReportingNoTrace, progressUpdate)
+import           Development.IDE.Core.ProgressReporting (progressUpdate)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
 import           Development.IDE.Core.Tracing           (withTrace)

--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -141,7 +141,7 @@ kick = do
                 toJSON $ map fromNormalizedFilePath files
 
     signal (Proxy @"kick/start")
-    progressUpdate progress ProgressNewStarted
+    liftIO $ progressUpdate progress ProgressNewStarted
 
     -- Update the exports map
     results <- uses GenerateCore files
@@ -152,7 +152,7 @@ kick = do
     let mguts = catMaybes results
     void $ liftIO $ atomically $ modifyTVar' exportsMap (updateExportsMapMg mguts)
 
-    progressUpdate progress ProgressCompleted
+    liftIO $ progressUpdate progress ProgressCompleted
 
     GarbageCollectVar var <- getIdeGlobalAction
     garbageCollectionScheduled <- liftIO $ readVar var

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -83,16 +83,13 @@ instance ProgressReportingClass (ProgressReporting m) where
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The progress of tasks can be tracked in two ways:
 
-1. `InProgressState`: This is an internal state that actively tracks the progress.
+1. `ProgressReporting`: we have an internal state that actively tracks the progress.
    Changes to the progress are made directly to this state.
 
-2. `InProgressStateOutSide`: This is an external state that tracks the progress.
+2. `ProgressReportingNoTrace`: there is an external state that tracks the progress.
    The external state is converted into an STM Int for the purpose of reporting progress.
 
-The `inProgress` function is only useful when we are using `InProgressState`.
-
-An alternative design could involve using GADTs to eliminate this discrepancy between
-`InProgressState` and `InProgressStateOutSide`.
+The `inProgress` function is only useful when we are using `ProgressReporting`.
 -}
 
 noProgressReportingNoTrace :: (MonadUnliftIO m) => (ProgressReportingNoTrace m)

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -194,8 +194,7 @@ progressReporting (Just lspEnv) title optProgressStyle = do
   inProgressState <- newInProgress
   progressReportingInner <- progressReportingNoTrace (readTVar $ todoVar inProgressState)
                                 (readTVar $ doneVar inProgressState) (Just lspEnv) title optProgressStyle
-  let
-      inProgress :: forall a. NormalizedFilePath -> m a -> m a
+  let inProgress :: forall a. NormalizedFilePath -> m a -> m a
       inProgress = updateStateForFile inProgressState
   return ProgressReporting {..}
   where

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -48,8 +48,8 @@ data ProgressEvent
   | ProgressStarted
 
 data ProgressReporting = ProgressReporting
-  { progressUpdateI :: ProgressEvent -> IO (),
-    progressStopI   :: IO ()
+  { _progressUpdate :: ProgressEvent -> IO (),
+    _progressStop   :: IO ()
     -- ^ we are using IO here because creating and stopping the `ProgressReporting`
     -- is different from how we use it.
   }
@@ -66,12 +66,12 @@ class ProgressReporter a where
     progressStop :: a -> IO ()
 
 instance ProgressReporter ProgressReporting where
-    progressUpdate = progressUpdateI
-    progressStop = progressStopI
+    progressUpdate = _progressUpdate
+    progressStop = _progressStop
 
 instance ProgressReporter PerFileProgressReporting where
-    progressUpdate = progressUpdateI . progressReportingInner
-    progressStop = progressStopI . progressReportingInner
+    progressUpdate = _progressUpdate . progressReportingInner
+    progressStop = _progressStop . progressReportingInner
 
 {- Note [ProgressReporting API and InProgressState]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -88,8 +88,8 @@ The `inProgress` function is only useful when we are using `ProgressReporting`.
 
 noProgressReporting :: ProgressReporting
 noProgressReporting = ProgressReporting
-      { progressUpdateI = const $ pure (),
-        progressStopI = pure ()
+      { _progressUpdate = const $ pure (),
+        _progressStop = pure ()
       }
 noPerFileProgressReporting :: IO PerFileProgressReporting
 noPerFileProgressReporting =
@@ -165,8 +165,8 @@ progressReportingNoTrace ::
 progressReportingNoTrace _ _ Nothing _title _optProgressStyle = return noProgressReporting
 progressReportingNoTrace todo done (Just lspEnv) title optProgressStyle = do
   progressState <- newVar NotStarted
-  let progressUpdateI event = liftIO $ updateStateVar $ Event event
-      progressStopI = updateStateVar StopProgress
+  let _progressUpdate event = liftIO $ updateStateVar $ Event event
+      _progressStop = updateStateVar StopProgress
       updateStateVar = modifyVar_ progressState . updateState (progressCounter lspEnv title optProgressStyle todo done)
   return ProgressReporting {..}
 

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -62,7 +62,6 @@ data ProgressReporting m = ProgressReporting
     progressReportingInner :: ProgressReportingNoTrace m
   }
 
-
 class ProgressReportingClass a where
     type M a :: * -> *
     progressUpdate ::  a -> ProgressEvent -> M a ()
@@ -135,7 +134,6 @@ data InProgressState
         doneVar    :: TVar Int,
         currentVar :: STM.Map NormalizedFilePath Int
       }
-
 
 newInProgress :: IO InProgressState
 newInProgress = InProgressState <$> newTVarIO 0 <*> newTVarIO 0 <*> STM.newIO

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -56,9 +56,9 @@ data ProgressReportingNoTrace = ProgressReportingNoTrace
 
 data ProgressReporting = ProgressReporting
   {
-    inProgress             :: forall a. NormalizedFilePath -> IO a -> IO a,
+    inProgress       :: forall a. NormalizedFilePath -> IO a -> IO a,
     -- ^ see Note [ProgressReporting API and InProgressState]
-    progressReportingInner :: ProgressReportingNoTrace
+    progressReporter :: ProgressReportingNoTrace
   }
 
 class ProgressReportingClass a where
@@ -70,8 +70,8 @@ instance ProgressReportingClass ProgressReportingNoTrace where
     progressStop = progressStopI
 
 instance ProgressReportingClass ProgressReporting where
-    progressUpdate = progressUpdateI . progressReportingInner
-    progressStop = progressStopI . progressReportingInner
+    progressUpdate = progressUpdateI . progressReporter
+    progressStop = progressStopI . progressReporter
 
 {- Note [ProgressReporting API and InProgressState]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,7 +96,7 @@ noProgressReporting =
   return $
     ProgressReporting
       { inProgress = const id,
-        progressReportingInner = noProgressReportingNoTrace
+        progressReporter = noProgressReportingNoTrace
       }
 
 -- | State used in 'delayedProgressReporting'
@@ -181,7 +181,7 @@ progressReporting ::
 progressReporting Nothing _title _optProgressStyle = noProgressReporting
 progressReporting (Just lspEnv) title optProgressStyle = do
   inProgressState <- newInProgress
-  progressReportingInner <- progressReportingNoTrace (readTVar $ todoVar inProgressState)
+  progressReporter <- progressReportingNoTrace (readTVar $ todoVar inProgressState)
                                 (readTVar $ doneVar inProgressState) (Just lspEnv) title optProgressStyle
   let
     inProgress :: NormalizedFilePath -> IO a -> IO a

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -56,9 +56,9 @@ data ProgressReportingNoTrace = ProgressReportingNoTrace
 
 data ProgressReporting = ProgressReporting
   {
-    inProgress       :: forall a. NormalizedFilePath -> IO a -> IO a,
+    inProgress             :: forall a. NormalizedFilePath -> IO a -> IO a,
     -- ^ see Note [ProgressReporting API and InProgressState]
-    progressReporter :: ProgressReportingNoTrace
+    progressReportingInner :: ProgressReportingNoTrace
   }
 
 class ProgressReportingClass a where
@@ -70,8 +70,8 @@ instance ProgressReportingClass ProgressReportingNoTrace where
     progressStop = progressStopI
 
 instance ProgressReportingClass ProgressReporting where
-    progressUpdate = progressUpdateI . progressReporter
-    progressStop = progressStopI . progressReporter
+    progressUpdate = progressUpdateI . progressReportingInner
+    progressStop = progressStopI . progressReportingInner
 
 {- Note [ProgressReporting API and InProgressState]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,7 +96,7 @@ noProgressReporting =
   return $
     ProgressReporting
       { inProgress = const id,
-        progressReporter = noProgressReportingNoTrace
+        progressReportingInner = noProgressReportingNoTrace
       }
 
 -- | State used in 'delayedProgressReporting'
@@ -181,7 +181,7 @@ progressReporting ::
 progressReporting Nothing _title _optProgressStyle = noProgressReporting
 progressReporting (Just lspEnv) title optProgressStyle = do
   inProgressState <- newInProgress
-  progressReporter <- progressReportingNoTrace (readTVar $ todoVar inProgressState)
+  progressReportingInner <- progressReportingNoTrace (readTVar $ todoVar inProgressState)
                                 (readTVar $ doneVar inProgressState) (Just lspEnv) title optProgressStyle
   let
     inProgress :: NormalizedFilePath -> IO a -> IO a

--- a/ghcide/src/Development/IDE/Core/ProgressReporting.hs
+++ b/ghcide/src/Development/IDE/Core/ProgressReporting.hs
@@ -61,15 +61,15 @@ data ProgressReporting = ProgressReporting
     progressReportingInner :: ProgressReportingNoTrace
   }
 
-class ProgressReportingClass a where
+class ProgressReporter a where
     progressUpdate ::  a -> ProgressEvent -> IO ()
     progressStop :: a -> IO ()
 
-instance ProgressReportingClass ProgressReportingNoTrace where
+instance ProgressReporter ProgressReportingNoTrace where
     progressUpdate = progressUpdateI
     progressStop = progressStopI
 
-instance ProgressReportingClass ProgressReporting where
+instance ProgressReporter ProgressReporting where
     progressUpdate = progressUpdateI . progressReportingInner
     progressStop = progressStopI . progressReportingInner
 

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -244,7 +244,7 @@ data HieDbWriter
   { indexQueue             :: IndexQueue
   , indexPending           :: TVar (HMap.HashMap NormalizedFilePath Fingerprint) -- ^ Avoid unnecessary/out of date indexing
   , indexCompleted         :: TVar Int -- ^ to report progress
-  , indexProgressReporting :: ProgressReporting IO
+  , indexProgressReporting :: ProgressReportingNoTrace IO
   }
 
 -- | Actions to queue up on the index worker thread
@@ -676,7 +676,7 @@ shakeOpen recorder lspEnv defaultConfig idePlugins debouncer
         indexPending <- newTVarIO HMap.empty
         indexCompleted <- newTVarIO 0
         semanticTokensId <- newTVarIO 0
-        indexProgressReporting <- progressReportingOutsideState
+        indexProgressReporting <- progressReportingNoTrace
             (liftM2 (+) (length <$> readTVar indexPending) (readTVar indexCompleted))
             (readTVar indexCompleted)
             lspEnv "Indexing" optProgressStyle

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -245,7 +245,7 @@ data HieDbWriter
   { indexQueue             :: IndexQueue
   , indexPending           :: TVar (HMap.HashMap NormalizedFilePath Fingerprint) -- ^ Avoid unnecessary/out of date indexing
   , indexCompleted         :: TVar Int -- ^ to report progress
-  , indexProgressReporting :: ProgressReportingNoTrace
+  , indexProgressReporting :: ProgressReporting
   }
 
 -- | Actions to queue up on the index worker thread
@@ -295,7 +295,7 @@ data ShakeExtras = ShakeExtras
     -- positions in a version of that document to positions in the latest version
     -- First mapping is delta from previous version and second one is an
     -- accumulation to the current version.
-    ,progress :: ProgressReporting
+    ,progress :: PerFileProgressReporting
     ,ideTesting :: IdeTesting
     -- ^ Whether to enable additional lsp messages used by the test suite for checking invariants
     ,restartShakeSession
@@ -694,7 +694,7 @@ shakeOpen recorder lspEnv defaultConfig idePlugins debouncer
         progress <-
             if reportProgress
                 then progressReporting lspEnv "Processing" optProgressStyle
-                else noProgressReporting
+                else noPerFileProgressReporting
         actionQueue <- newQueue
 
         let clientCapabilities = maybe def LSP.resClientCapabilities lspEnv

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -174,6 +174,7 @@ import qualified StmContainers.Map                      as STM
 import           System.FilePath                        hiding (makeRelative)
 import           System.IO.Unsafe                       (unsafePerformIO)
 import           System.Time.Extra
+import           UnliftIO                               (MonadUnliftIO (withRunInIO))
 
 
 data Log
@@ -244,7 +245,7 @@ data HieDbWriter
   { indexQueue             :: IndexQueue
   , indexPending           :: TVar (HMap.HashMap NormalizedFilePath Fingerprint) -- ^ Avoid unnecessary/out of date indexing
   , indexCompleted         :: TVar Int -- ^ to report progress
-  , indexProgressReporting :: ProgressReportingNoTrace IO
+  , indexProgressReporting :: ProgressReportingNoTrace
   }
 
 -- | Actions to queue up on the index worker thread
@@ -294,7 +295,7 @@ data ShakeExtras = ShakeExtras
     -- positions in a version of that document to positions in the latest version
     -- First mapping is delta from previous version and second one is an
     -- accumulation to the current version.
-    ,progress :: ProgressReporting Action
+    ,progress :: ProgressReporting
     ,ideTesting :: IdeTesting
     -- ^ Whether to enable additional lsp messages used by the test suite for checking invariants
     ,restartShakeSession
@@ -1216,7 +1217,8 @@ defineEarlyCutoff'
 defineEarlyCutoff' doDiagnostics cmp key file mbOld mode action = do
     ShakeExtras{state, progress, dirtyKeys} <- getShakeExtras
     options <- getIdeOptions
-    (if optSkipProgress options key then id else inProgress progress file) $ do
+    let trans g x =  withRunInIO $ \run -> g (run x)
+    (if optSkipProgress options key then id else trans (inProgress progress file)) $ do
         val <- case mbOld of
             Just old | mode == RunDependenciesSame -> do
                 mbValue <- liftIO $ atomicallyNamed "define - read 1" $ getValues state key file


### PR DESCRIPTION
follow up of https://github.com/haskell/haskell-language-server/pull/4205
This is intended to remove the useless `inProgress` when tracking the `inProgressState` from the outside.
1. Add kind `data ProgressStateTrackingType = ProgressStateInsideTracking | ProgressStateOutsideTracking` to distinguish the two type of `inProgressState` tracking.
2. Spread the `TProgressState` to related type location to mark what kind of tracking we used. Then we won't have `inProgress` for `ProgressStateOutsideTracking`
