### PR TITLE
Remove allow-newer for hiedb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,14 +60,14 @@ version: 2
 jobs:
   stackage-lts22:
     docker:
-      - image: haskell:9.6.6-slim-buster
+      - image: haskell:9.6-slim-bullseye
     environment:
       - STACK_FILE: "stack-lts22.yaml"
     <<: *defaults
 
   stackage-nightly:
     docker:
-      - image: haskell:9.8.4-slim-buster
+      - image: haskell:9.8-slim-bullseye
     environment:
       - STACK_FILE: "stack.yaml"
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,14 +60,14 @@ version: 2
 jobs:
   stackage-lts22:
     docker:
-      - image: haskell:9.6.5-slim-buster
+      - image: haskell:9.6.6-slim-buster
     environment:
       - STACK_FILE: "stack-lts22.yaml"
     <<: *defaults
 
   stackage-nightly:
     docker:
-      - image: haskell:9.8.2-slim-buster
+      - image: haskell:9.8.4-slim-buster
     environment:
       - STACK_FILE: "stack.yaml"
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,14 +60,14 @@ version: 2
 jobs:
   stackage-lts22:
     docker:
-      - image: haskell:9.6-slim-bullseye
+      - image: haskell:9.6.6-slim-bullseye
     environment:
       - STACK_FILE: "stack-lts22.yaml"
     <<: *defaults
 
-  stackage-nightly:
+  stackage-lts23:
     docker:
-      - image: haskell:9.8-slim-bullseye
+      - image: haskell:9.8.4-slim-bullseye
     environment:
       - STACK_FILE: "stack.yaml"
     <<: *defaults
@@ -77,4 +77,4 @@ workflows:
   multiple-ghcs:
     jobs:
       - stackage-lts22
-      - stackage-nightly
+      - stackage-lts23

--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-test-utils
 
 
-index-state:  2025-03-20T00:00:00Z
+index-state:  2025-04-08T01:30:37Z
 
 tests: True
 test-show-details: direct
@@ -57,8 +57,6 @@ if impl(ghc >= 9.8.4) && impl(ghc < 9.8.5)
 if impl(ghc >= 9.11)
   benchmarks: False
   allow-newer:
-    hiedb:base,
-    hiedb:ghc,
     hie-bios:ghc,
     ghc-trace-events:base,
     tasty-hspec:base,

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -75,7 +75,7 @@ library
     , hashable
     , hie-bios                     ^>=0.14.0
     , hie-compat                   ^>=0.3.0.0
-    , hiedb                        ^>= 0.6.0.0
+    , hiedb                        ^>= 0.6.0.2
     , hls-graph                    == 2.10.0.0
     , hls-plugin-api               == 2.10.0.0
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -407,7 +407,7 @@ library hls-call-hierarchy-plugin
     , containers
     , extra
     , ghcide                == 2.10.0.0
-    , hiedb                 ^>= 0.6.0.0
+    , hiedb                 ^>= 0.6.0.2
     , hls-plugin-api        == 2.10.0.0
     , lens
     , lsp                    >=2.7
@@ -594,7 +594,7 @@ library hls-rename-plugin
     , containers
     , ghcide                == 2.10.0.0
     , hashable
-    , hiedb                 ^>= 0.6.0.0
+    , hiedb                 ^>= 0.6.0.2
     , hie-compat
     , hls-plugin-api        == 2.10.0.0
     , haskell-language-server:hls-refactor-plugin
@@ -1596,7 +1596,7 @@ flag refactor
   manual:      True
 
 common refactor
-  if flag(refactor) 
+  if flag(refactor)
     build-depends: haskell-language-server:hls-refactor-plugin
     cpp-options: -Dhls_refactor
 

--- a/stack-lts22.yaml
+++ b/stack-lts22.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.25 # ghc-9.6.5
+resolver: lts-22.43 # ghc-9.6.6
 
 packages:
   - .
@@ -19,7 +19,7 @@ allow-newer-deps:
 extra-deps:
   - Diff-0.5
   - floskell-0.11.1
-  - hiedb-0.6.0.1
+  - hiedb-0.6.0.2
   - hie-bios-0.14.0
   - implicit-hie-0.1.4.0
   - lsp-2.7.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2024-06-12 # ghc-9.8.2
+resolver: lts-23.18 # ghc-9.8.4
 
 packages:
   - .
@@ -20,15 +20,10 @@ allow-newer-deps:
 
 extra-deps:
   - floskell-0.11.1
-  - hiedb-0.6.0.1
-  - hie-bios-0.14.0
+  - hiedb-0.6.0.2
   - implicit-hie-0.1.4.0
   - hw-fingertree-0.1.2.1
-  - lsp-2.7.0.0
-  - lsp-test-0.17.1.0
-  - lsp-types-2.3.0.0
   - monad-dijkstra-0.1.1.5
-  - stylish-haskell-0.14.6.0
   - retrie-1.2.3
 
   # stan dependencies not found in the stackage snapshot
@@ -38,8 +33,6 @@ extra-deps:
   - trial-0.0.0.0
   - trial-optparse-applicative-0.0.0.0
   - trial-tomland-0.0.0.0
-  - cabal-add-0.1
-  - cabal-install-parsers-0.6.1.1
 
 configure-options:
   ghcide:


### PR DESCRIPTION
Using GHC 9.12 compatible version of hiedb released yesterday.