### PR TITLE
Avoid expectFail in the test suite

### DIFF
--- a/ghcide/test/exe/FindDefinitionAndHoverTests.hs
+++ b/ghcide/test/exe/FindDefinitionAndHoverTests.hs
@@ -119,8 +119,9 @@ tests = let
       hover = (getHover      , checkHover)
 
   -- search locations            expectations on results
-  fffL4  = fffR  ^. L.start;  fffR = mkRange 8  4    8  7 ; fff  = [ExpectRange fffR]
-  fffL8  = Position 12  4  ;
+  -- TODO: Lookup of record field should return exactly one result
+  fffL4  = fffR  ^. L.start;  fffR = mkRange 8  4    8  7; fff  = [ExpectRanges [fffR, mkRange 7 23 9 16]]
+  fffL8  = Position 12  4  ;  fff' = [ExpectRange fffR]
   fffL14 = Position 18  7  ;
   aL20   = Position 19 15
   aaaL14 = Position 18 20  ;  aaa    = [mkR  11  0   11  3]
@@ -148,13 +149,19 @@ tests = let
                            ;  constr = [ExpectHoverText ["Monad m"]]
   eitL40 = Position 44 28  ;  kindE  = [ExpectHoverText [":: Type -> Type -> Type\n"]]
   intL40 = Position 44 34  ;  kindI  = [ExpectHoverText [":: Type\n"]]
-  tvrL40 = Position 44 37  ;  kindV  = [ExpectHoverText [":: * -> *\n"]]
-  intL41 = Position 45 20  ;  litI   = [ExpectHoverText ["7518"]]
-  chrL36 = Position 41 24  ;  litC   = [ExpectHoverText ["'f'"]]
-  txtL8  = Position 12 14  ;  litT   = [ExpectHoverText ["\"dfgy\""]]
-  lstL43 = Position 47 12  ;  litL   = [ExpectHoverText ["[8391 :: Int, 6268]"]]
+  -- TODO: Kind signature of type variables should be `Type -> Type`
+  tvrL40 = Position 44 37  ;  kindV  = [ExpectHoverText ["m"]]
+  -- TODO: Hover of integer literal should be `7518`
+  intL41 = Position 45 20  ;  litI   = [ExpectHoverText ["_ :: Int"]]
+  -- TODO: Hover info of char literal should be `'f'`
+  chrL36 = Position 41 24  ;  litC   = [ExpectHoverText ["_ :: Char"]]
+  -- TODO: Hover info of Text literal should be `"dfgy"`
+  txtL8  = Position 12 14  ;  litT   = [ExpectHoverText ["_ :: Text"]]
+  -- TODO: Hover info of List literal should be `[8391 :: Int, 6268]`
+  lstL43 = Position 47 12  ;  litL   = [ExpectHoverText ["[Int]"]]
   outL45 = Position 49  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 50 0 50 5]
-  innL48 = Position 52  5  ;  innSig = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
+  -- TODO: Hover info of local function signature should be `inner :: Bool`
+  innL48 = Position 52  5  ;  innSig = [ExpectHoverText ["inner"], mkR 53 2 53 7]
   holeL60 = Position 62 7  ;  hleInfo = [ExpectHoverText ["_ ::"]]
   holeL65 = Position 65 8  ;  hleInfo2 = [ExpectHoverText ["_ :: a -> Maybe a"]]
   cccL17 = Position 17 16  ;  docLink = [ExpectHoverTextRegex "\\*Defined in 'GHC.Types'\\* \\*\\(ghc-prim-[0-9.]+\\)\\*\n\n"]
@@ -167,9 +174,9 @@ tests = let
   mkFindTests
   --      def    hover  look       expect
   [ -- It suggests either going to the constructor or to the field
-    test  broken yes    fffL4      fff           "field in record definition"
-  , test  yes    yes    fffL8      fff           "field in record construction    #1102"
-  , test  yes    yes    fffL14     fff           "field name used as accessor"           -- https://github.com/haskell/ghcide/pull/120 in Calculate.hs
+    test  yes    yes    fffL4      fff           "field in record definition"
+  , test  yes    yes    fffL8      fff'          "field in record construction    #1102"
+  , test  yes    yes    fffL14     fff'          "field name used as accessor"           -- https://github.com/haskell/ghcide/pull/120 in Calculate.hs
   , test  yes    yes    aaaL14     aaa           "top-level name"                        -- https://github.com/haskell/ghcide/pull/120
   , test  yes    yes    dcL7       tcDC          "data constructor record         #1029"
   , test  yes    yes    dcL12      tcDC          "data constructor plain"                -- https://github.com/haskell/ghcide/pull/121
@@ -194,15 +201,15 @@ tests = let
   , test  no     yes    docL41     doc           "documentation                   #1129"
   , test  no     yes    eitL40     kindE         "kind of Either                  #1017"
   , test  no     yes    intL40     kindI         "kind of Int                     #1017"
-  , test  no     broken tvrL40     kindV         "kind of (* -> *) type variable  #1017"
-  , test  no     broken intL41     litI          "literal Int  in hover info      #1016"
-  , test  no     broken chrL36     litC          "literal Char in hover info      #1016"
-  , test  no     broken txtL8      litT          "literal Text in hover info      #1016"
-  , test  no     broken lstL43     litL          "literal List in hover info      #1016"
+  , test  no     yes    tvrL40     kindV         "kind of (* -> *) type variable  #1017"
+  , test  no     yes    intL41     litI          "literal Int  in hover info      #1016"
+  , test  no     yes    chrL36     litC          "literal Char in hover info      #1016"
+  , test  no     yes    txtL8      litT          "literal Text in hover info      #1016"
+  , test  no     yes    lstL43     litL          "literal List in hover info      #1016"
   , test  yes    yes    cmtL68     lackOfdEq     "no Core symbols                 #3280"
   , test  no     yes    docL41     constr        "type constraint in hover info   #1012"
   , test  no     yes    outL45     outSig        "top-level signature              #767"
-  , test  broken broken innL48     innSig        "inner     signature              #767"
+  , test  yes    yes    innL48     innSig        "inner     signature              #767"
   , test  no     yes    holeL60    hleInfo       "hole without internal name       #831"
   , test  no     yes    holeL65    hleInfo2      "hole with variable"
   , test  no     yes    cccL17     docLink       "Haddock html links"
@@ -215,14 +222,10 @@ tests = let
   , test  no     yes       thLocL57   thLoc         "TH Splice Hover"
   , test yes yes import310 pkgTxt "show package name and its version"
   ]
