### PR TITLE
Enhance formatting of the `cabal-version` error message

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -322,7 +322,7 @@ Provided by: `hls-cabal-plugin`
 
 Code action kind: `quickfix`
 
-Add a missing dependency to your `.cabal` file.
+Add a missing package dependency to your `.cabal` file.
 
 ## Code lenses
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -316,6 +316,14 @@ Code action kind: `quickfix`
 
 Correct common misspelling of SPDX Licenses such as `BSD-3-Clause`.
 
+### Add dependency to `cabal` file
+
+Provided by: `hls-cabal-plugin`
+
+Code action kind: `quickfix`
+
+Add a missing dependency to your `.cabal` file.
+
 ## Code lenses
 
 ### Add type signature

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -257,7 +257,7 @@ cabalRules recorder plId = do
                   [ "The used `cabal-version` is not fully supported by this `HLS` binary."
                   , "Either the `cabal-version` is unknown, or too new for this executable."
                   , "This means that some functionality might not work as expected."
-                  , "If you face any issues, try downgrading to a supported `cabal-version` or upgrading `HLS` if available."
+                  , "If you face any issues, try downgrading to a supported `cabal-version` or upgrading `HLS` if possible."
                   , ""
                   , "Supported versions are: " <>
                       List.intercalate ", "

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -254,8 +254,10 @@ cabalRules recorder plId = do
                 -- user did not do anything wrong. Instead we cast it to a warning
                 regex = "Unsupported cabal-version [0-9]+.[0-9]*"
                 unsupportedCabalHelpText = unlines
-                  [ "The used cabal version is not fully supported by HLS. This means that some functionality might not work as expected."
-                  , "If you face any issues try to downgrade to a supported cabal version."
+                  [ "The used `cabal-version` is not fully supported by this `HLS` binary."
+                  , "Either the `cabal-version` is unknown, or too new for this executable."
+                  , "This means that some functionality might not work as expected."
+                  , "If you face any issues, try downgrading to a supported `cabal-version` or upgrading `HLS` if available."
                   , ""
                   , "Supported versions are: " <>
                       List.intercalate ", "


### PR DESCRIPTION
Add docs for `cabal-add` based CodeAction