### PR TITLE
Nix tooling (minor changes)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718149104,
-        "narHash": "sha256-Ds1QpobBX2yoUDx9ZruqVGJ/uQPgcXoYuobBguyKEh8=",
+        "lastModified": 1739019272,
+        "narHash": "sha256-7Fu7oazPoYCbDzb9k8D/DdbKrC3aU1zlnc39Y8jy/s8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e913ae340076bbb73d9f4d3d065c2bca7caafb16",
+        "rev": "fa35a3c8e17a3de613240fea68f876e5b4896aec",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    # for default.nix
+    # For default.nix
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -12,7 +12,7 @@
   };
 
   outputs =
-    inputs@{ self, nixpkgs, flake-utils, ... }:
+    { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
     (system:
       let
@@ -50,15 +50,14 @@
 
         mkDevShell = hpkgs: with pkgs; mkShell {
           name = "haskell-language-server-dev-ghc${hpkgs.ghc.version}";
-          # For binary Haskell tools, we use the default nixpkgs GHC
-          # This removes a rebuild with a different GHC version
-          # The drawback of this approach is that our shell may pull two GHC
-          # version in scope.
+          # For binary Haskell tools, we use the default Nixpkgs GHC version.
+          # This removes a rebuild with a different GHC version. The drawback of
+          # this approach is that our shell may pull two GHC versions in scope.
           buildInputs = [
-            # our compiling toolchain
+            # Compiler toolchain
             hpkgs.ghc
             pkgs.haskellPackages.cabal-install
-            # Dependencies needed to build some parts of hackage
+            # Dependencies needed to build some parts of Hackage
             gmp zlib ncurses
             # Changelog tooling
             (gen-hls-changelogs pkgs.haskellPackages)
@@ -68,7 +67,6 @@
             hlint
             (pkgs.haskell.lib.justStaticExecutables (pkgs.haskell.lib.dontCheck pkgs.haskellPackages.opentelemetry-extra))
             capstone
-            # ormolu
             stylish-haskell
             pre-commit
             ] ++ lib.optionals (!stdenv.isDarwin)
@@ -92,7 +90,7 @@
           '';
         };
 
-      in with pkgs; rec {
+      in rec {
         # Developement shell with only dev tools
         devShells = {
           default = mkDevShell pkgs.haskellPackages;
@@ -102,9 +100,7 @@
           shell-ghc910 = mkDevShell pkgs.haskell.packages.ghc910;
         };
 
-        packages = {
-          docs = docs;
-        };
+        packages = { inherit docs; };
 
         # The attributes for the default shell and package changed in recent versions of Nix,
         # these are here for backwards compatibility with the old versions.

--- a/flake.nix
+++ b/flake.nix
@@ -63,8 +63,6 @@
             (gen-hls-changelogs pkgs.haskellPackages)
             # For the documentation
             pythonWithPackages
-            # @guibou: I'm not sure this is needed.
-            hlint
             (pkgs.haskell.lib.justStaticExecutables (pkgs.haskell.lib.dontCheck pkgs.haskellPackages.opentelemetry-extra))
             capstone
             stylish-haskell


### PR DESCRIPTION
Hi! This PR contains a few minor changes to the Nix Flake.

b473c731 * Nix: Update lock files (GHC 9.6.5 -> 9.6.6)
a1b5c431 * Nix Flake: Small fixes, make comments a bit more consistent
39df6247 * Nix Flake: Remove `hlint`

I also removed `hlint` from the flake (last commit). However, this is an opinion up for debate:

We do not really need the `hlint` executable because it is integrated in HLS.

However, `hlint` is used by a GitHub Action, which we may want to replicate locally.

Also, the `fmt.sh` script is downloading an (unknown) `hlint` version which will
not work on NixOS anyways. In my opinion, if `fmt.sh` is still used (I can not
find any usages) we should fix the script so it is reproducible.