### PR TITLE
Revert "Switch ghcide tests to sequential execution (#4307)"

### DIFF
--- a/ghcide-test/exe/Main.hs
+++ b/ghcide-test/exe/Main.hs
@@ -33,7 +33,6 @@ module Main (main) where
 import qualified HieDbRetry
 import           Test.Tasty
 import           Test.Tasty.Ingredients.Rerun
-import           Test.Tasty.Runners
 
 import           AsyncTests
 import           BootTests
@@ -71,7 +70,7 @@ import           WatchedFileTests
 main :: IO ()
 main = do
   -- We mess with env vars so run single-threaded.
-  defaultMainWithRerun $ PlusTestOptions mkSequential $ testGroup "ghcide"
+  defaultMainWithRerun $ testGroup "ghcide"
     [ OpenCloseTest.tests
     , InitializeResponseTests.tests
     , CompletionTests.tests
@@ -105,6 +104,3 @@ main = do
     , HieDbRetry.tests
     , ExceptionTests.tests
     ]
-    where
-       PlusTestOptions mkSequential _ =sequentialTestGroup "foo" AllFinish []
-

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -2115,7 +2115,7 @@ test-suite ghcide-tests
     , sqlite-simple
     , stm
     , stm-containers
-    , tasty                  >=1.5
+    , tasty
     , tasty-expected-failure
     , tasty-hunit             >=0.10
     , tasty-quickcheck

--- a/stack-lts22.yaml
+++ b/stack-lts22.yaml
@@ -27,7 +27,6 @@ extra-deps:
   - lsp-types-2.3.0.0
   - monad-dijkstra-0.1.1.4 # 5
   - retrie-1.2.3
-  - tasty-1.5.3
 
   # stan and friends
   - stan-0.1.3.0


### PR DESCRIPTION
This reverts commit 349ff6e18cbd35a502e05780f0bc6bca4bbc1074.

I don't know why, but this change breaks the usage of `TASTY_PATTERN` and `-p` for filtering by pattern.