### PR TITLE
Don't suggest -Wno-deferred-out-of-scope-variables

### DIFF
--- a/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
@@ -126,9 +126,13 @@ suggestDisableWarning Diagnostic {_code}
     pure ("Disable \"" <> w <> "\" warnings", OptGHC w)
   | otherwise = []
 
--- Don't suggest disabling type errors as a solution to all type errors
 warningBlacklist :: [T.Text]
-warningBlacklist = ["deferred-type-errors"]
+warningBlacklist =
+  -- Don't suggest disabling type errors as a solution to all type errors.
+  [ "deferred-type-errors"
+  -- Don't suggest disabling out of scope errors as a solution to all out of scope errors.
+  , "deferred-out-of-scope-variables"
+  ]
 
 -- ---------------------------------------------------------------------
 

--- a/plugins/hls-pragmas-plugin/test/Main.hs
+++ b/plugins/hls-pragmas-plugin/test/Main.hs
@@ -109,10 +109,15 @@ codeActionTests' =
         _ -> assertFailure $ "Expected one code action, but got: " <> show cas
       liftIO $ (ca ^. L.title == "Add \"NamedFieldPuns\"") @? "NamedFieldPuns code action"
       executeCodeAction ca
-  , goldenWithPragmas pragmasSuggestPlugin "doesn't suggest disabling type errors" "DeferredTypeErrors" $ \doc -> do
+  , goldenWithPragmas pragmasDisableWarningPlugin "doesn't suggest disabling type errors" "DeferredTypeErrors" $ \doc -> do
       _ <- waitForDiagnosticsFrom doc
       cas <- map fromAction <$> getAllCodeActions doc
       liftIO $ "Disable \"deferred-type-errors\" warnings" `notElem` map (^. L.title) cas @? "Doesn't contain deferred-type-errors code action"
+      liftIO $ length cas == 0 @? "Expected no code actions, but got: " <> show cas
+  , goldenWithPragmas pragmasDisableWarningPlugin "doesn't suggest disabling out of scope variables" "DeferredOutOfScopeVariables" $ \doc -> do
+      _ <- waitForDiagnosticsFrom doc
+      cas <- map fromAction <$> getAllCodeActions doc
+      liftIO $ "Disable \"deferred-out-of-scope-variables\" warnings" `notElem` map (^. L.title) cas @? "Doesn't contain deferred-out-of-scope-variables code action"
       liftIO $ length cas == 0 @? "Expected no code actions, but got: " <> show cas
   ]
 

--- a/plugins/hls-pragmas-plugin/test/testdata/DeferredOutOfScopeVariables.expected.hs
+++ b/plugins/hls-pragmas-plugin/test/testdata/DeferredOutOfScopeVariables.expected.hs
@@ -1,0 +1,5 @@
+module DeferredOutOfScopeVariables where
+
+f :: ()
+f = let x = Doesn'tExist
+     in undefined

--- a/plugins/hls-pragmas-plugin/test/testdata/DeferredOutOfScopeVariables.hs
+++ b/plugins/hls-pragmas-plugin/test/testdata/DeferredOutOfScopeVariables.hs
@@ -1,0 +1,5 @@
+module DeferredOutOfScopeVariables where
+
+f :: ()
+f = let x = Doesn'tExist
+     in undefined


### PR DESCRIPTION
Fixes #4440

This does the trick, I don't get the code action on my local branch.

~I'm just unsure if those tests do what they are supposed to do.~

~If I disable blacklist~

```haskell
warningBlacklist :: [T.Text]
warningBlacklist =
  -- Don't suggest disabling type errors as a solution to all type errors.
  [ --"deferred-type-errors"
  -- Don't suggest disabling out of scope errors as a solution to all out of scope errors.
  --, "deferred-out-of-scope-variables"
  ]
```

~they do pass on my machine. The list is empty anyway, also in the case of deferred-type-errors. But that is beyond my current knowledge of the codebase.~

Edit: fixed.