### PR TITLE
Prepare release 2.10.0.0

### DIFF
--- a/.github/generate-ci/gen_ci.hs
+++ b/.github/generate-ci/gen_ci.hs
@@ -281,8 +281,8 @@ data Config = MkConfig Arch Opsys [GHC]
 instance ToJSON CI where
   toJSON (CI cs) = object
     [ "name" .= str "Build and release"
-    , "on" .= object [ "push" .= [object ["tags" .= [str "*"]]]
-                       , "schedule" .= [object ["cron" .= str "0 2 * * 1"]]
+    , "on" .= object [ "push" .=      object ["tags" .= [str "*"]]
+                      , "schedule" .= [object ["cron" .= str "0 2 * * 1"]]
                      ]
     , "env" .= object
       [ "CABAL_CACHE_DISABLE" .= str "${{ vars.CABAL_CACHE_DISABLE }}"

--- a/.github/generate-ci/gen_ci.hs
+++ b/.github/generate-ci/gen_ci.hs
@@ -188,6 +188,15 @@ runner AArch64 Darwin = ["self-hosted", "macOS", "ARM64"]
 runner Amd64 Windows = ["windows-latest"]
 runner AArch64 Windows = error "aarch64 windows not supported"
 
+-- | Runner selection for bindist jobs
+bindistRunner :: Arch -> Opsys -> [Value]
+bindistRunner Amd64 (Linux _) = ["self-hosted", "linux-space", "maerwald"]
+bindistRunner AArch64 (Linux _) = ["self-hosted", "Linux", "ARM64", "maerwald"]
+bindistRunner Amd64 Darwin = ["macOS-13"]
+bindistRunner AArch64 Darwin = ["self-hosted", "macOS", "ARM64"]
+bindistRunner Amd64 Windows = ["windows-latest"]
+bindistRunner AArch64 Windows = error "aarch64 windows not supported"
+
 -------------------------------------------------------------------------------
 -- Action generatation
 -------------------------------------------------------------------------------
@@ -417,7 +426,7 @@ buildJob arch os v =
 mkBindistJob :: Arch -> Opsys -> [GHC] -> Job
 mkBindistJob arch os vs =
   K.fromString (bindistJobName arch os) .= object
-      [ "runs-on" .= runner arch os
+      [ "runs-on" .= bindistRunner arch os
       , "name" .= (bindistJobName arch os ++ " (Prepare bindist)")
       , "needs" .= [buildJobName arch os ver | ver <- vs]
       , "env" .= thisEnv

--- a/.github/generate-ci/gen_ci.hs
+++ b/.github/generate-ci/gen_ci.hs
@@ -62,16 +62,18 @@ artifactName arch opsys = archName arch ++ "-" ++ case opsys of
 
 data GHC
   = GHC948
-  | GHC966
+  | GHC967
   | GHC984
   | GHC9101
+  | GHC9122
   deriving (Eq, Enum, Bounded)
 
 ghcVersion :: GHC -> String
 ghcVersion GHC948 = "9.4.8"
-ghcVersion GHC966 = "9.6.6"
+ghcVersion GHC967 = "9.6.7"
 ghcVersion GHC984 = "9.8.4"
 ghcVersion GHC9101 = "9.10.1"
+ghcVersion GHC9122 = "9.12.2"
 
 ghcVersionIdent :: GHC -> String
 ghcVersionIdent = filter (/= '.') . ghcVersion

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -139,7 +139,7 @@ install_ghcup() {
 		source "$(dirname "${GHCUP_BIN}")/env"
 		# make sure we use the vanilla channel for installing binaries
 		# see https://github.com/haskell/ghcup-metadata/pull/166#issuecomment-1893075575
-		ghcup config set url-source https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-vanilla-0.0.8.yaml
+		ghcup config set url-source https://raw.githubusercontent.com/haskell/ghcup-metadata/refs/heads/master/ghcup-vanilla-0.0.9.yaml
 		ghcup install cabal --set "${BOOTSTRAP_HASKELL_CABAL_VERSION}"
 	fi
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,10 @@ jobs:
     name: bindist-aarch64-linux-ubuntu2004 (Prepare bindist)
     needs:
     - build-aarch64-linux-ubuntu2004-948
-    - build-aarch64-linux-ubuntu2004-966
+    - build-aarch64-linux-ubuntu2004-967
     - build-aarch64-linux-ubuntu2004-984
     - build-aarch64-linux-ubuntu2004-9101
+    - build-aarch64-linux-ubuntu2004-9122
     runs-on:
     - self-hosted
     - Linux
@@ -43,7 +44,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-aarch64-linux-ubuntu2004-966
+        name: artifacts-build-aarch64-linux-ubuntu2004-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -54,6 +55,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-aarch64-linux-ubuntu2004-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-aarch64-linux-ubuntu2004-9122
         path: ./
     - name: Unpack aarch64-linux binaries
       uses: docker://hasufell/arm64v8-ubuntu-haskell:focal
@@ -88,9 +94,10 @@ jobs:
     name: bindist-aarch64-mac (Prepare bindist)
     needs:
     - build-aarch64-mac-948
-    - build-aarch64-mac-966
+    - build-aarch64-mac-967
     - build-aarch64-mac-984
     - build-aarch64-mac-9101
+    - build-aarch64-mac-9122
     runs-on:
     - self-hosted
     - macOS
@@ -106,7 +113,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-aarch64-mac-966
+        name: artifacts-build-aarch64-mac-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -117,6 +124,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-aarch64-mac-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-aarch64-mac-9122
         path: ./
     - name: Run build
       run: |
@@ -157,9 +169,10 @@ jobs:
     name: bindist-x86_64-linux-centos7 (Prepare bindist)
     needs:
     - build-x86_64-linux-centos7-948
-    - build-x86_64-linux-centos7-966
+    - build-x86_64-linux-centos7-967
     - build-x86_64-linux-centos7-984
     - build-x86_64-linux-centos7-9101
+    - build-x86_64-linux-centos7-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -173,7 +186,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-centos7-966
+        name: artifacts-build-x86_64-linux-centos7-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -184,6 +197,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-centos7-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-centos7-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-centos7
@@ -213,9 +231,10 @@ jobs:
     name: bindist-x86_64-linux-deb10 (Prepare bindist)
     needs:
     - build-x86_64-linux-deb10-948
-    - build-x86_64-linux-deb10-966
+    - build-x86_64-linux-deb10-967
     - build-x86_64-linux-deb10-984
     - build-x86_64-linux-deb10-9101
+    - build-x86_64-linux-deb10-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -229,7 +248,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-deb10-966
+        name: artifacts-build-x86_64-linux-deb10-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -240,6 +259,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-deb10-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-deb10-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-deb10
@@ -269,9 +293,10 @@ jobs:
     name: bindist-x86_64-linux-deb11 (Prepare bindist)
     needs:
     - build-x86_64-linux-deb11-948
-    - build-x86_64-linux-deb11-966
+    - build-x86_64-linux-deb11-967
     - build-x86_64-linux-deb11-984
     - build-x86_64-linux-deb11-9101
+    - build-x86_64-linux-deb11-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -285,7 +310,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-deb11-966
+        name: artifacts-build-x86_64-linux-deb11-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -296,6 +321,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-deb11-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-deb11-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-deb11
@@ -325,9 +355,10 @@ jobs:
     name: bindist-x86_64-linux-deb9 (Prepare bindist)
     needs:
     - build-x86_64-linux-deb9-948
-    - build-x86_64-linux-deb9-966
+    - build-x86_64-linux-deb9-967
     - build-x86_64-linux-deb9-984
     - build-x86_64-linux-deb9-9101
+    - build-x86_64-linux-deb9-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -341,7 +372,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-deb9-966
+        name: artifacts-build-x86_64-linux-deb9-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -352,6 +383,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-deb9-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-deb9-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-deb9
@@ -381,9 +417,10 @@ jobs:
     name: bindist-x86_64-linux-fedora27 (Prepare bindist)
     needs:
     - build-x86_64-linux-fedora27-948
-    - build-x86_64-linux-fedora27-966
+    - build-x86_64-linux-fedora27-967
     - build-x86_64-linux-fedora27-984
     - build-x86_64-linux-fedora27-9101
+    - build-x86_64-linux-fedora27-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -397,7 +434,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-fedora27-966
+        name: artifacts-build-x86_64-linux-fedora27-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -408,6 +445,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-fedora27-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-fedora27-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-fedora27
@@ -437,9 +479,10 @@ jobs:
     name: bindist-x86_64-linux-fedora33 (Prepare bindist)
     needs:
     - build-x86_64-linux-fedora33-948
-    - build-x86_64-linux-fedora33-966
+    - build-x86_64-linux-fedora33-967
     - build-x86_64-linux-fedora33-984
     - build-x86_64-linux-fedora33-9101
+    - build-x86_64-linux-fedora33-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -453,7 +496,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-fedora33-966
+        name: artifacts-build-x86_64-linux-fedora33-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -464,6 +507,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-fedora33-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-fedora33-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-fedora33
@@ -493,9 +541,10 @@ jobs:
     name: bindist-x86_64-linux-mint193 (Prepare bindist)
     needs:
     - build-x86_64-linux-mint193-948
-    - build-x86_64-linux-mint193-966
+    - build-x86_64-linux-mint193-967
     - build-x86_64-linux-mint193-984
     - build-x86_64-linux-mint193-9101
+    - build-x86_64-linux-mint193-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -509,7 +558,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-mint193-966
+        name: artifacts-build-x86_64-linux-mint193-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -520,6 +569,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-mint193-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-mint193-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-mint193
@@ -549,9 +603,10 @@ jobs:
     name: bindist-x86_64-linux-mint202 (Prepare bindist)
     needs:
     - build-x86_64-linux-mint202-948
-    - build-x86_64-linux-mint202-966
+    - build-x86_64-linux-mint202-967
     - build-x86_64-linux-mint202-984
     - build-x86_64-linux-mint202-9101
+    - build-x86_64-linux-mint202-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -565,7 +620,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-mint202-966
+        name: artifacts-build-x86_64-linux-mint202-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -576,6 +631,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-mint202-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-mint202-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-mint202
@@ -605,9 +665,10 @@ jobs:
     name: bindist-x86_64-linux-ubuntu1804 (Prepare bindist)
     needs:
     - build-x86_64-linux-ubuntu1804-948
-    - build-x86_64-linux-ubuntu1804-966
+    - build-x86_64-linux-ubuntu1804-967
     - build-x86_64-linux-ubuntu1804-984
     - build-x86_64-linux-ubuntu1804-9101
+    - build-x86_64-linux-ubuntu1804-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -621,7 +682,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-ubuntu1804-966
+        name: artifacts-build-x86_64-linux-ubuntu1804-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -632,6 +693,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-ubuntu1804-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-ubuntu1804-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-ubuntu1804
@@ -661,9 +727,10 @@ jobs:
     name: bindist-x86_64-linux-ubuntu2004 (Prepare bindist)
     needs:
     - build-x86_64-linux-ubuntu2004-948
-    - build-x86_64-linux-ubuntu2004-966
+    - build-x86_64-linux-ubuntu2004-967
     - build-x86_64-linux-ubuntu2004-984
     - build-x86_64-linux-ubuntu2004-9101
+    - build-x86_64-linux-ubuntu2004-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -677,7 +744,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-ubuntu2004-966
+        name: artifacts-build-x86_64-linux-ubuntu2004-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -688,6 +755,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-ubuntu2004-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-ubuntu2004-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-ubuntu2004
@@ -717,9 +789,10 @@ jobs:
     name: bindist-x86_64-linux-ubuntu2204 (Prepare bindist)
     needs:
     - build-x86_64-linux-ubuntu2204-948
-    - build-x86_64-linux-ubuntu2204-966
+    - build-x86_64-linux-ubuntu2204-967
     - build-x86_64-linux-ubuntu2204-984
     - build-x86_64-linux-ubuntu2204-9101
+    - build-x86_64-linux-ubuntu2204-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -733,7 +806,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-ubuntu2204-966
+        name: artifacts-build-x86_64-linux-ubuntu2204-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -744,6 +817,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-ubuntu2204-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-ubuntu2204-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-ubuntu2204
@@ -773,9 +851,10 @@ jobs:
     name: bindist-x86_64-linux-unknown (Prepare bindist)
     needs:
     - build-x86_64-linux-unknown-948
-    - build-x86_64-linux-unknown-966
+    - build-x86_64-linux-unknown-967
     - build-x86_64-linux-unknown-984
     - build-x86_64-linux-unknown-9101
+    - build-x86_64-linux-unknown-9122
     runs-on:
     - ubuntu-latest
     steps:
@@ -789,7 +868,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-linux-unknown-966
+        name: artifacts-build-x86_64-linux-unknown-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -800,6 +879,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-linux-unknown-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-linux-unknown-9122
         path: ./
     - name: Bindist
       uses: ./.github/actions/bindist-actions/action-unknown
@@ -829,9 +913,10 @@ jobs:
     name: bindist-x86_64-mac (Prepare bindist)
     needs:
     - build-x86_64-mac-948
-    - build-x86_64-mac-966
+    - build-x86_64-mac-967
     - build-x86_64-mac-984
     - build-x86_64-mac-9101
+    - build-x86_64-mac-9122
     runs-on:
     - macOS-13
     steps:
@@ -845,7 +930,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-mac-966
+        name: artifacts-build-x86_64-mac-967
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -856,6 +941,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-mac-9101
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-mac-9122
         path: ./
     - name: Create bindist
       run: |
@@ -889,9 +979,10 @@ jobs:
     name: bindist-x86_64-windows (Prepare bindist)
     needs:
     - build-x86_64-windows-948
-    - build-x86_64-windows-966
+    - build-x86_64-windows-967
     - build-x86_64-windows-984
     - build-x86_64-windows-9101
+    - build-x86_64-windows-9122
     runs-on:
     - windows-latest
     steps:
@@ -905,7 +996,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifacts-build-x86_64-windows-966
+        name: artifacts-build-x86_64-windows-967
         path: ./out
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -916,6 +1007,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: artifacts-build-x86_64-windows-9101
+        path: ./out
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifacts-build-x86_64-windows-9122
         path: ./out
     - name: Run build
       run: |
@@ -982,6 +1078,51 @@ jobs:
         name: artifacts-build-aarch64-linux-ubuntu2004-9101
         path: out-aarch64-linux-ubuntu2004-9.10.1.tar
         retention-days: 2
+  build-aarch64-linux-ubuntu2004-9122:
+    env:
+      ADD_CABAL_ARGS: ''
+      ARCH: ARM64
+      ARTIFACT: aarch64-linux-ubuntu2004
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-aarch64-linux-ubuntu2004-9122 (Build binaries)
+    runs-on:
+    - self-hosted
+    - Linux
+    - ARM64
+    - maerwald
+    steps:
+    - name: clean and git config for aarch64-linux
+      run: |
+        find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+        git config --global --get-all safe.directory | grep '^\*$' || git config --global --add safe.directory "*"
+      shell: bash
+    - name: Checkout
+      uses: actions/checkout@v4
+    - env:
+        GHC_VERSION: 9.12.2
+      name: Build aarch64-linux binaries
+      uses: docker://hasufell/arm64v8-ubuntu-haskell:focal
+      with:
+        args: bash .github/scripts/build.sh
+    - env:
+        GHC_VERSION: 9.12.2
+      name: Tar aarch64-linux binaries
+      uses: docker://hasufell/arm64v8-ubuntu-haskell:focal
+      with:
+        args: bash .github/scripts/tar.sh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-aarch64-linux-ubuntu2004-9122
+        path: out-aarch64-linux-ubuntu2004-9.12.2.tar
+        retention-days: 2
   build-aarch64-linux-ubuntu2004-948:
     env:
       ADD_CABAL_ARGS: ''
@@ -1027,7 +1168,7 @@ jobs:
         name: artifacts-build-aarch64-linux-ubuntu2004-948
         path: out-aarch64-linux-ubuntu2004-9.4.8.tar
         retention-days: 2
-  build-aarch64-linux-ubuntu2004-966:
+  build-aarch64-linux-ubuntu2004-967:
     env:
       ADD_CABAL_ARGS: ''
       ARCH: ARM64
@@ -1039,7 +1180,7 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-aarch64-linux-ubuntu2004-966 (Build binaries)
+    name: build-aarch64-linux-ubuntu2004-967 (Build binaries)
     runs-on:
     - self-hosted
     - Linux
@@ -1054,13 +1195,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - env:
-        GHC_VERSION: 9.6.6
+        GHC_VERSION: 9.6.7
       name: Build aarch64-linux binaries
       uses: docker://hasufell/arm64v8-ubuntu-haskell:focal
       with:
         args: bash .github/scripts/build.sh
     - env:
-        GHC_VERSION: 9.6.6
+        GHC_VERSION: 9.6.7
       name: Tar aarch64-linux binaries
       uses: docker://hasufell/arm64v8-ubuntu-haskell:focal
       with:
@@ -1069,8 +1210,8 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-aarch64-linux-ubuntu2004-966
-        path: out-aarch64-linux-ubuntu2004-9.6.6.tar
+        name: artifacts-build-aarch64-linux-ubuntu2004-967
+        path: out-aarch64-linux-ubuntu2004-9.6.7.tar
         retention-days: 2
   build-aarch64-linux-ubuntu2004-984:
     env:
@@ -1155,6 +1296,44 @@ jobs:
         name: artifacts-build-aarch64-mac-9101
         path: out-aarch64-apple-darwin-9.10.1.tar
         retention-days: 2
+  build-aarch64-mac-9122:
+    env:
+      ADD_CABAL_ARGS: ''
+      ARCH: ARM64
+      ARTIFACT: aarch64-apple-darwin
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      HOMEBREW_CHANGE_ARCH_TO_ARM: '1'
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-aarch64-mac-9122 (Build binaries)
+    runs-on:
+    - self-hosted
+    - macOS
+    - ARM64
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - env:
+        GHC_VERSION: 9.12.2
+      name: Run build
+      run: |
+        bash .github/scripts/brew.sh git coreutils autoconf automake tree
+        export PATH="$HOME/.brew/bin:$HOME/.brew/sbin:$PATH"
+        export LD=ld
+        bash .github/scripts/build.sh
+        tar cf out-${ARTIFACT}-${GHC_VERSION}.tar out/ store/
+      shell: sh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-aarch64-mac-9122
+        path: out-aarch64-apple-darwin-9.12.2.tar
+        retention-days: 2
   build-aarch64-mac-948:
     env:
       ADD_CABAL_ARGS: ''
@@ -1193,7 +1372,7 @@ jobs:
         name: artifacts-build-aarch64-mac-948
         path: out-aarch64-apple-darwin-9.4.8.tar
         retention-days: 2
-  build-aarch64-mac-966:
+  build-aarch64-mac-967:
     env:
       ADD_CABAL_ARGS: ''
       ARCH: ARM64
@@ -1206,7 +1385,7 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-aarch64-mac-966 (Build binaries)
+    name: build-aarch64-mac-967 (Build binaries)
     runs-on:
     - self-hosted
     - macOS
@@ -1215,7 +1394,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - env:
-        GHC_VERSION: 9.6.6
+        GHC_VERSION: 9.6.7
       name: Run build
       run: |
         bash .github/scripts/brew.sh git coreutils autoconf automake tree
@@ -1228,8 +1407,8 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-aarch64-mac-966
-        path: out-aarch64-apple-darwin-9.6.6.tar
+        name: artifacts-build-aarch64-mac-967
+        path: out-aarch64-apple-darwin-9.6.7.tar
         retention-days: 2
   build-aarch64-mac-984:
     env:
@@ -1299,6 +1478,36 @@ jobs:
         name: artifacts-build-x86_64-linux-centos7-9101
         path: out-x86_64-linux-centos7-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-centos7-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-centos7
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-centos7-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-centos7
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-centos7-9122
+        path: out-x86_64-linux-centos7-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-centos7-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -1329,7 +1538,7 @@ jobs:
         name: artifacts-build-x86_64-linux-centos7-948
         path: out-x86_64-linux-centos7-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-centos7-966:
+  build-x86_64-linux-centos7-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -1341,23 +1550,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-centos7-966 (Build binaries)
+    name: build-x86_64-linux-centos7-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-centos7
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-centos7-966
-        path: out-x86_64-linux-centos7-9.6.6.tar
+        name: artifacts-build-x86_64-linux-centos7-967
+        path: out-x86_64-linux-centos7-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-centos7-984:
     env:
@@ -1419,6 +1628,36 @@ jobs:
         name: artifacts-build-x86_64-linux-deb10-9101
         path: out-x86_64-linux-deb10-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-deb10-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-deb10
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-deb10-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-deb10
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-deb10-9122
+        path: out-x86_64-linux-deb10-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-deb10-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -1449,7 +1688,7 @@ jobs:
         name: artifacts-build-x86_64-linux-deb10-948
         path: out-x86_64-linux-deb10-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-deb10-966:
+  build-x86_64-linux-deb10-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -1461,23 +1700,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-deb10-966 (Build binaries)
+    name: build-x86_64-linux-deb10-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-deb10
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-deb10-966
-        path: out-x86_64-linux-deb10-9.6.6.tar
+        name: artifacts-build-x86_64-linux-deb10-967
+        path: out-x86_64-linux-deb10-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-deb10-984:
     env:
@@ -1539,6 +1778,36 @@ jobs:
         name: artifacts-build-x86_64-linux-deb11-9101
         path: out-x86_64-linux-deb11-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-deb11-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-deb11
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-deb11-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-deb11
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-deb11-9122
+        path: out-x86_64-linux-deb11-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-deb11-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -1569,7 +1838,7 @@ jobs:
         name: artifacts-build-x86_64-linux-deb11-948
         path: out-x86_64-linux-deb11-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-deb11-966:
+  build-x86_64-linux-deb11-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -1581,23 +1850,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-deb11-966 (Build binaries)
+    name: build-x86_64-linux-deb11-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-deb11
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-deb11-966
-        path: out-x86_64-linux-deb11-9.6.6.tar
+        name: artifacts-build-x86_64-linux-deb11-967
+        path: out-x86_64-linux-deb11-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-deb11-984:
     env:
@@ -1659,6 +1928,36 @@ jobs:
         name: artifacts-build-x86_64-linux-deb9-9101
         path: out-x86_64-linux-deb9-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-deb9-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-deb9
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-deb9-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-deb9
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-deb9-9122
+        path: out-x86_64-linux-deb9-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-deb9-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -1689,7 +1988,7 @@ jobs:
         name: artifacts-build-x86_64-linux-deb9-948
         path: out-x86_64-linux-deb9-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-deb9-966:
+  build-x86_64-linux-deb9-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -1701,23 +2000,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-deb9-966 (Build binaries)
+    name: build-x86_64-linux-deb9-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-deb9
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-deb9-966
-        path: out-x86_64-linux-deb9-9.6.6.tar
+        name: artifacts-build-x86_64-linux-deb9-967
+        path: out-x86_64-linux-deb9-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-deb9-984:
     env:
@@ -1779,6 +2078,36 @@ jobs:
         name: artifacts-build-x86_64-linux-fedora27-9101
         path: out-x86_64-linux-fedora27-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-fedora27-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-fedora27
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-fedora27-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-fedora27
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-fedora27-9122
+        path: out-x86_64-linux-fedora27-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-fedora27-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -1809,7 +2138,7 @@ jobs:
         name: artifacts-build-x86_64-linux-fedora27-948
         path: out-x86_64-linux-fedora27-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-fedora27-966:
+  build-x86_64-linux-fedora27-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -1821,23 +2150,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-fedora27-966 (Build binaries)
+    name: build-x86_64-linux-fedora27-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-fedora27
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-fedora27-966
-        path: out-x86_64-linux-fedora27-9.6.6.tar
+        name: artifacts-build-x86_64-linux-fedora27-967
+        path: out-x86_64-linux-fedora27-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-fedora27-984:
     env:
@@ -1899,6 +2228,36 @@ jobs:
         name: artifacts-build-x86_64-linux-fedora33-9101
         path: out-x86_64-linux-fedora33-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-fedora33-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-fedora33
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-fedora33-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-fedora33
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-fedora33-9122
+        path: out-x86_64-linux-fedora33-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-fedora33-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -1929,7 +2288,7 @@ jobs:
         name: artifacts-build-x86_64-linux-fedora33-948
         path: out-x86_64-linux-fedora33-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-fedora33-966:
+  build-x86_64-linux-fedora33-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -1941,23 +2300,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-fedora33-966 (Build binaries)
+    name: build-x86_64-linux-fedora33-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-fedora33
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-fedora33-966
-        path: out-x86_64-linux-fedora33-9.6.6.tar
+        name: artifacts-build-x86_64-linux-fedora33-967
+        path: out-x86_64-linux-fedora33-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-fedora33-984:
     env:
@@ -2019,6 +2378,36 @@ jobs:
         name: artifacts-build-x86_64-linux-mint193-9101
         path: out-x86_64-linux-mint193-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-mint193-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-mint193
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-mint193-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-mint193
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-mint193-9122
+        path: out-x86_64-linux-mint193-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-mint193-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2049,7 +2438,7 @@ jobs:
         name: artifacts-build-x86_64-linux-mint193-948
         path: out-x86_64-linux-mint193-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-mint193-966:
+  build-x86_64-linux-mint193-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -2061,23 +2450,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-mint193-966 (Build binaries)
+    name: build-x86_64-linux-mint193-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-mint193
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-mint193-966
-        path: out-x86_64-linux-mint193-9.6.6.tar
+        name: artifacts-build-x86_64-linux-mint193-967
+        path: out-x86_64-linux-mint193-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-mint193-984:
     env:
@@ -2139,6 +2528,36 @@ jobs:
         name: artifacts-build-x86_64-linux-mint202-9101
         path: out-x86_64-linux-mint202-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-mint202-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-mint202
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-mint202-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-mint202
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-mint202-9122
+        path: out-x86_64-linux-mint202-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-mint202-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2169,7 +2588,7 @@ jobs:
         name: artifacts-build-x86_64-linux-mint202-948
         path: out-x86_64-linux-mint202-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-mint202-966:
+  build-x86_64-linux-mint202-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -2181,23 +2600,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-mint202-966 (Build binaries)
+    name: build-x86_64-linux-mint202-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-mint202
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-mint202-966
-        path: out-x86_64-linux-mint202-9.6.6.tar
+        name: artifacts-build-x86_64-linux-mint202-967
+        path: out-x86_64-linux-mint202-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-mint202-984:
     env:
@@ -2259,6 +2678,36 @@ jobs:
         name: artifacts-build-x86_64-linux-ubuntu1804-9101
         path: out-x86_64-linux-ubuntu1804-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-ubuntu1804-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-ubuntu1804
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-ubuntu1804-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-ubuntu1804
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-ubuntu1804-9122
+        path: out-x86_64-linux-ubuntu1804-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-ubuntu1804-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2289,7 +2738,7 @@ jobs:
         name: artifacts-build-x86_64-linux-ubuntu1804-948
         path: out-x86_64-linux-ubuntu1804-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-ubuntu1804-966:
+  build-x86_64-linux-ubuntu1804-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -2301,23 +2750,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-ubuntu1804-966 (Build binaries)
+    name: build-x86_64-linux-ubuntu1804-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-ubuntu1804
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-ubuntu1804-966
-        path: out-x86_64-linux-ubuntu1804-9.6.6.tar
+        name: artifacts-build-x86_64-linux-ubuntu1804-967
+        path: out-x86_64-linux-ubuntu1804-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-ubuntu1804-984:
     env:
@@ -2379,6 +2828,36 @@ jobs:
         name: artifacts-build-x86_64-linux-ubuntu2004-9101
         path: out-x86_64-linux-ubuntu2004-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-ubuntu2004-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-ubuntu2004
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-ubuntu2004-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-ubuntu2004
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-ubuntu2004-9122
+        path: out-x86_64-linux-ubuntu2004-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-ubuntu2004-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2409,7 +2888,7 @@ jobs:
         name: artifacts-build-x86_64-linux-ubuntu2004-948
         path: out-x86_64-linux-ubuntu2004-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-ubuntu2004-966:
+  build-x86_64-linux-ubuntu2004-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -2421,23 +2900,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-ubuntu2004-966 (Build binaries)
+    name: build-x86_64-linux-ubuntu2004-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-ubuntu2004
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-ubuntu2004-966
-        path: out-x86_64-linux-ubuntu2004-9.6.6.tar
+        name: artifacts-build-x86_64-linux-ubuntu2004-967
+        path: out-x86_64-linux-ubuntu2004-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-ubuntu2004-984:
     env:
@@ -2499,6 +2978,36 @@ jobs:
         name: artifacts-build-x86_64-linux-ubuntu2204-9101
         path: out-x86_64-linux-ubuntu2204-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-ubuntu2204-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-ubuntu2204
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-ubuntu2204-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-ubuntu2204
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-ubuntu2204-9122
+        path: out-x86_64-linux-ubuntu2204-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-ubuntu2204-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2529,7 +3038,7 @@ jobs:
         name: artifacts-build-x86_64-linux-ubuntu2204-948
         path: out-x86_64-linux-ubuntu2204-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-ubuntu2204-966:
+  build-x86_64-linux-ubuntu2204-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -2541,23 +3050,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-ubuntu2204-966 (Build binaries)
+    name: build-x86_64-linux-ubuntu2204-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-ubuntu2204
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-ubuntu2204-966
-        path: out-x86_64-linux-ubuntu2204-9.6.6.tar
+        name: artifacts-build-x86_64-linux-ubuntu2204-967
+        path: out-x86_64-linux-ubuntu2204-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-ubuntu2204-984:
     env:
@@ -2619,6 +3128,36 @@ jobs:
         name: artifacts-build-x86_64-linux-unknown-9101
         path: out-x86_64-linux-unknown-9.10.1.tar
         retention-days: 2
+  build-x86_64-linux-unknown-9122:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-unknown
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-unknown-9122 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.2
+      uses: ./.github/actions/bindist-actions/action-unknown
+      with:
+        stage: BUILD
+        version: 9.12.2
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-unknown-9122
+        path: out-x86_64-linux-unknown-9.12.2.tar
+        retention-days: 2
   build-x86_64-linux-unknown-948:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2649,7 +3188,7 @@ jobs:
         name: artifacts-build-x86_64-linux-unknown-948
         path: out-x86_64-linux-unknown-9.4.8.tar
         retention-days: 2
-  build-x86_64-linux-unknown-966:
+  build-x86_64-linux-unknown-967:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
       ARCH: '64'
@@ -2661,23 +3200,23 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-linux-unknown-966 (Build binaries)
+    name: build-x86_64-linux-unknown-967 (Build binaries)
     runs-on:
     - ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Build 9.6.6
+    - name: Build 9.6.7
       uses: ./.github/actions/bindist-actions/action-unknown
       with:
         stage: BUILD
-        version: 9.6.6
+        version: 9.6.7
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-linux-unknown-966
-        path: out-x86_64-linux-unknown-9.6.6.tar
+        name: artifacts-build-x86_64-linux-unknown-967
+        path: out-x86_64-linux-unknown-9.6.7.tar
         retention-days: 2
   build-x86_64-linux-unknown-984:
     env:
@@ -2742,6 +3281,39 @@ jobs:
         name: artifacts-build-x86_64-mac-9101
         path: out-x86_64-apple-darwin-9.10.1.tar
         retention-days: 2
+  build-x86_64-mac-9122:
+    env:
+      ADD_CABAL_ARGS: ''
+      ARCH: '64'
+      ARTIFACT: x86_64-apple-darwin
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-mac-9122 (Build binaries)
+    runs-on:
+    - macOS-13
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - env:
+        GHC_VERSION: 9.12.2
+      name: Run build
+      run: |
+        brew install coreutils tree
+        bash .github/scripts/build.sh
+        tar cf out-${ARTIFACT}-${GHC_VERSION}.tar out/ store/
+      shell: sh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-mac-9122
+        path: out-x86_64-apple-darwin-9.12.2.tar
+        retention-days: 2
   build-x86_64-mac-948:
     env:
       ADD_CABAL_ARGS: ''
@@ -2775,7 +3347,7 @@ jobs:
         name: artifacts-build-x86_64-mac-948
         path: out-x86_64-apple-darwin-9.4.8.tar
         retention-days: 2
-  build-x86_64-mac-966:
+  build-x86_64-mac-967:
     env:
       ADD_CABAL_ARGS: ''
       ARCH: '64'
@@ -2787,14 +3359,14 @@ jobs:
       TARBALL_EXT: tar.xz
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-mac-966 (Build binaries)
+    name: build-x86_64-mac-967 (Build binaries)
     runs-on:
     - macOS-13
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - env:
-        GHC_VERSION: 9.6.6
+        GHC_VERSION: 9.6.7
       name: Run build
       run: |
         brew install coreutils tree
@@ -2805,8 +3377,8 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-mac-966
-        path: out-x86_64-apple-darwin-9.6.6.tar
+        name: artifacts-build-x86_64-mac-967
+        path: out-x86_64-apple-darwin-9.6.7.tar
         retention-days: 2
   build-x86_64-mac-984:
     env:
@@ -2874,6 +3446,39 @@ jobs:
         name: artifacts-build-x86_64-windows-9101
         path: ./out/*
         retention-days: 2
+  build-x86_64-windows-9122:
+    env:
+      ADD_CABAL_ARGS: ''
+      ARCH: '64'
+      ARTIFACT: x86_64-mingw64
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: zip
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-windows-9122 (Build binaries)
+    runs-on:
+    - windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - env:
+        GHC_VERSION: 9.12.2
+      name: Run build
+      run: |
+        $env:CHERE_INVOKING = 1
+        $env:MSYS2_PATH_TYPE = "inherit"
+        $ErrorActionPreference = "Stop"
+        C:\msys64\usr\bin\bash -lc "bash .github/scripts/build.sh"
+      shell: pwsh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-windows-9122
+        path: ./out/*
+        retention-days: 2
   build-x86_64-windows-948:
     env:
       ADD_CABAL_ARGS: ''
@@ -2907,7 +3512,7 @@ jobs:
         name: artifacts-build-x86_64-windows-948
         path: ./out/*
         retention-days: 2
-  build-x86_64-windows-966:
+  build-x86_64-windows-967:
     env:
       ADD_CABAL_ARGS: ''
       ARCH: '64'
@@ -2918,14 +3523,14 @@ jobs:
       TARBALL_EXT: zip
       TZ: Asia/Singapore
     environment: CI
-    name: build-x86_64-windows-966 (Build binaries)
+    name: build-x86_64-windows-967 (Build binaries)
     runs-on:
     - windows-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - env:
-        GHC_VERSION: 9.6.6
+        GHC_VERSION: 9.6.7
       name: Run build
       run: |
         $env:CHERE_INVOKING = 1
@@ -2937,7 +3542,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: artifacts-build-x86_64-windows-966
+        name: artifacts-build-x86_64-windows-967
         path: ./out/*
         retention-days: 2
   build-x86_64-windows-984:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,9 @@ jobs:
     - build-x86_64-linux-centos7-9101
     - build-x86_64-linux-centos7-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -236,7 +238,9 @@ jobs:
     - build-x86_64-linux-deb10-9101
     - build-x86_64-linux-deb10-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -298,7 +302,9 @@ jobs:
     - build-x86_64-linux-deb11-9101
     - build-x86_64-linux-deb11-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -360,7 +366,9 @@ jobs:
     - build-x86_64-linux-deb9-9101
     - build-x86_64-linux-deb9-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -422,7 +430,9 @@ jobs:
     - build-x86_64-linux-fedora27-9101
     - build-x86_64-linux-fedora27-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -484,7 +494,9 @@ jobs:
     - build-x86_64-linux-fedora33-9101
     - build-x86_64-linux-fedora33-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -546,7 +558,9 @@ jobs:
     - build-x86_64-linux-mint193-9101
     - build-x86_64-linux-mint193-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -608,7 +622,9 @@ jobs:
     - build-x86_64-linux-mint202-9101
     - build-x86_64-linux-mint202-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -670,7 +686,9 @@ jobs:
     - build-x86_64-linux-ubuntu1804-9101
     - build-x86_64-linux-ubuntu1804-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -732,7 +750,9 @@ jobs:
     - build-x86_64-linux-ubuntu2004-9101
     - build-x86_64-linux-ubuntu2004-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -794,7 +814,9 @@ jobs:
     - build-x86_64-linux-ubuntu2204-9101
     - build-x86_64-linux-ubuntu2204-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -856,7 +878,9 @@ jobs:
     - build-x86_64-linux-unknown-9101
     - build-x86_64-linux-unknown-9122
     runs-on:
-    - ubuntu-latest
+    - self-hosted
+    - linux-space
+    - maerwald
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4195,7 +4195,7 @@ jobs:
 name: Build and release
 'on':
   push:
-  - tags:
+    tags:
     - '*'
   schedule:
   - cron: 0 2 * * 1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,159 @@
 # Changelog for haskell-language-server
 
+## 2.10.0.0
+
+- Bindists for GHC 9.12.2
+  - This is only basic support, many plugins are not yet compatible.
+- Bindists for GHC 9.8.4
+- Bindists for GHC 9.6.7
+- `hls-cabal-plugin` features
+  - Support for `cabal-add`
+  - Goto Definition for common sections
+  - Outline of .cabal files
+- Fix handling of LSP resolve requests
+- Display Inlay Hints
+  - Records
+  - Imports
+
+### Pull Requests
+
+- Fix cabal check for Hackage release
+  ([#4528](https://github.com/haskell/haskell-language-server/pull/4528)) by @fendor
+- GHC 9.12 support
+  ([#4527](https://github.com/haskell/haskell-language-server/pull/4527)) by @wz1000
+- Bump cachix/install-nix-action from 30 to 31
+  ([#4525](https://github.com/haskell/haskell-language-server/pull/4525)) by @dependabot[bot]
+- Bump cachix/cachix-action from 15 to 16
+  ([#4523](https://github.com/haskell/haskell-language-server/pull/4523)) by @dependabot[bot]
+- Bump haskell-actions/setup from 2.7.9 to 2.7.10
+  ([#4522](https://github.com/haskell/haskell-language-server/pull/4522)) by @dependabot[bot]
+- Bump haskell-actions/setup from 2.7.9 to 2.7.10 in /.github/actions/setup-build
+  ([#4521](https://github.com/haskell/haskell-language-server/pull/4521)) by @dependabot[bot]
+- Move ghcide-test to stand alone dir
+  ([#4520](https://github.com/haskell/haskell-language-server/pull/4520)) by @soulomoon
+- refactor: remove unnecessary instance and use of unsafeCoerce
+  ([#4518](https://github.com/haskell/haskell-language-server/pull/4518)) by @MangoIV
+- convert `pre-commit-config.yaml` from JSON to YAML
+  ([#4513](https://github.com/haskell/haskell-language-server/pull/4513)) by @peterbecich
+- Enable bench for 9.10
+  ([#4512](https://github.com/haskell/haskell-language-server/pull/4512)) by @soulomoon
+- Bugfix: Explicit record fields inlay hints for polymorphic records
+  ([#4510](https://github.com/haskell/haskell-language-server/pull/4510)) by @wczyz
+- Capitalization of "Replace"
+  ([#4509](https://github.com/haskell/haskell-language-server/pull/4509)) by @dschrempf
+- document eval plugin not supporting multiline expressions
+  ([#4495](https://github.com/haskell/haskell-language-server/pull/4495)) by @noughtmare
+- Documentation: Imrpove "Contributing" (and amend Sphinx builders)
+  ([#4494](https://github.com/haskell/haskell-language-server/pull/4494)) by @dschrempf
+- Documentation: HLS plugin tutorial improvements
+  ([#4491](https://github.com/haskell/haskell-language-server/pull/4491)) by @dschrempf
+- Nix tooling (minor changes)
+  ([#4490](https://github.com/haskell/haskell-language-server/pull/4490)) by @dschrempf
+- Bump haskell-actions/setup from 2.7.8 to 2.7.9
+  ([#4483](https://github.com/haskell/haskell-language-server/pull/4483)) by @dependabot[bot]
+- Bump haskell-actions/setup from 2.7.8 to 2.7.9 in /.github/actions/setup-build
+  ([#4482](https://github.com/haskell/haskell-language-server/pull/4482)) by @dependabot[bot]
+- Rework bindist CI
+  ([#4481](https://github.com/haskell/haskell-language-server/pull/4481)) by @wz1000
+- Remove Unsafe Dynflags deadcode, they don't exist any more!
+  ([#4480](https://github.com/haskell/haskell-language-server/pull/4480)) by @fendor
+- Implement fallback handler for `*/resolve` requests
+  ([#4478](https://github.com/haskell/haskell-language-server/pull/4478)) by @fendor
+- Bump haskell-actions/setup from 2.7.7 to 2.7.8
+  ([#4477](https://github.com/haskell/haskell-language-server/pull/4477)) by @dependabot[bot]
+- Bump haskell-actions/setup from 2.7.7 to 2.7.8 in /.github/actions/setup-build
+  ([#4476](https://github.com/haskell/haskell-language-server/pull/4476)) by @dependabot[bot]
+- Bump haskell-actions/setup from 2.7.6 to 2.7.7
+  ([#4471](https://github.com/haskell/haskell-language-server/pull/4471)) by @dependabot[bot]
+- Bump haskell-actions/setup from 2.7.6 to 2.7.7 in /.github/actions/setup-build
+  ([#4470](https://github.com/haskell/haskell-language-server/pull/4470)) by @dependabot[bot]
+- Allow building with GHC 9.8.4
+  ([#4459](https://github.com/haskell/haskell-language-server/pull/4459)) by @fendor
+- Update python read-the-docs dependencies to latest
+  ([#4457](https://github.com/haskell/haskell-language-server/pull/4457)) by @fendor
+- More tests and better docs for cabal-add
+  ([#4455](https://github.com/haskell/haskell-language-server/pull/4455)) by @VenInf
+- ci(mergify): upgrade configuration to current format
+  ([#4454](https://github.com/haskell/haskell-language-server/pull/4454)) by @mergify[bot]
+- Support record positional construction inlay hints
+  ([#4447](https://github.com/haskell/haskell-language-server/pull/4447)) by @jetjinser
+- Build HLS with GHC 9.8.3
+  ([#4444](https://github.com/haskell/haskell-language-server/pull/4444)) by @fendor
+- Don't suggest -Wno-deferred-out-of-scope-variables
+  ([#4441](https://github.com/haskell/haskell-language-server/pull/4441)) by @jeukshi
+- Enable hls-stan-plugin for GHC 9.10.1
+  ([#4437](https://github.com/haskell/haskell-language-server/pull/4437)) by @fendor
+- Enhance formatting of the `cabal-version` error message
+  ([#4436](https://github.com/haskell/haskell-language-server/pull/4436)) by @fendor
+- Support structured diagnostics 2
+  ([#4433](https://github.com/haskell/haskell-language-server/pull/4433)) by @noughtmare
+- Cabal ignore if for completions (#4289)
+  ([#4427](https://github.com/haskell/haskell-language-server/pull/4427)) by @SamuelLess
+- Fix cabal-add testdata for hls-cabal-plugin-tests
+  ([#4426](https://github.com/haskell/haskell-language-server/pull/4426)) by @fendor
+- gracefully handle errors for unsupported cabal version
+  ([#4425](https://github.com/haskell/haskell-language-server/pull/4425)) by @fridewald
+- Fix pre-commit in CI
+  ([#4424](https://github.com/haskell/haskell-language-server/pull/4424)) by @fendor
+- link executables dynamically to speed up linking
+  ([#4423](https://github.com/haskell/haskell-language-server/pull/4423)) by @develop7
+- Cabal plugin: implement check for package.yaml in a stack project
+  ([#4422](https://github.com/haskell/haskell-language-server/pull/4422)) by @JMoss-dev
+- Fix exporting operator pattern synonym
+  ([#4420](https://github.com/haskell/haskell-language-server/pull/4420)) by @pbrinkmeier
+- Add docs about running tests for new contributors
+  ([#4418](https://github.com/haskell/haskell-language-server/pull/4418)) by @pbrinkmeier
+- Bump cachix/install-nix-action from 29 to 30
+  ([#4413](https://github.com/haskell/haskell-language-server/pull/4413)) by @dependabot[bot]
+- Bump cachix/install-nix-action from V27 to 29
+  ([#4411](https://github.com/haskell/haskell-language-server/pull/4411)) by @dependabot[bot]
+- Avoid expectFail in the test suite
+  ([#4402](https://github.com/haskell/haskell-language-server/pull/4402)) by @sgillespie
+- Fix typos in hls-cabal-fmt-plugin
+  ([#4399](https://github.com/haskell/haskell-language-server/pull/4399)) by @fendor
+- Jump to instance definition and explain typeclass evidence
+  ([#4392](https://github.com/haskell/haskell-language-server/pull/4392)) by @fendor
+- Update cabal-add dependency
+  ([#4389](https://github.com/haskell/haskell-language-server/pull/4389)) by @VenInf
+- Improve error message for `--probe-tools`
+  ([#4387](https://github.com/haskell/haskell-language-server/pull/4387)) by @sgillespie
+- Documentation for build-depends on hover
+  ([#4385](https://github.com/haskell/haskell-language-server/pull/4385)) by @VenInf
+- Bump haskell-actions/setup from 2.7.3 to 2.7.6
+  ([#4384](https://github.com/haskell/haskell-language-server/pull/4384)) by @dependabot[bot]
+- Bump haskell-actions/setup from 2.7.5 to 2.7.6 in /.github/actions/setup-build
+  ([#4383](https://github.com/haskell/haskell-language-server/pull/4383)) by @dependabot[bot]
+- Clear GHCup caches in CI to not run out of space in CI
+  ([#4382](https://github.com/haskell/haskell-language-server/pull/4382)) by @fendor
+- Cabal go to module's definition
+  ([#4380](https://github.com/haskell/haskell-language-server/pull/4380)) by @VenInf
+- Add Goto Definition for cabal common sections
+  ([#4375](https://github.com/haskell/haskell-language-server/pull/4375)) by @ChristophHochrainer
+- cabal-add integration as a CodeAction
+  ([#4360](https://github.com/haskell/haskell-language-server/pull/4360)) by @VenInf
+- Bump haskell-actions/setup from 2.7.3 to 2.7.5 in /.github/actions/setup-build
+  ([#4354](https://github.com/haskell/haskell-language-server/pull/4354)) by @dependabot[bot]
+- Support Inlay hints for record wildcards
+  ([#4351](https://github.com/haskell/haskell-language-server/pull/4351)) by @jetjinser
+- Remove componentInternalUnits
+  ([#4350](https://github.com/haskell/haskell-language-server/pull/4350)) by @soulomoon
+- Fix core file location in `GetLinkable`
+  ([#4347](https://github.com/haskell/haskell-language-server/pull/4347)) by @soulomoon
+- Release 2.9.0.1
+  ([#4346](https://github.com/haskell/haskell-language-server/pull/4346)) by @wz1000
+- Using captureKicksDiagnostics to speed up multiple plugin tests
+  ([#4339](https://github.com/haskell/haskell-language-server/pull/4339)) by @komikat
+- Get files from Shake VFS from within plugin handlers
+  ([#4328](https://github.com/haskell/haskell-language-server/pull/4328)) by @awjchen
+- Cabal plugin outline view
+  ([#4323](https://github.com/haskell/haskell-language-server/pull/4323)) by @VenInf
+- Add missing documentation for cabal formatters
+  ([#4322](https://github.com/haskell/haskell-language-server/pull/4322)) by @fendor
+- Provide explicit import in inlay hints
+  ([#4235](https://github.com/haskell/haskell-language-server/pull/4235)) by @jetjinser
+- Add codeactions for cabal field names
+  ([#3273](https://github.com/haskell/haskell-language-server/pull/3273)) by @dyniec
+
 ## 2.9.0.1
 
 - Bindists for GHC 9.6.6

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,10 +3,9 @@
 ## Release checklist
 
 - [ ] check ghcup supports new GHC releases if any
-- [ ] set the supported GHCs in workflow file `.github/workflows/release.yaml`
-  - There is currently a list of GHC versions for each major platform. Search for `ghc: [` to find all lists.
-  - Look for `TODO:` to find locations that require extra care for GHC versions.
 - [ ] check all plugins still work if release includes code changes
+- [ ] set the supported GHCs in workflow file `.github/generate-ci/gen_ci.hs`
+- [ ] regenerate the CI via `./.github/generate-ci/generate-jobs`
 - [ ] bump package versions in all `*.cabal` files (same version as hls)
   - HLS uses lockstep versioning. The core packages and all plugins use the same version number, and only support exactly this version.
     - Exceptions:

--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -15,41 +15,44 @@ Support status (see the support policy below for more details):
 - "full support": this GHC version is currently actively supported, and most [tier 2 plugins](./plugin-support.md) work
 - "deprecated": this GHC version was supported in the past, but is now deprecated
 
-| GHC version  | Last supporting HLS version                                                          | Support status                                                              |
-|--------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| 9.10.1       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
-| 9.8.2        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
-| 9.8.1        | [2.6.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.6.0.0)   | full support                                                                |
-| 9.6.6        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
-| 9.6.5        | [2.9.0.1](https://github.com/haskell/haskell-language-server/releases/tag/2.9.0.1)   | full support                                                                |
-| 9.6.4        | [2.6.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.6.0.0)   | full support                                                                |
-| 9.6.3        | [2.5.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.5.0.0)   | full support                                                                |
-| 9.6.2        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |
-| 9.6.1        | [2.0.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.0.0.0)   | deprecated                                                                  |
-| 9.4.8        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support                                                                |
-| 9.4.7        | [2.5.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.5.0.0)   | deprecated                                                                  |
-| 9.4.6        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |
-| 9.4.5        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |
-| 9.4.4        | [1.10.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.10.0.0) | deprecated                                                                  |
-| 9.4.3        | [1.9.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.9.1.0)   | deprecated                                                                  |
-| 9.4.(1,2)    | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0)   | deprecated                                                                  |
-| 9.2.8        | [2.9.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.9.0.0)   | deprecated                                                                  |
-| 9.2.7        | [2.0.0.1](https://github.com/haskell/haskell-language-server/releases/tag/2.0.0.1)   | deprecated                                                                  |
-| 9.2.(5,6)    | [1.9.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.9.1.0)   | deprecated                                                                  |
-| 9.2.(3,4)    | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0)   | deprecated                                                                  |
-| 9.2.(1,2)    | [1.7.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.7.0.0)   | deprecated                                                                  |
-| 9.0.2        | [2.4.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.4.0.0)   | deprecated                                                                  |
-| 9.0.1        | [1.6.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.6.1.0)   | deprecated                                                                  |
-| 8.10.7       | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated                                                                  |
-| 8.10.6       | [1.6.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.6.1.0)   | deprecated                                                                  |
-| 8.10.5       | [1.5.1](https://github.com/haskell/haskell-language-server/releases/tag/1.5.1)       | deprecated                                                                  |
-| 8.10.(4,3,2) | [1.4.0](https://github.com/haskell/haskell-language-server/releases/tag/1.4.0)       | deprecated                                                                  |
-| 8.10.1       | [0.9.0](https://github.com/haskell/haskell-language-server/releases/tag/0.9.0)       | deprecated                                                                  |
-| 8.8.4        | [1.8.0](https://github.com/haskell/haskell-language-server/releases/1.8.0)           | deprecated                                                                  |
-| 8.8.3        | [1.5.1](https://github.com/haskell/haskell-language-server/releases/1.5.1)           | deprecated                                                                  |
-| 8.8.2        | [1.2.0](https://github.com/haskell/haskell-language-server/releases/tag/1.2.0)       | deprecated                                                                  |
-| 8.6.5        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0)   | deprecated                                                                  |
-| 8.6.4        | [1.4.0](https://github.com/haskell/haskell-language-server/releases/tag/1.4.0)       | deprecated                                                                  |
+| GHC version  | Last supporting HLS version                                                          | Support status |
+| ------------ | ------------------------------------------------------------------------------------ | -------------- |
+| 9.12.2       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | basic support  |
+| 9.10.1       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
+| 9.8.4        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
+| 9.8.2        | [2.9.0.1](https://github.com/haskell/haskell-language-server/releases/tag/2.9.0.1)   | deprecated     |
+| 9.8.1        | [2.6.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.6.0.0)   | deprecated   |
+| 9.6.7        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
+| 9.6.6        | [2.9.0.1](https://github.com/haskell/haskell-language-server/releases/tag/2.9.0.1)   | deprecated   |
+| 9.6.5        | [2.9.0.1](https://github.com/haskell/haskell-language-server/releases/tag/2.9.0.1)   | deprecated     |
+| 9.6.4        | [2.6.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.6.0.0)   | deprecated     |
+| 9.6.3        | [2.5.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.5.0.0)   | deprecated     |
+| 9.6.2        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated     |
+| 9.6.1        | [2.0.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.0.0.0)   | deprecated     |
+| 9.4.8        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
+| 9.4.7        | [2.5.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.5.0.0)   | deprecated     |
+| 9.4.6        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated     |
+| 9.4.5        | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated     |
+| 9.4.4        | [1.10.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.10.0.0) | deprecated     |
+| 9.4.3        | [1.9.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.9.1.0)   | deprecated     |
+| 9.4.(1,2)    | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0)   | deprecated     |
+| 9.2.8        | [2.9.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.9.0.0)   | deprecated     |
+| 9.2.7        | [2.0.0.1](https://github.com/haskell/haskell-language-server/releases/tag/2.0.0.1)   | deprecated     |
+| 9.2.(5,6)    | [1.9.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.9.1.0)   | deprecated     |
+| 9.2.(3,4)    | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0)   | deprecated     |
+| 9.2.(1,2)    | [1.7.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.7.0.0)   | deprecated     |
+| 9.0.2        | [2.4.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.4.0.0)   | deprecated     |
+| 9.0.1        | [1.6.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.6.1.0)   | deprecated     |
+| 8.10.7       | [2.2.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.2.0.0)   | deprecated     |
+| 8.10.6       | [1.6.1.0](https://github.com/haskell/haskell-language-server/releases/tag/1.6.1.0)   | deprecated     |
+| 8.10.5       | [1.5.1](https://github.com/haskell/haskell-language-server/releases/tag/1.5.1)       | deprecated     |
+| 8.10.(4,3,2) | [1.4.0](https://github.com/haskell/haskell-language-server/releases/tag/1.4.0)       | deprecated     |
+| 8.10.1       | [0.9.0](https://github.com/haskell/haskell-language-server/releases/tag/0.9.0)       | deprecated     |
+| 8.8.4        | [1.8.0](https://github.com/haskell/haskell-language-server/releases/1.8.0)           | deprecated     |
+| 8.8.3        | [1.5.1](https://github.com/haskell/haskell-language-server/releases/1.5.1)           | deprecated     |
+| 8.8.2        | [1.2.0](https://github.com/haskell/haskell-language-server/releases/tag/1.2.0)       | deprecated     |
+| 8.6.5        | [1.8.0.0](https://github.com/haskell/haskell-language-server/releases/tag/1.8.0.0)   | deprecated     |
+| 8.6.4        | [1.4.0](https://github.com/haskell/haskell-language-server/releases/tag/1.4.0)       | deprecated     |
 
 GHC versions not in the list have never been supported by HLS.
 LTS stands for [Stackage](https://www.stackage.org/) Long Term Support.
@@ -88,7 +91,7 @@ HLS will support major versions of GHC until they are older than _both_
 1. The major version of GHC used in the current Stackage LTS; and
 2. The major version of GHC recommended by GHCup
 
-For example, if 
+For example, if
 
 1. Stackage LTS uses GHC 9.2; and
 2. GHCUp recommends GHC 9.4

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            2.9.0.1
+version:            2.10.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -76,8 +76,8 @@ library
     , hie-bios                     ^>=0.14.0
     , hie-compat                   ^>=0.3.0.0
     , hiedb                        ^>= 0.6.0.0
-    , hls-graph                    == 2.9.0.1
-    , hls-plugin-api               == 2.9.0.1
+    , hls-graph                    == 2.10.0.0
+    , hls-plugin-api               == 2.10.0.0
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5
     , lens
     , lens-aeson

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.4
 category:           Development
 name:               haskell-language-server
-version:            2.9.0.1
+version:            2.10.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -136,8 +136,8 @@ library hls-cabal-fmt-plugin
   build-depends:
     , directory
     , filepath
-    , ghcide          == 2.9.0.1
-    , hls-plugin-api  == 2.9.0.1
+    , ghcide          == 2.10.0.0
+    , hls-plugin-api  == 2.10.0.0
     , lens
     , lsp-types
     , mtl
@@ -157,8 +157,8 @@ test-suite hls-cabal-fmt-plugin-tests
     , filepath
     , haskell-language-server:hls-cabal-plugin
     , haskell-language-server:hls-cabal-fmt-plugin
-    , hls-plugin-api        == 2.9.0.1
-    , hls-test-utils        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
+    , hls-test-utils        == 2.10.0.0
 
   if flag(isolateCabalfmtTests)
     build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.12
@@ -193,8 +193,8 @@ library hls-cabal-gild-plugin
   build-depends:
     , directory
     , filepath
-    , ghcide          == 2.9.0.1
-    , hls-plugin-api  == 2.9.0.1
+    , ghcide          == 2.10.0.0
+    , hls-plugin-api  == 2.10.0.0
     , lsp-types
     , text
     , mtl
@@ -213,8 +213,8 @@ test-suite hls-cabal-gild-plugin-tests
     , filepath
     , haskell-language-server:hls-cabal-plugin
     , haskell-language-server:hls-cabal-gild-plugin
-    , hls-plugin-api        == 2.9.0.1
-    , hls-test-utils        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
+    , hls-test-utils        == 2.10.0.0
 
   if flag(isolateCabalGildTests)
     -- https://github.com/tfausak/cabal-gild/issues/89
@@ -269,10 +269,10 @@ library hls-cabal-plugin
     , directory
     , filepath
     , extra                 >=1.7.4
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , hashable
-    , hls-plugin-api        == 2.9.0.1
-    , hls-graph             == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
+    , hls-graph             == 2.10.0.0
     , lens
     , lsp                   ^>=2.7
     , lsp-types             ^>=2.3
@@ -311,7 +311,7 @@ test-suite hls-cabal-plugin-tests
     , filepath
     , ghcide
     , haskell-language-server:hls-cabal-plugin
-    , hls-test-utils    == 2.9.0.1
+    , hls-test-utils    == 2.10.0.0
     , lens
     , lsp-types
     , text
@@ -349,9 +349,9 @@ library hls-class-plugin
     , extra
     , ghc
     , ghc-exactprint  >= 1.5 && < 1.13.0.0
-    , ghcide          == 2.9.0.1
+    , ghcide          == 2.10.0.0
     , hls-graph
-    , hls-plugin-api  == 2.9.0.1
+    , hls-plugin-api  == 2.10.0.0
     , lens
     , lsp
     , mtl
@@ -372,7 +372,7 @@ test-suite hls-class-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-class-plugin
-    , hls-test-utils     == 2.9.0.1
+    , hls-test-utils     == 2.10.0.0
     , lens
     , lsp-types
     , text
@@ -406,9 +406,9 @@ library hls-call-hierarchy-plugin
     , aeson
     , containers
     , extra
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , hiedb                 ^>= 0.6.0.0
-    , hls-plugin-api        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
     , lens
     , lsp                    >=2.7
     , sqlite-simple
@@ -429,7 +429,7 @@ test-suite hls-call-hierarchy-plugin-tests
     , extra
     , filepath
     , haskell-language-server:hls-call-hierarchy-plugin
-    , hls-test-utils        == 2.9.0.1
+    , hls-test-utils        == 2.10.0.0
     , lens
     , lsp
     , lsp-test
@@ -479,9 +479,9 @@ library hls-eval-plugin
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , hls-graph
-    , hls-plugin-api        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
     , lens
     , lsp
     , lsp-types
@@ -512,7 +512,7 @@ test-suite hls-eval-plugin-tests
     , filepath
     , haskell-language-server:hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   == 2.9.0.1
+    , hls-test-utils   == 2.10.0.0
     , lens
     , lsp-types
     , text
@@ -542,9 +542,9 @@ library hls-explicit-imports-plugin
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , hls-graph
-    , hls-plugin-api        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
     , lens
     , lsp
     , mtl
@@ -565,7 +565,7 @@ test-suite hls-explicit-imports-plugin-tests
     , extra
     , filepath
     , haskell-language-server:hls-explicit-imports-plugin
-    , hls-test-utils   == 2.9.0.1
+    , hls-test-utils   == 2.10.0.0
     , lens
     , lsp-types
     , text
@@ -592,11 +592,11 @@ library hls-rename-plugin
   hs-source-dirs:   plugins/hls-rename-plugin/src
   build-depends:
     , containers
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , hashable
     , hiedb                 ^>= 0.6.0.0
     , hie-compat
-    , hls-plugin-api        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp-types
@@ -621,7 +621,7 @@ test-suite hls-rename-plugin-tests
     , filepath
     , hls-plugin-api
     , haskell-language-server:hls-rename-plugin
-    , hls-test-utils             == 2.9.0.1
+    , hls-test-utils             == 2.10.0.0
     , lens
     , lsp-types
     , text
@@ -652,9 +652,9 @@ library hls-retrie-plugin
     , containers
     , extra
     , ghc
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , hashable
-    , hls-plugin-api        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp
@@ -683,7 +683,7 @@ test-suite hls-retrie-plugin-tests
     , filepath
     , hls-plugin-api
     , haskell-language-server:{hls-refactor-plugin, hls-retrie-plugin}
-    , hls-test-utils             == 2.9.0.1
+    , hls-test-utils             == 2.10.0.0
     , text
 
 -----------------------------
@@ -720,10 +720,10 @@ library hls-hlint-plugin
     , containers
     , deepseq
     , filepath
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , hashable
     , hlint                 >= 3.5 && < 3.9
-    , hls-plugin-api        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
     , lens
     , mtl
     , refact
@@ -767,7 +767,7 @@ test-suite hls-hlint-plugin-tests
     , filepath
     , haskell-language-server:hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.9.0.1
+    , hls-test-utils      == 2.10.0.0
     , lens
     , lsp-types
     , text
@@ -822,7 +822,7 @@ test-suite hls-stan-plugin-tests
     , filepath
     , haskell-language-server:hls-stan-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.9.0.1
+    , hls-test-utils      == 2.10.0.0
     , lens
     , lsp-types
     , text
@@ -853,8 +853,8 @@ library hls-module-name-plugin
     , aeson
     , containers
     , filepath
-    , ghcide                == 2.9.0.1
-    , hls-plugin-api        == 2.9.0.1
+    , ghcide                == 2.10.0.0
+    , hls-plugin-api        == 2.10.0.0
     , lsp
     , text
     , text-rope
@@ -871,7 +871,7 @@ test-suite hls-module-name-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-module-name-plugin
-    , hls-test-utils          == 2.9.0.1
+    , hls-test-utils          == 2.10.0.0
 
 -----------------------------
 -- pragmas plugin
@@ -897,8 +897,8 @@ library hls-pragmas-plugin
     , aeson
     , extra
     , fuzzy
-    , ghcide                == 2.9.0.1
-    , hls-plugin-api        == 2.9.0.1
+    , ghcide                == 2.10.0.0
+    , hls-plugin-api        == 2.10.0.0
     , lens
     , lens-aeson
     , lsp
@@ -917,7 +917,7 @@ test-suite hls-pragmas-plugin-tests
     , aeson
     , filepath
     , haskell-language-server:hls-pragmas-plugin
-    , hls-test-utils      == 2.9.0.1
+    , hls-test-utils      == 2.10.0.0
     , lens
     , lsp-types
     , text
@@ -950,8 +950,8 @@ library hls-splice-plugin
     , extra
     , foldl
     , ghc
-    , ghcide                == 2.9.0.1
-    , hls-plugin-api        == 2.9.0.1
+    , ghcide                == 2.10.0.0
+    , hls-plugin-api        == 2.10.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp
@@ -974,7 +974,7 @@ test-suite hls-splice-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-splice-plugin
-    , hls-test-utils == 2.9.0.1
+    , hls-test-utils == 2.10.0.0
     , text
 
 -----------------------------
@@ -1001,10 +1001,10 @@ library hls-alternate-number-format-plugin
   build-depends:
     , containers
     , extra
-    , ghcide               == 2.9.0.1
+    , ghcide               == 2.10.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       == 2.9.0.1
+    , hls-plugin-api       == 2.10.0.0
     , lens
     , lsp                  ^>=2.7
     , mtl
@@ -1029,7 +1029,7 @@ test-suite hls-alternate-number-format-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-alternate-number-format-plugin
-    , hls-test-utils       == 2.9.0.1
+    , hls-test-utils       == 2.10.0.0
     , regex-tdfa
     , tasty-quickcheck
     , text
@@ -1061,8 +1061,8 @@ library hls-qualify-imported-names-plugin
   hs-source-dirs:   plugins/hls-qualify-imported-names-plugin/src
   build-depends:
     , containers
-    , ghcide                == 2.9.0.1
-    , hls-plugin-api        == 2.9.0.1
+    , ghcide                == 2.10.0.0
+    , hls-plugin-api        == 2.10.0.0
     , lens
     , lsp
     , text
@@ -1084,7 +1084,7 @@ test-suite hls-qualify-imported-names-plugin-tests
     , text
     , filepath
     , haskell-language-server:hls-qualify-imported-names-plugin
-    , hls-test-utils             == 2.9.0.1
+    , hls-test-utils             == 2.10.0.0
 
 -----------------------------
 -- code range plugin
@@ -1114,9 +1114,9 @@ library hls-code-range-plugin
     , containers
     , deepseq
     , extra
-    , ghcide           == 2.9.0.1
+    , ghcide           == 2.10.0.0
     , hashable
-    , hls-plugin-api   == 2.9.0.1
+    , hls-plugin-api   == 2.10.0.0
     , lens
     , lsp
     , mtl
@@ -1138,7 +1138,7 @@ test-suite hls-code-range-plugin-tests
     , bytestring
     , filepath
     , haskell-language-server:hls-code-range-plugin
-    , hls-test-utils             == 2.9.0.1
+    , hls-test-utils             == 2.10.0.0
     , lens
     , lsp
     , lsp-test
@@ -1166,8 +1166,8 @@ library hls-change-type-signature-plugin
   exposed-modules:  Ide.Plugin.ChangeTypeSignature
   hs-source-dirs:   plugins/hls-change-type-signature-plugin/src
   build-depends:
-    , ghcide           == 2.9.0.1
-    , hls-plugin-api   == 2.9.0.1
+    , ghcide           == 2.10.0.0
+    , hls-plugin-api   == 2.10.0.0
     , lsp-types
     , regex-tdfa
     , syb
@@ -1191,7 +1191,7 @@ test-suite hls-change-type-signature-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-change-type-signature-plugin
-    , hls-test-utils       == 2.9.0.1
+    , hls-test-utils       == 2.10.0.0
     , regex-tdfa
     , text
   default-extensions:
@@ -1224,9 +1224,9 @@ library hls-gadt-plugin
     , containers
     , extra
     , ghc
-    , ghcide                 == 2.9.0.1
+    , ghcide                 == 2.10.0.0
     , ghc-exactprint
-    , hls-plugin-api         == 2.9.0.1
+    , hls-plugin-api         == 2.10.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp                    >=2.7
@@ -1246,7 +1246,7 @@ test-suite hls-gadt-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-gadt-plugin
-    , hls-test-utils              == 2.9.0.1
+    , hls-test-utils              == 2.10.0.0
     , text
 
 -----------------------------
@@ -1273,9 +1273,9 @@ library hls-explicit-fixity-plugin
     , containers
     , deepseq
     , extra
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , hashable
-    , hls-plugin-api        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
     , lsp                   >=2.7
     , text
 
@@ -1291,7 +1291,7 @@ test-suite hls-explicit-fixity-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-explicit-fixity-plugin
-    , hls-test-utils              == 2.9.0.1
+    , hls-test-utils              == 2.10.0.0
     , text
 
 -----------------------------
@@ -1314,8 +1314,8 @@ library hls-explicit-record-fields-plugin
     buildable: False
   exposed-modules:  Ide.Plugin.ExplicitFields
   build-depends:
-    , ghcide                == 2.9.0.1
-    , hls-plugin-api        == 2.9.0.1
+    , ghcide                == 2.10.0.0
+    , hls-plugin-api        == 2.10.0.0
     , lsp
     , lens
     , hls-graph
@@ -1341,7 +1341,7 @@ test-suite hls-explicit-record-fields-plugin-tests
     , text
     , ghcide
     , haskell-language-server:hls-explicit-record-fields-plugin
-    , hls-test-utils              == 2.9.0.1
+    , hls-test-utils              == 2.10.0.0
 
 -----------------------------
 -- overloaded record dot plugin
@@ -1387,7 +1387,7 @@ test-suite hls-overloaded-record-dot-plugin-tests
     , filepath
     , text
     , haskell-language-server:hls-overloaded-record-dot-plugin
-    , hls-test-utils              == 2.9.0.1
+    , hls-test-utils              == 2.10.0.0
 
 
 -----------------------------
@@ -1413,8 +1413,8 @@ library hls-floskell-plugin
   hs-source-dirs:   plugins/hls-floskell-plugin/src
   build-depends:
     , floskell        ^>=0.11.0
-    , ghcide          == 2.9.0.1
-    , hls-plugin-api  == 2.9.0.1
+    , ghcide          == 2.10.0.0
+    , hls-plugin-api  == 2.10.0.0
     , lsp-types       ^>=2.3
     , mtl
     , text
@@ -1430,7 +1430,7 @@ test-suite hls-floskell-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-floskell-plugin
-    , hls-test-utils       == 2.9.0.1
+    , hls-test-utils       == 2.10.0.0
 
 -----------------------------
 -- fourmolu plugin
@@ -1456,8 +1456,8 @@ library hls-fourmolu-plugin
     , filepath
     , fourmolu        ^>= 0.14 || ^>= 0.15 || ^>= 0.16
     , ghc-boot-th
-    , ghcide          == 2.9.0.1
-    , hls-plugin-api  == 2.9.0.1
+    , ghcide          == 2.10.0.0
+    , hls-plugin-api  == 2.10.0.0
     , lens
     , lsp
     , mtl
@@ -1483,7 +1483,7 @@ test-suite hls-fourmolu-plugin-tests
     , filepath
     , haskell-language-server:hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       == 2.9.0.1
+    , hls-test-utils       == 2.10.0.0
     , lsp-test
 
 -----------------------------
@@ -1510,8 +1510,8 @@ library hls-ormolu-plugin
     , extra
     , filepath
     , ghc-boot-th
-    , ghcide          == 2.9.0.1
-    , hls-plugin-api  == 2.9.0.1
+    , ghcide          == 2.10.0.0
+    , hls-plugin-api  == 2.10.0.0
     , lsp
     , mtl
     , process-extras  >= 0.7.1
@@ -1537,7 +1537,7 @@ test-suite hls-ormolu-plugin-tests
     , filepath
     , haskell-language-server:hls-ormolu-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.9.0.1
+    , hls-test-utils     == 2.10.0.0
     , lsp-types
     , ormolu
 
@@ -1566,8 +1566,8 @@ library hls-stylish-haskell-plugin
     , directory
     , filepath
     , ghc-boot-th
-    , ghcide           == 2.9.0.1
-    , hls-plugin-api   == 2.9.0.1
+    , ghcide           == 2.10.0.0
+    , hls-plugin-api   == 2.10.0.0
     , lsp-types
     , mtl
     , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14
@@ -1584,7 +1584,7 @@ test-suite hls-stylish-haskell-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-stylish-haskell-plugin
-    , hls-test-utils              == 2.9.0.1
+    , hls-test-utils              == 2.10.0.0
 
 -----------------------------
 -- refactor plugin
@@ -1636,8 +1636,8 @@ library hls-refactor-plugin
     , bytestring
     , ghc-boot
     , regex-tdfa
-    , ghcide                == 2.9.0.1
-    , hls-plugin-api        == 2.9.0.1
+    , ghcide                == 2.10.0.0
+    , hls-plugin-api        == 2.10.0.0
     , lsp
     , text
     , text-rope
@@ -1675,7 +1675,7 @@ test-suite hls-refactor-plugin-tests
     , filepath
     , ghcide:ghcide
     , haskell-language-server:hls-refactor-plugin
-    , hls-test-utils      == 2.9.0.1
+    , hls-test-utils      == 2.10.0.0
     , lens
     , lsp-test
     , lsp-types
@@ -1722,8 +1722,8 @@ library hls-semantic-tokens-plugin
     , extra
     , text-rope
     , mtl                   >= 2.2
-    , ghcide                == 2.9.0.1
-    , hls-plugin-api        == 2.9.0.1
+    , ghcide                == 2.10.0.0
+    , hls-plugin-api        == 2.10.0.0
     , lens
     , lsp                    >=2.6
     , text
@@ -1733,7 +1733,7 @@ library hls-semantic-tokens-plugin
     , array
     , deepseq
     , dlist
-    , hls-graph == 2.9.0.1
+    , hls-graph == 2.10.0.0
     , template-haskell
     , data-default
     , stm
@@ -1754,10 +1754,10 @@ test-suite hls-semantic-tokens-plugin-tests
     , containers
     , data-default
     , filepath
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , haskell-language-server:hls-semantic-tokens-plugin
-    , hls-plugin-api        == 2.9.0.1
-    , hls-test-utils        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
+    , hls-test-utils        == 2.10.0.0
     , lens
     , lsp
     , lsp-test
@@ -1787,9 +1787,9 @@ library hls-notes-plugin
   hs-source-dirs:     plugins/hls-notes-plugin/src
   build-depends:
     , array
-    , ghcide == 2.9.0.1
-    , hls-graph == 2.9.0.1
-    , hls-plugin-api == 2.9.0.1
+    , ghcide == 2.10.0.0
+    , hls-graph == 2.10.0.0
+    , hls-plugin-api == 2.10.0.0
     , lens
     , lsp >=2.7
     , mtl >= 2.2
@@ -1815,7 +1815,7 @@ test-suite hls-notes-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-notes-plugin
-    , hls-test-utils == 2.9.0.1
+    , hls-test-utils == 2.10.0.0
   default-extensions: OverloadedStrings
 
 ----------------------------
@@ -1875,10 +1875,10 @@ library
     , extra
     , filepath
     , ghc
-    , ghcide                == 2.9.0.1
+    , ghcide                == 2.10.0.0
     , githash               >=0.1.6.1
     , hie-bios
-    , hls-plugin-api        == 2.9.0.1
+    , hls-plugin-api        == 2.10.0.0
     , optparse-applicative
     , optparse-simple
     , prettyprinter         >= 1.7
@@ -1981,7 +1981,7 @@ test-suite func-test
     , ghcide:ghcide
     , hashable
     , hls-plugin-api
-    , hls-test-utils == 2.9.0.1
+    , hls-test-utils == 2.10.0.0
     , lens
     , lsp-test
     , lsp-types
@@ -2025,7 +2025,7 @@ test-suite wrapper-test
 
   build-depends:
     , extra
-    , hls-test-utils              == 2.9.0.1
+    , hls-test-utils              == 2.10.0.0
     , process
 
   hs-source-dirs:     test/wrapper
@@ -2120,7 +2120,7 @@ test-suite ghcide-tests
     , text
     , text-rope
     , unordered-containers
-    , hls-test-utils == 2.9.0.1
+    , hls-test-utils == 2.10.0.0
 
   if impl(ghc <9.3)
     build-depends: ghc-typelits-knownnat

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-graph
-version:            2.9.0.1
+version:            2.10.0.0
 synopsis:           Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       2.9.0.1
+version:       2.10.0.0
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -66,7 +66,7 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             == 2.9.0.1
+    , hls-graph             == 2.10.0.0
     , lens
     , lens-aeson
     , lsp                   ^>=2.7

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       2.9.0.1
+version:       2.10.0.0
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -43,8 +43,8 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  == 2.9.0.1
-    , hls-plugin-api          == 2.9.0.1
+    , ghcide                  == 2.10.0.0
+    , hls-plugin-api          == 2.10.0.0
     , lens
     , lsp
     , lsp-test                ^>=0.17


### PR DESCRIPTION
# Releasing

## Release checklist

- [x] check ghcup supports new GHC releases if any
- [x] check all plugins still work if release includes code changes
- [x] set the supported GHCs in workflow file `.github/generate-ci/gen_ci.hs`
- [x] regenerate the CI via `./.github/generate-ci/generate-jobs`
- [x] bump package versions in all `*.cabal` files (same version as hls)
  - HLS uses lockstep versioning. The core packages and all plugins use the same version number, and only support exactly this version.
    - Exceptions:
      - `hie-compat` requires no automatic version bump.
      - `shake-bench` is an internal testing tool, not exposed to the outside world. Thus, no version bump required for releases.
  - For updating cabal files, the following script can be used:
    - ```sh
      ./release/update_versions.sh <OLD_VERSION> <NEW_VERSION>
      ```
    - It still requires manual verification and review
- [x] generate and update changelog
  - Generate a ChangeLog via `./GenChangelogs.hs <api-key> <tag>`
    - `<tag>` is the git tag you want to generate the ChangeLog from.
    - `<api-key>` is a github access key: https://github.com/settings/tokens
- [x] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
- [x] create release branch as `wip/<version>`
  - `git switch -c wip/<version>`
- [x] create release tag as `<version>`
  - `git tag <version>`
- [x] trigger release pipeline by pushing the tag
  - this creates a draft release
  - `git push <remote> <version>`
- [x] run `sh scripts/release/download-gh-artifacts.sh <version> <your-gpg-email>`
  - downloads artifacts to `gh-release-artifacts/haskell-language-server-<version>/`
  - also downloads FreeBSD bindist from circle CI
  - adds signatures
- [x] upload artifacts to downloads.haskell.org from `gh-release-artifacts/haskell-language-server-<version>/`
  - You require sftp access, contact wz1000, bgamari or chreekat
  - `cd gh-release-artifacts/haskell-language-server-<version>`
  - `SIGNING_KEY=... ../../release/upload.sh upload`
    - Your SIGNING_KEY can be obtained with `gpg --list-secret-keys --keyid-format=long`
  - Afterwards, the artifacts are available at: `https://downloads.haskell.org/~hls/haskell-language-server-<version>/`
  - Run `SIGNING_KEY=... ../../release/upload.sh purge_all` to remove CDN caches
- [x] create PR to [ghcup-metadata](https://github.com/haskell/ghcup-metadata)
  - [x] update `ghcup-vanilla-0.0.8.yaml` and `ghcup-vanilla-0.0.7.yaml`
    - can use `sh scripts/release/create-yaml-snippet.sh <version>` to generate a snippet that can be manually inserted into the yaml files
  - ~~update `hls-metadata-0.0.1.json`~~ Currently unnecessary, GHCup builds its own HLS binaries and updates that file.
    - utilize `cabal run ghcup-gen -- generate-hls-ghcs -f ghcup-0.0.7.yaml --format json --stdout` in the root of ghcup-metadata repository
  - Be sure to mark the correct latest version and add the 'recommended' tag to the latest release.
- [x] get sign-off on release
  - from wz1000, michealpj, maerwald and fendor
- [x] publish release on github
- [x] upload hackage packages
  - requires credentials
- [x] Supported tools table needs to be updated:
  - https://www.haskell.org/ghcup/install/#supported-platforms
  - https://github.com/haskell/ghcup-hs/blob/master/docs/install.md#supported-platforms
  - https://github.com/haskell/ghcup-metadata/blob/44c6e2b5d0fcae15abeffff03e87544edf76dd7a/ghcup-gen/Main.hs#L67
- [x] post release on discourse and reddit
- [ ] merge release PR to master or forward port relevant changes
