### PR TITLE
Enable bench for 9.10

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,8 +52,8 @@ jobs:
         # see discussion https://github.com/haskell/haskell-language-server/pull/4118
         # also possible to add more GHCs if we performs better in the future.
         ghc:
-          - '9.6'
           - '9.8'
+          - '9.10'
         os:
           - ubuntu-latest
 
@@ -61,7 +61,7 @@ jobs:
     # change of the strategy may require changing the bootstrapping/run code
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
 
         # By default, the `pull_request` event has a `GITHUB_SHA` env variable
@@ -100,14 +100,14 @@ jobs:
         tar -czf cabal.tar.gz *
 
     - name: Upload workspace
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: workspace-${{ matrix.ghc }}-${{ matrix.os }}
         retention-days: 1
         path: workspace.tar.gz
 
     - name: Upload .cabal
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cabal-home-${{ matrix.ghc }}-${{ matrix.os }}
         retention-days: 1
@@ -134,13 +134,13 @@ jobs:
         enable-stack: false
 
     - name: Download cabal home
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: cabal-home-${{ matrix.ghc }}-${{ matrix.os }}
         path: .
 
     - name: Download workspace
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: workspace-${{ matrix.ghc }}-${{ matrix.os }}
         path: .
@@ -165,7 +165,7 @@ jobs:
       run:  find bench-results -name "*.csv" -or -name "*.svg" -or -name "*.html" | xargs tar -czf benchmark-artifacts.tar.gz
 
     - name: Archive benchmarking artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: bench-results-${{ matrix.example }}-${{ runner.os }}-${{ matrix.ghc }}
         path: benchmark-artifacts.tar.gz
@@ -175,7 +175,7 @@ jobs:
       run: find bench-results -name "*.log" -or -name "*.hp" | xargs tar -czf benchmark-logs.tar.gz
 
     - name: Archive benchmark logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: bench-logs-${{ matrix.example }}-${{ runner.os }}-${{ matrix.ghc }}
         path: benchmark-logs.tar.gz

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,7 +39,7 @@ jobs:
                          ]'
 
   bench_init:
-    if: needs.pre_job.outputs.should_skip != 'true' && contains(github.event.pull_request.labels.*.name, 'performance')
+    if: needs.pre_job.outputs.should_skip != 'true'
     needs: pre_job
     runs-on: ${{ matrix.os }}
 
@@ -114,6 +114,7 @@ jobs:
         path: ~/.cabal/cabal.tar.gz
 
   bench_example:
+    if: contains(github.event.pull_request.labels.*.name, 'performance')
     needs: [bench_init, pre_job]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -134,7 +134,7 @@ jobs:
         enable-stack: false
 
     - name: Download cabal home
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: cabal-home-${{ matrix.ghc }}-${{ matrix.os }}
         path: .

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.6', '9.8']
+        ghc: ['9.8', '9.10']
         os: [ubuntu-latest]
         cabal: ['3.10']
         example: ['cabal', 'lsp-types']

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,6 @@ on:
 jobs:
   pre_job:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'performance')
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -40,7 +39,7 @@ jobs:
                          ]'
 
   bench_init:
-    if: needs.pre_job.outputs.should_skip != 'true'
+    if: needs.pre_job.outputs.should_skip != 'true' && contains(github.event.pull_request.labels.*.name, 'performance')
     needs: pre_job
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -134,7 +134,7 @@ jobs:
         enable-stack: false
 
     - name: Download cabal home
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: cabal-home-${{ matrix.ghc }}-${{ matrix.os }}
         path: .

--- a/cabal.project
+++ b/cabal.project
@@ -49,7 +49,6 @@ constraints:
   -- in the future, thus: TODO: remove this flag.
   bitvec -simd,
 
--- https://github.com/haskell/haskell-language-server/issues/4324
 
 if impl(ghc >= 9.8.4) && impl(ghc < 9.8.5)
   -- By depending on ghc-lib-parser and ghc, we are encountering
