### PR TITLE
Fix build for GHC 9.10.2

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Error.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Error.hs
@@ -104,7 +104,7 @@ _MismatchMessage _ report = pure report
 
 -- | Focus 'teq_mismatch_expected' from 'TypeEqMismatch'.
 _TypeEqMismatchExpected :: Traversal' MismatchMsg Type
-#if MIN_VERSION_ghc(9,12,0)
+#if MIN_VERSION_ghc(9,10,2)
 _TypeEqMismatchExpected focus mismatch@(TypeEqMismatch _ _ _ expected _ _ _) =
     (\expected' -> mismatch { teq_mismatch_expected = expected' }) <$> focus expected
 #else
@@ -115,7 +115,7 @@ _TypeEqMismatchExpected _ mismatch = pure mismatch
 
 -- | Focus 'teq_mismatch_actual' from 'TypeEqMismatch'.
 _TypeEqMismatchActual :: Traversal' MismatchMsg Type
-#if MIN_VERSION_ghc(9,12,0)
+#if MIN_VERSION_ghc(9,10,2)
 _TypeEqMismatchActual focus mismatch@(TypeEqMismatch _ _ _ _ actual _ _) =
     (\actual' -> mismatch { teq_mismatch_actual = actual' }) <$> focus actual
 #else


### PR DESCRIPTION
This was introduced in #4632. The constructor for `TypeEqMismatch` changed at 9.10.2 (not at 9.12 as I previously thought)

 Previously, this would fail on GHC 9.10.2 (`nix-shell -p haskell.compiler.ghc9102 --command "cabal build all"`):

```
src/Development/IDE/GHC/Compat/Error.hs:111:41: error: [GHC-27346]                                                                                                                                                                                             
    • The data constructor ‘TypeEqMismatch’ should have 7 arguments, but has been given 8                                                                                                                                                                      
    • In the pattern: TypeEqMismatch _ _ _ _ expected _ _ _                                                                                                                                                                                                    
      In an equation for ‘_TypeEqMismatchExpected’:                                                                                                                                                                                                            
          _TypeEqMismatchExpected                                                                                                                                                                                                                              
            focus                                                                                                                                                                                                                                              
            mismatch@(TypeEqMismatch _ _ _ _ expected _ _ _)                                                                                                                                                                                                   
            = (\ expected' -> mismatch {teq_mismatch_expected = expected'})                                                                                                                                                                                    
                <$> focus expected                                                                                                                                                                                                                             
    |                                                                                                                                                                                                                                                          
111 | _TypeEqMismatchExpected focus mismatch@(TypeEqMismatch _ _ _ _ expected _ _ _) =                                                                                                                                                                         
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                            
                                                                                                                                                                                                                                                               
src/Development/IDE/GHC/Compat/Error.hs:122:39: error: [GHC-27346]                                                                                                                                                                                             
    • The data constructor ‘TypeEqMismatch’ should have 7 arguments, but has been given 8                                                                                                                                                                      
    • In the pattern: TypeEqMismatch _ _ _ _ _ actual _ _                                                                                                                                                                                                      
      In an equation for ‘_TypeEqMismatchActual’:                                                                                                                                                                                                              
          _TypeEqMismatchActual                                                                                                                                                                                                                                
            focus                                                                                                                                                                                                                                              
            mismatch@(TypeEqMismatch _ _ _ _ _ actual _ _)                                                                                                                                                                                                     
            = (\ actual' -> mismatch {teq_mismatch_expected = actual'})                                                                                                                                                                                        
                <$> focus actual                                                                                                                                                                                                                               
    |                                                                                                                                                                                                                                                          
122 | _TypeEqMismatchActual focus mismatch@(TypeEqMismatch _ _ _ _ _ actual _ _) =                                                                                                                                                                             
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                
                                                                                                                                                                                                                                                               
Error: [Cabal-7125]                                                                                                                                                                                                                                            
Failed to build ghcide-2.11.0.0 (which is required by exe:ghcide from ghcide-2.11.0.0). 
```