### PR TITLE
Add docs about running tests for newbies

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -81,6 +81,14 @@ Running just the wrapper tests
 $ cabal test wrapper-test
 ```
 
+Running just the tests for a specific plugin
+
+```bash
+$ cabal test hls-<plugin-name>-plugin-tests
+# E.g.
+$ cabal test hls-refactor-plugin-tests
+```
+
 Running a subset of tests
 
 Tasty supports providing
@@ -97,6 +105,13 @@ An alternative, which only recompiles when tests (or dependencies) change:
 
 ```bash
 $ cabal run haskell-language-server:func-test -- -p "hlint enables"
+```
+
+Yet another way to pass the pattern without recompilation is to use the `TASTY_PATTERN` environment variable.
+Run any of the `cabal test` commands above and set it to your pattern, e.g.:
+
+```bash
+$ TASTY_PATTERN='-p hlint' cabal test func-test
 ```
 
 ## Using HLS on HLS code

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -100,15 +100,7 @@ $ cabal test func-test --test-option "-p hlint"
 ```
 
 The above recompiles everything every time you use a different test option though.
-
-An alternative, which only recompiles when tests (or dependencies) change:
-
-```bash
-$ cabal run haskell-language-server:func-test -- -p "hlint enables"
-```
-
-Yet another way to pass the pattern without recompilation is to use the `TASTY_PATTERN` environment variable.
-Run any of the `cabal test` commands above and set it to your pattern, e.g.:
+An alternative, which only recompiles when tests (or dependencies) change is to pass the `TASTY_PATTERN` environment variable:
 
 ```bash
 $ TASTY_PATTERN='hlint' cabal test func-test

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -111,7 +111,7 @@ Yet another way to pass the pattern without recompilation is to use the `TASTY_P
 Run any of the `cabal test` commands above and set it to your pattern, e.g.:
 
 ```bash
-$ TASTY_PATTERN='-p hlint' cabal test func-test
+$ TASTY_PATTERN='hlint' cabal test func-test
 ```
 
 ## Using HLS on HLS code


### PR DESCRIPTION
I added two things to the `contributing.md`:

- How to run tests for a specific plugin
- How to pass a `tasty` pattern using `TASTY_PATTERN`