### PR TITLE
Use hie-bios 0.15.0

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -7,7 +7,7 @@ inputs:
   cabal:
     description: "Cabal version"
     required: false
-    default: "3.10.2.0"
+    default: "3.14.2.0"
   os:
     description: "Operating system: Linux, Windows or macOS"
     required: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -123,7 +123,7 @@ jobs:
       matrix:
         ghc: ['9.8', '9.10']
         os: [ubuntu-latest]
-        cabal: ['3.10']
+        cabal: ['3.14']
         example: ['cabal', 'lsp-types']
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-test-utils
 
 
-index-state: 2025-04-19T07:34:07Z
+index-state: 2025-05-06T13:26:29Z
 
 tests: True
 test-show-details: direct

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -73,7 +73,7 @@ library
     , Glob
     , haddock-library              >=1.8      && <1.12
     , hashable
-    , hie-bios                     ^>=0.14.0
+    , hie-bios                     ^>=0.15.0
     , hie-compat                   ^>=0.3.0.0
     , hiedb                        ^>= 0.6.0.2
     , hls-graph                    == 2.10.0.0

--- a/ghcide/session-loader/Development/IDE/Session/Diagnostics.hs
+++ b/ghcide/session-loader/Development/IDE/Session/Diagnostics.hs
@@ -28,7 +28,7 @@ data CradleErrorDetails =
   Depicts the cradle error in a user-friendly way.
 -}
 renderCradleError :: CradleError -> Cradle a -> NormalizedFilePath -> FileDiagnostic
-renderCradleError (CradleError deps _ec ms) cradle nfp =
+renderCradleError cradleError cradle nfp =
   let noDetails =
         ideErrorWithSource (Just "cradle") (Just DiagnosticSeverity_Error) nfp (T.unlines $ map T.pack userFriendlyMessage) Nothing
   in
@@ -36,7 +36,9 @@ renderCradleError (CradleError deps _ec ms) cradle nfp =
      then noDetails & fdLspDiagnosticL %~ \diag -> diag{_data_ = Just $ Aeson.toJSON CradleErrorDetails{cabalProjectFiles=absDeps}}
      else noDetails
   where
-    absDeps = fmap (cradleRootDir cradle </>) deps
+    ms = cradleErrorStderr cradleError
+
+    absDeps = fmap (cradleRootDir cradle </>) (cradleErrorDependencies cradleError)
     userFriendlyMessage :: [String]
     userFriendlyMessage
       | HieBios.isCabalCradle cradle = fromMaybe ms $ fileMissingMessage <|> mkUnknownModuleMessage

--- a/stack-lts22.yaml
+++ b/stack-lts22.yaml
@@ -20,7 +20,7 @@ extra-deps:
   - Diff-0.5
   - floskell-0.11.1
   - hiedb-0.6.0.2
-  - hie-bios-0.14.0
+  - hie-bios-0.15.0
   - implicit-hie-0.1.4.0
   - lsp-2.7.0.0
   - lsp-test-0.17.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,6 +22,7 @@ extra-deps:
   - floskell-0.11.1
   - hiedb-0.6.0.2
   - implicit-hie-0.1.4.0
+  - hie-bios-0.15.0
   - hw-fingertree-0.1.2.1
   - monad-dijkstra-0.1.1.5
   - retrie-1.2.3


### PR DESCRIPTION
This allows us to benefit from the `cabal path` command in hie-bios for improved start-up time.

Also, update CI to use `cabal 3.14` so that we actually test the `cabal path` code path.

Closes #4562