### PR TITLE
enable hlint for ghc-9.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
         run: cabal test hls-rename-plugin-tests || cabal test hls-rename-plugin-tests
 
       # TODO enable when it supports 9.10
-      - if: matrix.test && matrix.ghc != '9.10' && matrix.ghc != '9.12'
+      - if: matrix.test && matrix.ghc != '9.10'
         name: Test hls-hlint-plugin test suite
         run: cabal test hls-hlint-plugin-tests || cabal test hls-hlint-plugin-tests
 

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -55,7 +55,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-explicit-record-fields-plugin`  | 2    |                          |
 | `hls-fourmolu-plugin`                | 2    |                          |
 | `hls-gadt-plugin`                    | 2    | 9.12.2                   |
-| `hls-hlint-plugin`                   | 2    | 9.10.1, 9.12.2           |
+| `hls-hlint-plugin`                   | 2    | 9.10.1                   |
 | `hls-module-name-plugin`             | 2    |                          |
 | `hls-notes-plugin`                   | 2    |                          |
 | `hls-qualify-imported-names-plugin`  | 2    |                          |

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -703,14 +703,14 @@ flag hlint
   manual:      True
 
 common hlint
-  if flag(hlint) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds))
+  if flag(hlint) && ((impl(ghc < 9.10) || impl(ghc > 9.11)) || flag(ignore-plugins-ghc-bounds))
     build-depends: haskell-language-server:hls-hlint-plugin
     cpp-options: -Dhls_hlint
 
 library hls-hlint-plugin
   import:           defaults, pedantic, warnings
   -- https://github.com/ndmitchell/hlint/pull/1594
-  if !(flag(hlint)) || (impl(ghc > 9.10) && !flag(ignore-plugins-ghc-bounds))
+  if !(flag(hlint)) || ((impl(ghc >= 9.10) && impl(ghc < 9.11)) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   exposed-modules:  Ide.Plugin.Hlint
   hs-source-dirs:   plugins/hls-hlint-plugin/src
@@ -722,7 +722,7 @@ library hls-hlint-plugin
     , filepath
     , ghcide                == 2.10.0.0
     , hashable
-    , hlint                 >= 3.5 && < 3.9
+    , hlint                 >= 3.5 && < 3.11
     , hls-plugin-api        == 2.10.0.0
     , lens
     , mtl
@@ -753,7 +753,7 @@ library hls-hlint-plugin
 
 test-suite hls-hlint-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if (!flag(hlint)) || (impl(ghc > 9.10) && !flag(ignore-plugins-ghc-bounds))
+  if !flag(hlint) || ((impl(ghc >= 9.10) && impl(ghc < 9.11)) && !flag(ignore-plugins-ghc-bounds))
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-hlint-plugin/test

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -276,14 +276,24 @@ suggestionsTests =
                              , "g = 2"
                              , "#endif", ""
                              ]
-        expectedComments =  [ "-- comment before header"
-                             , "module Comments where", ""
-                             , "{-# standalone annotation #-}", ""
-                             , "-- standalone comment", ""
-                             , "-- | haddock comment"
-                             , "f = {- inline comment -} {- inline comment inside refactored code -}1 -- ending comment", ""
-                             , "-- final comment"
-                             ]
+        expectedComments = case ghcVersion of
+                             GHC912 -> [ "-- comment before header"
+                              , "module Comments where", ""
+                              , "{-# standalone annotation #-}", ""
+                              , "-- standalone comment", ""
+                              , "-- | haddock comment"
+                              , "f = {- inline comment -}{- inline comment inside refactored code -} 1 -- ending comment", ""
+                              , "-- final comment"
+                              ]
+
+                             _ -> [ "-- comment before header"
+                              , "module Comments where", ""
+                              , "{-# standalone annotation #-}", ""
+                              , "-- standalone comment", ""
+                              , "-- | haddock comment"
+                              , "f = {- inline comment -} {- inline comment inside refactored code -}1 -- ending comment", ""
+                              , "-- final comment"
+                              ]
         expectedComments2 =  [ "module TwoHintsAndComment where"
                              , "biggest = foldr1 max -- the line above will show two hlint hints, \"eta reduce\" and \"use maximum\""
                              ]

--- a/test/testdata/schema/ghc912/default-config.golden.json
+++ b/test/testdata/schema/ghc912/default-config.golden.json
@@ -87,6 +87,13 @@
             },
             "globalOn": true
         },
+        "hlint": {
+            "codeActionsOn": true,
+            "config": {
+                "flags": []
+            },
+            "diagnosticsOn": true
+        },
         "importLens": {
             "codeActionsOn": true,
             "codeLensOn": true,

--- a/test/testdata/schema/ghc912/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc912/vscode-extension-schema.golden.json
@@ -201,6 +201,24 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.hlint.codeActionsOn": {
+        "default": true,
+        "description": "Enables hlint code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.hlint.config.flags": {
+        "default": [],
+        "markdownDescription": "Flags used by hlint",
+        "scope": "resource",
+        "type": "array"
+    },
+    "haskell.plugin.hlint.diagnosticsOn": {
+        "default": true,
+        "description": "Enables hlint diagnostics",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.importLens.codeActionsOn": {
         "default": true,
         "description": "Enables importLens code actions",


### PR DESCRIPTION
@fendor : I know this fails a test, but could you check it out? It seems to not be doing what the test is checking that it doesn't do, and the added space is actually what I would expect to happen so before I dive for a bug that might actually be a feature, I'd rather have your advice.

P.S.: Not enabling for ghc-9.10 as apply-refact doesn't work with ghc-9.10.

P.P.S.: apparently I've done something wrong with the flags :( . Happy for some pointers.