### PR TITLE
Cabal plugin: implement check for package.yaml in a stack project

### DIFF
--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
@@ -278,9 +278,8 @@ getDependencyEdit recorder env cabalFilePath buildTarget dependency = do
       pure edit
 
 -- | Given a path to a haskell file, returns the closest cabal file.
---   If package.yaml is present in same directory as .cabal file, it returns nothing, because adding a dependency to a generated cabal file
---   will break propagation of changes from package.yaml to cabal file in stack project.
---
+--   If a package.yaml is present in same directory as the .cabal file, returns nothing, because adding a dependency to a generated cabal file
+--   will break propagation of changes from package.yaml to cabal files in stack projects.
 --   If cabal file wasn't found, gives Nothing.
 findResponsibleCabalFile :: FilePath -> IO (Maybe FilePath)
 findResponsibleCabalFile haskellFilePath = do

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
@@ -277,7 +277,10 @@ getDependencyEdit recorder env cabalFilePath buildTarget dependency = do
       logWith recorder Debug $ LogCreatedEdit edit
       pure edit
 
--- | Given a path to a haskell file, returns the closest cabal file, except if package.yaml is also present.
+-- | Given a path to a haskell file, returns the closest cabal file.
+--   If package.yaml is present in same directory as .cabal file, it returns nothing, because adding a dependency to a generated cabal file
+--   will break propagation of changes from package.yaml to cabal file in stack project.
+--
 --   If cabal file wasn't found, gives Nothing.
 findResponsibleCabalFile :: FilePath -> IO (Maybe FilePath)
 findResponsibleCabalFile haskellFilePath = do

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-packageYaml/cabal-add-bench.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-packageYaml/cabal-add-bench.cabal
@@ -1,0 +1,17 @@
+cabal-version:      2.4
+name:               cabal-add-bench
+version:            0.1.0.0
+license:            NONE
+author:             George Gerasev
+maintainer:         george30032002@gmail.com
+build-type:         Simple
+
+common warnings
+    ghc-options: -Wall
+
+benchmark benchmark
+    type: exitcode-stdio-1.0
+    ghc-options: -threaded
+    main-is: Main.hs
+    hs-source-dirs: bench
+    build-depends: base

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-packageYaml/src/Main.hs
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-packageYaml/src/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Data.List.Split
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented."

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal.project
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal.project
@@ -2,3 +2,4 @@ packages: cabal-add-exe
           cabal-add-lib
           cabal-add-tests
           cabal-add-bench
+          cabal-add-packageYaml


### PR DESCRIPTION
Solves: #4400

Modifies `findResponsibleCabalFile` function to add `guardAgainstHpack` function which checks if a `package.yaml` file exists in the same directory as the `.cabal` file and handles the response in the cabal plugin.

Prevents stack from not more re-generating .cabal file if package.yaml is changed.