### PR TITLE
Add missing python read-the-docs dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx~=8.1.3
 sphinx-rtd-theme~=3.0.2
 myst-parser~=4.0.0
 docutils~=0.21.2
+standard-imghdr==3.13.0


### PR DESCRIPTION
Read-the-docs build [failed](https://readthedocs.org/projects/haskell-language-server/builds/26449285/) in #4447, missing the `standard-imghdr` dependency.

Related: #4457.