-  where yes, broken :: (TestTree -> Maybe TestTree)
-        yes    = Just -- test should run and pass
-        broken = Just . (`xfail` "known broken")
+  where yes :: (TestTree -> Maybe TestTree)
+        yes = Just -- test should run and pass
         no = const Nothing -- don't run this test at all
         --skip = const Nothing -- unreliable, don't run
-
-xfail :: TestTree -> String -> TestTree
-xfail = flip expectFailBecause
 
 checkFileCompiles :: FilePath -> Session () -> TestTree
 checkFileCompiles fp diag =

--- a/ghcide/test/exe/FindDefinitionAndHoverTests.hs
+++ b/ghcide/test/exe/FindDefinitionAndHoverTests.hs
@@ -150,18 +150,18 @@ tests = let
   eitL40 = Position 44 28  ;  kindE  = [ExpectHoverText [":: Type -> Type -> Type\n"]]
   intL40 = Position 44 34  ;  kindI  = [ExpectHoverText [":: Type\n"]]
   -- TODO: Kind signature of type variables should be `Type -> Type`
-  tvrL40 = Position 44 37  ;  kindV  = [ExpectHoverText ["m"]]
+  tvrL40 = Position 44 37  ;  kindV  = [ExpectHoverText ["m"]];        kindV' = [ExpectHoverText [":: * -> *\n"]]
   -- TODO: Hover of integer literal should be `7518`
-  intL41 = Position 45 20  ;  litI   = [ExpectHoverText ["_ :: Int"]]
+  intL41 = Position 45 20  ;  litI   = [ExpectHoverText ["_ :: Int"]];  litI' = [ExpectHoverText ["7518"]]
   -- TODO: Hover info of char literal should be `'f'`
-  chrL36 = Position 41 24  ;  litC   = [ExpectHoverText ["_ :: Char"]]
+  chrL36 = Position 41 24  ;  litC   = [ExpectHoverText ["_ :: Char"]]; litC' = [ExpectHoverText ["'f'"]]
   -- TODO: Hover info of Text literal should be `"dfgy"`
-  txtL8  = Position 12 14  ;  litT   = [ExpectHoverText ["_ :: Text"]]
+  txtL8  = Position 12 14  ;  litT   = [ExpectHoverText ["_ :: Text"]]; litT' = [ExpectHoverText ["\"dfgy\""]]
   -- TODO: Hover info of List literal should be `[8391 :: Int, 6268]`
-  lstL43 = Position 47 12  ;  litL   = [ExpectHoverText ["[Int]"]]
+  lstL43 = Position 47 12  ;  litL   = [ExpectHoverText ["[Int]"]];     litL' = [ExpectHoverText ["[8391 :: Int, 6268]"]]
   outL45 = Position 49  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 50 0 50 5]
   -- TODO: Hover info of local function signature should be `inner :: Bool`
-  innL48 = Position 52  5  ;  innSig = [ExpectHoverText ["inner"], mkR 53 2 53 7]
+  innL48 = Position 52  5  ;  innSig = [ExpectHoverText ["inner"], mkR 53 2 53 7]; innSig' = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
   holeL60 = Position 62 7  ;  hleInfo = [ExpectHoverText ["_ ::"]]
   holeL65 = Position 65 8  ;  hleInfo2 = [ExpectHoverText ["_ :: a -> Maybe a"]]
   cccL17 = Position 17 16  ;  docLink = [ExpectHoverTextRegex "\\*Defined in 'GHC.Types'\\* \\*\\(ghc-prim-[0-9.]+\\)\\*\n\n"]
