### PR TITLE
Import suggestion for missing newtype constructor, all types constructor and indirect overloadedrecorddot fields

### DIFF
--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -1864,9 +1864,9 @@ extractNotInScopeName x
   -- hint changes in the future
   -- - Next regex will account for polymorphic types, which appears as `HasField
   -- "foo" (Bar Int)...`, e.g. see the parenthesis
-  | Just [_module, name] <- matchRegexUnifySpaces x "No instance for ‘.*HasField \"[^\"]+\" ([^ (.]+\\.)*([^ (.]+).*’"
+  | Just [_module, name] <- matchRegexUnifySpaces x "No instance for [‘(].*HasField \"[^\"]+\" ([^ (.]+\\.)*([^ (.]+).*[’)]"
   = Just $ NotInScopeThing name
-  | Just [_module, name] <- matchRegexUnifySpaces x "No instance for ‘.*HasField \"[^\"]+\" \\(([^ .]+\\.)*([^ .]+)[^)]*\\).*’"
+  | Just [_module, name] <- matchRegexUnifySpaces x "No instance for [‘(].*HasField \"[^\"]+\" \\(([^ .]+\\.)*([^ .]+)[^)]*\\).*[’)]"
   = Just $ NotInScopeThing name
   | Just [name] <- matchRegexUnifySpaces x "ot in scope: \\(([^‘ ]+)\\)"
   = Just $ NotInScopeThing name

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -1840,6 +1840,8 @@ extractNotInScopeName x
   = Just $ NotInScopeDataConstructor name
   | Just [name] <- matchRegexUnifySpaces x "ot in scope: type constructor or class [^‘]*‘([^’]*)’"
   = Just $ NotInScopeTypeConstructorOrClass name
+  | Just [name] <- matchRegexUnifySpaces x "of newtype ‘([^’]*)’ is not in scope"
+  = Just $ NotInScopeThing name
   | Just [name] <- matchRegexUnifySpaces x "ot in scope: \\(([^‘ ]+)\\)"
   = Just $ NotInScopeThing name
   | Just [name] <- matchRegexUnifySpaces x "ot in scope: ([^‘ ]+)"

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -1840,6 +1840,8 @@ extractNotInScopeName x
   = Just $ NotInScopeDataConstructor name
   | Just [name] <- matchRegexUnifySpaces x "ot in scope: type constructor or class [^‘]*‘([^’]*)’"
   = Just $ NotInScopeTypeConstructorOrClass name
+  | Just [name] <- matchRegexUnifySpaces x "The data constructors of ‘([^ ]+)’ are not all in scope"
+  = Just $ NotInScopeDataConstructor name
   | Just [name] <- matchRegexUnifySpaces x "of newtype ‘([^’]*)’ is not in scope"
   = Just $ NotInScopeThing name
   | Just [name] <- matchRegexUnifySpaces x "ot in scope: \\(([^‘ ]+)\\)"

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -1870,6 +1870,10 @@ extractNotInScopeName x
   = Just $ NotInScopeThing name
   | Just [_module, name] <- matchRegexUnifySpaces x "No instance for [‘(].*HasField \"[^\"]+\" \\(([^ .]+\\.)*([^ .]+)[^)]*\\).*[’)]"
   = Just $ NotInScopeThing name
+  -- The order of the "Not in scope" is important, for example, some of the
+  -- matcher may catch the "record" value instead of the value later.
+  | Just [name] <- matchRegexUnifySpaces x "Not in scope: record field ‘([^’]*)’"
+  = Just $ NotInScopeThing name
   | Just [name] <- matchRegexUnifySpaces x "ot in scope: \\(([^‘ ]+)\\)"
   = Just $ NotInScopeThing name
   | Just [name] <- matchRegexUnifySpaces x "ot in scope: ([^‘ ]+)"

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -12,7 +12,9 @@ module Development.IDE.Plugin.CodeAction
     fillHolePluginDescriptor,
     extendImportPluginDescriptor,
     -- * For testing
-    matchRegExMultipleImports
+    matchRegExMultipleImports,
+    extractNotInScopeName,
+    NotInScope(..)
     ) where
 
 import           Control.Applicative                               ((<|>))
@@ -1825,7 +1827,7 @@ data NotInScope
     = NotInScopeDataConstructor T.Text
     | NotInScopeTypeConstructorOrClass T.Text
     | NotInScopeThing T.Text
-    deriving Show
+    deriving (Show, Eq)
 
 notInScope :: NotInScope -> T.Text
 notInScope (NotInScopeDataConstructor t)        = t

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/Plugins/Diagnostic.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/Plugins/Diagnostic.hs
@@ -21,6 +21,9 @@ matchRegex message regex = case message =~~ regex of
     Nothing                                                -> Nothing
 
 -- | 'matchRegex' combined with 'unifySpaces'
+--
+-- >>> matchRegexUnifySpaces  "hello I'm a cow" "he(ll)o"
+-- Just ["ll"]
 matchRegexUnifySpaces :: T.Text -> T.Text -> Maybe [T.Text]
 matchRegexUnifySpaces message = matchRegex (unifySpaces message)
 


### PR DESCRIPTION
This MR contains 3 commits which improves the import suggestion code actions:

- suggests to import a module when the `newtype` constructor is not in scope. This usually happen when `coerce`ing `newtype`.
- suggests to import a module when all the data constructors for a type are not in scope. This usually happen when creating an instance of a type from another module. For example, `deriving instance Generic Bar` when `Bar` (the type) may be in scope, but not the construtors (e.g. requiring `Bar(..)`).
- suggests to import a module when a field of a type is not in scope and used in an `OverloadedRecordDot` context, such as `foo.bar` where `foo :: Foo` and `Foo(bar)` is not in scope. Note that this is already partially handled by HLS in the case where the module containing `Foo` is already imported, but not the fields. In this context, GHC is kind enough to give us an hint (something like "maybe add field `bar` to import line...") and this is already handled by HLS. However, if the module containing `Foo` is not already imported, it does not work.

All of these case usually happen when types are "indirectly" in scope. For example, consider the followings:

```haskell
module T where

data Foo = Foo { foo :: Int }
```

```haskell
module Value where
import T

foo = Foo 10
```

```haskell
module Usage where

import Value

result = foo.foo
```

In the module `Usage`, the type `Foo` is not explicitly imported, it exists just indirectly because `foo` is imported from `Value`.

# Discussion

I tried to take care of multiples patterns in the regex used to match the error messages, such as qualified or not qualified types or class, as well as polymorphic or not. If you see a case not taken into account, please tell me.

# Tests

I've added simple tests for the `coerce` and `instance Generic` "cases" and a more involved test for the overloaded record dot cases.

I've developed this using GHC 9.10. I'll test on other version of GHC asap, perhaps some adaptations of the regex need to be introduced.

