### PR TITLE
provide `curl` in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,8 @@
             pkgs.haskellPackages.cabal-install
             # Dependencies needed to build some parts of Hackage
             gmp zlib ncurses
+            # for compatibility of curl with provided gcc
+            curl
             # Changelog tooling
             (gen-hls-changelogs pkgs.haskellPackages)
             # For the documentation


### PR DESCRIPTION
GCC is provided in dev shell. External `curl` is incompatible with dev shell-provided GCC, resulting in `GLIBC` error. Solution is for dev shell to provide both GCC and `curl`.