### PR TITLE
Revert "link executables dynamically to speed up linking (#4423)"

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,12 +17,6 @@ benchmarks: True
 
 write-ghc-environment-files: never
 
--- Link executables dynamically so the linker doesn't produce test
--- executables of ~150MB each and works lightning fast at that too
--- Disabled on Windows
-if(!os(windows))
-  executable-dynamic: True
-
 -- Many of our tests only work single-threaded, and the only way to
 -- ensure tasty runs everything purely single-threaded is to pass
 -- this at the top-level


### PR DESCRIPTION
This reverts commit 2df8775fa6062073904e96c48b456045511f05b5.

The PR #4423 seems to have introduced issues for release binaries. Thus, we are reverting the changes as advised in https://github.com/haskell/haskell-language-server/issues/4533#issuecomment-2774883109

We still want to benefit from the reduced test-times, so we might want to enable this option for our test-CI only.