### PR TITLE
Inlay hints for package imports

### DIFF
--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -303,13 +303,10 @@ importPackageInlayHintProvider _ state _ InlayHintParams {_textDocument = TextDo
             annToPosition ann = case importDeclAnnQualified ann of
                 Just loc -> (srcSpanToPosition $ getHasLoc loc)
                 _ -> (srcSpanToPosition $ getHasLoc $ importDeclAnnImport ann)
-
         in hsImports
             & filter (\(L _ importDecl) -> not $ isPackageImport importDecl)
             & map (\(L _ importDecl) ->
               (annToPosition $ anns $ ideclAnn $ ideclExt importDecl, unLoc $ ideclName importDecl))
-
-
 
 -- |For explicit imports: If there are any implicit imports, provide both one
 -- code action per import to make that specific import explicit, and one code

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -299,9 +299,16 @@ importPackageInlayHintProvider _ state _ InlayHintParams {_textDocument = TextDo
             realSrcSpanToEndPosition :: RealSrcSpan -> Position
             realSrcSpanToEndPosition realSrcSpan = realSrcSpanToRange realSrcSpan ^. L.end
 
+            importAnnotation :: ImportDecl GhcPs -> EpAnnImportDecl
+#if MIN_VERSION_ghc(9,5,0)
+            importAnnotation = anns . ideclAnn . ideclExt
+#else
+            importAnnotation = anns . ideclExt
+#endif
+
             hintPosition :: ImportDecl GhcPs -> Position
             hintPosition importDecl =
-              let importAnn = anns $ ideclAnn $ ideclExt importDecl
+              let importAnn = importAnnotation importDecl
                   importPosition = realSrcSpanToEndPosition . epaLocationRealSrcSpan $ importDeclAnnImport importAnn
                   moduleNamePosition = realSrcSpanToEndPosition $ realSrcSpan $ getLoc $ ideclName importDecl
                   maybeQualifiedPosition = realSrcSpanToEndPosition . epaLocationRealSrcSpan <$> importDeclAnnQualified importAnn

--- a/plugins/hls-explicit-imports-plugin/test/Main.hs
+++ b/plugins/hls-explicit-imports-plugin/test/Main.hs
@@ -111,23 +111,39 @@ main = defaultTestRunner $ testGroup "import-actions"
   testGroup
     "Import package inlay hints"
     [ testGroup "Without package imports"
-      [ inlayHintsTestWithCap "ImportUsual" 2 $ (@=?)
-          [mkInlayHintNoTextEdit (Position 2 6) "\"base\""]
-      , inlayHintsTestWithCap "ImportUsual" 3 $ (@=?)
-          [mkInlayHintNoTextEdit (Position 3 16) "\"containers\""]
-      , inlayHintsTestWithCap "ImportUsual" 4 $ (@=?) []
-      , inlayHintsTestWithoutCap "ImportUsual" 2 $ (@=?) []
-      , inlayHintsTestWithoutCap "ImportUsual" 3 $ (@=?) []
-      , inlayHintsTestWithoutCap "ImportUsual" 4 $ (@=?) []
-    ], testGroup "With package imports"
-      [ inlayHintsTestWithCap "ImportWithPackageImport" 3 $ (@=?) []
-      , inlayHintsTestWithCap "ImportWithPackageImport" 4 $ (@=?)
-          [mkInlayHintNoTextEdit (Position 4 16) "\"containers\""]
-      , inlayHintsTestWithCap "ImportWithPackageImport" 5 $ (@=?) []
-      , inlayHintsTestWithoutCap "ImportWithPackageImport" 3 $ (@=?) []
-      , inlayHintsTestWithoutCap "ImportWithPackageImport" 4 $ (@=?) []
-      , inlayHintsTestWithoutCap "ImportWithPackageImport" 5 $ (@=?) []
-    ]]]
+      (let testWithCap = inlayHintsTestWithCap "ImportUsual"
+           testWithoutCap = inlayHintsTestWithoutCap "ImportUsual"
+      in
+        [ testWithCap 2 $ (@=?) [mkInlayHintNoTextEdit (Position 2 6) "\"base\""]
+        , testWithCap 3 $ (@=?) [mkInlayHintNoTextEdit (Position 3 16) "\"containers\""]
+        , testWithCap 4 $ (@=?) []
+        , testWithoutCap 2 $ (@=?) []
+        , testWithoutCap 3 $ (@=?) []
+        , testWithoutCap 4 $ (@=?) []
+        ])
+    , testGroup "With package imports"
+      (let testWithCap = inlayHintsTestWithCap "ImportWithPackageImport"
+           testWithoutCap = inlayHintsTestWithoutCap "ImportWithPackageImport"
+      in
+        [ testWithCap 3 $ (@=?) []
+        , testWithCap 4 $ (@=?) [mkInlayHintNoTextEdit (Position 4 16) "\"containers\""]
+        , testWithCap 5 $ (@=?) []
+        , testWithoutCap 3 $ (@=?) []
+        , testWithoutCap 4 $ (@=?) []
+        , testWithoutCap 5 $ (@=?) []
+        ])
+    , testGroup "When using ImportQualifiedPost"
+      (let testWithCap = inlayHintsTestWithCap "ImportWithQualifiedPost"
+           testWithoutCap = inlayHintsTestWithoutCap "ImportWithQualifiedPost"
+      in
+        [ testWithCap 3 $ (@=?) [mkInlayHintNoTextEdit (Position 3 6) "\"base\""]
+        , testWithCap 4 $ (@=?) [mkInlayHintNoTextEdit (Position 4 6) "\"containers\""]
+        , testWithCap 5 $ (@=?) []
+        , testWithoutCap 3 $ (@=?) []
+        , testWithoutCap 4 $ (@=?) []
+        , testWithoutCap 5 $ (@=?) []
+        ])
+    ]]
 
 -- code action tests
 

