### PR TITLE
Fix pre-commit in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -53,7 +53,7 @@ jobs:
               ${{ inputs.cache-prefix }}${{ env.cache-name }}-${{ inputs.os }}-${{ inputs.ghc }}-
               ${{ inputs.cache-prefix }}${{ env.cache-name }}-${{ inputs.os }}-
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v3
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --files ${{ needs.file-diff.outputs.git-diff }}


### PR DESCRIPTION
According to https://github.com/pre-commit/action, we need to use `actions/setup-python@v3` in CI, since GHA did something wonky.