### PR TITLE
Update python read-the-docs dependencies to latest

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx~=5.3.0
-sphinx-rtd-theme~=1.1.0
-myst-parser~=1.0.0
-docutils<0.19
+Sphinx~=8.1.3
+sphinx-rtd-theme~=3.0.2
+myst-parser~=4.0.0
+docutils~=0.21.2


### PR DESCRIPTION
I noticed in #4433 that the read-the-docs build was failing. Let's try upgrading our dependencies :upside_down_face: 