### PR TITLE
Fix for multiple build targets at cabal-add

### DIFF
--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -322,10 +322,8 @@ cabalAddCodeAction state plId (CodeActionParams _ _ (TextDocumentIdentifier uri)
               case mbGPD of
                 Nothing -> pure $ InL []
                 Just (gpd, _) -> do
-                  actions <- liftIO $ CabalAdd.addDependencySuggestCodeAction plId verTxtDocId
-                                                                              suggestions
-                                                                              haskellFilePath cabalFilePath
-                                                                              gpd
+                  actions <- liftIO $ CabalAdd.addDependencySuggestCodeAction plId verTxtDocId suggestions
+                                                                              cabalFilePath gpd
                   pure $ InL $ fmap InR actions
 
 

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
@@ -121,14 +121,7 @@ instance Pretty CabalAddCommandParams where
 -- | Creates a code action that calls the `cabalAddCommand`,
 --   using dependency-version suggestion pairs as input.
 --
---   Returns disabled action if no cabal files given.
---
---   Takes haskell file and cabal file paths to create a relative path
---   to the haskell file, which is used to get a `BuildTarget`.
---
---   In current implementation the dependency is being added to the main found
---   build target, but if there will be a way to get all build targets from a file
---   it will be possible to support addition to a build target of choice.
+--   Gives a code action for all found build targets.
 addDependencySuggestCodeAction
   :: PluginId
   -> VersionedTextDocumentIdentifier -- ^ Cabal's versioned text identifier

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-exe/cabal-add-exe.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-exe/cabal-add-exe.cabal
@@ -9,7 +9,3 @@ executable cabal-add-exe
   ghc-options:         -Wall
   build-depends:       base
   default-language:    Haskell2010
-
-library
-  build-depends:   base >= 4 && < 5
-  ghc-options:     -Wall

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-multitarget/cabal-add-multitarget.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-multitarget/cabal-add-multitarget.cabal
@@ -1,0 +1,31 @@
+cabal-version:       2.4
+name:                cabal-add-multitarget
+version:             0.1.0.0
+build-type:          Simple
+
+executable cabal-add-exe
+  main-is:             Main.hs
+  hs-source-dirs:      src
+  ghc-options:         -Wall
+  build-depends:       base
+  default-language:    Haskell2010
+
+library
+  build-depends:   base >= 4 && < 5
+  ghc-options:     -Wall
+
+test-suite cabal-add-tests-test
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Main.hs
+    build-depends:    base
+
+benchmark benchmark
+    type: exitcode-stdio-1.0
+    ghc-options: -threaded
+    main-is: Main.hs
+    hs-source-dirs: bench
+    build-depends: base
+
+

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-multitarget/src/Main.hs
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-multitarget/src/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Data.List.Split
+
+main = putStrLn "Hello, Haskell!"

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal.project
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal.project
@@ -2,3 +2,4 @@ packages: cabal-add-exe
           cabal-add-lib
           cabal-add-tests
           cabal-add-bench
+          cabal-add-multitarget


### PR DESCRIPTION
### Fix for multiple build targets at cabal-add

In my current merged solution, cabal-add `CodeAction` is provided only for the main target.
This was only a temporary solution due to limitations of the `getBuildTargets` function.
For more information, [consult](https://github.com/haskell/haskell-language-server/pull/4360#discussion_r1681352283) this thread.

Now it was fixed, and you can choose to what target add the dependency.
Video with an example:

https://github.com/user-attachments/assets/b75587df-e277-48de-8c3c-3fb705b64f32

Also, I changed the title for the `CodeAction`, to a hopefully better one.

### Implementation details
I changed the functions `getBuildTargets` and  `buildTargetComponentName` to  
the `getBuildTargetComponentNames` that handles `GenericPackageDescription` and gives `ComponentName`s of all targets.

### What isn't implemented
- [x] Previous tests were built assuming that there is need to wait only for one `CodeAction`. Now this leads to a race condition.