### PR TITLE
[WIP] parallelising ghcide tests

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -129,6 +129,7 @@ library
   exposed-modules:
     Control.Concurrent.Strict
     Development.IDE
+    Development.IDE.Core.AbstractPath
     Development.IDE.Core.Actions
     Development.IDE.Core.Compile
     Development.IDE.Core.Debouncer

--- a/ghcide/src/Development/IDE/Core/AbstractPath.hs
+++ b/ghcide/src/Development/IDE/Core/AbstractPath.hs
@@ -1,0 +1,11 @@
+module Development.IDE.Core.AbstractPath where
+
+import           System.FilePath
+
+data AbstractPath = RelativePath FilePath
+                    | AbsolutePath FilePath
+                    deriving (Show)
+
+mkAbstract :: FilePath -> AbstractPath
+mkAbstract x | isRelative x = RelativePath x
+             | otherwise = AbsolutePath x

--- a/ghcide/src/Development/IDE/Core/Service.hs
+++ b/ghcide/src/Development/IDE/Core/Service.hs
@@ -93,7 +93,7 @@ initialise recorder defaultConfig plugins mainRule lspEnv debouncer options with
             ofInterestRules (cmapWithPrio LogOfInterest recorder)
             fileExistsRules (cmapWithPrio LogFileExists recorder) lspEnv
             mainRule)
-        rootDir
+
 
 -- | Shutdown the Compiler Service.
 shutdown :: IdeState -> IO ()

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -649,14 +649,11 @@ shakeOpen :: Recorder (WithPriority Log)
           -> ShakeOptions
           -> Monitoring
           -> Rules ()
-          -> FilePath
-          -- ^ Root directory, this one might be picking up from `LanguageContextEnv`'s `resRootPath`
-          -- , see Note [Root Directory]
           -> IO IdeState
 shakeOpen recorder lspEnv defaultConfig idePlugins debouncer
   shakeProfileDir (IdeReportProgress reportProgress)
   ideTesting
-  withHieDb threadQueue opts monitoring rules rootDir = mdo
+  withHieDb threadQueue opts monitoring rules = mdo
     -- see Note [Serializing runs in separate thread]
     let indexQueue = tIndexQueue threadQueue
         restartQueue = tRestartQueue threadQueue

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1578,6 +1578,7 @@ library hls-stylish-haskell-plugin
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/src
   build-depends:
     , base             >=4.12 && <5
+    , bytestring
     , directory
     , filepath
     , ghc-boot-th
@@ -1587,6 +1588,7 @@ library hls-stylish-haskell-plugin
     , mtl
     , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14
     , text
+    , yaml
 
 
 test-suite hls-stylish-haskell-plugin-tests


### PR DESCRIPTION
Using `getCurrentDirectory` and `setCurrentDirectory` makes it difficult to run tests in parallel since one thread modifying the global `CWD` variable would affect all other test threads. The goal of this PR is to deliberate on ways to avoid using the aforementioned functions (by making paths absolute) and have type guarantees for these absolute paths.
<details><summary>Note [Root Directory] from <i>Development.IDE.Core.Shake</i> </summary>
<p>

We keep track of the root directory explicitly, which is the directory of the project root.
We might be setting it via these options with decreasing priority:

1. from LSP workspace root, `resRootPath` in `LanguageContextEnv`.
2. command line (--cwd)
3. default to the current directory.

Using `getCurrentDirectory` makes it more difficult to run the tests, as we spawn one thread of HLS per test case.
If we modify the global Variable CWD, via `setCurrentDirectory`, all other test threads are suddenly affected,
forcing us to run all integration tests sequentially.

Also, there might be a race condition if we depend on the current directory, as some plugin might change it.
e.g. stylish's `loadConfig`. https://github.com/haskell/haskell-language-server/issues/4234

But according to https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders
The root dir is deprecated, that means we should cleanup dependency on the project root(Or $CWD) thing gradually,
so multi-workspaces can actually be supported when we use absolute path everywhere(might also need some high level design).
That might not be possible unless we have everything adapted to it, like 'hlint' and 'evaluation of template haskell'.
But we should still be working towards the goal.

We can drop it in the future once:
1. We can get rid all the usages of root directory in the codebase.
2. LSP version we support actually removes the root directory from the protocol.

</p>
</details> 

Thank you @fendor for mentioning https://github.com/haskell/cabal/pull/9718 which seems to be doing something similar albeit for completely different reasons.

- [ ] #4277
      ref #4372 
- [x] remove references to `setCurrentDirectory` where possible
   - [x] hls-stylish-plugin
- [ ] investigate using lspEnv's resRootPath as the source of truth for the root directory.
    <details><summary>Details</summary><p>`doInitialize` uses the `defaultRoot` parameter, which is passed down from `setupLSP` (`argsProjectRoot`) in `Arguments{..}` in `defaultArguments` which seems to be taken from `getCurrentDirectory`.</p></details>
