### PR TITLE
CI: Fix hls-eval-plugin tests for GHC-9.10

### DIFF
--- a/plugins/hls-eval-plugin/test/testdata/TPropertyError.ghc910.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TPropertyError.ghc910.expected.hs
@@ -10,4 +10,8 @@ module TProperty where
 --     errorEmptyList, called at libraries/ghc-internal/src/GHC/Internal/List.hs:96:11 in ghc-internal:GHC.Internal.List
 --     badHead, called at libraries/ghc-internal/src/GHC/Internal/List.hs:90:28 in ghc-internal:GHC.Internal.List
 --     head, called at <interactive>:1:27 in interactive:Ghci2
+--   HasCallStack backtrace:
+--     collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:92:13 in ghc-internal:GHC.Internal.Exception
+--     toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:128:3 in ghc-internal:GHC.Internal.Exception
+--   
 -- []


### PR DESCRIPTION
`hls-eval-plugin` tests are currently failing in CI with:

```
Test output was different from 'plugins/hls-eval-plugin/test/testdata/TPropertyError.ghc910.expected.hs'. Output of ["git","-c","core.fileMode=false","diff","--no-index","--text","--exit-code","plugins/hls-eval-plugin/test/testdata/TPropertyError.ghc910.expected.hs","/tmp/TPropertyError.ghc910.expected89418-27.actual"]:
    diff --git a/plugins/hls-eval-plugin/test/testdata/TPropertyError.ghc910.expected.hs b/tmp/TPropertyError.ghc910.expected89418-27.actual
    index e3208e3..87fbda0 100644
    --- a/plugins/hls-eval-plugin/test/testdata/TPropertyError.ghc910.expected.hs
    +++ b/tmp/TPropertyError.ghc910.expected89418-27.actual
    @@ -10,4 +10,8 @@ module TProperty where
     --     errorEmptyList, called at libraries/ghc-internal/src/GHC/Internal/List.hs:96:11 in ghc-internal:GHC.Internal.List
     --     badHead, called at libraries/ghc-internal/src/GHC/Internal/List.hs:90:28 in ghc-internal:GHC.Internal.List
     --     head, called at <interactive>:1:27 in interactive:Ghci2
    +--   HasCallStack backtrace:
    +--     collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:92:13 in ghc-internal:GHC.Internal.Exception
    +--     toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:128:3 in ghc-internal:GHC.Internal.Exception
    +--   
     -- []
```

This change fixes the failing test