### PR TITLE
Use hie-bios 0.16

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
          ./hls-test-utils
 
 
-index-state: 2025-06-16T09:44:13Z
+index-state: 2025-07-09T16:51:20Z
 
 tests: True
 test-show-details: direct

--- a/ghcide-test/data/multi-unit/a-1.0.0-inplace
+++ b/ghcide-test/data/multi-unit/a-1.0.0-inplace
@@ -16,3 +16,6 @@ base
 text
 -XHaskell98
 A
++RTS
+-A32M
+-RTS

--- a/ghcide-test/data/multi-unit/c-1.0.0-inplace
+++ b/ghcide-test/data/multi-unit/c-1.0.0-inplace
@@ -17,3 +17,5 @@ a-1.0.0-inplace
 base
 -XHaskell98
 C
++RTS
+-A32M

--- a/ghcide-test/exe/CradleTests.hs
+++ b/ghcide-test/exe/CradleTests.hs
@@ -117,7 +117,11 @@ simpleSubDirectoryTest =
 
 multiTests :: FilePath -> [TestTree]
 multiTests dir =
-  [simpleMultiTest dir, simpleMultiTest2 dir, simpleMultiTest3 dir, simpleMultiDefTest dir]
+  [ simpleMultiTest dir
+  , simpleMultiTest2 dir
+  , simpleMultiTest3 dir
+  , simpleMultiDefTest dir
+  ]
 
 multiTestName :: FilePath -> String -> String
 multiTestName dir name = "simple-" ++ dir ++ "-" ++ name

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -73,7 +73,7 @@ library
     , Glob
     , haddock-library              >=1.8      && <1.12
     , hashable
-    , hie-bios                     ^>=0.15.0
+    , hie-bios                     ^>=0.16.0
     , hie-compat                   ^>=0.3.0.0
     , hiedb                        ^>= 0.7.0.0
     , hls-graph                    == 2.11.0.0

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -67,10 +67,10 @@ import           Development.IDE.Types.Location
 import           Development.IDE.Types.Options
 import           GHC.ResponseFile
 import qualified HIE.Bios                            as HieBios
+import qualified HIE.Bios.Cradle.Utils               as HieBios
 import           HIE.Bios.Environment                hiding (getCacheDir)
 import           HIE.Bios.Types                      hiding (Log)
 import qualified HIE.Bios.Types                      as HieBios
-import qualified HIE.Bios.Cradle.Utils               as HieBios
 import           Ide.Logger                          (Pretty (pretty),
                                                       Priority (Debug, Error, Info, Warning),
                                                       Recorder, WithPriority,

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -70,6 +70,7 @@ import qualified HIE.Bios                            as HieBios
 import           HIE.Bios.Environment                hiding (getCacheDir)
 import           HIE.Bios.Types                      hiding (Log)
 import qualified HIE.Bios.Types                      as HieBios
+import qualified HIE.Bios.Cradle.Utils               as HieBios
 import           Ide.Logger                          (Pretty (pretty),
                                                       Priority (Debug, Error, Info, Warning),
                                                       Recorder, WithPriority,
@@ -1144,7 +1145,10 @@ setOptions cfp (ComponentOptions theOpts compRoot _) dflags rootDir = do
       initMulti unitArgFiles =
         forM unitArgFiles $ \f -> do
           args <- liftIO $ expandResponse [f]
-          initOne args
+          -- The reponse files may contain arguments like "+RTS",
+          -- and hie-bios doesn't expand the response files of @-unit@ arguments.
+          -- Thus, we need to do the stripping here.
+          initOne $ HieBios.removeRTS $ HieBios.removeVerbosityOpts args
       initOne this_opts = do
         (dflags', targets') <- addCmdOpts this_opts dflags
         let dflags'' =

--- a/stack-lts22.yaml
+++ b/stack-lts22.yaml
@@ -22,7 +22,7 @@ extra-deps:
   - Diff-0.5
   - floskell-0.11.1
   - hiedb-0.7.0.0
-  - hie-bios-0.15.0
+  - hie-bios-0.16.0
   - implicit-hie-0.1.4.0
   - lsp-2.7.0.0
   - lsp-test-0.17.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ extra-deps:
   - floskell-0.11.1
   - hiedb-0.7.0.0
   - implicit-hie-0.1.4.0
-  - hie-bios-0.15.0
+  - hie-bios-0.16.0
   - hw-fingertree-0.1.2.1
   - monad-dijkstra-0.1.1.5
   - retrie-1.2.3


### PR DESCRIPTION
Adds support for `cabal repl --with-repl`, see https://github.com/haskell/hie-bios/issues/467 and https://github.com/haskell/cabal/issues/9115 for context.

This tests whether HLS uncovers any errors already.

Closes #4590 and closes #3730