### PR TITLE
Remove index state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,9 +7,6 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-
-index-state:  2024-12-02T00:00:00Z
-
 tests: True
 test-show-details: direct
 


### PR DESCRIPTION
Index state in master makes things more complicated for end users to test (this is the case for 9.6.7-rc2).

It is not maintained properly either and is over 2 months old.

It's better to:

- maintain correct dependency bounds
- possibly introduce index state for release branches
