### PR TITLE
Provide code action in hls-eval-plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   - hooks:
       - entry: stylish-haskell --inplace
         exclude: >-
-          (^Setup.hs$|test/testdata/.*$|test/data/.*$|test/manual/lhs/.*$|^hie-compat/.*$|^plugins/hls-tactics-plugin/.*$|^ghcide/src/Development/IDE/GHC/Compat.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/Compat/ExactPrint.hs$|^ghcide/src/Development/IDE/GHC/Compat/Core.hs$|^ghcide/src/Development/IDE/Spans/Pragmas.hs$|^ghcide/src/Development/IDE/LSP/Outline.hs$|^plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs$|^ghcide/src/Development/IDE/Core/Rules.hs$|^ghcide/src/Development/IDE/Core/Compile.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs$)
+          (^Setup.hs$|test/testdata/.*$|test/data/.*$|test/manual/lhs/.*$|^hie-compat/.*$|^plugins/hls-tactics-plugin/.*$|^ghcide/src/Development/IDE/GHC/Compat.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/Compat/ExactPrint.hs$|^ghcide/src/Development/IDE/GHC/Compat/Core.hs$|^ghcide/src/Development/IDE/Spans/Pragmas.hs$|^ghcide/src/Development/IDE/LSP/Outline.hs$|^plugins/hls-splice-plugin/src/Ide/Plugin/Splice.hs$|^ghcide/src/Development/IDE/Core/Rules.hs$|^ghcide/src/Development/IDE/Core/Compile.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/GHC/ExactPrint.hs$|^plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs$|^plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs$)
         files: \.l?hs$
         id: stylish-haskell
         language: system

--- a/docs/features.md
+++ b/docs/features.md
@@ -346,7 +346,7 @@ Shows the type signature for bindings without type signatures, and adds it with 
 
 Provided by: `hls-eval-plugin`
 
