### PR TITLE
link executables dynamically to speed up linking

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,7 +19,9 @@ write-ghc-environment-files: never
 
 -- Link executables dynamically so the linker doesn't produce test
 -- executables of ~150MB each and works lightning fast at that too
-executable-dynamic: True
+-- Disabled on Windows
+if(!os(windows))
+  executable-dynamic: True
 
 -- Many of our tests only work single-threaded, and the only way to
 -- ensure tasty runs everything purely single-threaded is to pass

--- a/cabal.project
+++ b/cabal.project
@@ -17,6 +17,10 @@ benchmarks: True
 
 write-ghc-environment-files: never
 
+-- Link executables dynamically so the linker doesn't produce test
+-- executables of ~150MB each and works lightning fast at that too
+executable-dynamic: True
+
 -- Many of our tests only work single-threaded, and the only way to
 -- ensure tasty runs everything purely single-threaded is to pass
 -- this at the top-level


### PR DESCRIPTION
Dramatically decreases linking times and shaves 6 of 14G off HLS' `dist-newstyle` directory on my machine by producing way smaller executables.

While `cabal build`ing HLS after switching a branch I've noticed linking test executables takes minutes, plural, _each_. Then I've checked the size of a freshly-built test binary and it was 150-something megabytes, no wonder linker took a while. With `executable-dynamic` enabled, linking is lightning fast and binaries are a megabyte at most, which should probably improve the developer experience and decrease the feedback loop time.

UPD: https://github.com/haskell/haskell-language-server/issues/2659 seems related, not sure how up-to-date though