### PR TITLE
Support PackageImports in hiddenPackageSuggestion

### DIFF
--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
@@ -190,6 +190,12 @@ addDependencySuggestCodeAction plId verTxtDocId suggestions haskellFilePath caba
 -- > It is a member of the hidden package ‘split-0.2.5’.
 -- > Perhaps you need to add ‘split’ to the build-depends in your .cabal file."
 --
+-- or this if PackageImports extension is used:
+--
+-- > "Could not find module ‘Data.List.Split’
+-- > Perhaps you meant
+-- >   Data.List.Split (needs flag -package-id split-0.2.5)"
+--
 -- It extracts mentioned package names and version numbers.
 -- In this example, it will be @[("split", "0.2.5")]@
 --
@@ -204,12 +210,17 @@ hiddenPackageSuggestion diag = getMatch (msg =~ regex)
     msg :: T.Text
     msg = _message diag
     regex :: T.Text -- TODO: Support multiple packages suggestion
-    regex = "It is a member of the hidden package [\8216']([a-zA-Z0-9-]*[a-zA-Z0-9])(-([0-9\\.]*))?[\8217']"
+    regex =
+        let regex' = "([a-zA-Z0-9-]*[a-zA-Z0-9])(-([0-9\\.]*))?"
+        in "It is a member of the hidden package [\8216']" <> regex' <> "[\8217']"
+           <> "|"
+           <> "needs flag -package-id " <> regex'
     -- Have to do this matching because `Regex.TDFA` doesn't(?) support
     -- not-capturing groups like (?:message)
     getMatch :: (T.Text, T.Text, T.Text, [T.Text]) -> [(T.Text, T.Text)]
     getMatch (_, _, _, []) = []
-    getMatch (_, _, _, [dependency, _, cleanVersion]) = [(dependency, cleanVersion)]
+    getMatch (_, _, _, [dependency, _, cleanVersion, "", "", ""]) = [(dependency, cleanVersion)]
+    getMatch (_, _, _, ["", "", "", dependency, _, cleanVersion]) = [(dependency, cleanVersion)]
     getMatch (_, _, _, _) = error "Impossible pattern matching case"
 
 command :: Recorder (WithPriority Log) -> CommandFunction IdeState CabalAddCommandParams

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd.hs
@@ -221,7 +221,7 @@ hiddenPackageSuggestion diag = getMatch (msg =~ regex)
     getMatch (_, _, _, []) = []
     getMatch (_, _, _, [dependency, _, cleanVersion, "", "", ""]) = [(dependency, cleanVersion)]
     getMatch (_, _, _, ["", "", "", dependency, _, cleanVersion]) = [(dependency, cleanVersion)]
-    getMatch (_, _, _, _) = error "Impossible pattern matching case"
+    getMatch (_, _, _, _) = []
 
 command :: Recorder (WithPriority Log) -> CommandFunction IdeState CabalAddCommandParams
 command recorder state _ params@(CabalAddCommandParams {cabalPath = path, verTxtDocId = verTxtDocId, buildTarget = target, dependency = dep, version = mbVer}) = do

--- a/plugins/hls-cabal-plugin/test/CabalAdd.hs
+++ b/plugins/hls-cabal-plugin/test/CabalAdd.hs
@@ -33,6 +33,8 @@ cabalAddTests =
         (generateAddDependencyTestSession "cabal-add-lib.cabal" ("src" </> "MyLib.hs") "split" [348])
     , runHaskellTestCaseSession "Code Actions - Can add hidden package to a test" ("cabal-add-testdata" </> "cabal-add-tests")
         (generateAddDependencyTestSession "cabal-add-tests.cabal" ("test" </> "Main.hs") "split" [478])
+    , runHaskellTestCaseSession "Code Actions - Can add hidden package to a test with PackageImports" ("cabal-add-testdata" </> "cabal-add-tests")
+        (generateAddDependencyTestSession "cabal-add-tests.cabal" ("test" </> "MainPackageImports.hs") "split" [731])
     , runHaskellTestCaseSession "Code Actions - Can add hidden package to a benchmark" ("cabal-add-testdata" </> "cabal-add-bench")
         (generateAddDependencyTestSession "cabal-add-bench.cabal" ("bench" </> "Main.hs") "split" [403])
 
@@ -121,6 +123,23 @@ cabalAddTests =
                                    ]
                                    [ ("3d-graphics-examples", T.empty)
                                    , ("3d-graphics-examples", "1.1.6")
+                                   ]
+    , testHiddenPackageSuggestions "Check CabalAdd's parser, with version, with PackageImports"
+                                   [ "(needs flag -package-id base-0.1.0.0)"
+                                   , "(needs flag -package-id Blammo-wai-0.11.0)"
+                                   , "(needs flag -package-id BlastHTTP-2.6.4.3)"
+                                   , "(needs flag -package-id CC-delcont-ref-tf-0.0.0.2)"
+                                   , "(needs flag -package-id 3d-graphics-examples-1.1.6)"
+                                   , "(needs flag -package-id AAI-0.1)"
+                                   , "(needs flag -package-id AWin32Console-1.19.1)"
+                                   ]
+                                   [ ("base","0.1.0.0")
+                                   , ("Blammo-wai", "0.11.0")
+                                   , ("BlastHTTP", "2.6.4.3")
+                                   , ("CC-delcont-ref-tf", "0.0.0.2")
+                                   , ("3d-graphics-examples", "1.1.6")
+                                   , ("AAI", "0.1")
+                                   , ("AWin32Console", "1.19.1")
                                    ]
     ]
  where

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-tests/cabal-add-tests.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-tests/cabal-add-tests.cabal
@@ -16,3 +16,11 @@ test-suite cabal-add-tests-test
     hs-source-dirs:   test
     main-is:          Main.hs
     build-depends:    base
+
+test-suite cabal-add-tests-test-package-imports
+    import:           warnings
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          MainPackageImports.hs
+    build-depends:    base

--- a/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-tests/test/MainPackageImports.hs
+++ b/plugins/hls-cabal-plugin/test/testdata/cabal-add-testdata/cabal-add-tests/test/MainPackageImports.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PackageImports #-}
+
+module Main (main) where
+
+import "split" Data.List.Split
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented."


### PR DESCRIPTION
Fix: #4479

TODO: Probably I need to add more tests.

CC @VeryMilkyJoe @fendor

## Video demo



https://github.com/user-attachments/assets/692f441e-19be-46ac-8197-a74bfe6c481c


## More info

Here is the string being matched.

With `PackageImports`
```
not found: Could not find module ‘Data.List.Split’
Perhaps you meant
  Data.List.Split (needs flag -package-id split-0.2.5)
  Data.List.Split (needs flag -package-id split-0.2.5)
```

Without `PackageImports`
```
not found: Could not load module ‘Data.List.Split’
It is a member of the hidden package ‘split-0.2.5’.
Perhaps you need to add ‘split’ to the build-depends in your .cabal file.
It is a member of the hidden package ‘split-0.2.5’.
Perhaps you need to add ‘split’ to the build-depends in your .cabal file.
```

I also notice that the "not found" error remains even after the dependency is added by the code action (with and without `PackageImports`).  That may be a bug of my lsp client (`eglot` on Emacs) or HLS.  Needs further investigation.