### PR TITLE
Add "autogen-" field completions and tests for cabal files

### DIFF
--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Paths.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Paths.hs
@@ -7,6 +7,7 @@ import           Distribution.PackageDescription   (Benchmark (..),
                                                     BuildInfo (..),
                                                     CondTree (condTreeData),
                                                     Executable (..),
+                                                    ForeignLib (..),
                                                     GenericPackageDescription (..),
                                                     Library (..),
                                                     UnqualComponentName,
@@ -117,6 +118,10 @@ sourceDirsExtractionTestSuite name gpd = extractRelativeDirsFromStanza name gpd 
 -- | Extracts the source directories of benchmark stanza with the given name.
 sourceDirsExtractionBenchmark :: Maybe StanzaName -> GenericPackageDescription -> [FilePath]
 sourceDirsExtractionBenchmark name gpd = extractRelativeDirsFromStanza name gpd condBenchmarks benchmarkBuildInfo
+
+-- | Extracts the source directories of foreign-lib stanza with the given name.
+sourceDirsExtractionForeignLib :: Maybe StanzaName -> GenericPackageDescription -> [FilePath]
+sourceDirsExtractionForeignLib name gpd = extractRelativeDirsFromStanza name gpd condForeignLibs foreignLibBuildInfo
 
 {- | Takes a possible stanza name, a GenericPackageDescription,
   a function to access the stanza information we are interested in

--- a/plugins/hls-cabal-plugin/test/testdata/completion/autogen-completion.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/completion/autogen-completion.cabal
@@ -1,0 +1,25 @@
+cabal-version: 3.0
+name: autogen-completion
+version: 0.1.0.0
+
+library
+  hs-source-dirs: src
+  autogen-
+
+executable autoexe
+  main-is: Main.hs
+  hs-source-dirs: src
+  autogen-
+
+test-suite autotest
+  type: exitcode-stdio-1.0
+  hs-source-dirs: src
+  autogen-
+
+benchmark autobench
+  type: exitcode-stdio-1.0
+  hs-source-dirs: src
+  autogen-
+
+common defaults
+  autogen-


### PR DESCRIPTION
Adds completions 'autogen-incudes' and 'autogen-modules'.


Supersedes both #4534 and #4535