### PR TITLE
Change tracking of file types to language kinds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,8 +6,7 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-
-index-state: 2026-02-02T09:03:26Z
+index-state: 2026-02-24T00:00:00Z
 
 tests: True
 test-show-details: direct
@@ -41,6 +40,7 @@ constraints:
   -- We want to be able to benefit from the performance optimisations
   -- in the future, thus: TODO: remove this flag.
   bitvec -simd,
+  monad-control >=1.0.3,  
 
 
 -- Some of the formatters need the latest Cabal-syntax version,
@@ -59,15 +59,11 @@ if impl(ghc >= 9.11)
 
 if impl(ghc >= 9.14)
   allow-newer:
-    lsp-types:containers,
-    lsp:containers,
     indexed-traversable:containers,
     quickcheck-instances:containers,
     dependent-map:containers,
     aeson:containers,
     semialign:containers,
-    lsp-test:containers,
-    hie-bios:ghc,
     string-interpolate:template-haskell,
     tasty-hspec:base,
     tagged:template-haskell,
@@ -79,19 +75,20 @@ if impl(ghc >= 9.14)
     some:base,
     boring:base,
     indexed-traversable-instances:base,
-    lsp-types:template-haskell,
     uuid-types:template-haskell,
     hie-compat:base,
-    hie-bios:time,
-    hie-bios:template-haskell,
     ghc-trace-events:base,
     constraints-extras:template-haskell,
     aeson:time,
     text-iso8601:time,
     semialign:base,
     aeson:template-haskell,
-    lsp-test:time,
     lukko:base,
     binary-instances:base,
     binary-orphans:base,
-    cabal-install-parsers:containers
+    cabal-install-parsers:containers,
+    haddock-library:base,
+    websockets:containers,
+    monad-control:transformers,
+    mmorph:transformers-compat,
+    binary-instances:tagged,

--- a/ghcide-test/exe/InitializeResponseTests.hs
+++ b/ghcide-test/exe/InitializeResponseTests.hs
@@ -55,7 +55,14 @@ tests = withResource acquire release tests where
                                                                            { _supported = Just True
                                                                            , _changeNotifications = Just (InR True)
                                                                            }
-                                                                      , _fileOperations = Nothing
+                                                                      , _fileOperations = Just $ FileOperationOptions
+                                                                          { _didCreate = Nothing
+                                                                          , _willCreate = Nothing
+                                                                          , _didRename = Nothing
+                                                                          , _willRename = Nothing
+                                                                          , _didDelete = Nothing
+                                                                          , _willDelete = Nothing
+                                                                          }
                                                                       })
     , chk "NO experimental"             (^. L.experimental) Nothing
     ] where

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -74,7 +74,7 @@ library
     , Glob
     , haddock-library              >=1.8      && <1.12
     , hashable
-    , hie-bios                     ^>=0.17.0
+    , hie-bios                     ^>= 0.18.0
     , hiedb                        ^>= 0.8.0.0
     , hls-graph                    == 2.13.0.0
     , hls-plugin-api               == 2.13.0.0
@@ -82,8 +82,8 @@ library
     , lens
     , lens-aeson
     , list-t
-    , lsp                          ^>=2.7
-    , lsp-types                    ^>=2.3
+    , lsp                          ^>=2.8
+    , lsp-types                    ^>=2.4
     , mtl
     , opentelemetry                >=0.6.1
     , optparse-applicative

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -252,8 +252,8 @@ getVersionedTextDoc doc = do
     maybe (pure Nothing) getVirtualFile $
         uriToNormalizedFilePath $ toNormalizedUri uri
   let ver = case mvf of
