### PR TITLE
Enable stylish-haskell for ghc-9.10 and ghc-9.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,8 +164,7 @@ jobs:
         name: Test hls-stan-plugin
         run: cabal test hls-stan-plugin-tests || cabal test hls-stan-plugin-tests
 
-      # TODO enable when it supports 9.10
-      - if: matrix.test && matrix.ghc != '9.10' && matrix.ghc != '9.12'
+      - if: matrix.test
         name: Test hls-stylish-haskell-plugin
         run: cabal test hls-stylish-haskell-plugin-tests || cabal test hls-stylish-haskell-plugin-tests
 

--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-test-utils
 
 
-index-state:  2025-04-08T01:30:37Z
+index-state: 2025-04-19T07:34:07Z
 
 tests: True
 test-show-details: direct

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -61,7 +61,7 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-qualify-imported-names-plugin`  | 2    |                          |
 | `hls-ormolu-plugin`                  | 2    |                          |
 | `hls-rename-plugin`                  | 2    |                          |
-| `hls-stylish-haskell-plugin`         | 2    | 9.10.1,  9.12.2          |
+| `hls-stylish-haskell-plugin`         | 2    |                          |
 | `hls-overloaded-record-dot-plugin`   | 2    |                          |
 | `hls-semantic-tokens-plugin`         | 2    |                          |
 | `hls-floskell-plugin`                | 3    | 9.10.1, 9.12.2           |

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1551,14 +1551,14 @@ flag stylishHaskell
   manual:      True
 
 common stylishHaskell
-  if flag(stylishHaskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds))
+  if flag(stylishHaskell)
     build-depends: haskell-language-server:hls-stylish-haskell-plugin
     cpp-options: -Dhls_stylishHaskell
 
 library hls-stylish-haskell-plugin
   import:           defaults, pedantic, warnings
   -- https://github.com/haskell/stylish-haskell/issues/479
-  if !(flag(stylishHaskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
+  if !flag(stylishHaskell)
     buildable: False
   exposed-modules:  Ide.Plugin.StylishHaskell
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/src
@@ -1570,13 +1570,13 @@ library hls-stylish-haskell-plugin
     , hls-plugin-api   == 2.10.0.0
     , lsp-types
     , mtl
-    , stylish-haskell  ^>=0.12 || ^>=0.13 || ^>=0.14
+    , stylish-haskell  >=0.12 && <0.16
     , text
 
 
 test-suite hls-stylish-haskell-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  if !(flag(stylishHaskell) && (impl(ghc < 9.10) || flag(ignore-plugins-ghc-bounds)))
+  if !flag(stylishHaskell)
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-stylish-haskell-plugin/test

--- a/plugins/hls-stylish-haskell-plugin/src/Ide/Plugin/StylishHaskell.hs
+++ b/plugins/hls-stylish-haskell-plugin/src/Ide/Plugin/StylishHaskell.hs
@@ -79,10 +79,15 @@ provider recorder ide _token typ contents fp _opts = do
 -- If no such file has been found, return default config.
 loadConfigFrom :: FilePath -> IO Config
 loadConfigFrom file = do
+#if MIN_VERSION_stylish_haskell(0,15,0)
+  let configSearchStrategy = SearchFromDirectory (takeDirectory file)
+  config <- loadConfig (makeVerbose False) configSearchStrategy
+#else
   currDir <- getCurrentDirectory
   setCurrentDirectory (takeDirectory file)
   config <- loadConfig (makeVerbose False) Nothing
   setCurrentDirectory currDir
+#endif
   pure config
 
 -- | Run stylish-haskell on the given text with the given configuration.


### PR DESCRIPTION
With the release of stylish-haskell-0.15.0.0, it now builds with ghc-lib-parser-9.10, so we can enable the plugin for ghc-9.10.
Note that a ghc-lib-parser-9.12 version should be released soon.