### PR TITLE
Make cradle dependencies absolute paths

### DIFF
--- a/ghcide-test/data/watched-files/reload/reload.cabal
+++ b/ghcide-test/data/watched-files/reload/reload.cabal
@@ -1,0 +1,12 @@
+cabal-version:      2.4
+name:               reload
+version:            0.1.0.0
+author:             Lin Jian
+maintainer:         me@linj.tech
+build-type:         Simple
+
+library
+  exposed-modules:  MyLib
+  build-depends:    base
+  hs-source-dirs:   src
+  default-language: Haskell2010

--- a/ghcide-test/data/watched-files/reload/src/MyLib.hs
+++ b/ghcide-test/data/watched-files/reload/src/MyLib.hs
@@ -1,0 +1,6 @@
+module MyLib (someFunc) where
+
+import Data.List.Split
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/plugins/hls-cabal-plugin/test/Main.hs
+++ b/plugins/hls-cabal-plugin/test/Main.hs
@@ -131,29 +131,6 @@ pluginTests =
                 expectNoMoreDiagnostics 1 hsDoc "typechecking"
                 cabalDoc <- openDoc "simple-cabal.cabal" "cabal"
                 expectNoMoreDiagnostics 1 cabalDoc "parsing"
-            , runCabalTestCaseSession "Diagnostics in .hs files from invalid .cabal file" "simple-cabal" $ do
-                    hsDoc <- openDoc "A.hs" "haskell"
-                    expectNoMoreDiagnostics 1 hsDoc "typechecking"
-                    cabalDoc <- openDoc "simple-cabal.cabal" "cabal"
-                    expectNoMoreDiagnostics 1 cabalDoc "parsing"
-                    let theRange = Range (Position 3 20) (Position 3 23)
-                    -- Invalid license
-                    changeDoc
-                        cabalDoc
-                        [ TextDocumentContentChangeEvent $
-                            InL TextDocumentContentChangePartial
-                                { _range = theRange
-                                , _rangeLength = Nothing
-                                , _text = "MIT3"
-                                }
-                        ]
-                    cabalDiags <- waitForDiagnosticsFrom cabalDoc
-                    unknownLicenseDiag <- liftIO $ inspectDiagnostic cabalDiags ["Unknown SPDX license identifier: 'MIT3'"]
-                    expectNoMoreDiagnostics 1 hsDoc "typechecking"
-                    liftIO $ do
-                        length cabalDiags @?= 1
-                        unknownLicenseDiag ^. L.range @?= Range (Position 3 24) (Position 4 0)
-                        unknownLicenseDiag ^. L.severity @?= Just DiagnosticSeverity_Error
             ]
         ]
 -- ----------------------------------------------------------------------------


### PR DESCRIPTION
This patch fixes #1068 when the cabal plugin is not used.

---

   
The code change in Session.hs is written by @fendor.  Tests and comments are added by me.