### PR TITLE
porting hls-refactor to ghc-9.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,7 +134,7 @@ jobs:
           HLS_WRAPPER_TEST_EXE: hls-wrapper
         run: cabal test wrapper-test
 
-      - if: matrix.test && matrix.ghc != '9.12'
+      - if: matrix.test
         name: Test hls-refactor-plugin
         run: cabal test hls-refactor-plugin-tests || cabal test hls-refactor-plugin-tests
 
@@ -185,7 +185,7 @@ jobs:
         name: Test hls-call-hierarchy-plugin test suite
         run: cabal test hls-call-hierarchy-plugin-tests || cabal test hls-call-hierarchy-plugin-tests
 
-      - if: matrix.test && matrix.os != 'windows-latest' && matrix.ghc != '9.12'
+      - if: matrix.test && matrix.os != 'windows-latest'
         name: Test hls-rename-plugin test suite
         run: cabal test hls-rename-plugin-tests || cabal test hls-rename-plugin-tests
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -580,13 +580,13 @@ flag rename
   manual:      True
 
 common rename
-  if flag(rename) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
+  if flag(rename)
     build-depends: haskell-language-server:hls-rename-plugin
     cpp-options: -Dhls_rename
 
 library hls-rename-plugin
   import:           defaults, pedantic, warnings
-  if !flag(rename) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
+  if !flag(rename)
     buildable: False
   exposed-modules:  Ide.Plugin.Rename
   hs-source-dirs:   plugins/hls-rename-plugin/src
@@ -610,7 +610,7 @@ library hls-rename-plugin
 
 test-suite hls-rename-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(rename) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
+  if !flag(rename)
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-rename-plugin/test
@@ -1596,13 +1596,13 @@ flag refactor
   manual:      True
 
 common refactor
-  if flag(refactor) && (impl(ghc < 9.11) || flag(ignore-plugins-ghc-bounds))
+  if flag(refactor) 
     build-depends: haskell-language-server:hls-refactor-plugin
     cpp-options: -Dhls_refactor
 
 library hls-refactor-plugin
   import:           defaults, pedantic, warnings
-  if !flag(refactor) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
+  if !flag(refactor)
     buildable: False
   exposed-modules:  Development.IDE.GHC.ExactPrint
                     Development.IDE.GHC.Compat.ExactPrint
@@ -1661,7 +1661,7 @@ library hls-refactor-plugin
 
 test-suite hls-refactor-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !flag(refactor) || (impl(ghc > 9.11) && !flag(ignore-plugins-ghc-bounds))
+  if !flag(refactor)
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-refactor-plugin/test

--- a/plugins/hls-refactor-plugin/test/Test/AddArgument.hs
+++ b/plugins/hls-refactor-plugin/test/Test/AddArgument.hs
@@ -35,7 +35,7 @@ tests =
       mkGoldenAddArgTest "AddArgFromLet" (r 2 0 2 50),
       mkGoldenAddArgTest "AddArgFromWhere" (r 3 0 3 50),
       -- TODO can we make this work for GHC 9.10?
-      knownBrokenForGhcVersions [GHC910] "In GHC 9.10 end-of-line comment annotation is in different place" $
+      knownBrokenForGhcVersions [GHC910, GHC912] "In GHC 9.10 and 9.12 end-of-line comment annotation is in different place" $
           mkGoldenAddArgTest "AddArgFromWhereComments" (r 3 0 3 50),
       mkGoldenAddArgTest "AddArgWithTypeSynSig" (r 2 0 2 50),
       mkGoldenAddArgTest "AddArgWithTypeSynSigContravariant" (r 2 0 2 50),

--- a/test/testdata/schema/ghc912/default-config.golden.json
+++ b/test/testdata/schema/ghc912/default-config.golden.json
@@ -47,6 +47,18 @@
         "explicit-fixity": {
             "globalOn": true
         },
+        "ghcide-code-actions-bindings": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-fill-holes": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-imports-exports": {
+            "globalOn": true
+        },
+        "ghcide-code-actions-type-signatures": {
+            "globalOn": true
+        },
         "ghcide-completions": {
             "config": {
                 "autoExtendOn": true,
@@ -85,6 +97,12 @@
             "globalOn": true
         },
         "qualifyImportedNames": {
+            "globalOn": true
+        },
+        "rename": {
+            "config": {
+                "crossModule": false
+            },
             "globalOn": true
         },
         "semanticTokens": {

--- a/test/testdata/schema/ghc912/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc912/vscode-extension-schema.golden.json
@@ -107,6 +107,30 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.ghcide-code-actions-bindings.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-bindings plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-fill-holes.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-fill-holes plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-imports-exports.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-imports-exports plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ghcide-code-actions-type-signatures.globalOn": {
+        "default": true,
+        "description": "Enables ghcide-code-actions-type-signatures plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.ghcide-completions.config.autoExtendOn": {
         "default": true,
         "markdownDescription": "Extends the import list automatically when completing a out-of-scope identifier",
@@ -210,6 +234,18 @@
     "haskell.plugin.qualifyImportedNames.globalOn": {
         "default": true,
         "description": "Enables qualifyImportedNames plugin",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.rename.config.crossModule": {
+        "default": false,
+        "markdownDescription": "Enable experimental cross-module renaming",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.rename.globalOn": {
+        "default": true,
+        "description": "Enables rename plugin",
         "scope": "resource",
         "type": "boolean"
     },


### PR DESCRIPTION
These changes allow the hls-refactor plugin to compile and pass the tests with ghc-9.12