### PR TITLE
reinstating ignore-plugins-ghc-bounds

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -174,7 +174,7 @@ flag cabalgild
   manual:      True
 
 common cabalgild
-  if flag(cabalgild) && impl(ghc < 9.11)
+  if flag(cabalgild) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-cabal-gild-plugin
     cpp-options: -Dhls_cabalgild
 
@@ -186,7 +186,7 @@ flag isolateCabalGildTests
 
 library hls-cabal-gild-plugin
   import:           defaults, pedantic, warnings
-  if !flag(cabalgild) || impl(ghc > 9.11)
+  if !flag(cabalgild) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:  Ide.Plugin.CabalGild
   hs-source-dirs:   plugins/hls-cabal-gild-plugin/src
@@ -203,7 +203,7 @@ library hls-cabal-gild-plugin
 -- The `hls-cabal-plugin` is needed for tests, as we need to install notification handlers
 test-suite hls-cabal-gild-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(cabalgild) || !flag(cabal) || impl(ghc > 9.11)
+  if !flag(cabalgild) || !flag(cabal) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-cabal-gild-plugin/test
@@ -580,13 +580,13 @@ flag rename
   manual:      True
 
 common rename
-  if flag(rename) && impl(ghc < 9.11)
+  if flag(rename) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-rename-plugin
     cpp-options: -Dhls_rename
 
 library hls-rename-plugin
   import:           defaults, pedantic, warnings
-  if !flag(rename) || impl(ghc > 9.11)
+  if !flag(rename) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:  Ide.Plugin.Rename
   hs-source-dirs:   plugins/hls-rename-plugin/src
@@ -610,7 +610,7 @@ library hls-rename-plugin
 
 test-suite hls-rename-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(rename) || impl(ghc > 9.11)
+  if !flag(rename) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-rename-plugin/test
@@ -636,13 +636,13 @@ flag retrie
   manual:      True
 
 common retrie
-  if flag(retrie) && impl(ghc < 9.10)
+  if flag(retrie) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-retrie-plugin
     cpp-options: -Dhls_retrie
 
 library hls-retrie-plugin
   import:           defaults, pedantic, warnings
