### PR TITLE
convert `pre-commit-config.yaml` from JSON to YAML

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,32 +1,21 @@
-{
-  "repos": [
-    {
-      "hooks": [
-        {
-          "entry": "stylish-haskell --inplace",
-          "exclude": "(^Setup.hs$|test/testdata/.*$|test/data/.*$|test/manual/lhs/.*$|^hie-compat/.*$|^plugins/hls-tactics-plugin/.*$|^ghcide/src/Development/IDE/GHC/Compat.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/Compat/ExactPrint.hs$|^ghcide/src/Development/IDE/GHC/Compat/Core.hs$|^ghcide/src/Development/IDE/Spans/Pragmas.hs$|^ghcide/src/Development/IDE/LSP/Outline.hs$|^plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs$|^ghcide/src/Development/IDE/Core/Rules.hs$|^ghcide/src/Development/IDE/Core/Compile.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs$)",
-          "files": "\\.l?hs$",
-          "id": "stylish-haskell",
-          "language": "system",
-          "name": "stylish-haskell",
-          "pass_filenames": true,
-          "types": [
-            "file"
-          ]
-        }
-      ],
-      "repo": "local"
-    },
-    {
-       "repo": "https://github.com/pre-commit/pre-commit-hooks",
-       "rev": "v4.1.0",
-       "hooks": [
-          {
-            "id": "mixed-line-ending",
-            "args": ["--fix", "lf"],
-            "exclude": "test/testdata/.*CRLF.*?\\.hs$"
-          }
-       ]
-    }
-  ]
-}
+repos:
+  - hooks:
+      - entry: stylish-haskell --inplace
+        exclude: >-
+          (^Setup.hs$|test/testdata/.*$|test/data/.*$|test/manual/lhs/.*$|^hie-compat/.*$|^plugins/hls-tactics-plugin/.*$|^ghcide/src/Development/IDE/GHC/Compat.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/Compat/ExactPrint.hs$|^ghcide/src/Development/IDE/GHC/Compat/Core.hs$|^ghcide/src/Development/IDE/Spans/Pragmas.hs$|^ghcide/src/Development/IDE/LSP/Outline.hs$|^plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs$|^ghcide/src/Development/IDE/Core/Rules.hs$|^ghcide/src/Development/IDE/Core/Compile.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs$)
+        files: \.l?hs$
+        id: stylish-haskell
+        language: system
+        name: stylish-haskell
+        pass_filenames: true
+        types:
+          - file
+    repo: local
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: mixed-line-ending
+        args:
+          - '--fix'
+          - lf
+        exclude: test/testdata/.*CRLF.*?\.hs$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# https://pre-commit.com/
+# https://github.com/pre-commit/pre-commit
 repos:
   - hooks:
       - entry: stylish-haskell --inplace


### PR DESCRIPTION
using https://www.geeksforgeeks.org/json-to-yaml-converter/ .

The new YAML configuration appears to be fine:
```
$ pre-commit run --all-files
stylish-haskell..........................................................Passed
mixed line ending........................................................Passed
```

This matches the standard YAML config of the tool: https://pre-commit.com/#installation

------
However, I am not certain `.pre-commit-config.yaml` is working as intended, on `master` or this PR. Can I fix this in a separate PR?

After putting some spaces into `Experiments.hs`
```
module Experiments
( Bench(..)
, BenchRun(..)
, Config(..)


, Verbosity(..)
...
import           Data.Either                        (fromRight)

import           Data.List
import           Data.Maybe
...
```

```
$ pre-commit run --all-files
stylish-haskell..........................................................Passed
mixed line ending........................................................Passed
```

`pre-commit` succeeds on `master` branch with the JSON configuration.
