### PR TITLE
Add tests for references to record fields and update symbol retrieval to only include source nodes

### DIFF
--- a/ghcide-test/data/references/Fields.hs
+++ b/ghcide-test/data/references/Fields.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE RecordWildCards #-}
+module Fields where
+
+data Foo = MkFoo
+  {
+    barr :: String,
+    bazz :: String
+  }
+
+fooUse0 :: Foo -> String
+fooUse0 MkFoo{barr} = "5"
+
+fooUse1 :: Foo -> String
+fooUse1 MkFoo{..} = "6"
+
+fooUse2 :: String -> String -> Foo
+fooUse2 bar baz =
+  MkFoo{..}

--- a/ghcide-test/data/references/Main.hs
+++ b/ghcide-test/data/references/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import References
-
+import Fields
 main :: IO ()
 main = return ()
 
@@ -12,3 +12,6 @@ b = a + 1
 
 acc :: Account
 acc = Savings
+
+fooUse3 :: String -> String -> Foo
+fooUse3 bar baz = MkFoo{barr = bar, bazz = baz}

--- a/ghcide-test/data/references/hie.yaml
+++ b/ghcide-test/data/references/hie.yaml
@@ -1,1 +1,1 @@
-cradle: {direct: {arguments: ["Main","OtherModule","OtherOtherModule","References"]}}
+cradle: {direct: {arguments: ["Main","OtherModule","OtherOtherModule","References", "Fields"]}}

--- a/ghcide-test/exe/ReferenceTests.hs
+++ b/ghcide-test/exe/ReferenceTests.hs
@@ -156,6 +156,28 @@ tests = testGroup "references"
                           , ("References.hs", 16, 0)
                           ]
           ]
+        -- Fields.hs does not depend on Main.hs
+        -- so we can only find references in Fields.hs
+        , testGroup "references to record fields"
+          [ referenceTest "references record fields in the same file"
+                          ("Fields.hs", 5, 4)
+                          YesIncludeDeclaration
+                          [ ("Fields.hs", 5, 4)
+                          , ("Fields.hs", 10, 14)
+                          , ("Fields.hs", 13, 14)
+                          ]
+
+          -- Main.hs depends on Fields.hs, so we can find references
+          -- from Main.hs to Fields.hs
+          , referenceTest "references record fields cross modules"
+                          ("Main.hs", 16, 24)
+                          YesIncludeDeclaration
+                          [ ("Fields.hs", 5, 4)
+                          , ("Fields.hs", 10, 14)
+                          , ("Fields.hs", 13, 14)
+                          , ("Main.hs", 16, 24)
+                          ]
+          ]
     ]
 
 -- | When we ask for all references to symbol "foo", should the declaration "foo

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -113,7 +113,7 @@ foiReferencesAtPoint file pos (FOIReferences asts) =
 
 getNamesAtPoint :: HieASTs a -> Position -> PositionMapping -> [Name]
 getNamesAtPoint hf pos mapping =
-  concat $ pointCommand hf posFile (rights . M.keys . getNodeIds)
+  concat $ pointCommand hf posFile (rights . M.keys . getSourceNodeIds)
     where
       posFile = fromMaybe pos $ fromCurrentPosition mapping pos
 


### PR DESCRIPTION
Fix #4412
Very small change, Change `getNamesAtPoint` to only include names in the source.