### PR TITLE
Improve error message for `--probe-tools`

### DIFF
--- a/exe/Wrapper.hs
+++ b/exe/Wrapper.hs
@@ -9,7 +9,6 @@ module Main where
 
 import           Control.Monad.Extra
 import           Data.Default
-import           Data.Either.Extra                  (eitherToMaybe)
 import           Data.Foldable
 import           Data.List
 import           Data.List.Extra                    (trimEnd)
@@ -76,8 +75,11 @@ main = do
           putStrLn $ showProgramVersionOfInterest programsOfInterest
           putStrLn "Tool versions in your project"
           cradle <- findProjectCradle' recorder False
-          ghcVersion <- runExceptT $ getRuntimeGhcVersion' cradle
-          putStrLn $ showProgramVersion "ghc" $ mkVersion =<< eitherToMaybe ghcVersion
+          runExceptT (getRuntimeGhcVersion' cradle) >>= \case
+            Left err ->
+              T.hPutStrLn stderr (prettyError err NoShorten)
+            Right ghcVersion ->
+              putStrLn $ showProgramVersion "ghc" $ mkVersion ghcVersion
 
       VersionMode PrintVersion ->
           putStrLn hlsVer


### PR DESCRIPTION
Addresses #4336. When resolving the runtime GHC throws an error, print it. Otherwise show the GHC version.

```
> haskell-language-server-wrapper --probe-tools
haskell-language-server version: 2.9.0.1 (GHC: 9.6.5) (PATH: /home/sgillespie/dev/haskell/haskell-language-server/dist-newstyle/build/x86_64-linux/ghc-9.6.5/haskell-language-server-2.9.0.1/x/haskell-language-server-wrapper/build/haskell-language-server-wrapper/haskell-language-server-wrapper) (GIT hash: 6f6f75bc410c51352e56a87a38a5345bdd44d0bb)
Tool versions found on the $PATH
cabal:          3.10.3.0
stack:          2.15.7
ghc:            9.6.5

Tool versions in your project
2024-08-20T20:42:48.640305Z | Debug | cabal exec -v0 -- ghc --print-libdir
Failed to find the GHC version of this Cabal project.
Error when calling cabal exec -v0 -- ghc --print-libdir

Errors encountered when parsing cabal file ./hls4336.cabal:

hls4336.cabal:20:39: error:
unexpected end of input
expecting white space

   17 |     main-is:          Main.hs
   18 |     -- other-modules:
   19 |     -- other-extensions:
   20 |     build-depends:    base >=4.18.2.1,
      |                                       ^
```