### PR TITLE
Only expand positional records if the DataCon application is fully saturated

### DIFF
--- a/plugins/hls-explicit-record-fields-plugin/test/Main.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/Main.hs
@@ -36,6 +36,7 @@ test = testGroup "explicit-fields"
     , mkTestNoAction "Puns" "Puns" 12 10 12 31
     , mkTestNoAction "Infix" "Infix" 11 11 11 31
     , mkTestNoAction "Prefix" "Prefix" 10 11 10 28
+    , mkTestNoAction "PartiallyAppliedCon" "PartiallyAppliedCon" 7 8 7 12
     , mkTest "PolymorphicRecordConstruction" "PolymorphicRecordConstruction" 15 5 15 15
     ]
   , testGroup "inlay hints"

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/PartiallyAppliedCon.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/noop/PartiallyAppliedCon.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE Haskell2010 #-}
+
+module PartiallyAppliedCon where
+
+data T = MkT { fa :: Int, fb :: Char }
+
+foo :: Int -> Char -> T
+foo x = MkT x


### PR DESCRIPTION
Fixes #4564.

"Positional record expansion" only makes sense if the constructor application has all the required arguments provided, otherwise invalid code is generated as demonstrated in the linked issue. This PR augments the collected records with "saturation" information, so that unsatured applications can be filtered out during the code action generation.

(cc: @jetjinser, do you mind taking a look into this, as you were the author of #4447)