### PR TITLE
Add doc for project-wide renaming

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,7 @@ This option obviously would not make sense for language servers for other langua
 Here is a list of the additional settings currently supported by `haskell-language-server`, along with their setting key (you may not need to know this) and default:
 
 - Formatting provider (`haskell.formattingProvider`, default `ormolu`): what formatter to use; one of `floskell`, `ormolu`, `fourmolu`, or `stylish-haskell`.
+- Cabal formatting provider (`haskell.cabalFormattingProvider`, default `cabal-gild`): what formatter to use for cabal files; one of `cabal-gild` or `cabal-fmt`.
 - Max completions (`haskell.maxCompletions`, default 40): maximum number of completions sent to the LSP client.
 - Check project (`haskell.checkProject`, default true): whether to typecheck the entire project on initial load. As it is activated by default could drive to bad performance in large projects.
 - Check parents (`haskell.checkParents`, default `CheckOnSave`): when to typecheck reverse dependencies of a file; one of `NeverCheck`, `CheckOnSave` (means dependent/parent modules will only be checked when you save), or `AlwaysCheck` (means re-typechecking them on every change).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,7 @@ Here is a list of the additional settings currently supported by `haskell-langua
 - Max completions (`haskell.maxCompletions`, default 40): maximum number of completions sent to the LSP client.
 - Check project (`haskell.checkProject`, default true): whether to typecheck the entire project on initial load. As it is activated by default could drive to bad performance in large projects.
 - Check parents (`haskell.checkParents`, default `CheckOnSave`): when to typecheck reverse dependencies of a file; one of `NeverCheck`, `CheckOnSave` (means dependent/parent modules will only be checked when you save), or `AlwaysCheck` (means re-typechecking them on every change).
+- Session loading preference (`haskell.sessionLoading`, default `singleComponent`): how to load sessions; one of `singleComponent` (means always loading only a single component when a new component is discovered) or `multipleComponents` (means always preferring loading multiple components in the cradle at once). `multipleComponents` might not be always possible, if the tool doesn't support multiple components loading. The cradle can decide how to handle these situations, and whether to honour the preference at all.
 
 #### Generic plugin configuration
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -411,6 +411,17 @@ Known limitations:
 
 - Cross-module renaming requires all components to be indexed, which sometimes causes [partial renames in multi-component projects](https://github.com/haskell/haskell-language-server/issues/2193).
 
+To eagerly load all components, you need to
+
+- set `haskell.sessionLoading` to `multipleComponents`,
+- set `hie.yaml` to load all components (currently only cabal supports this),
+  ```yaml
+  cradle:
+    cabal:
+      component: all
+  ```
+- and enable tests and benchmarks in `cabal.project` with `tests: True` and `benchmarks: True`.
+
 ## Semantic tokens
 
 Provided by: `hls-semantic-tokens-plugin`


### PR DESCRIPTION
Also add doc for `sessionLoading` since it is needed by project-wide renaming.

Doc for `cabalFormattingProvider` is also added.  It is not tightly connected to the theme of this PR though.

related: #2193 #3738
closes: #4355