### PR TITLE
 Update cabal-add dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-test-utils
 
 
-index-state:  2024-08-21T15:30:00Z
+index-state:  2024-08-22T00:00:00Z
 
 tests: True
 test-show-details: direct

--- a/cabal.project
+++ b/cabal.project
@@ -7,12 +7,6 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
--- Only keep this until https://github.com/Bodigrim/cabal-add/issues/7
--- is resolved
-source-repository-package
-    type: git
-    location: https://github.com/Bodigrim/cabal-add.git
-    tag: 8c004e2a4329232f9824425f5472b2d6d7958bbd
 
 index-state: 2024-06-29T00:00:00Z
 

--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-test-utils
 
 
-index-state: 2024-06-29T00:00:00Z
+index-state:  2024-08-21T15:30:00Z
 
 tests: True
 test-show-details: direct

--- a/stack-lts22.yaml
+++ b/stack-lts22.yaml
@@ -37,10 +37,7 @@ extra-deps:
   - trial-optparse-applicative-0.0.0.0
   - trial-tomland-0.0.0.0
   - validation-selective-0.2.0.0
-  # Only keep this until https://github.com/Bodigrim/cabal-add/issues/7
-  # is resolved
-  - git: https://github.com/Bodigrim/cabal-add.git
-    commit: 8c004e2a4329232f9824425f5472b2d6d7958bbd
+  - cabal-add-0.1
   - cabal-install-parsers-0.6.1.1
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,10 +38,7 @@ extra-deps:
   - trial-0.0.0.0
   - trial-optparse-applicative-0.0.0.0
   - trial-tomland-0.0.0.0
-  # Only keep this until https://github.com/Bodigrim/cabal-add/issues/7
-  # is resolved
-  - git: https://github.com/Bodigrim/cabal-add.git
-    commit: 8c004e2a4329232f9824425f5472b2d6d7958bbd
+  - cabal-add-0.1
   - cabal-install-parsers-0.6.1.1
 
 configure-options:


### PR DESCRIPTION
The temporary dependency solution should be changed since `cabal-add` was released on [Haskage](https://github.com/Bodigrim/cabal-add/issues/7).