### PR TITLE
capture error in worker thread

### DIFF
--- a/ghcide/src/Development/IDE/Core/WorkerThread.hs
+++ b/ghcide/src/Development/IDE/Core/WorkerThread.hs
@@ -45,7 +45,8 @@ withWorkerQueue workerAction = ContT $ \mainAction -> do
                 workerAction l
 
 -- | 'awaitRunInThread' queues up an 'IO' action to be run by a worker thread,
--- and then blocks until the result is computed.
+-- and then blocks until the result is computed. If the action throws an
+-- non-async exception, it is rethrown in the calling thread.
 awaitRunInThread :: TQueue (IO ()) -> IO result -> IO result
 awaitRunInThread q act = do
     -- Take an action from TQueue, run it and


### PR DESCRIPTION
Fix #4340
let the caller handle the error happened during `awaitRunInThread`. In such case the HLS won't be stuck if the session setup fails and the LSP should be able to show the error to the client as other error cases happening in the rule system.
cc @fendor 