### PR TITLE
Fix core file location in `GetLinkable`

### DIFF
--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -125,7 +125,6 @@ import           GHC.Driver.Errors.Types
 import           GHC.Types.Error                     (errMsgDiagnostic,
                                                       singleMessage)
 import           GHC.Unit.State
-import Debug.Trace (traceM)
 
 data Log
   = LogSettingInitialDynFlags
@@ -531,10 +530,7 @@ loadSessionWithOptions recorder SessionLoadingOptions{..} rootDir que = do
                   -- See Note [Avoiding bad interface files]
                   let hscComponents = sort $ map show uids
                       cacheDirOpts = hscComponents ++ componentOptions opts
-                  let opts_hash = B.unpack $ B16.encode $ H.finalize $ H.updates H.init (map B.pack cacheDirOpts)
-                  traceM $ "Setting cache dirs for " ++ show rawComponentUnitId ++ " " ++ opts_hash ++ " " ++ show cacheDirOpts
                   cacheDirs <- liftIO $ getCacheDirs prefix cacheDirOpts
-
                   processed_df <- setCacheDirs recorder cacheDirs df2
                   -- The final component information, mostly the same but the DynFlags don't
                   -- contain any packages which are also loaded

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -125,6 +125,7 @@ import           GHC.Driver.Errors.Types
 import           GHC.Types.Error                     (errMsgDiagnostic,
                                                       singleMessage)
 import           GHC.Unit.State
+import Debug.Trace (traceM)
 
 data Log
   = LogSettingInitialDynFlags
@@ -530,7 +531,10 @@ loadSessionWithOptions recorder SessionLoadingOptions{..} rootDir que = do
                   -- See Note [Avoiding bad interface files]
                   let hscComponents = sort $ map show uids
                       cacheDirOpts = hscComponents ++ componentOptions opts
+                  let opts_hash = B.unpack $ B16.encode $ H.finalize $ H.updates H.init (map B.pack cacheDirOpts)
+                  traceM $ "Setting cache dirs for " ++ show rawComponentUnitId ++ " " ++ opts_hash ++ " " ++ show cacheDirOpts
                   cacheDirs <- liftIO $ getCacheDirs prefix cacheDirOpts
+
                   processed_df <- setCacheDirs recorder cacheDirs df2
                   -- The final component information, mostly the same but the DynFlags don't
                   -- contain any packages which are also loaded

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -94,7 +94,7 @@ import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
 import           GHC                                    (ForeignHValue,
                                                          GetDocsFailure (..),
-                                                         parsedSource)
+                                                         parsedSource, ModLocation (..))
 import qualified GHC.LanguageExtensions                 as LangExt
 import           GHC.Serialized
 import           HieDb                                  hiding (withHieDb)
@@ -1021,7 +1021,17 @@ getModSummaryFromImports env fp _modTime mContents = do
             return $! Util.fingerprintFingerprints $
                     [ Util.fingerprintString fp
                     , fingerPrintImports
+                    , modLocationFingerprint ms_location
                     ] ++ map Util.fingerprintString opts
+
+        modLocationFingerprint :: ModLocation -> Util.Fingerprint
+        modLocationFingerprint ModLocation{..} = Util.fingerprintFingerprints $
+            Util.fingerprintString <$> [ fromMaybe "" ml_hs_file
+                                         , ml_hi_file
+                                         , ml_dyn_hi_file
+                                         , ml_obj_file
+                                         , ml_dyn_obj_file
+                                         , ml_hie_file]
 
 
 -- | Parse only the module header

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -126,7 +126,6 @@ import           GHC.Driver.Config.CoreToStg.Prep
 #if MIN_VERSION_ghc(9,7,0)
 import           Data.Foldable                          (toList)
 import           GHC.Unit.Module.Warnings
-import Development.IDE.Core.WorkerThread (awaitRunInThread)
 #else
 import           Development.IDE.Core.FileStore         (shareFilePath)
 #endif
@@ -196,7 +195,6 @@ typecheckModule (IdeDefer defer) hsc tc_helpers pm = do
               Right tcm -> return (map snd diags, Just $ tcm{tmrDeferredError = deferredError})
     where
         demoteIfDefer = if defer then demoteTypeErrorsToWarnings else id
-
 
 -- | Install hooks to capture the splices as well as the runtime module dependencies
 captureSplicesAndDeps :: TypecheckHelpers -> HscEnv -> (HscEnv -> IO a) -> IO (a, Splices, ModuleEnv BS.ByteString)
