### PR TITLE
Fix completion for record dot syntax when record isn't known

### DIFF
--- a/ghcide-test/exe/CompletionTests.hs
+++ b/ghcide-test/exe/CompletionTests.hs
@@ -211,7 +211,36 @@ localCompletionTests = [
 
         compls <- getCompletions doc (Position 0 15)
         liftIO $ filter ("AAA" `T.isPrefixOf`) (mapMaybe _insertText compls) @?= ["AAAAA"]
-        pure ()
+        pure (),
+    completionTest
+        "polymorphic record dot completion"
+        [ "{-# LANGUAGE OverloadedRecordDot #-}"
+        , "module A () where"
+        , "data Record = Record"
+        , "  { field1 :: Int"
+        , "  , field2 :: Int"
+        , "  }"
+        , "foo record = record.f"
+        ]
+        (Position 6 21)
+        [("field1", CompletionItemKind_Function, "field1", True, False, Nothing)
+        ,("field2", CompletionItemKind_Function, "field2", True, False, Nothing)
+        ],
+    completionTest
+        "qualified polymorphic record dot completion"
+        [ "{-# LANGUAGE OverloadedRecordDot #-}"
+        , "module A () where"
+        , "data Record = Record"
+        , "  { field1 :: Int"
+        , "  , field2 :: Int"
+        , "  }"
+        , "someValue = undefined"
+        , "foo = A.someValue.f"
+        ]
+        (Position 7 19)
+        [("field1", CompletionItemKind_Function, "field1", True, False, Nothing)
+        ,("field2", CompletionItemKind_Function, "field2", True, False, Nothing)
+        ]
     ]
 
 nonLocalCompletionTests :: [TestTree]

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -912,7 +912,7 @@ getCompletionPrefixFromRope pos@(Position l c) ropetext =
           [] -> Nothing
           (x:xs) -> do
             let modParts = reverse $ filter (not .T.null) xs
-                modName = T.intercalate "." modParts
+                modName = if all (isUpper . T.head) modParts then T.intercalate "." modParts else ""
             return $ PosPrefixInfo { fullLine = curLine, prefixScope = modName, prefixText = x, cursorPos = pos }
 
 completionPrefixPos :: PosPrefixInfo -> Position


### PR DESCRIPTION
The issue was that the prefix info extractor didn't check that the "modName" it pulls out is a valid module name, so would include cases when using record dot syntax.
This is only an issue when the record type beforehand's type isn't known , i.e. `undefined.myField`, as otherwise the incorrect completions were replaced with the field names directly. 