-        Just (VirtualFile lspver _ _) -> lspver
-        Nothing                       -> 0
+        Just (VirtualFile lspver _ _ _) -> lspver
+        Nothing                         -> 0
   return (VersionedTextDocumentIdentifier uri ver)
 
 fileStoreRules :: Recorder (WithPriority Log) -> (NormalizedFilePath -> Action Bool) -> Rules ()

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -167,7 +167,7 @@ import           Ide.Plugin.Properties                        (HasProperty,
                                                                useProperty,
                                                                usePropertyByPath)
 import           Ide.Types                                    (DynFlagsModifications (dynFlagsModifyGlobal, dynFlagsModifyParser),
-                                                               PluginId)
+                                                               PluginId, getVirtualFileFromVFS)
 import qualified Language.LSP.Protocol.Lens                   as JL
 import           Language.LSP.Protocol.Message                (SMethod (SMethod_CustomMethod, SMethod_WindowShowMessage))
 import           Language.LSP.Protocol.Types                  (MessageType (MessageType_Info),
@@ -525,7 +525,7 @@ persistentHieFileRule recorder = addPersistentRule GetHieAst $ \file -> runMaybe
   res <- readHieFileForSrcFromDisk recorder file
   vfsRef <- asks vfsVar
   vfsData <- liftIO $ _vfsMap <$> readTVarIO vfsRef
-  (currentSource, ver) <- liftIO $ case M.lookup (filePathToUri' file) vfsData of
+  (currentSource, ver) <- liftIO $ case getVirtualFileFromVFS (VFS vfsData) (filePathToUri' file) of
     Nothing -> (,Nothing) . T.decodeUtf8 <$> BS.readFile (fromNormalizedFilePath file)
     Just vf -> pure (virtualFileText vf, Just $ virtualFileVersion vf)
   let refmap = generateReferencesMap . getAsts . Compat.hie_asts $ res

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -130,6 +130,7 @@ import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Types.Options          as Options
 import qualified Language.LSP.Protocol.Message          as LSP
 import qualified Language.LSP.Server                    as LSP
+import qualified Language.LSP.VFS                       as VFS
 
 import           Development.IDE.Core.Tracing
 import           Development.IDE.Core.WorkerThread
@@ -401,7 +402,8 @@ class Typeable a => IsIdeGlobal a where
 getVirtualFile :: NormalizedFilePath -> Action (Maybe VirtualFile)
 getVirtualFile nf = do
   vfs <- fmap _vfsMap . liftIO . readTVarIO . vfsVar =<< getShakeExtras
-  pure $! Map.lookup (filePathToUri' nf) vfs -- Don't leak a reference to the entire map
+  pure $!  -- Don't leak a reference to the entire map
+    getVirtualFileFromVFS (VFS vfs) $ filePathToUri' nf
 
 -- Take a snapshot of the current LSP VFS
 vfsSnapshot :: Maybe (LSP.LanguageContextEnv a) -> IO VFS

--- a/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -867,7 +867,7 @@ mergeListsBy cmp all_lists = merge_lists all_lists
 
 -- |From the given cursor position, gets the prefix module or record for autocompletion
 getCompletionPrefix :: Position -> VFS.VirtualFile -> PosPrefixInfo
-getCompletionPrefix pos (VFS.VirtualFile _ _ ropetext) = getCompletionPrefixFromRope pos ropetext
+getCompletionPrefix pos (VFS.VirtualFile _ _ ropetext _) = getCompletionPrefixFromRope pos ropetext
 
 getCompletionPrefixFromRope :: Position -> Rope.Rope -> PosPrefixInfo
 getCompletionPrefixFromRope pos@(Position l c) ropetext =

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -279,8 +279,8 @@ library hls-cabal-plugin
     , hls-plugin-api        == 2.13.0.0
     , hls-graph             == 2.13.0.0
     , lens
-    , lsp                   ^>=2.7
-    , lsp-types             ^>=2.3
+    , lsp                   ^>=2.8
+    , lsp-types             ^>=2.4
     , mtl
     , regex-tdfa            ^>=1.3.1
     , text
@@ -415,7 +415,7 @@ library hls-call-hierarchy-plugin
     , hiedb                 ^>= 0.8.0.0
     , hls-plugin-api        == 2.13.0.0
     , lens
-    , lsp                    >=2.7
+    , lsp                    >=2.8
     , sqlite-simple
     , text
 
@@ -1040,7 +1040,7 @@ library hls-alternate-number-format-plugin
     , hls-graph
     , hls-plugin-api       == 2.13.0.0
     , lens
-    , lsp                  ^>=2.7
+    , lsp                  ^>=2.8
     , mtl
     , syb
     , text
@@ -1268,7 +1268,7 @@ library hls-gadt-plugin
     , hls-plugin-api         == 2.13.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
-    , lsp                    >=2.7
+    , lsp                    >=2.8
     , mtl
     , text
     , transformers
@@ -1315,7 +1315,7 @@ library hls-explicit-fixity-plugin
     , ghcide                == 2.13.0.0
     , hashable
     , hls-plugin-api        == 2.13.0.0
-    , lsp                   >=2.7
+    , lsp                   >=2.8
     , text
 
   default-extensions: DataKinds
@@ -1799,7 +1799,7 @@ library hls-notes-plugin
     , hls-graph == 2.13.0.0
     , hls-plugin-api == 2.13.0.0
     , lens
-    , lsp >=2.7
+    , lsp >=2.8
     , mtl >= 2.2
     , regex-tdfa >= 1.3.1
     , text
@@ -2104,7 +2104,7 @@ test-suite ghcide-tests
     , lens
     , list-t
     , lsp
-    , lsp-test                ^>=0.17.1
+    , lsp-test                ^>=0.18.0
     , lsp-types
     , mtl
     , network-uri
@@ -2261,7 +2261,7 @@ test-suite ghcide-bench-test
     build-depends:
         extra,
         haskell-language-server:ghcide-bench-lib,
-        lsp-test ^>= 0.17,
+        lsp-test ^>= 0.18,
         tasty,
         tasty-hunit >= 0.10,
         tasty-rerun

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -69,7 +69,7 @@ library
     , hls-graph             == 2.13.0.0
     , lens
     , lens-aeson
-    , lsp                   ^>=2.7
+    , lsp                   ^>=2.8
     , megaparsec            >=9.0
     , mtl
     , opentelemetry         >=0.4

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -48,8 +48,8 @@ library
     , hls-plugin-api          == 2.13.0.0
     , lens
     , lsp
-    , lsp-test                ^>=0.17
-    , lsp-types               ^>=2.3
+    , lsp-test                ^>=0.18
+    , lsp-types               ^>=2.4
     , safe-exceptions
     , string-interpolate      >= 0.3.1
     , tasty

--- a/plugins/hls-semantic-tokens-plugin/test/SemanticTokensTest.hs
+++ b/plugins/hls-semantic-tokens-plugin/test/SemanticTokensTest.hs
@@ -22,6 +22,7 @@ import           Ide.Plugin.SemanticTokens.Types
 import           Ide.Types
 import qualified Language.LSP.Protocol.Lens         as L
 import           Language.LSP.Protocol.Types
+import qualified Language.LSP.Protocol.Types        as J
 import qualified Language.LSP.Test                  as Test
 import           Language.LSP.VFS                   (VirtualFile (..))
 import           System.FilePath
@@ -90,7 +91,7 @@ docLspSemanticTokensString :: (HasCallStack) => TextDocumentIdentifier -> Sessio
 docLspSemanticTokensString doc = do
   res <- Test.getSemanticTokens doc
   textContent <- documentContents doc
-  let vfs = VirtualFile 0 0 (Rope.fromText textContent)
+  let vfs = VirtualFile 0 0 (Rope.fromText textContent) $ Just J.LanguageKind_Haskell
   case res ^? Language.LSP.Protocol.Types._L of
     Just tokens -> do
       either (error . show) pure $ recoverLspSemanticTokens vfs tokens

--- a/stack-lts22.yaml
+++ b/stack-lts22.yaml
@@ -19,12 +19,13 @@ allow-newer-deps:
 extra-deps:
   - Diff-0.5
   - hiedb-0.8.0.0
-  - hie-bios-0.17.0
+  - hie-bios-0.18.0
   - hie-compat-0.3.1.2
   - implicit-hie-0.1.4.0
-  - lsp-2.7.0.0
-  - lsp-test-0.17.1.0
-  - lsp-types-2.3.0.0
+  - lsp-2.8.0.0
+  - lsp-test-0.18.0.0
+  - lsp-types-2.4.0.0
+  - websockets-0.13.0.0@sha256:9b3680ba5055e0b34ab29c341b21d70084bf067519fc059af0e597cd90a4a05a,7567
   - monad-dijkstra-0.1.1.4 # 5
   - retrie-1.2.3
   - unordered-containers-0.2.21

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,12 +22,14 @@ extra-deps:
   - hiedb-0.8.0.0
   - hie-compat-0.3.1.2
   - implicit-hie-0.1.4.0
-  - hie-bios-0.17.0
+  - hie-bios-0.18.0
   - hw-fingertree-0.1.2.1
   - monad-dijkstra-0.1.1.5
   - retrie-1.2.3
   - unordered-containers-0.2.21
-
+  - lsp-2.8.0.0
+  - lsp-test-0.18.0.0
+  - lsp-types-2.4.0.0
   # stan dependencies not found in the stackage snapshot
   - stan-0.2.1.0
   - dir-traverse-0.2.3.0


### PR DESCRIPTION
The plugin descriptor now tracks the language kinds it is responsible for instead of the file endings.
This will allow files without ".hs" or other relevant file endings to still be handled by HLS if their language kind is set properly.

We get the language kinds of any file from the VFS.

Currently we are using a source repository to be able to use the lsp changes needed, but once lsp is released this can be removed.

Closes #3567

![image](https://github.com/user-attachments/assets/7cc1f3a0-6a8a-44ea-b747-739dd7303ccc)
