### PR TITLE
Ensure usage of stan-0.2.1.0 to fix #4515

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-test-utils
 
 
-index-state: 2025-05-12T13:26:29Z
+index-state: 2025-06-07T14:57:40Z
 
 tests: True
 test-show-details: direct

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -806,7 +806,7 @@ library hls-stan-plugin
     , lsp-types
     , text
     , unordered-containers
-    , stan >= 0.1.2.0
+    , stan >= 0.2.1.0
     , trial
     , directory
 

--- a/stack-lts22.yaml
+++ b/stack-lts22.yaml
@@ -15,6 +15,8 @@ ghc-options:
 allow-newer: true
 allow-newer-deps:
   - extensions
+  # stan dependencies
+  - directory-ospath-streaming
 
 extra-deps:
   - Diff-0.5
@@ -30,7 +32,7 @@ extra-deps:
   - tasty-1.5.3
 
   # stan and friends
-  - stan-0.1.3.0
+  - stan-0.2.1.0
   - dir-traverse-0.2.3.0
   - extensions-0.1.0.1
   - tomland-1.3.3.2
@@ -40,6 +42,7 @@ extra-deps:
   - validation-selective-0.2.0.0
   - cabal-add-0.1
   - cabal-install-parsers-0.6.1.1
+  - directory-ospath-streaming-0.2.2
 
 
 configure-options:
@@ -57,6 +60,9 @@ flags:
     BuildExecutable: false
   cabal-add:
     cabal-syntax: true
+  # stan dependencies
+  directory-ospath-streaming:
+      os-string: false
 
 nix:
   packages: [icu libcxx zlib]

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,6 +17,8 @@ allow-newer-deps:
   - extensions
   - hw-fingertree
   - retrie
+  # stan dependencies
+  - directory-ospath-streaming
 
 extra-deps:
   - floskell-0.11.1
@@ -28,12 +30,13 @@ extra-deps:
   - retrie-1.2.3
 
   # stan dependencies not found in the stackage snapshot
-  - stan-0.1.3.0
+  - stan-0.2.1.0
   - dir-traverse-0.2.3.0
   - extensions-0.1.0.1
   - trial-0.0.0.0
   - trial-optparse-applicative-0.0.0.0
   - trial-tomland-0.0.0.0
+  - directory-ospath-streaming-0.2.2
 
 configure-options:
   ghcide:
@@ -50,6 +53,9 @@ flags:
     BuildExecutable: false
   cabal-add:
     cabal-syntax: true
+  # stan dependencies
+  directory-ospath-streaming:
+      os-string: false
 
 nix:
   packages: [icu libcxx zlib]


### PR DESCRIPTION
- Issue fixed in stan by: https://github.com/kowainik/stan/pull/586
  - The issue persists in ghc < 9.6, but recently hls dropped support for those versions
  - Released in [stan-0.2.1.0](https://hackage.haskell.org/package/stan-0.2.1.0)
- Should close https://github.com/haskell/haskell-language-server/issues/4515#issuecomment-2806627537

Just an update to the index-state and the stan version used. Though the stan version has a major version bump, it's only because of new warnings: https://hackage.haskell.org/package/stan-0.2.1.0/changelog