@@ -174,46 +174,46 @@ tests = let
   mkFindTests
   --      def    hover  look       expect
   [ -- It suggests either going to the constructor or to the field
-    test  yes    yes    fffL4      fff           "field in record definition"
-  , test  yes    yes    fffL8      fff'          "field in record construction    #1102"
-  , test  yes    yes    fffL14     fff'          "field name used as accessor"           -- https://github.com/haskell/ghcide/pull/120 in Calculate.hs
-  , test  yes    yes    aaaL14     aaa           "top-level name"                        -- https://github.com/haskell/ghcide/pull/120
-  , test  yes    yes    dcL7       tcDC          "data constructor record         #1029"
-  , test  yes    yes    dcL12      tcDC          "data constructor plain"                -- https://github.com/haskell/ghcide/pull/121
-  , test  yes    yes    tcL6       tcData        "type constructor                #1028" -- https://github.com/haskell/ghcide/pull/147
-  , test  yes    yes    xtcL5      xtc           "type constructor external   #717,1028"
-  , test  yes    yes    xvL20      xvMsg         "value external package           #717" -- https://github.com/haskell/ghcide/pull/120
-  , test  yes    yes    vvL16      vv            "plain parameter"                       -- https://github.com/haskell/ghcide/pull/120
-  , test  yes    yes    aL18       apmp          "pattern match name"                    -- https://github.com/haskell/ghcide/pull/120
-  , test  yes    yes    opL16      op            "top-level operator               #713" -- https://github.com/haskell/ghcide/pull/120
-  , test  yes    yes    opL18      opp           "parameter operator"                    -- https://github.com/haskell/ghcide/pull/120
-  , test  yes    yes    b'L19      bp            "name in backticks"                     -- https://github.com/haskell/ghcide/pull/120
-  , test  yes    yes    clL23      cls           "class in instance declaration   #1027"
-  , test  yes    yes    clL25      cls           "class in signature              #1027" -- https://github.com/haskell/ghcide/pull/147
-  , test  yes    yes    eclL15     ecls          "external class in signature #717,1027"
-  , test  yes    yes    dnbL29     dnb           "do-notation   bind              #1073"
-  , test  yes    yes    dnbL30     dnb           "do-notation lookup"
-  , test  yes    yes    lcbL33     lcb           "listcomp   bind                 #1073"
-  , test  yes    yes    lclL33     lcb           "listcomp lookup"
-  , test  yes    yes    mclL36     mcl           "top-level fn 1st clause"
-  , test  yes    yes    mclL37     mcl           "top-level fn 2nd clause         #1030"
-  , test  yes    yes    spaceL37   space         "top-level fn on space           #1002"
-  , test  no     yes    docL41     doc           "documentation                   #1129"
-  , test  no     yes    eitL40     kindE         "kind of Either                  #1017"
-  , test  no     yes    intL40     kindI         "kind of Int                     #1017"
-  , test  no     yes    tvrL40     kindV         "kind of (* -> *) type variable  #1017"
-  , test  no     yes    intL41     litI          "literal Int  in hover info      #1016"
-  , test  no     yes    chrL36     litC          "literal Char in hover info      #1016"
-  , test  no     yes    txtL8      litT          "literal Text in hover info      #1016"
-  , test  no     yes    lstL43     litL          "literal List in hover info      #1016"
-  , test  yes    yes    cmtL68     lackOfdEq     "no Core symbols                 #3280"
-  , test  no     yes    docL41     constr        "type constraint in hover info   #1012"
-  , test  no     yes    outL45     outSig        "top-level signature              #767"
-  , test  yes    yes    innL48     innSig        "inner     signature              #767"
-  , test  no     yes    holeL60    hleInfo       "hole without internal name       #831"
-  , test  no     yes    holeL65    hleInfo2      "hole with variable"
-  , test  no     yes    cccL17     docLink       "Haddock html links"
-  , testM yes    yes    imported   importedSig   "Imported symbol"
+    test  (broken fff')  yes               fffL4      fff           "field in record definition"
+  , test  yes            yes               fffL8      fff'          "field in record construction    #1102"
+  , test  yes            yes               fffL14     fff'          "field name used as accessor"           -- https://github.com/haskell/ghcide/pull/120 in Calculate.hs
+  , test  yes            yes               aaaL14     aaa           "top-level name"                        -- https://github.com/haskell/ghcide/pull/120
+  , test  yes            yes               dcL7       tcDC          "data constructor record         #1029"
+  , test  yes            yes               dcL12      tcDC          "data constructor plain"                -- https://github.com/haskell/ghcide/pull/121
+  , test  yes            yes               tcL6       tcData        "type constructor                #1028" -- https://github.com/haskell/ghcide/pull/147
+  , test  yes            yes               xtcL5      xtc           "type constructor external   #717,1028"
+  , test  yes            yes               xvL20      xvMsg         "value external package           #717" -- https://github.com/haskell/ghcide/pull/120
+  , test  yes            yes               vvL16      vv            "plain parameter"                       -- https://github.com/haskell/ghcide/pull/120
+  , test  yes            yes               aL18       apmp          "pattern match name"                    -- https://github.com/haskell/ghcide/pull/120
+  , test  yes            yes               opL16      op            "top-level operator               #713" -- https://github.com/haskell/ghcide/pull/120
+  , test  yes            yes               opL18      opp           "parameter operator"                    -- https://github.com/haskell/ghcide/pull/120
+  , test  yes            yes               b'L19      bp            "name in backticks"                     -- https://github.com/haskell/ghcide/pull/120
+  , test  yes            yes               clL23      cls           "class in instance declaration   #1027"
+  , test  yes            yes               clL25      cls           "class in signature              #1027" -- https://github.com/haskell/ghcide/pull/147
+  , test  yes            yes               eclL15     ecls          "external class in signature #717,1027"
+  , test  yes            yes               dnbL29     dnb           "do-notation   bind              #1073"
+  , test  yes            yes               dnbL30     dnb           "do-notation lookup"
+  , test  yes            yes               lcbL33     lcb           "listcomp   bind                 #1073"
+  , test  yes            yes               lclL33     lcb           "listcomp lookup"
+  , test  yes            yes               mclL36     mcl           "top-level fn 1st clause"
+  , test  yes            yes               mclL37     mcl           "top-level fn 2nd clause         #1030"
+  , test  yes            yes               spaceL37   space         "top-level fn on space           #1002"
+  , test  no             yes               docL41     doc           "documentation                   #1129"
+  , test  no             yes               eitL40     kindE         "kind of Either                  #1017"
+  , test  no             yes               intL40     kindI         "kind of Int                     #1017"
+  , test  no             (broken kindV')   tvrL40     kindV         "kind of (* -> *) type variable  #1017"
+  , test  no             (broken litI')    intL41     litI          "literal Int  in hover info      #1016"
+  , test  no             (broken litC')    chrL36     litC          "literal Char in hover info      #1016"
+  , test  no             (broken litT')    txtL8      litT          "literal Text in hover info      #1016"
+  , test  no             (broken litL')    lstL43     litL          "literal List in hover info      #1016"
+  , test  yes            yes               cmtL68     lackOfdEq     "no Core symbols                 #3280"
+  , test  no             yes               docL41     constr        "type constraint in hover info   #1012"
+  , test  no             yes               outL45     outSig        "top-level signature              #767"
+  , test  yes            (broken innSig')  innL48     innSig        "inner     signature              #767"
+  , test  no             yes               holeL60    hleInfo       "hole without internal name       #831"
+  , test  no             yes               holeL65    hleInfo2      "hole with variable"
+  , test  no             yes               cccL17     docLink       "Haddock html links"
+  , testM yes            yes               imported   importedSig   "Imported symbol"
   , if isWindows then
         -- Flaky on Windows: https://github.com/haskell/haskell-language-server/issues/2997
         testM no     yes    reexported reexportedSig "Imported symbol (reexported)"
@@ -226,6 +226,8 @@ tests = let
         yes = Just -- test should run and pass
         no = const Nothing -- don't run this test at all
         --skip = const Nothing -- unreliable, don't run
+        broken :: [Expect] -> TestTree -> Maybe TestTree
+        broken _ = yes
 
 checkFileCompiles :: FilePath -> Session () -> TestTree
 checkFileCompiles fp diag =

--- a/ghcide/test/exe/ReferenceTests.hs
+++ b/ghcide/test/exe/ReferenceTests.hs
@@ -36,7 +36,6 @@ import           Test.Hls                        (FromServerMessage' (..),
                                                   TNotificationMessage (..))
 import           Test.Hls.FileSystem             (copyDir)
 import           Test.Tasty
-import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.HUnit
 
 
@@ -90,16 +89,7 @@ tests = testGroup "references"
                           , ("Main.hs", 10, 0)
                           ]
 
-          , expectFailBecause "references provider does not respect includeDeclaration parameter" $
- referenceTest "works when we ask to exclude declarations"
-                          ("References.hs", 4, 7)
-                          NoExcludeDeclaration
-                          [ ("References.hs", 6, 0)
-                          , ("References.hs", 6, 14)
-                          , ("References.hs", 9, 7)
-                          , ("References.hs", 10, 11)
-                          ]
-
+          -- TODO: references provider does not respect includeDeclaration parameter
           , referenceTest "INCORRECTLY returns declarations when we ask to exclude them"
                           ("References.hs", 4, 7)
                           NoExcludeDeclaration

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -39,6 +39,10 @@ module Test.Hls
     -- * Helpful re-exports
     PluginDescriptor,
     IdeState,
+    -- * Helpers for expected test case failuers
+    BrokenBehavior(..),
+    ExpectBroken(..),
+    unCurrent,
     -- * Assertion helper functions
     waitForProgressDone,
     waitForAllProgressDone,
@@ -165,6 +169,15 @@ instance Pretty LogTestHarness where
     LogTestDir dir -> "Test Project located in directory:" <+> pretty dir
     LogCleanup     -> "Cleaned up temporary directory"
     LogNoCleanup   -> "No cleanup of temporary directory"
+
+data BrokenBehavior = Current | Ideal
+
+data ExpectBroken (k :: BrokenBehavior) a where
+  BrokenCurrent :: a -> ExpectBroken 'Current a
+  BrokenIdeal :: a -> ExpectBroken 'Ideal a
+
+unCurrent :: ExpectBroken 'Current a -> a
+unCurrent (BrokenCurrent a) = a
 
 -- | Run 'defaultMainWithRerun', limiting each single test case running at most 10 minutes
 defaultTestRunner :: TestTree -> IO ()
@@ -903,4 +916,3 @@ kick proxyMsg = do
   case fromJSON _params of
     Success x -> return x
     other     -> error $ "Failed to parse kick/done details: " <> show other
-

--- a/plugins/hls-cabal-fmt-plugin/test/Main.hs
+++ b/plugins/hls-cabal-fmt-plugin/test/Main.hs
@@ -54,8 +54,9 @@ tests found = testGroup "cabal-fmt"
     cabalFmtGolden found "formats a simple document" "simple_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
 
-  , expectFailBecause "cabal-fmt can't expand modules if .cabal file is read from stdin. Tracking issue: https://github.com/phadej/cabal-fmt/pull/82" $
-    cabalFmtGolden found "formats a document with expand:src comment" "commented_testdata" "formatted_document" $ \doc -> do
+  -- TODO: cabal-fmt can't expand modules if .cabal file is read from stdin. Tracking
+  -- issue: https://github.com/phadej/cabal-fmt/pull/82
+  , cabalFmtGolden found "formats a document with expand:src comment" "commented_testdata" "formatted_document" $ \doc -> do
       formatDoc doc (FormattingOptions 2 True Nothing Nothing Nothing)
 
   , cabalFmtGolden found "formats a document with lib information" "lib_testdata" "formatted_document" $ \doc -> do

--- a/plugins/hls-cabal-fmt-plugin/test/testdata/commented_testdata.formatted_document.cabal
+++ b/plugins/hls-cabal-fmt-plugin/test/testdata/commented_testdata.formatted_document.cabal
@@ -6,10 +6,7 @@ extra-source-files: CHANGELOG.md
 
 library
   -- cabal-fmt: expand src
-  exposed-modules:
-    MyLib
-    MyOtherLib
-
+  exposed-modules:  MyLib
   build-depends:    base ^>=4.14.1.0
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/plugins/hls-cabal-plugin/test/CabalAdd.hs
+++ b/plugins/hls-cabal-plugin/test/CabalAdd.hs
@@ -17,7 +17,6 @@ import           System.FilePath
 import           Test.Hls                    (Session, TestTree, _R, anyMessage,
                                               assertEqual, documentContents,
                                               executeCodeAction,
-                                              expectFailBecause,
                                               getAllCodeActions,
                                               getDocumentEdit, liftIO, openDoc,
                                               skipManyTill, testCase, testGroup,
@@ -100,10 +99,9 @@ cabalAddTests =
                                    , ("AAI", "0.1")
                                    , ("AWin32Console", "1.19.1")
                                    ]
-    , expectFailBecause "TODO fix regex for these cases" $
-      testHiddenPackageSuggestions "Check CabalAdd's parser, with version, unicode comma"
-                                   [ "It is a member of the hidden package \82163d-graphics-examples\8217"
-                                   , "It is a member of the hidden package \82163d-graphics-examples-1.1.6\8217"
+    , testHiddenPackageSuggestions "Check CabalAdd's parser, with version, unicode comma"
+                                   [ "It is a member of the hidden package \8216\&3d-graphics-examples\8217"
+                                   , "It is a member of the hidden package \8216\&3d-graphics-examples-1.1.6\8217"
                                    ]
                                    [ ("3d-graphics-examples", T.empty)
                                    , ("3d-graphics-examples", "1.1.6")

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -89,8 +89,8 @@ tests =
   , goldenWithEval ":type reports an error when given with unknown +x option" "T17" "hs"
   , goldenWithEval "Reports an error when given with unknown command" "T18" "hs"
   , goldenWithEval "Returns defaulted type for :type +d reflecting the default declaration specified in the >>> prompt" "T19" "hs"
-  , expectFailBecause "known issue - see a note in P.R. #361" $
-      goldenWithEval ":type +d reflects the `default' declaration of the module" "T20" "hs"
+  -- TODO: known issue - see a note in P.R. #361
+  , goldenWithEval ":type +d reflects the `default' declaration of the module" "T20" "hs"
   , testCase ":type handles a multilined result properly" $
       evalInFile "T21.hs" "-- >>> :type fun" $ T.unlines [
         "-- fun",

--- a/plugins/hls-eval-plugin/test/testdata/T20.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/T20.expected.hs
@@ -4,4 +4,4 @@ import Data.Word (Word)
 default (Word)
 
 -- >>> :type  +d   40+ 2 
--- 40+ 2 :: Word
+-- 40+ 2 :: Integer

--- a/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
+++ b/plugins/hls-explicit-fixity-plugin/src/Ide/Plugin/ExplicitFixity.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies      #-}

--- a/plugins/hls-explicit-fixity-plugin/test/Main.hs
+++ b/plugins/hls-explicit-fixity-plugin/test/Main.hs
@@ -40,10 +40,9 @@ tests = testGroup "Explicit fixity"
     , hoverTest "signature" (Position 35 2) "infixr 9 `>>>:`"
     , hoverTest "operator" (Position 36 2) "infixr 9 `>>>:`"
     , hoverTest "escape" (Position 39 2) "infixl 3 `~\\:`"
-    -- Ensure that there is no one extra new line in import statement
-    , expectFail $ hoverTest "import" (Position 2 18) "Control.Monad***"
-    -- Known issue, See https://github.com/haskell/haskell-language-server/pull/2973/files#r916535742
-    , expectFail $ hoverTestImport "import" (Position 4 7) "infixr 9 `>>>:`"
+    -- TODO: Ensure that there is no one extra new line in import statement
+    , hoverTest "import" (Position 2 18) "Control.Monad\n\n"
+    , hoverTestImport "import" (Position 4 7) "infixr 9 `>>>:`"
     ]
 
 hoverTest :: TestName -> Position -> T.Text -> TestTree

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -39,7 +39,6 @@ import qualified System.IO.Extra
 import           System.IO.Extra                          hiding (withTempDir)
 import           System.Time.Extra
 import           Test.Tasty
-import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.HUnit
 import           Text.Regex.TDFA                          ((=~))
 
@@ -337,67 +336,61 @@ insertImportTests = testGroup "insert import"
         "WhereDeclLowerInFileWithCommentsBeforeIt.hs"
         "WhereDeclLowerInFileWithCommentsBeforeIt.expected.hs"
         "import Data.Int"
-  , expectFailBecause
-      "'findNextPragmaPosition' function doesn't account for case when shebang is not placed at top of file"
-      (checkImport
-         "Shebang not at top with spaces"
-         "ShebangNotAtTopWithSpaces.hs"
-         "ShebangNotAtTopWithSpaces.expected.hs"
-         "import Data.Monoid")
-  , expectFailBecause
-      "'findNextPragmaPosition' function doesn't account for case when shebang is not placed at top of file"
-      (checkImport
-         "Shebang not at top no space"
-         "ShebangNotAtTopNoSpace.hs"
-         "ShebangNotAtTopNoSpace.expected.hs"
-         "import Data.Monoid")
-  , expectFailBecause
-      ("'findNextPragmaPosition' function doesn't account for case "
-      ++ "when OPTIONS_GHC pragma is not placed at top of file")
-      (checkImport
-         "OPTIONS_GHC pragma not at top with spaces"
-         "OptionsNotAtTopWithSpaces.hs"
-         "OptionsNotAtTopWithSpaces.expected.hs"
-         "import Data.Monoid")
-  , expectFailBecause
-      ("'findNextPragmaPosition' function doesn't account for "
-      ++ "case when shebang is not placed at top of file")
-      (checkImport
-         "Shebang not at top of file"
-         "ShebangNotAtTop.hs"
-         "ShebangNotAtTop.expected.hs"
-         "import Data.Monoid")
-  , expectFailBecause
-      ("'findNextPragmaPosition' function doesn't account for case "
-      ++ "when OPTIONS_GHC is not placed at top of file")
-      (checkImport
-         "OPTIONS_GHC pragma not at top of file"
-         "OptionsPragmaNotAtTop.hs"
-         "OptionsPragmaNotAtTop.expected.hs"
-         "import Data.Monoid")
-  , expectFailBecause
-      ("'findNextPragmaPosition' function doesn't account for case when "
-      ++ "OPTIONS_GHC pragma is not placed at top of file")
-      (checkImport
-         "pragma not at top with comment at top"
-         "PragmaNotAtTopWithCommentsAtTop.hs"
-         "PragmaNotAtTopWithCommentsAtTop.expected.hs"
-         "import Data.Monoid")
-  , expectFailBecause
-      ("'findNextPragmaPosition' function doesn't account for case when "
-      ++ "OPTIONS_GHC pragma is not placed at top of file")
-      (checkImport
-         "pragma not at top multiple comments"
-         "PragmaNotAtTopMultipleComments.hs"
-         "PragmaNotAtTopMultipleComments.expected.hs"
-         "import Data.Monoid")
-  , expectFailBecause
-      "'findNextPragmaPosition' function doesn't account for case of multiline pragmas"
-      (checkImport
-         "after multiline language pragmas"
-         "MultiLinePragma.hs"
-         "MultiLinePragma.expected.hs"
-         "import Data.Monoid")
+  -- TODO: 'findNextPragmaPosition' function doesn't account for case when shebang is not
+  -- placed at top of file"
+  , checkImport
+        "Shebang not at top with spaces"
+        "ShebangNotAtTopWithSpaces.hs"
+        "ShebangNotAtTopWithSpaces.expected.hs"
+        "import Data.Monoid"
+  -- TODO: 'findNextPragmaPosition' function doesn't account for case when shebang is not
+  -- placed at top of file"
+  , checkImport
+        "Shebang not at top no space"
+        "ShebangNotAtTopNoSpace.hs"
+        "ShebangNotAtTopNoSpace.expected.hs"
+        "import Data.Monoid"
+  -- TODO: 'findNextPragmaPosition' function doesn't account for case when OPTIONS_GHC pragma is
+  -- not placed at top of file
+  , checkImport
+        "OPTIONS_GHC pragma not at top with spaces"
+        "OptionsNotAtTopWithSpaces.hs"
+        "OptionsNotAtTopWithSpaces.expected.hs"
+        "import Data.Monoid"
+  -- TODO: findNextPragmaPosition' function doesn't account for case when shebang is not placed
+  -- at top of file
+  , checkImport
+        "Shebang not at top of file"
+        "ShebangNotAtTop.hs"
+        "ShebangNotAtTop.expected.hs"
+        "import Data.Monoid"
+  -- TODO: findNextPragmaPosition' function doesn't account for case when OPTIONS_GHC is not
+  -- placed at top of file
+  , checkImport
+        "OPTIONS_GHC pragma not at top of file"
+        "OptionsPragmaNotAtTop.hs"
+        "OptionsPragmaNotAtTop.expected.hs"
+        "import Data.Monoid"
+  -- TODO: findNextPragmaPosition' function doesn't account for case when OPTIONS_GHC pragma is
+  -- not placed at top of file
+  , checkImport
+        "pragma not at top with comment at top"
+        "PragmaNotAtTopWithCommentsAtTop.hs"
+        "PragmaNotAtTopWithCommentsAtTop.expected.hs"
+        "import Data.Monoid"
+  -- TODO: findNextPragmaPosition' function doesn't account for case when OPTIONS_GHC pragma is
+  -- not placed at top of file
+  , checkImport
+        "pragma not at top multiple comments"
+        "PragmaNotAtTopMultipleComments.hs"
+        "PragmaNotAtTopMultipleComments.expected.hs"
+       "import Data.Monoid"
+  -- TODO: 'findNextPragmaPosition' function doesn't account for case of multiline pragmas
+  , checkImport
+        "after multiline language pragmas"
+        "MultiLinePragma.hs"
+        "MultiLinePragma.expected.hs"
+        "import Data.Monoid"
   , checkImport
       "pragmas not at top with module declaration"
       "PragmaNotAtTopWithModuleDecl.hs"
@@ -1513,8 +1506,9 @@ extendImportTests = testGroup "extend import actions"
                     , "x :: (:~:) [] []"
                     , "x = Refl"
                     ])
-        , expectFailBecause "importing pattern synonyms is unsupported"
-          $ testSession "extend import list with pattern synonym" $ template
+        -- TODO: importing pattern synonyms is unsupported
+        -- Ideally the result is "Add pattern Some of the import list of A"
+        , testSession "extend import list with pattern synonym" $ noCodeActionsTemplate
             [("ModuleA.hs", T.unlines
                     [ "{-# LANGUAGE PatternSynonyms #-}"
                       , "module ModuleA where"
@@ -1527,12 +1521,6 @@ extendImportTests = testGroup "extend import actions"
                     , "k (Some x) = x"
                     ])
             (Range (Position 2 3) (Position 2 7))
-            ["Add pattern Some to the import list of A"]
-            (T.unlines
-                    [ "module ModuleB where"
-                    , "import A (pattern Some)"
-                    , "k (Some x) = x"
-                    ])
         , ignoreForGhcVersions [GHC94] "Diagnostic message has no suggestions" $
           testSession "type constructor name same as data constructor name" $ template
             [("ModuleA.hs", T.unlines
@@ -1601,19 +1589,10 @@ extendImportTests = testGroup "extend import actions"
         codeActionTitle CodeAction{_title=x} = x
 
         template setUpModules moduleUnderTest range expectedTitles expectedContentB = do
-            configureCheckProject overrideCheckProject
+            docB <- evalProject setUpModules moduleUnderTest
+            codeActions <- codeActions docB range
+            let actualTitles = codeActionTitle <$> codeActions
 
-            mapM_ (\(fileName, contents) -> createDoc fileName "haskell" contents) setUpModules
-            docB <- createDoc (fst moduleUnderTest) "haskell" (snd moduleUnderTest)
-            _  <- waitForDiagnostics
-            waitForProgressDone
-            actionsOrCommands <- getCodeActions docB range
-            let codeActions =
-                  [ ca | InR ca <- actionsOrCommands
-                  , let title = codeActionTitle ca
-                  , "Add" `T.isPrefixOf` title && not ("Add argument" `T.isPrefixOf` title)
-                  ]
-                actualTitles = codeActionTitle <$> codeActions
             -- Note that we are not testing the order of the actions, as the
             -- order of the expected actions indicates which one we'll execute
             -- in this test, i.e., the first one.
@@ -1627,6 +1606,30 @@ extendImportTests = testGroup "extend import actions"
             executeCodeAction action
             contentAfterAction <- documentContents docB
             liftIO $ expectedContentB @=? contentAfterAction
+
+        noCodeActionsTemplate setUpModules moduleUnderTest range = do
+            docB <- evalProject setUpModules moduleUnderTest
+            codeActions' <- codeActions docB range
+            let actualTitles = codeActionTitle <$> codeActions'
+            liftIO $ [] @=? actualTitles
+
+        evalProject setUpModules moduleUnderTest = do
+            configureCheckProject overrideCheckProject
+
+            mapM_ (\(fileName, contents) -> createDoc fileName "haskell" contents) setUpModules
+            docB <- createDoc (fst moduleUnderTest) "haskell" (snd moduleUnderTest)
+            _  <- waitForDiagnostics
+            waitForProgressDone
+
+            pure docB
+
+        codeActions docB range = do
+            actionsOrCommands <- getCodeActions docB range
+            pure $
+              [ ca | InR ca <- actionsOrCommands
+              , let title = codeActionTitle ca
+              , "Add" `T.isPrefixOf` title && not ("Add argument" `T.isPrefixOf` title)
+              ]
 
 fixModuleImportTypoTests :: TestTree
 fixModuleImportTypoTests = testGroup "fix module import typo"
@@ -1787,7 +1790,8 @@ suggestImportTests = testGroup "suggest import actions"
     , test True []          "f = (.|.)"                   []                "import Data.Bits (Bits(..))"
     , test True []          "f = empty"                   []                "import Control.Applicative (Alternative(..))"
     ]
-  , expectFailBecause "importing pattern synonyms is unsupported" $ test True [] "k (Some x) = x" [] "import B (pattern Some)"
+  -- TODO: Importing pattern synonyms is unsupported
+  , test False [] "k (Some x) = x" [] "import B (pattern Some)"
   ]
   where
     test = test' False

--- a/plugins/hls-refactor-plugin/test/data/import-placement/MultiLinePragma.expected.hs
+++ b/plugins/hls-refactor-plugin/test/data/import-placement/MultiLinePragma.expected.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE RecordWildCards, 
    OverloadedStrings #-}
 {-# OPTIONS_GHC -Wall,
-  -Wno-unused-imports #-}
 import Data.Monoid
+  -Wno-unused-imports #-}
 
 
 -- some comment

--- a/plugins/hls-refactor-plugin/test/data/import-placement/OptionsNotAtTopWithSpaces.expected.hs
+++ b/plugins/hls-refactor-plugin/test/data/import-placement/OptionsNotAtTopWithSpaces.expected.hs
@@ -2,7 +2,6 @@
 
 
 {-# LANGUAGE TupleSections #-}
-import Data.Monoid
 
 
 
@@ -11,6 +10,7 @@ class Semigroup a => SomeData a
 instance SomeData All
 
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+import Data.Monoid
 
 addOne :: Int -> Int
 addOne x = x + 1

--- a/plugins/hls-refactor-plugin/test/data/import-placement/OptionsPragmaNotAtTop.expected.hs
+++ b/plugins/hls-refactor-plugin/test/data/import-placement/OptionsPragmaNotAtTop.expected.hs
@@ -1,8 +1,8 @@
-import Data.Monoid
 class Semigroup a => SomeData a
 instance SomeData All
 
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+import Data.Monoid
 
 addOne :: Int -> Int
 addOne x = x + 1

--- a/plugins/hls-refactor-plugin/test/data/import-placement/PragmaNotAtTopMultipleComments.expected.hs
+++ b/plugins/hls-refactor-plugin/test/data/import-placement/PragmaNotAtTopMultipleComments.expected.hs
@@ -9,7 +9,6 @@ comment
 -}
 
 {-# LANGUAGE TupleSections #-}
-import Data.Monoid
 {- some comment -}
 
 -- again
@@ -18,6 +17,7 @@ instance SomeData All
 
 #! nix-shell --pure -i runghc -p "haskellPackages.ghcWithPackages (hp: with hp; [ turtle ])"
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+import Data.Monoid
 
 addOne :: Int -> Int
 addOne x = x + 1

--- a/plugins/hls-refactor-plugin/test/data/import-placement/PragmaNotAtTopWithCommentsAtTop.expected.hs
+++ b/plugins/hls-refactor-plugin/test/data/import-placement/PragmaNotAtTopWithCommentsAtTop.expected.hs
@@ -4,7 +4,6 @@
 -- another comment
 
 {-# LANGUAGE TupleSections #-}
-import Data.Monoid
 {- some comment -}
 
 
@@ -13,6 +12,7 @@ instance SomeData All
 
 #! nix-shell --pure -i runghc -p "haskellPackages.ghcWithPackages (hp: with hp; [ turtle ])"
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+import Data.Monoid
 
 addOne :: Int -> Int
 addOne x = x + 1

--- a/plugins/hls-refactor-plugin/test/data/import-placement/ShebangNotAtTop.expected.hs
+++ b/plugins/hls-refactor-plugin/test/data/import-placement/ShebangNotAtTop.expected.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
-import Data.Monoid
 
 class Semigroup a => SomeData a
 instance SomeData All
 
 #! nix-shell --pure -i runghc -p "haskellPackages.ghcWithPackages (hp: with hp; [ turtle ])"
+import Data.Monoid
 
 f :: Int -> Int 
 f x = x * x

--- a/plugins/hls-refactor-plugin/test/data/import-placement/ShebangNotAtTopNoSpace.expected.hs
+++ b/plugins/hls-refactor-plugin/test/data/import-placement/ShebangNotAtTopNoSpace.expected.hs
@@ -1,8 +1,8 @@
-import Data.Monoid
 class Semigroup a => SomeData a
 instance SomeData All
 
 #! nix-shell --pure -i runghc -p "haskellPackages.ghcWithPackages (hp: with hp; [ turtle ])"
+import Data.Monoid
 
 f :: Int -> Int 
 f x = x * x

--- a/plugins/hls-refactor-plugin/test/data/import-placement/ShebangNotAtTopWithSpaces.expected.hs
+++ b/plugins/hls-refactor-plugin/test/data/import-placement/ShebangNotAtTopWithSpaces.expected.hs
@@ -6,7 +6,6 @@
 
 
 {-# LANGUAGE TupleSections #-}
-import Data.Monoid
 
 
 
@@ -16,6 +15,7 @@ instance SomeData All
 
 #! nix-shell --pure -i runghc -p "haskellPackages.ghcWithPackages (hp: with hp; [ turtle ])"
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+import Data.Monoid
 
 addOne :: Int -> Int
 addOne x = x + 1

--- a/test/functional/Config.hs
+++ b/test/functional/Config.hs
@@ -43,13 +43,13 @@ genericConfigTests = testGroup "generic plugin config"
             setHlsConfig $ changeConfig "someplugin" def{plcHoverOn = False}
             -- getting only the expected diagnostics means the plugin wasn't enabled
             expectDiagnostics standardDiagnostics
-    ,   expectFailBecause "partial config is not supported" $
-        testCase "custom defaults and non overlapping user config" $ runConfigSession "diagnostics" $ do
+     -- TODO: Partial config is not supported
+    ,   testCase "custom defaults and non overlapping user config" $ runConfigSession "diagnostics" $ do
             _doc <- createDoc "Foo.hs" "haskell" "module Foo where\nfoo = False"
             -- test that the user config doesn't accidentally override the initial config
             setHlsConfig $ changeConfig testPluginId def{plcHoverOn = False}
             -- getting only the expected diagnostics means the plugin wasn't enabled
-            expectDiagnostics standardDiagnostics
+            expectDiagnostics testPluginDiagnostics
     ,   testCase "custom defaults and overlapping user plugin config" $ runConfigSession "diagnostics" $ do
             _doc <- createDoc "Foo.hs" "haskell" "module Foo where\nfoo = False"
             -- test that the user config overrides the default initial config


### PR DESCRIPTION
Replace _some_ `expectFail` references with explicit checks.  Note that there are some remaining references that should probably be changed.

Addresses #4130 

I've added TODO comments to most of the tests to explain what's wrong (that is, if I could correctly guess it). I wonder if it would be better to have issue numbers instead.