### PR TITLE
Migrate `hls-class-plugin` to use structured diagnostics

### DIFF
--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class/Types.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class/Types.hs
@@ -112,15 +112,15 @@ instance NFData InstanceBindLensResult where
 type instance RuleResult GetInstanceBindLens = InstanceBindLensResult
 
 data Log
-  = LogImplementedMethods Class [T.Text]
+  = LogImplementedMethods DynFlags Class ClassMinimalDef
   | LogShake Shake.Log
 
 instance Pretty Log where
   pretty = \case
-    LogImplementedMethods cls methods ->
-      pretty ("Detected implemented methods for class" :: String)
+    LogImplementedMethods dflags cls methods ->
+      pretty ("The following methods are missing" :: String)
         <+> pretty (show (getOccString cls) <> ":") -- 'show' is used here to add quotes around the class name
-        <+> pretty methods
+        <+> pretty (showSDoc dflags $ ppr methods)
     LogShake log -> pretty log
 
 data BindInfo = BindInfo


### PR DESCRIPTION
Split off from #4433, this PR moves the `hls-class-plugin` to use the structured diagnostics. 

It worked well in my tests, but unfortunately it is incompatible with GHC 9.4, because the error message the plugin cares about is not structured in 9.4.
We can either wait until we drop support for 9.4 or maintain both paths until we drop support for 9.4.

Unfortunately, the only way to push GHC into the direction we want, is to do the latter and report any lacking error messages to GHC ASAP.

FYI, only the last commit matters.