-  if !(flag(retrie) && impl(ghc < 9.10))
+  if !(flag(retrie) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
     buildable: False
   exposed-modules:  Ide.Plugin.Retrie
   hs-source-dirs:   plugins/hls-retrie-plugin/src
@@ -673,7 +673,7 @@ library hls-retrie-plugin
 
 test-suite hls-retrie-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !(flag(retrie) && impl(ghc < 9.10))
+  if !(flag(retrie) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-retrie-plugin/test
@@ -703,14 +703,14 @@ flag hlint
   manual:      True
 
 common hlint
-  if flag(hlint) && impl(ghc < 9.10)
+  if flag(hlint) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-hlint-plugin
     cpp-options: -Dhls_hlint
 
 library hls-hlint-plugin
   import:           defaults, pedantic, warnings
   -- https://github.com/ndmitchell/hlint/pull/1594
-  if !(flag(hlint)) || impl(ghc > 9.10)
+  if !(flag(hlint)) || (impl(ghc > 9.10) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:  Ide.Plugin.Hlint
   hs-source-dirs:   plugins/hls-hlint-plugin/src
@@ -753,7 +753,7 @@ library hls-hlint-plugin
 
 test-suite hls-hlint-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if (!flag(hlint)) || impl(ghc > 9.10)
+  if (!flag(hlint)) || (impl(ghc > 9.10) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-hlint-plugin/test
@@ -782,13 +782,13 @@ flag stan
   manual:      True
 
 common stan
-  if flag(stan) && impl(ghc < 9.11)
+  if flag(stan) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-stan-plugin
     cpp-options: -Dhls_stan
 
 library hls-stan-plugin
   import:           defaults, pedantic, warnings
-  if !flag(stan) || impl(ghc > 9.11)
+  if !flag(stan) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:    Ide.Plugin.Stan
   hs-source-dirs:     plugins/hls-stan-plugin/src
@@ -813,7 +813,7 @@ library hls-stan-plugin
 
 test-suite hls-stan-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(stan) || impl(ghc > 9.11)
+  if !flag(stan) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-stan-plugin/test
@@ -932,13 +932,13 @@ flag splice
   manual:      True
 
 common splice
-  if flag(splice) && impl(ghc < 9.10)
+  if flag(splice) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-splice-plugin
     cpp-options: -Dhls_splice
 
 library hls-splice-plugin
   import:           defaults, pedantic, warnings
-  if !(flag(splice) && impl(ghc < 9.10))
+  if !(flag(splice) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
     buildable: False
   exposed-modules:
     Ide.Plugin.Splice
@@ -966,7 +966,7 @@ library hls-splice-plugin
 
 test-suite hls-splice-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !(flag(splice) && impl(ghc < 9.10))
+  if !(flag(splice) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-splice-plugin/test
@@ -1208,13 +1208,13 @@ flag gadt
   manual:      True
 
 common gadt
-  if flag(gadt) && impl(ghc < 9.11)
+  if flag(gadt) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-gadt-plugin
     cpp-options: -Dhls_gadt
 
 library hls-gadt-plugin
   import:           defaults, pedantic, warnings
-  if !flag(gadt) || impl(ghc > 9.11)
+  if !flag(gadt) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:  Ide.Plugin.GADT
   other-modules:    Ide.Plugin.GHC
@@ -1238,7 +1238,7 @@ library hls-gadt-plugin
 
 test-suite hls-gadt-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(gadt) || impl(ghc > 9.11)
+  if !flag(gadt) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-gadt-plugin/test
@@ -1400,14 +1400,14 @@ flag floskell
   manual:      True
 
 common floskell
-  if flag(floskell) && impl(ghc < 9.10)
+  if flag(floskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-floskell-plugin
     cpp-options: -Dhls_floskell
 
 library hls-floskell-plugin
   import:           defaults, pedantic, warnings
   -- https://github.com/ennocramer/floskell/pull/82
-  if !(flag(floskell) && impl(ghc < 9.10))
+  if !(flag(floskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
     buildable: False
   exposed-modules:  Ide.Plugin.Floskell
   hs-source-dirs:   plugins/hls-floskell-plugin/src
@@ -1422,7 +1422,7 @@ library hls-floskell-plugin
 
 test-suite hls-floskell-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !(flag(floskell) && impl(ghc < 9.10))
+  if !(flag(floskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-floskell-plugin/test
@@ -1442,13 +1442,13 @@ flag fourmolu
   manual:      True
 
 common fourmolu
-  if flag(fourmolu) && impl(ghc < 9.11)
+  if flag(fourmolu) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-fourmolu-plugin
     cpp-options: -Dhls_fourmolu
 
 library hls-fourmolu-plugin
   import:           defaults, pedantic, warnings
-  if !flag(fourmolu) || impl(ghc > 9.11)
+  if !flag(fourmolu) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:  Ide.Plugin.Fourmolu
   hs-source-dirs:   plugins/hls-fourmolu-plugin/src
@@ -1468,7 +1468,7 @@ library hls-fourmolu-plugin
 
 test-suite hls-fourmolu-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(fourmolu) || impl(ghc > 9.11)
+  if !flag(fourmolu) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-fourmolu-plugin/test
@@ -1496,13 +1496,13 @@ flag ormolu
   manual:      True
 
 common ormolu
-  if flag(ormolu) && impl(ghc < 9.11)
+  if flag(ormolu) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-ormolu-plugin
     cpp-options: -Dhls_ormolu
 
 library hls-ormolu-plugin
   import:           defaults, pedantic, warnings
-  if !flag(ormolu) || impl(ghc > 9.11)
+  if !flag(ormolu) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:  Ide.Plugin.Ormolu
   hs-source-dirs:   plugins/hls-ormolu-plugin/src
@@ -1522,7 +1522,7 @@ library hls-ormolu-plugin
 
 test-suite hls-ormolu-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(ormolu) || impl(ghc > 9.11)
+  if !flag(ormolu) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-ormolu-plugin/test
@@ -1551,14 +1551,14 @@ flag stylishHaskell
   manual:      True
 
 common stylishHaskell
-  if flag(stylishHaskell) && impl(ghc < 9.10)
+  if flag(stylishHaskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-stylish-haskell-plugin
     cpp-options: -Dhls_stylishHaskell
 
 library hls-stylish-haskell-plugin
   import:           defaults, pedantic, warnings
   -- https://github.com/haskell/stylish-haskell/issues/479
-  if !(flag(stylishHaskell) && impl(ghc < 9.10))
+  if !(flag(stylishHaskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
     buildable: False
   exposed-modules:  Ide.Plugin.StylishHaskell
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/src
@@ -1576,7 +1576,7 @@ library hls-stylish-haskell-plugin
 
 test-suite hls-stylish-haskell-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !(flag(stylishHaskell) && impl(ghc < 9.10))
+  if !(flag(stylishHaskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/test
@@ -1596,13 +1596,13 @@ flag refactor
   manual:      True
 
 common refactor
-  if flag(refactor) && impl(ghc < 9.11)
+  if flag(refactor) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-refactor-plugin
     cpp-options: -Dhls_refactor
 
 library hls-refactor-plugin
   import:           defaults, pedantic, warnings
-  if !flag(refactor) || impl(ghc > 9.11)
+  if !flag(refactor) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:  Development.IDE.GHC.ExactPrint
                     Development.IDE.GHC.Compat.ExactPrint
@@ -1661,7 +1661,7 @@ library hls-refactor-plugin
 
 test-suite hls-refactor-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(refactor) || impl(ghc > 9.11)
+  if !flag(refactor) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-refactor-plugin/test
@@ -2007,11 +2007,11 @@ test-suite func-test
   if flag(eval)
     cpp-options: -Dhls_eval
 -- formatters
-  if flag(floskell) && impl(ghc < 9.10)
+  if flag(floskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds))
     cpp-options: -Dhls_floskell
-  if flag(fourmolu) && impl(ghc < 9.11)
+  if flag(fourmolu) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     cpp-options: -Dhls_fourmolu
-  if flag(ormolu) && impl(ghc < 9.11)
+  if flag(ormolu) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
     cpp-options: -Dhls_ormolu
 
 test-suite wrapper-test


### PR DESCRIPTION
Seen from Gentoo, the ignore-plugins-ghc-bounds is useful, this patch tries to make it do something again.

https://github.com/gentoo-haskell/gentoo-haskell/issues/1766