-Evaluates code blocks in comments with a click. [Tutorial](https://github.com/haskell/haskell-language-server/blob/master/plugins/hls-eval-plugin/README.md).
+Evaluates code blocks in comments with a click.  A code action is also provided. [Tutorial](https://github.com/haskell/haskell-language-server/blob/master/plugins/hls-eval-plugin/README.md).
 
 ![Eval Demo](../plugins/hls-eval-plugin/demo.gif)
 

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -460,9 +460,9 @@ library hls-eval-plugin
   hs-source-dirs:     plugins/hls-eval-plugin/src
   other-modules:
     Ide.Plugin.Eval.Code
-    Ide.Plugin.Eval.CodeLens
     Ide.Plugin.Eval.Config
     Ide.Plugin.Eval.GHC
+    Ide.Plugin.Eval.Handlers
     Ide.Plugin.Eval.Parse.Comments
     Ide.Plugin.Eval.Parse.Option
     Ide.Plugin.Eval.Rules

--- a/plugins/hls-eval-plugin/README.md
+++ b/plugins/hls-eval-plugin/README.md
@@ -40,7 +40,7 @@ A test is composed by a sequence of contiguous lines, the result of their evalua
 "CDAB"
 ```
 
-You execute a test by clicking on the _Evaluate_ code lens that appears above it (or _Refresh_, if the test has been run previously).
+You execute a test by clicking on the _Evaluate_ code lens that appears above it (or _Refresh_, if the test has been run previously). A code action is also provided.
 
 All tests in the same comment block are executed together.
 

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval.hs
@@ -13,8 +13,8 @@ module Ide.Plugin.Eval (
 
 import           Development.IDE               (IdeState)
 import           Ide.Logger                    (Recorder, WithPriority)
-import qualified Ide.Plugin.Eval.CodeLens      as CL
 import           Ide.Plugin.Eval.Config
+import qualified Ide.Plugin.Eval.Handlers      as Handlers
 import           Ide.Plugin.Eval.Rules         (rules)
 import qualified Ide.Plugin.Eval.Types         as Eval
 import           Ide.Types                     (ConfigDescriptor (..),
@@ -27,9 +27,12 @@ import           Language.LSP.Protocol.Message
 -- |Plugin descriptor
 descriptor :: Recorder (WithPriority Eval.Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder plId =
-    (defaultPluginDescriptor plId "Provies a code lens to evaluate expressions in doctest comments")
-        { pluginHandlers = mkPluginHandler SMethod_TextDocumentCodeLens (CL.codeLens recorder)
-        , pluginCommands = [CL.evalCommand recorder plId]
+    (defaultPluginDescriptor plId "Provies code action and lens to evaluate expressions in doctest comments")
+        { pluginHandlers = mconcat
+            [ mkPluginHandler SMethod_TextDocumentCodeAction (Handlers.codeAction recorder)
+            , mkPluginHandler SMethod_TextDocumentCodeLens (Handlers.codeLens recorder)
+            ]
+        , pluginCommands = [Handlers.evalCommand recorder plId]
         , pluginRules = rules recorder
         , pluginConfigDescriptor = defaultConfigDescriptor
                                    { configCustomConfig = mkCustomConfig properties

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -85,6 +85,7 @@ import qualified Development.IDE.GHC.Compat.Core              as SrcLoc (unLoc)
 import           Development.IDE.Types.HscEnvEq               (HscEnvEq (hscEnv))
 import qualified GHC.LanguageExtensions.Type                  as LangExt (Extension (..))
 
+import           Data.List.Extra                              (unsnoc)
 import           Development.IDE.Core.FileStore               (setSomethingModified)
 import           Development.IDE.Core.PluginUtils
 import           Development.IDE.Types.Shake                  (toKey)
@@ -317,7 +318,7 @@ finalReturn :: Text -> TextEdit
 finalReturn txt =
     let ls = T.lines txt
         l = fromIntegral $ length ls -1
-        c = fromIntegral $ T.length . last $ ls
+        c = fromIntegral $ T.length $ maybe T.empty snd (unsnoc ls)
         p = Position l c
      in TextEdit (Range p p) "\n"
 

--- a/test/testdata/schema/ghc912/default-config.golden.json
+++ b/test/testdata/schema/ghc912/default-config.golden.json
@@ -39,11 +39,12 @@
             "codeLensOn": true
         },
         "eval": {
+            "codeActionsOn": true,
+            "codeLensOn": true,
             "config": {
                 "diff": true,
                 "exception": false
-            },
-            "globalOn": true
+            }
         },
         "explicit-fields": {
             "codeActionsOn": true,

--- a/test/testdata/schema/ghc912/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc912/vscode-extension-schema.golden.json
@@ -77,6 +77,18 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.eval.codeActionsOn": {
+        "default": true,
+        "description": "Enables eval code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.codeLensOn": {
+        "default": true,
+        "description": "Enables eval code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.eval.config.diff": {
         "default": true,
         "markdownDescription": "Enable the diff output (WAS/NOW) of eval lenses",
@@ -86,12 +98,6 @@
     "haskell.plugin.eval.config.exception": {
         "default": false,
         "markdownDescription": "Enable marking exceptions with `*** Exception:` similarly to doctest and GHCi.",
-        "scope": "resource",
-        "type": "boolean"
-    },
-    "haskell.plugin.eval.globalOn": {
-        "default": true,
-        "description": "Enables eval plugin",
         "scope": "resource",
         "type": "boolean"
     },

--- a/test/testdata/schema/ghc94/default-config.golden.json
+++ b/test/testdata/schema/ghc94/default-config.golden.json
@@ -39,11 +39,12 @@
             "codeLensOn": true
         },
         "eval": {
+            "codeActionsOn": true,
+            "codeLensOn": true,
             "config": {
                 "diff": true,
                 "exception": false
-            },
-            "globalOn": true
+            }
         },
         "explicit-fields": {
             "codeActionsOn": true,

--- a/test/testdata/schema/ghc94/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc94/vscode-extension-schema.golden.json
@@ -77,6 +77,18 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.eval.codeActionsOn": {
+        "default": true,
+        "description": "Enables eval code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.codeLensOn": {
+        "default": true,
+        "description": "Enables eval code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.eval.config.diff": {
         "default": true,
         "markdownDescription": "Enable the diff output (WAS/NOW) of eval lenses",
@@ -86,12 +98,6 @@
     "haskell.plugin.eval.config.exception": {
         "default": false,
         "markdownDescription": "Enable marking exceptions with `*** Exception:` similarly to doctest and GHCi.",
-        "scope": "resource",
-        "type": "boolean"
-    },
-    "haskell.plugin.eval.globalOn": {
-        "default": true,
-        "description": "Enables eval plugin",
         "scope": "resource",
         "type": "boolean"
     },

--- a/test/testdata/schema/ghc96/default-config.golden.json
+++ b/test/testdata/schema/ghc96/default-config.golden.json
@@ -39,11 +39,12 @@
             "codeLensOn": true
         },
         "eval": {
+            "codeActionsOn": true,
+            "codeLensOn": true,
             "config": {
                 "diff": true,
                 "exception": false
-            },
-            "globalOn": true
+            }
         },
         "explicit-fields": {
             "codeActionsOn": true,

--- a/test/testdata/schema/ghc96/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc96/vscode-extension-schema.golden.json
@@ -77,6 +77,18 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.eval.codeActionsOn": {
+        "default": true,
+        "description": "Enables eval code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.codeLensOn": {
+        "default": true,
+        "description": "Enables eval code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.eval.config.diff": {
         "default": true,
         "markdownDescription": "Enable the diff output (WAS/NOW) of eval lenses",
@@ -86,12 +98,6 @@
     "haskell.plugin.eval.config.exception": {
         "default": false,
         "markdownDescription": "Enable marking exceptions with `*** Exception:` similarly to doctest and GHCi.",
-        "scope": "resource",
-        "type": "boolean"
-    },
-    "haskell.plugin.eval.globalOn": {
-        "default": true,
-        "description": "Enables eval plugin",
         "scope": "resource",
         "type": "boolean"
     },

--- a/test/testdata/schema/ghc98/default-config.golden.json
+++ b/test/testdata/schema/ghc98/default-config.golden.json
@@ -39,11 +39,12 @@
             "codeLensOn": true
         },
         "eval": {
+            "codeActionsOn": true,
+            "codeLensOn": true,
             "config": {
                 "diff": true,
                 "exception": false
-            },
-            "globalOn": true
+            }
         },
         "explicit-fields": {
             "codeActionsOn": true,

--- a/test/testdata/schema/ghc98/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc98/vscode-extension-schema.golden.json
@@ -77,6 +77,18 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.eval.codeActionsOn": {
+        "default": true,
+        "description": "Enables eval code actions",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.eval.codeLensOn": {
+        "default": true,
+        "description": "Enables eval code lenses",
+        "scope": "resource",
+        "type": "boolean"
+    },
     "haskell.plugin.eval.config.diff": {
         "default": true,
         "markdownDescription": "Enable the diff output (WAS/NOW) of eval lenses",
@@ -86,12 +98,6 @@
     "haskell.plugin.eval.config.exception": {
         "default": false,
         "markdownDescription": "Enable marking exceptions with `*** Exception:` similarly to doctest and GHCi.",
-        "scope": "resource",
-        "type": "boolean"
-    },
-    "haskell.plugin.eval.globalOn": {
-        "default": true,
-        "description": "Enables eval plugin",
         "scope": "resource",
         "type": "boolean"
     },


### PR DESCRIPTION
Code action and lens are provided at the same time.

In addition, a file is excluded from stylish-haskell pre-commit hook due to a CPP issue introduced in #4527.

Fix: #496