### PR TITLE
allow Diff 1.x

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -57,7 +57,7 @@ library
     , deepseq
     , dependent-map
     , dependent-sum
-    , Diff                         ^>=0.5
+    , Diff                         ^>=0.5 || ^>=1.0.0
     , directory
     , dlist
     , enummapset

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -473,7 +473,7 @@ library hls-eval-plugin
     , bytestring
     , containers
     , deepseq
-    , Diff                  ^>=0.5
+    , Diff                  ^>=0.5 || ^>=1.0.0
     , dlist
     , extra
     , filepath

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -60,7 +60,7 @@ library
     , data-default
     , dependent-map
     , dependent-sum         >=0.7
-    , Diff                  ^>=0.5
+    , Diff                  ^>=0.5 || ^>=1.0.0
     , dlist
     , extra
     , filepath


### PR DESCRIPTION
https://hackage.haskell.org/package/Diff

Compilation succeeds with `Diff ^>= 1.0`


```
cabal test --enable-tests --constraint 'Diff>=1.0'
```

1 test fails:
```
1 out of 376 tests failed (535.93s)
```

```
FAIL (1.74s)
        plugins/hls-refactor-plugin/test/Main.hs:3966:
        CodeAction with title "add signature: hello :: GHC.Types.Any -> IO ()" not found in ["add signature: hello :: GHC.Types.ZonkAny 0 -> IO ()"]
        Use -p '/hello = print/' to rerun this test only.

```