--- a/plugins/hls-explicit-imports-plugin/test/Main.hs
+++ b/plugins/hls-explicit-imports-plugin/test/Main.hs
@@ -107,7 +107,27 @@ main = defaultTestRunner $ testGroup "import-actions"
               o = "(Athing, Bthing, ... (4 items))"
           in ExplicitImports.abbreviateImportTitleWithoutModule i @?= o
       ]
-    ]]
+    ],
+  testGroup
+    "Import package inlay hints"
+    [ testGroup "Without package imports"
+      [ inlayHintsTestWithCap "ImportUsual" 2 $ (@=?)
+          [mkInlayHintNoTextEdit (Position 2 6) "\"base\""]
+      , inlayHintsTestWithCap "ImportUsual" 3 $ (@=?)
+          [mkInlayHintNoTextEdit (Position 3 16) "\"containers\""]
+      , inlayHintsTestWithCap "ImportUsual" 4 $ (@=?) []
+      , inlayHintsTestWithoutCap "ImportUsual" 2 $ (@=?) []
+      , inlayHintsTestWithoutCap "ImportUsual" 3 $ (@=?) []
+      , inlayHintsTestWithoutCap "ImportUsual" 4 $ (@=?) []
+    ], testGroup "With package imports"
+      [ inlayHintsTestWithCap "ImportWithPackageImport" 3 $ (@=?) []
+      , inlayHintsTestWithCap "ImportWithPackageImport" 4 $ (@=?)
+          [mkInlayHintNoTextEdit (Position 4 16) "\"containers\""]
+      , inlayHintsTestWithCap "ImportWithPackageImport" 5 $ (@=?) []
+      , inlayHintsTestWithoutCap "ImportWithPackageImport" 3 $ (@=?) []
+      , inlayHintsTestWithoutCap "ImportWithPackageImport" 4 $ (@=?) []
+      , inlayHintsTestWithoutCap "ImportWithPackageImport" 5 $ (@=?) []
+    ]]]
 
 -- code action tests
 
