### PR TITLE
Disable ghcide-bench by default

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -93,6 +93,11 @@ flag dynamic
   default:     True
   manual:      True
 
+flag ghcide-bench
+  description: Enable building of the ghcide-bench executable
+  default:     False
+  manual:      True
+
 ----------------------------
 ----------------------------
 -- PLUGINS
@@ -2193,6 +2198,8 @@ test-suite ghcide-tests
 
 
 executable ghcide-bench
+    if !flag(ghcide-bench)
+      buildable: False
     default-language: GHC2021
     build-depends:
         aeson,


### PR DESCRIPTION
Introduce a cabal flag to control the building of `ghcide-bench`, which is an internal tool for benchmarking HLS.

This fixes a regression, where running `cabal install haskell-language-server` to install HLS from Hackage would install `ghcide-bench` as well as the required HLS executables.

Fixes #4359 

POC, so we can iterate on this.