### PR TITLE
gracefully handle errors for unsupported cabal version

### DIFF
--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -252,12 +252,13 @@ cabalRules recorder plId = do
                 -- We don't support the cabal version, this should not be an error, as the
                 -- user did not do anything wrong. Instead we cast it to a warning
                 regex = "Unsupported cabal-version [0-9]+.[0-9]*"
+                unsupportedCabalHelpText = "\nThe used cabal version is not fully supported by hls. This means that some functionallity might not work as expected.\nIf you face any issues try to downgrade to a supported cabal version."
                 errorDiags =
                   NE.toList $
                     NE.map
                       ( \pe@(PError pos text) ->
                           if text =~ regex
-                            then Diagnostics.warningDiagnostic file (Syntax.PWarning Syntax.PWTOther pos text)
+                            then Diagnostics.warningDiagnostic file (Syntax.PWarning Syntax.PWTOther pos (text <> unsupportedCabalHelpText))
                             else Diagnostics.errorDiagnostic file pe
                       )
                       pErrorNE

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -17,8 +17,10 @@ import qualified Data.ByteString                               as BS
 import           Data.Hashable
 import           Data.HashMap.Strict                           (HashMap)
 import qualified Data.HashMap.Strict                           as HashMap
+import qualified Data.List                                     as List
 import qualified Data.List.NonEmpty                            as NE
 import qualified Data.Maybe                                    as Maybe
+import qualified Data.Text                                     ()
 import qualified Data.Text                                     as T
 import qualified Data.Text.Encoding                            as Encoding
 import           Data.Text.Utf16.Rope.Mixed                    as Rope
