### PR TITLE
Release 2.9.0.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
                     , ADD_CABAL_ARGS: "--enable-split-sections"
                     },
                     { image: "centos:7"
-                    , installCmd: "yum -y install epel-release && yum install -y"
+                    , installCmd: "sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && yum -y install epel-release && yum install -y"
                     , toolRequirements: "autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf"
                     , DISTRO: "CentOS"
                     , ARTIFACT: "x86_64-linux-centos7"
@@ -450,7 +450,7 @@ jobs:
             DISTRO: Fedora
             ARTIFACT: "x86_64-linux-fedora33"
           - image: centos:7
-            installCmd: yum -y install epel-release && yum install -y
+            installCmd: sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && yum -y install epel-release && yum install -y
             toolRequirements: autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf tree
             DISTRO: CentOS
             ARTIFACT: "x86_64-linux-centos7"
@@ -745,7 +745,7 @@ jobs:
             DISTRO: Fedora
             ARTIFACT: "x86_64-linux-fedora33"
           - image: centos:7
-            installCmd: yum -y install epel-release && yum install -y
+            installCmd: sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && yum -y install epel-release && yum install -y
             toolRequirements: autoconf automake binutils bzip2 coreutils curl elfutils-devel elfutils-libs findutils gcc gcc-c++ git gmp gmp-devel jq lbzip2 make ncurses ncurses-compat-libs ncurses-devel openssh-clients patch perl pxz python3 sqlite sudo wget which xz zlib-devel patchelf tree
             DISTRO: CentOS
             ARTIFACT: "x86_64-linux-centos7"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -259,7 +259,7 @@ jobs:
     ## The environments can be seen in https://github.com/haskell/haskell-language-server/settings/environments
     ## assuming you have the proper permissions.
     environment: CI
-    runs-on: macOS-11
+    runs-on: macOS-12
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -567,7 +567,7 @@ jobs:
 
   bindist-mac-x86_64:
     name: Tar bindists (Mac x86_64)
-    runs-on: macOS-11
+    runs-on: macOS-12
     needs: ["build-mac-x86_64"]
     env:
       TARBALL_EXT: tar.xz
@@ -828,7 +828,7 @@ jobs:
 
   test-mac-x86_64:
     name: Test binary (Mac x86_64)
-    runs-on: macOS-11
+    runs-on: macOS-12
     needs: ["bindist-mac-x86_64"]
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.10.1", "9.8.2", "9.6.5", "9.4.8"]
+        ghc: ["9.10.1", "9.8.2", "9.6.6", "9.4.8"]
         platform: [ { image: "debian:9"
                     , installCmd: "sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && sed -i /-updates/d /etc/apt/sources.list && apt-get update && apt-get install -y"
                     , toolRequirements: "libnuma-dev zlib1g-dev libgmp-dev libgmp10 libssl-dev liblzma-dev libbz2-dev git wget lsb-release software-properties-common gnupg2 apt-transport-https gcc autoconf automake build-essential curl ghc gzip libffi-dev libncurses-dev libncurses5 libtinfo5 patchelf"
@@ -127,7 +127,7 @@ jobs:
               , ARTIFACT: "x86_64-linux-unknown"
               , ADD_CABAL_ARGS: "--enable-split-sections"
               }
-          - ghc: 9.6.5
+          - ghc: 9.6.6
             platform:
               { image: "rockylinux:8"
               , installCmd: "yum -y install epel-release && yum install -y --allowerasing"
@@ -213,7 +213,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ghc: ["9.10.1", "9.8.2", "9.6.5", "9.4.8"]
+        ghc: ["9.10.1", "9.8.2", "9.6.6", "9.4.8"]
     steps:
       - uses: docker://arm64v8/ubuntu:focal
         name: Cleanup (aarch64 linux)
@@ -273,7 +273,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.10.1", "9.8.2", "9.6.5", "9.4.8"]
+        ghc: ["9.10.1", "9.8.2", "9.6.6", "9.4.8"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -318,7 +318,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.10.1", "9.8.2", "9.6.5", "9.4.8"]
+        ghc: ["9.10.1", "9.8.2", "9.6.6", "9.4.8"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -363,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.10.1", "9.8.2", "9.6.5", "9.4.8"]
+        ghc: ["9.10.1", "9.8.2", "9.6.6", "9.4.8"]
     steps:
       - name: install windows deps
         shell: pwsh

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for haskell-language-server
 
+## 2.9.0.1
+
+- Bindists for GHC 9.6.6
+
 ## 2.9.0.0
 
 - Bindists for GHC 9.10.1 by @wz1000, @jhrcek, @michaelpj

--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -20,7 +20,8 @@ Support status (see the support policy below for more details):
 | 9.10.1       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
 | 9.8.2        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
 | 9.8.1        | [2.6.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.6.0.0)   | full support                                                                |
-| 9.6.5        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
+| 9.6.6        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
+| 9.6.5        | [2.9.0.1](https://github.com/haskell/haskell-language-server/releases/tag/2.9.0.1)   | full support                                                                |
 | 9.6.4        | [2.6.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.6.0.0)   | full support                                                                |
 | 9.6.3        | [2.5.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.5.0.0)   | full support                                                                |
 | 9.6.2        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            2.9.0.0
+version:            2.9.0.1
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -81,8 +81,8 @@ library
     , hie-bios                     ^>=0.14.0
     , hie-compat                   ^>=0.3.0.0
     , hiedb                        ^>= 0.6.0.0
-    , hls-graph                    == 2.9.0.0
-    , hls-plugin-api               == 2.9.0.0
+    , hls-graph                    == 2.9.0.1
+    , hls-plugin-api               == 2.9.0.1
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5
     , lens
     , list-t

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.4
 category:           Development
 name:               haskell-language-server
-version:            2.9.0.0
+version:            2.9.0.1
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -129,8 +129,8 @@ library hls-cabal-fmt-plugin
     , base            >=4.12 && <5
     , directory
     , filepath
-    , ghcide          == 2.9.0.0
-    , hls-plugin-api  == 2.9.0.0
+    , ghcide          == 2.9.0.1
+    , hls-plugin-api  == 2.9.0.1
     , lens
     , lsp-types
     , mtl
@@ -149,7 +149,7 @@ test-suite hls-cabal-fmt-plugin-tests
     , directory
     , filepath
     , haskell-language-server:hls-cabal-fmt-plugin
-    , hls-test-utils        == 2.9.0.0
+    , hls-test-utils        == 2.9.0.1
 
   if flag(isolateCabalfmtTests)
     build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.12
@@ -185,8 +185,8 @@ library hls-cabal-gild-plugin
     , base            >=4.12 && <5
     , directory
     , filepath
-    , ghcide          == 2.9.0.0
-    , hls-plugin-api  == 2.9.0.0
+    , ghcide          == 2.9.0.1
+    , hls-plugin-api  == 2.9.0.1
     , lsp-types
     , text
     , mtl
@@ -204,7 +204,7 @@ test-suite hls-cabal-gild-plugin-tests
     , directory
     , filepath
     , haskell-language-server:hls-cabal-gild-plugin
-    , hls-test-utils        == 2.9.0.0
+    , hls-test-utils        == 2.9.0.1
 
   if flag(isolateCabalGildTests)
     -- https://github.com/tfausak/cabal-gild/issues/89
@@ -256,10 +256,10 @@ library hls-cabal-plugin
     , directory
     , filepath
     , extra                 >=1.7.4
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , hashable
-    , hls-plugin-api        == 2.9.0.0
-    , hls-graph             == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
+    , hls-graph             == 2.9.0.1
     , lens
     , lsp                   ^>=2.7
     , lsp-types             ^>=2.3
@@ -288,7 +288,7 @@ test-suite hls-cabal-plugin-tests
     , filepath
     , ghcide
     , haskell-language-server:hls-cabal-plugin
-    , hls-test-utils    == 2.9.0.0
+    , hls-test-utils    == 2.9.0.1
     , lens
     , lsp-types
     , text
@@ -326,9 +326,9 @@ library hls-class-plugin
     , extra
     , ghc
     , ghc-exactprint  >= 1.5 && < 1.10.0.0
-    , ghcide          == 2.9.0.0
+    , ghcide          == 2.9.0.1
     , hls-graph
-    , hls-plugin-api  == 2.9.0.0
+    , hls-plugin-api  == 2.9.0.1
     , lens
     , lsp
     , mtl
@@ -350,7 +350,7 @@ test-suite hls-class-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-class-plugin
-    , hls-test-utils     == 2.9.0.0
+    , hls-test-utils     == 2.9.0.1
     , lens
     , lsp-types
     , text
@@ -385,9 +385,9 @@ library hls-call-hierarchy-plugin
     , base                  >=4.12 && <5
     , containers
     , extra
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , hiedb                 ^>= 0.6.0.0
-    , hls-plugin-api        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
     , lens
     , lsp                    >=2.7
     , sqlite-simple
@@ -409,7 +409,7 @@ test-suite hls-call-hierarchy-plugin-tests
     , extra
     , filepath
     , haskell-language-server:hls-call-hierarchy-plugin
-    , hls-test-utils        == 2.9.0.0
+    , hls-test-utils        == 2.9.0.1
     , lens
     , lsp
     , lsp-test
@@ -460,9 +460,9 @@ library hls-eval-plugin
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , hls-graph
-    , hls-plugin-api        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
     , lens
     , lsp
     , lsp-types
@@ -493,7 +493,7 @@ test-suite hls-eval-plugin-tests
     , filepath
     , haskell-language-server:hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   == 2.9.0.0
+    , hls-test-utils   == 2.9.0.1
     , lens
     , lsp-types
     , text
@@ -524,9 +524,9 @@ library hls-explicit-imports-plugin
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , hls-graph
-    , hls-plugin-api        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
     , lens
     , lsp
     , mtl
@@ -548,7 +548,7 @@ test-suite hls-explicit-imports-plugin-tests
     , extra
     , filepath
     , haskell-language-server:hls-explicit-imports-plugin
-    , hls-test-utils   == 2.9.0.0
+    , hls-test-utils   == 2.9.0.1
     , lens
     , lsp-types
     , text
@@ -576,11 +576,11 @@ library hls-rename-plugin
   build-depends:
     , base                  >=4.12    && <5
     , containers
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , hashable
     , hiedb                 ^>= 0.6.0.0
     , hie-compat
-    , hls-plugin-api        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp-types
@@ -606,7 +606,7 @@ test-suite hls-rename-plugin-tests
     , filepath
     , hls-plugin-api
     , haskell-language-server:hls-rename-plugin
-    , hls-test-utils             == 2.9.0.0
+    , hls-test-utils             == 2.9.0.1
     , lens
     , lsp-types
     , text
@@ -638,9 +638,9 @@ library hls-retrie-plugin
     , containers
     , extra
     , ghc
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , hashable
-    , hls-plugin-api        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp
@@ -669,7 +669,7 @@ test-suite hls-retrie-plugin-tests
     , filepath
     , hls-plugin-api
     , haskell-language-server:{hls-refactor-plugin, hls-retrie-plugin}
-    , hls-test-utils             == 2.9.0.0
+    , hls-test-utils             == 2.9.0.1
     , text
 
 -----------------------------
@@ -707,10 +707,10 @@ library hls-hlint-plugin
     , containers
     , deepseq
     , filepath
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , hashable
     , hlint                 >= 3.5 && < 3.9
-    , hls-plugin-api        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
     , lens
     , lsp
     , mtl
@@ -750,7 +750,7 @@ test-suite hls-hlint-plugin-tests
     , filepath
     , haskell-language-server:hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.9.0.0
+    , hls-test-utils      == 2.9.0.1
     , lens
     , lsp-types
     , text
@@ -811,7 +811,7 @@ test-suite hls-stan-plugin-tests
     , filepath
     , haskell-language-server:hls-stan-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.9.0.0
+    , hls-test-utils      == 2.9.0.1
     , lens
     , lsp-types
     , text
@@ -843,8 +843,8 @@ library hls-module-name-plugin
     , base                  >=4.12 && <5
     , containers
     , filepath
-    , ghcide                == 2.9.0.0
-    , hls-plugin-api        == 2.9.0.0
+    , ghcide                == 2.9.0.1
+    , hls-plugin-api        == 2.9.0.1
     , lsp
     , text
     , transformers
@@ -861,7 +861,7 @@ test-suite hls-module-name-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-module-name-plugin
-    , hls-test-utils          == 2.9.0.0
+    , hls-test-utils          == 2.9.0.1
 
 -----------------------------
 -- pragmas plugin
@@ -887,8 +887,8 @@ library hls-pragmas-plugin
     , base                  >=4.12 && <5
     , extra
     , fuzzy
-    , ghcide                == 2.9.0.0
-    , hls-plugin-api        == 2.9.0.0
+    , ghcide                == 2.9.0.1
+    , hls-plugin-api        == 2.9.0.1
     , lens
     , lsp
     , text
@@ -907,7 +907,7 @@ test-suite hls-pragmas-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-pragmas-plugin
-    , hls-test-utils      == 2.9.0.0
+    , hls-test-utils      == 2.9.0.1
     , lens
     , lsp-types
     , text
@@ -941,8 +941,8 @@ library hls-splice-plugin
     , extra
     , foldl
     , ghc
-    , ghcide                == 2.9.0.0
-    , hls-plugin-api        == 2.9.0.0
+    , ghcide                == 2.9.0.1
+    , hls-plugin-api        == 2.9.0.1
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp
@@ -966,7 +966,7 @@ test-suite hls-splice-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-splice-plugin
-    , hls-test-utils == 2.9.0.0
+    , hls-test-utils == 2.9.0.1
     , text
 
 -----------------------------
@@ -994,10 +994,10 @@ library hls-alternate-number-format-plugin
     , base                 >=4.12 && < 5
     , containers
     , extra
-    , ghcide               == 2.9.0.0
+    , ghcide               == 2.9.0.1
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       == 2.9.0.0
+    , hls-plugin-api       == 2.9.0.1
     , lens
     , lsp                  ^>=2.7
     , mtl
@@ -1023,7 +1023,7 @@ test-suite hls-alternate-number-format-plugin-tests
     , base                 >=4.12 && < 5
     , filepath
     , haskell-language-server:hls-alternate-number-format-plugin
-    , hls-test-utils       == 2.9.0.0
+    , hls-test-utils       == 2.9.0.1
     , regex-tdfa
     , tasty-quickcheck
     , text
@@ -1056,8 +1056,8 @@ library hls-qualify-imported-names-plugin
   build-depends:
     , base                  >=4.12 && <5
     , containers
-    , ghcide                == 2.9.0.0
-    , hls-plugin-api        == 2.9.0.0
+    , ghcide                == 2.9.0.1
+    , hls-plugin-api        == 2.9.0.1
     , lens
     , lsp
     , text
@@ -1079,7 +1079,7 @@ test-suite hls-qualify-imported-names-plugin-tests
     , text
     , filepath
     , haskell-language-server:hls-qualify-imported-names-plugin
-    , hls-test-utils             == 2.9.0.0
+    , hls-test-utils             == 2.9.0.1
 
 -----------------------------
 -- code range plugin
@@ -1110,9 +1110,9 @@ library hls-code-range-plugin
     , containers
     , deepseq
     , extra
-    , ghcide           == 2.9.0.0
+    , ghcide           == 2.9.0.1
     , hashable
-    , hls-plugin-api   == 2.9.0.0
+    , hls-plugin-api   == 2.9.0.1
     , lens
     , lsp
     , mtl
@@ -1135,7 +1135,7 @@ test-suite hls-code-range-plugin-tests
     , bytestring
     , filepath
     , haskell-language-server:hls-code-range-plugin
-    , hls-test-utils             == 2.9.0.0
+    , hls-test-utils             == 2.9.0.1
     , lens
     , lsp
     , lsp-test
@@ -1164,8 +1164,8 @@ library hls-change-type-signature-plugin
   hs-source-dirs:   plugins/hls-change-type-signature-plugin/src
   build-depends:
     , base             >=4.12 && < 5
-    , ghcide           == 2.9.0.0
-    , hls-plugin-api   == 2.9.0.0
+    , ghcide           == 2.9.0.1
+    , hls-plugin-api   == 2.9.0.1
     , lsp-types
     , regex-tdfa
     , syb
@@ -1190,7 +1190,7 @@ test-suite hls-change-type-signature-plugin-tests
     , base                 >=4.12 && < 5
     , filepath
     , haskell-language-server:hls-change-type-signature-plugin
-    , hls-test-utils       == 2.9.0.0
+    , hls-test-utils       == 2.9.0.1
     , regex-tdfa
     , text
   default-extensions:
@@ -1224,9 +1224,9 @@ library hls-gadt-plugin
     , containers
     , extra
     , ghc
-    , ghcide                 == 2.9.0.0
+    , ghcide                 == 2.9.0.1
     , ghc-exactprint
-    , hls-plugin-api         == 2.9.0.0
+    , hls-plugin-api         == 2.9.0.1
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp                    >=2.7
@@ -1247,7 +1247,7 @@ test-suite hls-gadt-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-gadt-plugin
-    , hls-test-utils              == 2.9.0.0
+    , hls-test-utils              == 2.9.0.1
     , text
 
 -----------------------------
@@ -1275,9 +1275,9 @@ library hls-explicit-fixity-plugin
     , containers
     , deepseq
     , extra
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , hashable
-    , hls-plugin-api        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
     , lsp                   >=2.7
     , text
 
@@ -1294,7 +1294,7 @@ test-suite hls-explicit-fixity-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-explicit-fixity-plugin
-    , hls-test-utils              == 2.9.0.0
+    , hls-test-utils              == 2.9.0.1
     , text
 
 -----------------------------
@@ -1318,8 +1318,8 @@ library hls-explicit-record-fields-plugin
   exposed-modules:  Ide.Plugin.ExplicitFields
   build-depends:
     , base                  >=4.12 && <5
-    , ghcide                == 2.9.0.0
-    , hls-plugin-api        == 2.9.0.0
+    , ghcide                == 2.9.0.1
+    , hls-plugin-api        == 2.9.0.1
     , lsp
     , lens
     , hls-graph
@@ -1345,7 +1345,7 @@ test-suite hls-explicit-record-fields-plugin-tests
     , filepath
     , text
     , haskell-language-server:hls-explicit-record-fields-plugin
-    , hls-test-utils              == 2.9.0.0
+    , hls-test-utils              == 2.9.0.1
 
 -----------------------------
 -- overloaded record dot plugin
@@ -1393,7 +1393,7 @@ test-suite hls-overloaded-record-dot-plugin-tests
     , filepath
     , text
     , haskell-language-server:hls-overloaded-record-dot-plugin
-    , hls-test-utils              == 2.9.0.0
+    , hls-test-utils              == 2.9.0.1
 
 
 -----------------------------
@@ -1420,8 +1420,8 @@ library hls-floskell-plugin
   build-depends:
     , base            >=4.12 && <5
     , floskell        ^>=0.11.0
-    , ghcide          == 2.9.0.0
-    , hls-plugin-api  == 2.9.0.0
+    , ghcide          == 2.9.0.1
+    , hls-plugin-api  == 2.9.0.1
     , lsp-types       ^>=2.3
     , mtl
     , text
@@ -1438,7 +1438,7 @@ test-suite hls-floskell-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-floskell-plugin
-    , hls-test-utils       == 2.9.0.0
+    , hls-test-utils       == 2.9.0.1
 
 -----------------------------
 -- fourmolu plugin
@@ -1465,8 +1465,8 @@ library hls-fourmolu-plugin
     , filepath
     , fourmolu        ^>= 0.14 || ^>= 0.15 || ^>= 0.16
     , ghc-boot-th
-    , ghcide          == 2.9.0.0
-    , hls-plugin-api  == 2.9.0.0
+    , ghcide          == 2.9.0.1
+    , hls-plugin-api  == 2.9.0.1
     , lens
     , lsp
     , mtl
@@ -1493,7 +1493,7 @@ test-suite hls-fourmolu-plugin-tests
     , filepath
     , haskell-language-server:hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       == 2.9.0.0
+    , hls-test-utils       == 2.9.0.1
     , lsp-test
 
 -----------------------------
@@ -1521,8 +1521,8 @@ library hls-ormolu-plugin
     , extra
     , filepath
     , ghc-boot-th
-    , ghcide          == 2.9.0.0
-    , hls-plugin-api  == 2.9.0.0
+    , ghcide          == 2.9.0.1
+    , hls-plugin-api  == 2.9.0.1
     , lsp
     , mtl
     , process-extras  >= 0.7.1
@@ -1549,7 +1549,7 @@ test-suite hls-ormolu-plugin-tests
     , filepath
     , haskell-language-server:hls-ormolu-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.9.0.0
+    , hls-test-utils     == 2.9.0.1
     , lsp-types
     , ormolu
 
@@ -1579,8 +1579,8 @@ library hls-stylish-haskell-plugin
     , directory
     , filepath
     , ghc-boot-th
-    , ghcide           == 2.9.0.0
-    , hls-plugin-api   == 2.9.0.0
+    , ghcide           == 2.9.0.1
+    , hls-plugin-api   == 2.9.0.1
     , lsp-types
     , mtl
     , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14
@@ -1598,7 +1598,7 @@ test-suite hls-stylish-haskell-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-stylish-haskell-plugin
-    , hls-test-utils              == 2.9.0.0
+    , hls-test-utils              == 2.9.0.1
 
 -----------------------------
 -- refactor plugin
@@ -1651,8 +1651,8 @@ library hls-refactor-plugin
     , bytestring
     , ghc-boot
     , regex-tdfa
-    , ghcide                == 2.9.0.0
-    , hls-plugin-api        == 2.9.0.0
+    , ghcide                == 2.9.0.1
+    , hls-plugin-api        == 2.9.0.1
     , lsp
     , text
     , transformers
@@ -1690,7 +1690,7 @@ test-suite hls-refactor-plugin-tests
     , filepath
     , ghcide:ghcide
     , haskell-language-server:hls-refactor-plugin
-    , hls-test-utils      == 2.9.0.0
+    , hls-test-utils      == 2.9.0.1
     , lens
     , lsp-test
     , lsp-types
@@ -1738,8 +1738,8 @@ library hls-semantic-tokens-plugin
     , extra
     , text-rope
     , mtl                   >= 2.2
-    , ghcide                == 2.9.0.0
-    , hls-plugin-api        == 2.9.0.0
+    , ghcide                == 2.9.0.1
+    , hls-plugin-api        == 2.9.0.1
     , lens
     , lsp                    >=2.6
     , text
@@ -1749,7 +1749,7 @@ library hls-semantic-tokens-plugin
     , array
     , deepseq
     , dlist
-    , hls-graph == 2.9.0.0
+    , hls-graph == 2.9.0.1
     , template-haskell
     , data-default
     , stm
@@ -1771,10 +1771,10 @@ test-suite hls-semantic-tokens-plugin-tests
     , containers
     , data-default
     , filepath
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , haskell-language-server:hls-semantic-tokens-plugin
-    , hls-plugin-api        == 2.9.0.0
-    , hls-test-utils        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
+    , hls-test-utils        == 2.9.0.1
     , lens
     , lsp
     , lsp-test
@@ -1805,9 +1805,9 @@ library hls-notes-plugin
   build-depends:
     , base >=4.12 && <5
     , array
-    , ghcide == 2.9.0.0
-    , hls-graph == 2.9.0.0
-    , hls-plugin-api == 2.9.0.0
+    , ghcide == 2.9.0.1
+    , hls-graph == 2.9.0.1
+    , hls-plugin-api == 2.9.0.1
     , lens
     , lsp >=2.7
     , mtl >= 2.2
@@ -1834,7 +1834,7 @@ test-suite hls-notes-plugin-tests
     , base
     , filepath
     , haskell-language-server:hls-notes-plugin
-    , hls-test-utils == 2.9.0.0
+    , hls-test-utils == 2.9.0.1
   default-extensions: OverloadedStrings
 
 ----------------------------
@@ -1895,10 +1895,10 @@ library
     , extra
     , filepath
     , ghc
-    , ghcide                == 2.9.0.0
+    , ghcide                == 2.9.0.1
     , githash               >=0.1.6.1
     , hie-bios
-    , hls-plugin-api        == 2.9.0.0
+    , hls-plugin-api        == 2.9.0.1
     , optparse-applicative
     , optparse-simple
     , prettyprinter         >= 1.7
@@ -2005,7 +2005,7 @@ test-suite func-test
     , ghcide:ghcide
     , hashable
     , hls-plugin-api
-    , hls-test-utils == 2.9.0.0
+    , hls-test-utils == 2.9.0.1
     , lens
     , lsp-test
     , lsp-types
@@ -2050,7 +2050,7 @@ test-suite wrapper-test
   build-depends:
     , base       >=4.16 && <5
     , extra
-    , hls-test-utils              == 2.9.0.0
+    , hls-test-utils              == 2.9.0.1
     , process
 
   hs-source-dirs:     test/wrapper
@@ -2134,7 +2134,7 @@ test-suite ghcide-tests
     , text
     , text-rope
     , unordered-containers
-    , hls-test-utils == 2.9.0.0
+    , hls-test-utils == 2.9.0.1
 
   if impl(ghc <9.3)
     build-depends: ghc-typelits-knownnat

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-graph
-version:            2.9.0.0
+version:            2.9.0.1
 synopsis:           Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       2.9.0.0
+version:       2.9.0.1
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -66,7 +66,7 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             == 2.9.0.0
+    , hls-graph             == 2.9.0.1
     , lens
     , lens-aeson
     , lsp                   ^>=2.7

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       2.9.0.0
+version:       2.9.0.1
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -43,8 +43,8 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  == 2.9.0.0
-    , hls-plugin-api          == 2.9.0.0
+    , ghcide                  == 2.9.0.1
+    , hls-plugin-api          == 2.9.0.1
     , lens
     , lsp
     , lsp-test                ^>=0.17


### PR DESCRIPTION
This is a bindist only release.


## Release checklist

- [x] check ghcup supports new GHC releases if any
- [x] set the supported GHCs in workflow file `.github/workflows/release.yaml`
  - There is currently a list of GHC versions for each major platform. Search for `ghc: [` to find all lists.
  - Look for `TODO:` to find locations that require extra care for GHC versions.
- [x] check all plugins still work if release includes code changes
- [x] bump package versions in all `*.cabal` files (same version as hls)
  - HLS uses lockstep versioning. The core packages and all plugins use the same version number, and only support exactly this version.
    - Exceptions:
      - `hie-compat` requires no automatic version bump.
      - `shake-bench` is an internal testing tool, not exposed to the outside world. Thus, no version bump required for releases.
  - For updating cabal files, the following script can be used:
    - ```sh
      ./release/update_versions.sh <OLD_VERSION> <NEW_VERSION>
      ```
    - It still requires manual verification and review
- [x] generate and update changelog
  - Generate a ChangeLog via `./GenChangelogs.hs <api-key> <tag>`
    - `<tag>` is the git tag you want to generate the ChangeLog from.
    - `<api-key>` is a github access key: https://github.com/settings/tokens
- [x] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
- [x] create release branch as `wip/<version>`
  - `git switch -c wip/<version>`
- [x] create release tag as `<version>`
  - `git tag <version>`
- [ ] trigger release pipeline by pushing the tag
  - this creates a draft release
  - `git push <remote> <version>`
- [ ] run `sh scripts/release/download-gh-artifacts.sh <version> <your-gpg-email>`
  - downloads artifacts to `gh-release-artifacts/haskell-language-server-<version>/`
  - also downloads FreeBSD bindist from circle CI
  - adds signatures
- [ ] upload artifacts to downloads.haskell.org from `gh-release-artifacts/haskell-language-server-<version>/`
  - You require sftp access, contact wz1000, bgamari or chreekat
  - `cd gh-release-artifacts/haskell-language-server-<version>`
  - `SIGNING_KEY=... ../../release/upload.sh upload`
    - Your SIGNING_KEY can be obtained with `gpg --list-secret-keys --keyid-format=long`
  - Afterwards, the artifacts are available at: `https://downloads.haskell.org/~hls/haskell-language-server-<version>/`
  - Run `SIGNING_KEY=... ../../release/upload.sh purge_all` to remove CDN caches
- [ ] create PR to [ghcup-metadata](https://github.com/haskell/ghcup-metadata)
  - [ ] update `ghcup-vanilla-0.0.8.yaml` and `ghcup-vanilla-0.0.7.yaml`
    - can use `sh scripts/release/create-yaml-snippet.sh <version>` to generate a snippet that can be manually inserted into the yaml files
  - ~~update `hls-metadata-0.0.1.json`~~ Currently unnecessary, GHCup builds its own HLS binaries and updates that file.
    - utilize `cabal run ghcup-gen -- generate-hls-ghcs -f ghcup-0.0.7.yaml --format json --stdout` in the root of ghcup-metadata repository
  - Be sure to mark the correct latest version and add the 'recommended' tag to the latest release.
- [ ] get sign-off on release
  - from wz1000, michealpj, maerwald and fendor
- [ ] publish release on github
- [ ] upload hackage packages
  - requires credentials
- [ ] Supported tools table needs to be updated:
  - https://www.haskell.org/ghcup/install/#supported-platforms
  - https://github.com/haskell/ghcup-hs/blob/master/docs/install.md#supported-platforms
  - https://github.com/haskell/ghcup-metadata/blob/44c6e2b5d0fcae15abeffff03e87544edf76dd7a/ghcup-gen/Main.hs#L67
- [ ] post release on discourse and reddit
- [ ] merge release PR to master or forward port relevant changes
