### PR TITLE
Fix exporting operator pattern synonym

### DIFF
--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -769,7 +769,7 @@ suggestExportUnusedTopBinding srcOpt ParsedModule{pm_parsed_source = L _ HsModul
 
     printExport :: ExportsAs -> T.Text -> T.Text
     printExport ExportName x    = parenthesizeIfNeeds False x
-    printExport ExportPattern x = "pattern " <> x
+    printExport ExportPattern x = "pattern " <> parenthesizeIfNeeds False x
     printExport ExportFamily x  = parenthesizeIfNeeds True x
     printExport ExportAll x     = parenthesizeIfNeeds True x <> "(..)"
 

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -755,23 +755,21 @@ suggestExportUnusedTopBinding srcOpt ParsedModule{pm_parsed_source = L _ HsModul
     opLetter :: T.Text
     opLetter = ":!#$%&*+./<=>?@\\^|-~"
 
-    parenthesizeIfNeeds :: Bool -> T.Text -> T.Text
-    parenthesizeIfNeeds needsTypeKeyword x
-      | T.any (c ==) opLetter = (if needsTypeKeyword then "type " else "") <> "(" <> x <> ")"
-      | otherwise = x
-      where
-        c = T.head x
-
     matchWithDiagnostic :: Range -> Located (IdP GhcPs) -> Bool
     matchWithDiagnostic Range{_start=l,_end=r} x =
       let loc = fmap _start . getLocatedRange $ x
        in loc >= Just l && loc <= Just r
 
     printExport :: ExportsAs -> T.Text -> T.Text
-    printExport ExportName x    = parenthesizeIfNeeds False x
-    printExport ExportPattern x = "pattern " <> parenthesizeIfNeeds False x
-    printExport ExportFamily x  = parenthesizeIfNeeds True x
-    printExport ExportAll x     = parenthesizeIfNeeds True x <> "(..)"
+    printExport ea name = prefix <> parenthesizedName <> suffix
+      where
+        parenthesizedName = if T.any (firstChar ==) opLetter then "(" <> name <> ")" else name
+        firstChar = T.head name
+        (prefix, suffix) = case ea of
+          ExportName    -> ("", "")
+          ExportPattern -> ("pattern ", "")
+          ExportFamily  -> ("type ", "")
+          ExportAll     -> ("type ", "(..)")
 
     isTopLevel :: SrcSpan -> Bool
     isTopLevel span = fmap (_character . _start) (srcSpanToRange span) == Just 0

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -3413,6 +3413,19 @@ exportUnusedTests = testGroup "export unused actions"
       , "module A (pattern Foo) where"
       , "pattern Foo a <- (a, _)"
       ]
+    , testSession "unused pattern synonym symbol" $ template
+      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+      , "{-# LANGUAGE PatternSynonyms #-}"
+      , "module A () where"
+      , "pattern x :+ y = (x, y)"
+      ]
+      (R 3 0 3 12)
+      "Export ‘:+’"
+      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+      , "{-# LANGUAGE PatternSynonyms #-}"
+      , "module A (pattern (:+)) where"
+      , "pattern x :+ y = (x, y)"
+      ]
     , testSession "unused data type" $ template
       [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
       , "module A () where"
@@ -3459,6 +3472,19 @@ exportUnusedTests = testGroup "export unused actions"
       , "module A (Foo) where"
       , "type family Foo p"
       ]
+    , testSession "unused type family symbol" $ template
+      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+      , "{-# LANGUAGE TypeFamilies #-}"
+      , "module A () where"
+      , "type family p &&& q"
+      ]
+      (R 3 0 3 10)
+      "Export ‘&&&’"
+      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+      , "{-# LANGUAGE TypeFamilies #-}"
+      , "module A (type (&&&)) where"
+      , "type family p &&& q"
+      ]
     , testSession "unused typeclass" $ template
       [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
       , "module A () where"
@@ -3469,6 +3495,17 @@ exportUnusedTests = testGroup "export unused actions"
       [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
       , "module A (Foo(..)) where"
       , "class Foo a"
+      ]
+    , testSession "unused typeclass symbol" $ template
+      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+      , "module A () where"
+      , "class p &&& q"
+      ]
+      (R 2 0 2 10)
+      "Export ‘&&&’"
+      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
+      , "module A (type (&&&)(..)) where"
+      , "class p &&& q"
       ]
     , testSession "infix" $ template
       [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -3413,7 +3413,7 @@ exportUnusedTests = testGroup "export unused actions"
       , "module A (pattern Foo) where"
       , "pattern Foo a <- (a, _)"
       ]
-    , testSession "unused pattern synonym symbol" $ template
+    , testSession "unused pattern synonym operator" $ template
       [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
       , "{-# LANGUAGE PatternSynonyms #-}"
       , "module A () where"
@@ -3472,19 +3472,6 @@ exportUnusedTests = testGroup "export unused actions"
       , "module A (Foo) where"
       , "type family Foo p"
       ]
-    , testSession "unused type family symbol" $ template
-      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
-      , "{-# LANGUAGE TypeFamilies #-}"
-      , "module A () where"
-      , "type family p &&& q"
-      ]
-      (R 3 0 3 10)
-      "Export ‘&&&’"
-      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
-      , "{-# LANGUAGE TypeFamilies #-}"
-      , "module A (type (&&&)) where"
-      , "type family p &&& q"
-      ]
     , testSession "unused typeclass" $ template
       [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
       , "module A () where"
@@ -3495,17 +3482,6 @@ exportUnusedTests = testGroup "export unused actions"
       [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
       , "module A (Foo(..)) where"
       , "class Foo a"
-      ]
-    , testSession "unused typeclass symbol" $ template
-      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
-      , "module A () where"
-      , "class p &&& q"
-      ]
-      (R 2 0 2 10)
-      "Export ‘&&&’"
-      [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"
-      , "module A (type (&&&)(..)) where"
-      , "class p &&& q"
       ]
     , testSession "infix" $ template
       [ "{-# OPTIONS_GHC -Wunused-top-binds #-}"


### PR DESCRIPTION
This PR addresses #4379.

- Adds a few tests for exporting pattern synonyms with operator names.
- Parenthesizes any name to be exported if it starts with an operator character.

The last commit restructures the code such that any name is parenthesized regardless of what it is exported as.