### PR TITLE
Build HLS with GHC 9.8.3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-test-utils
 
 
-index-state:  2024-10-21T00:00:00Z
+index-state:  2024-11-02T00:00:00Z
 
 tests: True
 test-show-details: direct

--- a/ghcide/src/Development/IDE/GHC/Compat/Core.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Core.hs
@@ -674,7 +674,7 @@ initObjLinker env =
 loadDLL :: HscEnv -> String -> IO (Maybe String)
 loadDLL env str = do
     res <- GHCi.loadDLL (GHCi.hscInterp env) str
-#if MIN_VERSION_ghc(9,11,0)
+#if MIN_VERSION_ghc(9,11,0) || (MIN_VERSION_ghc(9, 8, 3) && !MIN_VERSION_ghc(9, 9, 0))
     pure $
       case res of
         Left err_msg -> Just err_msg


### PR DESCRIPTION
Can't add CI as https://github.com/haskell-actions/setup doesn't support 9.8.3, yet