@@ -247,6 +267,19 @@ mkInlayHint pos label textEdit =
   , _kind = Nothing
   , _textEdits = Just [textEdit]
   , _tooltip = Just $ InL "Make this import explicit"
+  , _paddingLeft = Just True
+  , _paddingRight = Nothing
+  , _data_ = Nothing
+  }
+
+mkInlayHintNoTextEdit :: Position -> Text -> InlayHint
+mkInlayHintNoTextEdit pos label =
+  InlayHint
+  { _position = pos
+  , _label = InL label
+  , _kind = Nothing
+  , _textEdits = Nothing
+  , _tooltip = Nothing
   , _paddingLeft = Just True
   , _paddingRight = Nothing
   , _data_ = Nothing

--- a/plugins/hls-explicit-imports-plugin/test/testdata/ImportUsual.hs
+++ b/plugins/hls-explicit-imports-plugin/test/testdata/ImportUsual.hs
@@ -1,0 +1,15 @@
+module ImportUsual where
+
+import Data.List (intersperse)
+import qualified Data.Map as Map
+import ExplicitA ( a1, a2 )
+
+ordinaryMap :: Map.Map String String
+ordinaryMap = Map.fromList [(a1, a2)]
+
+main :: IO ()
+main =
+    putStrLn (concat (intersperse " " ["hello", "world", name, "!"]))
+  where
+    name =
+      Map.findWithDefault "default" a1 ordinaryMap

--- a/plugins/hls-explicit-imports-plugin/test/testdata/ImportWithPackageImport.hs
+++ b/plugins/hls-explicit-imports-plugin/test/testdata/ImportWithPackageImport.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE PackageImports #-}
+module ImportWithPackageImport where
+
+import "base" Data.List (intersperse)
+import qualified Data.Map as Map
+import ExplicitA ( a1, a2 )
+
+ordinaryMap :: Map.Map String String
+ordinaryMap = Map.fromList [(a1, a2)]
+
+main :: IO ()
+main =
+    putStrLn (concat (intersperse " " ["hello", "world", name, "!"]))
+  where
+    name =
+      Map.findWithDefault "default" a1 ordinaryMap

--- a/plugins/hls-explicit-imports-plugin/test/testdata/ImportWithQualifiedPost.hs
+++ b/plugins/hls-explicit-imports-plugin/test/testdata/ImportWithQualifiedPost.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+module ImportWithQualifiedPost where
+
+import Data.List (intersperse)
+import Data.Map qualified as Map
+import ExplicitA ( a1, a2 )
+
+ordinaryMap :: Map.Map String String
+ordinaryMap = Map.fromList [(a1, a2)]
+
+main :: IO ()
+main =
+    putStrLn (concat (intersperse " " ["hello", "world", name, "!"]))
+  where
+    name =
+      Map.findWithDefault "default" a1 ordinaryMap


### PR DESCRIPTION
Hey!
I sometimes find myself trying to figure out which package certain imports come from, so when I saw #4485, I thought a good first contribution would be to implement inlay hints for package imports.

This PR isn’t finished yet, but I’d appreciate any feedback on whether I’m headed in the right direction. 
I’m uncertain about where exactly this functionality should live. Do you think there's a plugin to which it could be added or would a new plugin be more appropriate? For now, I put it in a somewhat related plugin as a proof of concept.

TODO:
* [x] Decide where to put it (add to existing plugin / create a new one)
* [x] ~~Add configurability, disabled by default~~
* [x] Tests

This change would close #4485.

After implementing I have mixed feelings about it because it messes with the layout when imports are neatly aligned with whitespace (as it is in hls repo).
Here's what it looks like:
![Screenshot from 2025-02-19 03-33-02](https://github.com/user-attachments/assets/ef8991ae-ae18-4d04-9bd4-587b0c140abd)
