### PR TITLE
Remove no longer needed allow-newer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -55,8 +55,5 @@ allow-newer:
 if impl(ghc >= 9.11)
   benchmarks: False
   allow-newer:
-    hie-bios:ghc,
-    ghc-trace-events:base,
-    tasty-hspec:base,
     cabal-install-parsers:base,
     cabal-install-parsers:time,


### PR DESCRIPTION
Few more dependencies now have GHC 9.12 versions / revisions available.