@@ -33,17 +35,21 @@ import           Development.IDE.Graph                         (Key,
 import           Development.IDE.LSP.HoverDefinition           (foundHover)
 import qualified Development.IDE.Plugin.Completions.Logic      as Ghcide
 import           Development.IDE.Types.Shake                   (toKey)
+import qualified Distribution.CabalSpecVersion                 as Cabal
 import qualified Distribution.Fields                           as Syntax
 import           Distribution.Package                          (Dependency)
 import           Distribution.PackageDescription               (allBuildDepends,
                                                                 depPkgName,
                                                                 unPackageName)
 import           Distribution.PackageDescription.Configuration (flattenPackageDescription)
+import           Distribution.Parsec.Error
 import qualified Distribution.Parsec.Position                  as Syntax
 import           GHC.Generics
+import qualified Ide.Plugin.Cabal.CabalAdd                     as CabalAdd
 import           Ide.Plugin.Cabal.Completion.CabalFields       as CabalFields
 import qualified Ide.Plugin.Cabal.Completion.Completer.Types   as CompleterTypes
 import qualified Ide.Plugin.Cabal.Completion.Completions       as Completions
+import qualified Ide.Plugin.Cabal.Completion.Data              as Data
 import           Ide.Plugin.Cabal.Completion.Types             (ParseCabalCommonSections (ParseCabalCommonSections),
                                                                 ParseCabalFields (..),
                                                                 ParseCabalFile (..))
@@ -62,11 +68,6 @@ import qualified Language.LSP.Protocol.Message                 as LSP
 import           Language.LSP.Protocol.Types
 import qualified Language.LSP.VFS                              as VFS
 import           Text.Regex.TDFA
-
-
-import qualified Data.Text                                     ()
-import           Distribution.Parsec.Error
-import qualified Ide.Plugin.Cabal.CabalAdd                     as CabalAdd
 
 data Log
   = LogModificationTime NormalizedFilePath FileVersion
@@ -252,13 +253,24 @@ cabalRules recorder plId = do
                 -- We don't support the cabal version, this should not be an error, as the
                 -- user did not do anything wrong. Instead we cast it to a warning
                 regex = "Unsupported cabal-version [0-9]+.[0-9]*"
-                unsupportedCabalHelpText = "\nThe used cabal version is not fully supported by hls. This means that some functionallity might not work as expected.\nIf you face any issues try to downgrade to a supported cabal version."
+                unsupportedCabalHelpText = unlines
+                  [ "The used cabal version is not fully supported by HLS. This means that some functionality might not work as expected."
+                  , "If you face any issues try to downgrade to a supported cabal version."
+                  , ""
+                  , "Supported versions are: " <>
+                      List.intercalate ", "
+                        (fmap Cabal.showCabalSpecVersion Data.supportedCabalVersions)
+                  ]
                 errorDiags =
                   NE.toList $
                     NE.map
                       ( \pe@(PError pos text) ->
                           if text =~ regex
-                            then Diagnostics.warningDiagnostic file (Syntax.PWarning Syntax.PWTOther pos (text <> unsupportedCabalHelpText))
+                            then Diagnostics.warningDiagnostic file (Syntax.PWarning Syntax.PWTOther pos $
+                                  unlines
+                                    [ text
+                                    , unsupportedCabalHelpText
+                                    ])
                             else Diagnostics.errorDiagnostic file pe
                       )
                       pErrorNE

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Data.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Data.hs
@@ -23,6 +23,9 @@ import           Ide.Plugin.Cabal.LicenseSuggest                (licenseNames)
 -- Completion Data
 -- ----------------------------------------------------------------
 
+supportedCabalVersions :: [CabalSpecVersion]
+supportedCabalVersions = [CabalSpecV2_2 .. maxBound]
+
 -- | Keyword for cabal version; required to be the top line in a cabal file
 cabalVersionKeyword :: Map KeyWordName Completer
 cabalVersionKeyword =
@@ -30,7 +33,7 @@ cabalVersionKeyword =
     constantCompleter $
       -- We only suggest cabal versions newer than 2.2
       -- since we don't recommend using older ones.
-      map (T.pack . showCabalSpecVersion) [CabalSpecV2_2 .. maxBound]
+      map (T.pack . showCabalSpecVersion) supportedCabalVersions
 
 -- | Top level keywords of a cabal file.
 --

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Diagnostics.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Diagnostics.hs
@@ -63,8 +63,9 @@ positionFromCabalPosition :: Syntax.Position -> Position
 positionFromCabalPosition (Syntax.Position line column) = Position (fromIntegral line') (fromIntegral col')
   where
     -- LSP is zero-based, Cabal is one-based
-    line' = line-1
-    col' = column-1
+    -- Cabal can return line 0 for errors in the first line
+    line' = if line <= 0 then 0 else line-1
+    col' = if column <= 0 then 0 else column-1
 
 -- | Create a 'FileDiagnostic'
 mkDiag

--- a/plugins/hls-cabal-plugin/test/Main.hs
+++ b/plugins/hls-cabal-plugin/test/Main.hs
@@ -107,6 +107,14 @@ pluginTests =
                     length diags @?= 1
                     unknownLicenseDiag ^. L.range @?= Range (Position 3 24) (Position 4 0)
                     unknownLicenseDiag ^. L.severity @?= Just DiagnosticSeverity_Error
+            ,   runCabalTestCaseSession "Publishes Diagnostics on Error in the first line" "" $ do
+                _ <- openDoc "unsupportedVersion.cabal" "cabal"
+                diags <- cabalCaptureKick
+                unknownVersionDiag <- liftIO $ inspectDiagnostic diags ["Unsupported cabal-version 99999.0"]
+                liftIO $ do
+                    length diags @?= 1
+                    unknownVersionDiag ^. L.range @?= Range (Position 0 0) (Position 1 0)
+                    unknownVersionDiag ^. L.severity @?= Just DiagnosticSeverity_Error
             , runCabalTestCaseSession "Clears diagnostics" "" $ do
                 doc <- openDoc "invalid.cabal" "cabal"
                 diags <- cabalCaptureKick

--- a/plugins/hls-cabal-plugin/test/Main.hs
+++ b/plugins/hls-cabal-plugin/test/Main.hs
@@ -107,14 +107,14 @@ pluginTests =
                     length diags @?= 1
                     unknownLicenseDiag ^. L.range @?= Range (Position 3 24) (Position 4 0)
                     unknownLicenseDiag ^. L.severity @?= Just DiagnosticSeverity_Error
-            ,   runCabalTestCaseSession "Publishes Diagnostics on Error in the first line" "" $ do
+            ,   runCabalTestCaseSession "Publishes Diagnostics on unsupported cabal version as Warning" "" $ do
                 _ <- openDoc "unsupportedVersion.cabal" "cabal"
                 diags <- cabalCaptureKick
                 unknownVersionDiag <- liftIO $ inspectDiagnostic diags ["Unsupported cabal-version 99999.0"]
                 liftIO $ do
                     length diags @?= 1
                     unknownVersionDiag ^. L.range @?= Range (Position 0 0) (Position 1 0)
-                    unknownVersionDiag ^. L.severity @?= Just DiagnosticSeverity_Error
+                    unknownVersionDiag ^. L.severity @?= Just DiagnosticSeverity_Warning
             , runCabalTestCaseSession "Clears diagnostics" "" $ do
                 doc <- openDoc "invalid.cabal" "cabal"
                 diags <- cabalCaptureKick

--- a/plugins/hls-cabal-plugin/test/testdata/unsupportedVersion.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/unsupportedVersion.cabal
@@ -1,0 +1,3 @@
+cabal-version:      99999.0
+name:               invalid
+version:            0.1.0.0


### PR DESCRIPTION
This PR makes sure that line number 0 returned from cabal is handled correctly.

This caused the  marking of the whole cabal file if the cabal version is not supported as described in #4401 