### PR TITLE
Fix cabal check for Hackage release

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -42,6 +42,8 @@ common defaults
   default-language: GHC2021
   -- Should have been in GHC2021, an oversight
   default-extensions: ExplicitNamespaces
+  build-depends:
+    , base >=4.12 && <5
 
 common test-defaults
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
@@ -126,7 +128,6 @@ library hls-cabal-fmt-plugin
   exposed-modules:  Ide.Plugin.CabalFmt
   hs-source-dirs:   plugins/hls-cabal-fmt-plugin/src
   build-depends:
-    , base            >=4.12 && <5
     , directory
     , filepath
     , ghcide          == 2.9.0.1
@@ -146,7 +147,6 @@ test-suite hls-cabal-fmt-plugin-tests
   hs-source-dirs:   plugins/hls-cabal-fmt-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , directory
     , filepath
     , haskell-language-server:hls-cabal-plugin
@@ -185,7 +185,6 @@ library hls-cabal-gild-plugin
   exposed-modules:  Ide.Plugin.CabalGild
   hs-source-dirs:   plugins/hls-cabal-gild-plugin/src
   build-depends:
-    , base            >=4.12 && <5
     , directory
     , filepath
     , ghcide          == 2.9.0.1
@@ -204,7 +203,6 @@ test-suite hls-cabal-gild-plugin-tests
   hs-source-dirs:   plugins/hls-cabal-gild-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , directory
     , filepath
     , haskell-language-server:hls-cabal-plugin
@@ -258,7 +256,6 @@ library hls-cabal-plugin
 
 
   build-depends:
-    , base                  >=4.12     && <5
     , bytestring
     , Cabal-syntax          >= 3.7
     , containers
@@ -302,7 +299,6 @@ test-suite hls-cabal-plugin-tests
     Outline
     Utils
   build-depends:
-    , base
     , bytestring
     , Cabal-syntax          >= 3.7
     , extra
@@ -342,7 +338,6 @@ library hls-class-plugin
   hs-source-dirs:     plugins/hls-class-plugin/src
   build-depends:
     , aeson
-    , base            >=4.12 && <5
     , containers
     , deepseq
     , extra
@@ -369,7 +364,6 @@ test-suite hls-class-plugin-tests
   hs-source-dirs:   plugins/hls-class-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-class-plugin
     , hls-test-utils     == 2.9.0.1
@@ -404,7 +398,6 @@ library hls-call-hierarchy-plugin
   hs-source-dirs:     plugins/hls-call-hierarchy-plugin/src
   build-depends:
     , aeson
-    , base                  >=4.12 && <5
     , containers
     , extra
     , ghcide                == 2.9.0.1
@@ -426,7 +419,6 @@ test-suite hls-call-hierarchy-plugin-tests
   main-is:          Main.hs
   build-depends:
     , aeson
-    , base
     , containers
     , extra
     , filepath
@@ -472,7 +464,6 @@ library hls-eval-plugin
 
   build-depends:
     , aeson
-    , base                  >=4.12  && <5
     , bytestring
     , containers
     , deepseq
@@ -510,7 +501,6 @@ test-suite hls-eval-plugin-tests
   ghc-options:      -fno-ignore-asserts
   build-depends:
     , aeson
-    , base
     , containers
     , extra
     , filepath
@@ -543,7 +533,6 @@ library hls-explicit-imports-plugin
   hs-source-dirs:   plugins/hls-explicit-imports-plugin/src
   build-depends:
     , aeson
-    , base                  >=4.12 && <5
     , containers
     , deepseq
     , ghc
@@ -567,7 +556,6 @@ test-suite hls-explicit-imports-plugin-tests
   hs-source-dirs:   plugins/hls-explicit-imports-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , extra
     , filepath
     , haskell-language-server:hls-explicit-imports-plugin
@@ -597,7 +585,6 @@ library hls-rename-plugin
   exposed-modules:  Ide.Plugin.Rename
   hs-source-dirs:   plugins/hls-rename-plugin/src
   build-depends:
-    , base                  >=4.12    && <5
     , containers
     , ghcide                == 2.9.0.1
     , hashable
@@ -624,7 +611,6 @@ test-suite hls-rename-plugin-tests
   main-is:          Main.hs
   build-depends:
     , aeson
-    , base
     , containers
     , filepath
     , hls-plugin-api
@@ -656,7 +642,6 @@ library hls-retrie-plugin
   hs-source-dirs:   plugins/hls-retrie-plugin/src
   build-depends:
     , aeson
-    , base                  >=4.12    && <5
     , bytestring
     , containers
     , extra
@@ -688,7 +673,6 @@ test-suite hls-retrie-plugin-tests
   hs-source-dirs:   plugins/hls-retrie-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , containers
     , filepath
     , hls-plugin-api
@@ -726,7 +710,6 @@ library hls-hlint-plugin
   hs-source-dirs:   plugins/hls-hlint-plugin/src
   build-depends:
     , aeson
-    , base                  >=4.12    && <5
     , bytestring
     , containers
     , deepseq
@@ -774,7 +757,6 @@ test-suite hls-hlint-plugin-tests
     ghc-options: -optl-Wl,-ld_classic
   build-depends:
       aeson
-    , base
     , containers
     , filepath
     , haskell-language-server:hls-hlint-plugin
@@ -807,7 +789,6 @@ library hls-stan-plugin
   exposed-modules:    Ide.Plugin.Stan
   hs-source-dirs:     plugins/hls-stan-plugin/src
   build-depends:
-      base
     , deepseq
     , hashable
     , hie-compat
@@ -836,7 +817,6 @@ test-suite hls-stan-plugin-tests
   hs-source-dirs:   plugins/hls-stan-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-stan-plugin
     , hls-plugin-api
@@ -869,7 +849,6 @@ library hls-module-name-plugin
   hs-source-dirs:   plugins/hls-module-name-plugin/src
   build-depends:
     , aeson
-    , base                  >=4.12 && <5
     , containers
     , filepath
     , ghcide                == 2.9.0.1
@@ -888,7 +867,6 @@ test-suite hls-module-name-plugin-tests
   hs-source-dirs:   plugins/hls-module-name-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-module-name-plugin
     , hls-test-utils          == 2.9.0.1
@@ -914,7 +892,6 @@ library hls-pragmas-plugin
   exposed-modules:  Ide.Plugin.Pragmas
   hs-source-dirs:   plugins/hls-pragmas-plugin/src
   build-depends:
-    , base                  >=4.12 && <5
     , aeson
     , extra
     , fuzzy
@@ -936,7 +913,6 @@ test-suite hls-pragmas-plugin-tests
   main-is:          Main.hs
   build-depends:
     , aeson
-    , base
     , filepath
     , haskell-language-server:hls-pragmas-plugin
     , hls-test-utils      == 2.9.0.1
@@ -969,7 +945,6 @@ library hls-splice-plugin
   hs-source-dirs:     plugins/hls-splice-plugin/src
   build-depends:
     , aeson
-    , base                  >=4.12 && <5
     , extra
     , foldl
     , ghc
@@ -995,7 +970,6 @@ test-suite hls-splice-plugin-tests
   hs-source-dirs:   plugins/hls-splice-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-splice-plugin
     , hls-test-utils == 2.9.0.1
@@ -1023,7 +997,6 @@ library hls-alternate-number-format-plugin
   other-modules:    Ide.Plugin.Literals
   hs-source-dirs:   plugins/hls-alternate-number-format-plugin/src
   build-depends:
-    , base                 >=4.12 && < 5
     , containers
     , extra
     , ghcide               == 2.9.0.1
@@ -1052,7 +1025,6 @@ test-suite hls-alternate-number-format-plugin-tests
   main-is:          Main.hs
   ghc-options:      -fno-ignore-asserts
   build-depends:
-    , base                 >=4.12 && < 5
     , filepath
     , haskell-language-server:hls-alternate-number-format-plugin
     , hls-test-utils       == 2.9.0.1
@@ -1086,7 +1058,6 @@ library hls-qualify-imported-names-plugin
   exposed-modules:  Ide.Plugin.QualifyImportedNames
   hs-source-dirs:   plugins/hls-qualify-imported-names-plugin/src
   build-depends:
-    , base                  >=4.12 && <5
     , containers
     , ghcide                == 2.9.0.1
     , hls-plugin-api        == 2.9.0.1
@@ -1108,7 +1079,6 @@ test-suite hls-qualify-imported-names-plugin-tests
   hs-source-dirs:   plugins/hls-qualify-imported-names-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , text
     , filepath
     , haskell-language-server:hls-qualify-imported-names-plugin
@@ -1139,7 +1109,6 @@ library hls-code-range-plugin
     Ide.Plugin.CodeRange.ASTPreProcess
   hs-source-dirs: plugins/hls-code-range-plugin/src
   build-depends:
-    , base             >=4.12 && <5
     , containers
     , deepseq
     , extra
@@ -1164,7 +1133,6 @@ test-suite hls-code-range-plugin-tests
     Ide.Plugin.CodeRangeTest
     Ide.Plugin.CodeRange.RulesTest
   build-depends:
-    , base
     , bytestring
     , filepath
     , haskell-language-server:hls-code-range-plugin
@@ -1196,7 +1164,6 @@ library hls-change-type-signature-plugin
   exposed-modules:  Ide.Plugin.ChangeTypeSignature
   hs-source-dirs:   plugins/hls-change-type-signature-plugin/src
   build-depends:
-    , base             >=4.12 && < 5
     , ghcide           == 2.9.0.1
     , hls-plugin-api   == 2.9.0.1
     , lsp-types
@@ -1220,7 +1187,6 @@ test-suite hls-change-type-signature-plugin-tests
   hs-source-dirs:   plugins/hls-change-type-signature-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base                 >=4.12 && < 5
     , filepath
     , haskell-language-server:hls-change-type-signature-plugin
     , hls-test-utils       == 2.9.0.1
@@ -1253,7 +1219,6 @@ library hls-gadt-plugin
   hs-source-dirs:   plugins/hls-gadt-plugin/src
   build-depends:
     , aeson
-    , base                  >=4.12 && <5
     , containers
     , extra
     , ghc
@@ -1277,7 +1242,6 @@ test-suite hls-gadt-plugin-tests
   hs-source-dirs:   plugins/hls-gadt-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-gadt-plugin
     , hls-test-utils              == 2.9.0.1
@@ -1304,7 +1268,6 @@ library hls-explicit-fixity-plugin
   exposed-modules:  Ide.Plugin.ExplicitFixity
   hs-source-dirs:   plugins/hls-explicit-fixity-plugin/src
   build-depends:
-      base                  >=4.12 && <5
     , containers
     , deepseq
     , extra
@@ -1324,7 +1287,6 @@ test-suite hls-explicit-fixity-plugin-tests
   hs-source-dirs:   plugins/hls-explicit-fixity-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-explicit-fixity-plugin
     , hls-test-utils              == 2.9.0.1
@@ -1350,7 +1312,6 @@ library hls-explicit-record-fields-plugin
     buildable: False
   exposed-modules:  Ide.Plugin.ExplicitFields
   build-depends:
-    , base                  >=4.12 && <5
     , ghcide                == 2.9.0.1
     , hls-plugin-api        == 2.9.0.1
     , lsp
@@ -1374,7 +1335,6 @@ test-suite hls-explicit-record-fields-plugin-tests
   hs-source-dirs:   plugins/hls-explicit-record-fields-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , text
     , ghcide
@@ -1401,7 +1361,6 @@ library hls-overloaded-record-dot-plugin
     buildable: False
   exposed-modules:  Ide.Plugin.OverloadedRecordDot
   build-depends:
-    , base                  >=4.16 && <5
     , aeson
     , ghcide
     , hls-plugin-api
@@ -1423,7 +1382,6 @@ test-suite hls-overloaded-record-dot-plugin-tests
   hs-source-dirs:   plugins/hls-overloaded-record-dot-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , text
     , haskell-language-server:hls-overloaded-record-dot-plugin
@@ -1452,7 +1410,6 @@ library hls-floskell-plugin
   exposed-modules:  Ide.Plugin.Floskell
   hs-source-dirs:   plugins/hls-floskell-plugin/src
   build-depends:
-    , base            >=4.12 && <5
     , floskell        ^>=0.11.0
     , ghcide          == 2.9.0.1
     , hls-plugin-api  == 2.9.0.1
@@ -1469,7 +1426,6 @@ test-suite hls-floskell-plugin-tests
   hs-source-dirs:   plugins/hls-floskell-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-floskell-plugin
     , hls-test-utils       == 2.9.0.1
@@ -1495,7 +1451,6 @@ library hls-fourmolu-plugin
   exposed-modules:  Ide.Plugin.Fourmolu
   hs-source-dirs:   plugins/hls-fourmolu-plugin/src
   build-depends:
-    , base            >=4.12 && <5
     , filepath
     , fourmolu        ^>= 0.14 || ^>= 0.15 || ^>= 0.16
     , ghc-boot-th
@@ -1522,7 +1477,6 @@ test-suite hls-fourmolu-plugin-tests
   build-tool-depends:
     fourmolu:fourmolu
   build-depends:
-    , base            >=4.12 && <5
     , aeson
     , filepath
     , haskell-language-server:hls-fourmolu-plugin
@@ -1551,7 +1505,6 @@ library hls-ormolu-plugin
   exposed-modules:  Ide.Plugin.Ormolu
   hs-source-dirs:   plugins/hls-ormolu-plugin/src
   build-depends:
-    , base            >=4.12  && <5
     , extra
     , filepath
     , ghc-boot-th
@@ -1578,7 +1531,6 @@ test-suite hls-ormolu-plugin-tests
   build-tool-depends:
     ormolu:ormolu
   build-depends:
-    , base
     , aeson
     , filepath
     , haskell-language-server:hls-ormolu-plugin
@@ -1609,7 +1561,6 @@ library hls-stylish-haskell-plugin
   exposed-modules:  Ide.Plugin.StylishHaskell
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/src
   build-depends:
-    , base             >=4.12 && <5
     , directory
     , filepath
     , ghc-boot-th
@@ -1629,7 +1580,6 @@ test-suite hls-stylish-haskell-plugin-tests
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/test
   main-is:          Main.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-stylish-haskell-plugin
     , hls-test-utils              == 2.9.0.1
@@ -1680,7 +1630,6 @@ library hls-refactor-plugin
     ViewPatterns
   hs-source-dirs:   plugins/hls-refactor-plugin/src
   build-depends:
-    , base                  >=4.12 && <5
     , ghc
     , bytestring
     , ghc-boot
@@ -1718,7 +1667,6 @@ test-suite hls-refactor-plugin-tests
   other-modules:    Test.AddArgument
   ghc-options:      -O0
   build-depends:
-    , base
     , data-default
     , directory
     , extra
@@ -1768,7 +1716,6 @@ library hls-semantic-tokens-plugin
 
   hs-source-dirs:     plugins/hls-semantic-tokens-plugin/src
   build-depends:
-    , base                  >=4.12 && <5
     , containers
     , extra
     , text-rope
@@ -1802,7 +1749,6 @@ test-suite hls-semantic-tokens-plugin-tests
 
   build-depends:
     , aeson
-    , base
     , containers
     , data-default
     , filepath
@@ -1838,7 +1784,6 @@ library hls-notes-plugin
     Ide.Plugin.Notes
   hs-source-dirs:     plugins/hls-notes-plugin/src
   build-depends:
-    , base >=4.12 && <5
     , array
     , ghcide == 2.9.0.1
     , hls-graph == 2.9.0.1
@@ -1866,7 +1811,6 @@ test-suite hls-notes-plugin-tests
   hs-source-dirs:   plugins/hls-notes-plugin/test
   main-is:          NotesTest.hs
   build-depends:
-    , base
     , filepath
     , haskell-language-server:hls-notes-plugin
     , hls-test-utils == 2.9.0.1
@@ -1924,7 +1868,6 @@ library
   hs-source-dirs:   src
   build-depends:
     , aeson-pretty
-    , base                  >=4.16 && <5
     , data-default
     , directory
     , extra
@@ -1970,7 +1913,6 @@ executable haskell-language-server
     ghc-options: -dynamic
 
   build-depends:
-    , base                    >=4.16 && <5
     , haskell-language-server
     , hls-plugin-api
     , lsp
@@ -1996,7 +1938,6 @@ executable haskell-language-server-wrapper
     "-with-rtsopts=-I0 -A128M"
 
   build-depends:
-    , base       >=4.16 && <5
     , data-default
     , directory
     , extra
@@ -2031,7 +1972,6 @@ test-suite func-test
 
   build-depends:
     , aeson
-    , base            >=4.16 && <5
     , bytestring
     , containers
     , deepseq
@@ -2083,7 +2023,6 @@ test-suite wrapper-test
     haskell-language-server:haskell-language-server
 
   build-depends:
-    , base       >=4.16 && <5
     , extra
     , hls-test-utils              == 2.9.0.1
     , process
@@ -2108,7 +2047,6 @@ benchmark benchmark
 
     build-depends:
       , aeson
-      , base       >=4.16 && <5
       , containers
       , data-default
       , directory
@@ -2126,7 +2064,7 @@ benchmark benchmark
 
 
 test-suite ghcide-tests
-  import: warnings
+  import: warnings, defaults
   type:               exitcode-stdio-1.0
   default-language:   GHC2021
   build-tool-depends:
@@ -2136,7 +2074,6 @@ test-suite ghcide-tests
 
   build-depends:
     , aeson
-    , base
     , containers
     , data-default
     , directory
@@ -2225,10 +2162,9 @@ test-suite ghcide-tests
 
 
 executable ghcide-bench
-    default-language: GHC2021
+    import: defaults
     build-depends:
         aeson,
-        base,
         bytestring,
         containers,
         data-default,
@@ -2257,7 +2193,7 @@ executable ghcide-bench
         ViewPatterns
 
 library ghcide-bench-lib
-    default-language: GHC2021
+    import: defaults
     hs-source-dirs: ghcide-bench/src
     ghc-options: -Wall -Wno-name-shadowing
     exposed-modules:
@@ -2266,7 +2202,6 @@ library ghcide-bench-lib
     build-depends:
         aeson,
         async,
-        base == 4.*,
         binary,
         bytestring,
         deepseq,
@@ -2293,8 +2228,8 @@ library ghcide-bench-lib
 
 
 test-suite ghcide-bench-test
+    import: defaults
     type: exitcode-stdio-1.0
-    default-language: GHC2021
     build-tool-depends:
         ghcide:ghcide,
     main-is: Main.hs
@@ -2302,7 +2237,6 @@ test-suite ghcide-bench-test
     ghc-options: -Wunused-packages
     ghc-options: -threaded -Wall
     build-depends:
-        base,
         extra,
         haskell-language-server:ghcide-bench-lib,
         lsp-test ^>= 0.17,


### PR DESCRIPTION
The current `haskell-language-server.cabal` fails when running `cabal check` for `cabal-install  3.12.1.0`. 
I don't know which `cabal` version is used on Hackage, but I know that this `cabal check` was an issue for the last Hackage release.

We need to add a check to the release CI, but it is quite annoying since `cabal check` doesn't accept `all` as a target.