### PR TITLE
Fix cabal.project index-state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,7 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-index-state: 2024-07-20T00:00:00Z
+index-state: 2024-06-29T00:00:00Z
 
 tests: True
 test-show-details: direct


### PR DESCRIPTION
Time travel back since the new release cabal-install 12 is not happy with us and refuse to build