### PR TITLE
Fix misplaced inlay hints by applying PositionMapping

### DIFF
--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -218,16 +218,18 @@ inlayHintProvider _ state _ InlayHintParams {_textDocument = TextDocumentIdentif
     --                  |^-_paddingLeft
     --                  ^-_position
     generateInlayHints :: Range -> ImportEdit -> PositionMapping -> Maybe InlayHint
-    generateInlayHints (Range _ end) ie pm = mkLabel ie <&> \label ->
-      InlayHint { _position = end
-                , _label = InL label
-                , _kind = Nothing -- neither a type nor a parameter
-                , _textEdits = fmap singleton $ toTEdit pm ie
-                , _tooltip = Just $ InL "Make this import explicit" -- simple enough, no need to resolve
-                , _paddingLeft = Just True -- show an extra space before the inlay hint
-                , _paddingRight = Nothing
-                , _data_ = Nothing
-                }
+    generateInlayHints (Range _ end) ie pm = do
+      label <- mkLabel ie
+      currentEnd <- toCurrentPosition pm end
+      return InlayHint { _position = currentEnd
+                       , _label = InL label
+                       , _kind = Nothing -- neither a type nor a parameter
+                       , _textEdits = fmap singleton $ toTEdit pm ie
+                       , _tooltip = Just $ InL "Make this import explicit" -- simple enough, no need to resolve
+                       , _paddingLeft = Just True -- show an extra space before the inlay hint
+                       , _paddingRight = Nothing
+                       , _data_ = Nothing
+                       }
     mkLabel :: ImportEdit -> Maybe T.Text
     mkLabel (ImportEdit{ieResType, ieText}) =
       let title ExplicitImport = Just $ abbreviateImportTitleWithoutModule ieText

--- a/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
+++ b/plugins/hls-explicit-imports-plugin/src/Ide/Plugin/ExplicitImports.hs
@@ -25,7 +25,6 @@ import           Control.Monad.Trans.Maybe
 import qualified Data.Aeson                           as A (ToJSON (toJSON))
 import           Data.Aeson.Types                     (FromJSON)
 import           Data.Char                            (isSpace)
-import           Data.Functor                         ((<&>))
 import qualified Data.IntMap                          as IM (IntMap, elems,
                                                              fromList, (!?))
 import           Data.IORef                           (readIORef)


### PR DESCRIPTION
resolve #4561.

fixed `hls-explicit-imports-plugin`, `hls-explicit-record-fields-plugin`.