@@ -434,7 +432,6 @@ mkHiFileResultCompile se session' tcm simplified_guts = catchErrs $ do
   let session = hscSetFlags (ms_hspp_opts ms) session'
       ms = pm_mod_summary $ tmrParsed tcm
 
-  traceM $ "[TRACE] Generating hi file for " ++ show (moduleName $ ms_mod ms)
   (details, guts) <- do
         -- write core file
         -- give variables unique OccNames
@@ -727,13 +724,11 @@ addRelativeImport fp modu dflags = dflags
 -- | Also resets the interface store
 atomicFileWrite :: ShakeExtras -> FilePath -> (FilePath -> IO a) -> IO a
 atomicFileWrite se targetPath write = do
-  -- awaitRunInThread (restartQueue se) $ do
-  traceM $ "[TRACE] Writing file: " <> targetPath
   let dir = takeDirectory targetPath
   createDirectoryIfMissing True dir
   (tempFilePath, cleanUp) <- newTempFileWithin dir
   (write tempFilePath >>= \x -> renameFile tempFilePath targetPath >> atomically (resetInterfaceStore se (toNormalizedFilePath' targetPath)) >> pure x)
-    `onException` (cleanUp >> throwIO (userError "atomicFileWrite: write failed"))
+    `onException` cleanUp
 
 generateHieAsts :: HscEnv -> TcModuleResult -> IO ([FileDiagnostic], Maybe (HieASTs Type))
 generateHieAsts hscEnv tcm =

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1033,7 +1033,6 @@ getModSummaryFromImports env fp _modTime mContents = do
                                          , ml_dyn_obj_file
                                          , ml_hie_file]
 
-
 -- | Parse only the module header
 parseHeader
        :: Monad m

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -169,7 +169,6 @@ import           System.Info.Extra                            (isWindows)
 
 import qualified Data.IntMap                                  as IM
 import           GHC.Fingerprint
-import Debug.Trace (traceM)
 
 
 data Log
@@ -1040,13 +1039,10 @@ usePropertyByPathAction path plId p = do
 getLinkableRule :: Recorder (WithPriority Log) -> Rules ()
 getLinkableRule recorder =
   defineEarlyCutoff (cmapWithPrio LogShake recorder) $ Rule $ \GetLinkable f -> do
-    -- ModSummaryResult{msrModSummary = ms} <- use_ GetModSummary f
-    tmr <- use_ TypeCheck f
-    let ms = tmrModSummary tmr
+    ms <- tmrModSummary <$> use_ TypeCheck f
     HiFileResult{hirModIface, hirModDetails, hirCoreFp} <- use_ GetModIface f
     let obj_file  = ml_obj_file (ms_location ms)
         core_file = ml_core_file (ms_location ms)
-    traceM $ "GetLinkable core_file " ++ show core_file
     case hirCoreFp of
       Nothing -> error $ "called GetLinkable for a file without a linkable: " ++ show f
       Just (bin_core, fileHash) -> do

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -169,6 +169,7 @@ import           System.Info.Extra                            (isWindows)
 
 import qualified Data.IntMap                                  as IM
 import           GHC.Fingerprint
+import Debug.Trace (traceM)
 
 
 data Log
@@ -1039,10 +1040,13 @@ usePropertyByPathAction path plId p = do
 getLinkableRule :: Recorder (WithPriority Log) -> Rules ()
 getLinkableRule recorder =
   defineEarlyCutoff (cmapWithPrio LogShake recorder) $ Rule $ \GetLinkable f -> do
-    ModSummaryResult{msrModSummary = ms} <- use_ GetModSummary f
+    -- ModSummaryResult{msrModSummary = ms} <- use_ GetModSummary f
+    tmr <- use_ TypeCheck f
+    let ms = tmrModSummary tmr
     HiFileResult{hirModIface, hirModDetails, hirCoreFp} <- use_ GetModIface f
     let obj_file  = ml_obj_file (ms_location ms)
         core_file = ml_core_file (ms_location ms)
+    traceM $ "GetLinkable core_file " ++ show core_file
     case hirCoreFp of
       Nothing -> error $ "called GetLinkable for a file without a linkable: " ++ show f
       Just (bin_core, fileHash) -> do


### PR DESCRIPTION
Fix #4145
The error case is demonstrated in https://github.com/haskell/haskell-language-server/issues/4145#issuecomment-2206965649
1. Include ModLocation in the `ModSummaryResult`  fingerprint.
2. Instead of getting the core file location from `GetModSummary`, get it from the result of `GetModIface` directly since that is the actual location the core file written to. While the `GetModSummary` contains the future core file location that would be written only if we would have made some change cause the rewrite. See Note [Avoiding bad interface files]