@@ -61,6 +60,8 @@ if impl(ghc >= 9.8.4) && impl(ghc < 9.8.5)
   constraints:
     ghc-lib-parser==9.8.4.20241130
 
+-- We need to use a specific version of hp2pretty because of a bug
+-- https://github.com/haskell/haskell-language-server/issues/4324
 source-repository-package
   type: git
   location: https://github.com/soulomoon/hp2pretty.git

--- a/cabal.project
+++ b/cabal.project
@@ -60,9 +60,3 @@ if impl(ghc >= 9.8.4) && impl(ghc < 9.8.5)
   constraints:
     ghc-lib-parser==9.8.4.20241130
 
--- We need to use a specific version of hp2pretty because of a bug
--- https://github.com/haskell/haskell-language-server/issues/4324
-source-repository-package
-  type: git
-  location: https://github.com/soulomoon/hp2pretty.git
-  tag: 2c794fb0ef8cfae3fa6fcdaa6797fa381207d48e

--- a/cabal.project
+++ b/cabal.project
@@ -49,9 +49,7 @@ constraints:
   -- in the future, thus: TODO: remove this flag.
   bitvec -simd,
 
-if impl(ghc >= 9.9)
-  -- https://github.com/haskell/haskell-language-server/issues/4324
-  benchmarks: False
+-- https://github.com/haskell/haskell-language-server/issues/4324
 
 if impl(ghc >= 9.8.4) && impl(ghc < 9.8.5)
   -- By depending on ghc-lib-parser and ghc, we are encountering
@@ -62,3 +60,8 @@ if impl(ghc >= 9.8.4) && impl(ghc < 9.8.5)
     ghc-lib-parser:filepath
   constraints:
     ghc-lib-parser==9.8.4.20241130
+
+source-repository-package
+  type: git
+  location: https://github.com/soulomoon/hp2pretty.git
+  tag: 2c794fb0ef8cfae3fa6fcdaa6797fa381207d48e

--- a/cabal.project
+++ b/cabal.project
@@ -59,4 +59,3 @@ if impl(ghc >= 9.8.4) && impl(ghc < 9.8.5)
     ghc-lib-parser:filepath
   constraints:
     ghc-lib-parser==9.8.4.20241130
-

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -2100,7 +2100,7 @@ benchmark benchmark
     hs-source-dirs: bench
     build-tool-depends:
         haskell-language-server:ghcide-bench,
-        hp2pretty:hp2pretty,
+        eventlog2html:eventlog2html,
     default-extensions:
         LambdaCase
         RecordWildCards

--- a/shake-bench/shake-bench.cabal
+++ b/shake-bench/shake-bench.cabal
@@ -16,8 +16,6 @@ source-repository head
     location: https://github.com/haskell/haskell-language-server.git
 
 library
-  if impl(ghc >= 9.10)
-    buildable: False
   exposed-modules:  Development.Benchmark.Rules
   hs-source-dirs:   src
   build-depends:

--- a/shake-bench/src/Development/Benchmark/Rules.hs
+++ b/shake-bench/src/Development/Benchmark/Rules.hs
@@ -535,7 +535,7 @@ heapProfileRules build = do
     build -/- "*/*/*/*/*.heap.svg" %> \out -> do
       let hpFile = dropExtension2 out <.> "hp"
       need [hpFile]
-      cmd_ ("hp2pretty" :: String) [hpFile]
+      cmd_ ("eventlog2html" :: String) ["--heap-profile", hpFile]
       liftIO $ renameFile (dropExtension hpFile <.> "svg") out
 
 dropExtension2 :: FilePath -> FilePath


### PR DESCRIPTION
1. Fix the dependency problem preventing 9.10 from building bench 
2. Enable the bench to build even not for performance label, still need performance label if we need to run it.
3. bump up to actions/checkout-v4 in bench
