### PR TITLE
fix: add context code action with trailing comment

### DIFF
--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Util.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Util.hs
@@ -10,6 +10,7 @@ import           Development.IDE.GHC.Compat.ExactPrint as GHC
 import           Development.IDE.GHC.Dump              (showAstDataHtml)
 import           GHC.Stack
 import           GHC.Utils.Outputable
+import           System.Directory.Extra                (createDirectoryIfMissing)
 import           System.Environment.Blank              (getEnvDefault)
 import           System.IO.Unsafe
 import           Text.Printf
@@ -37,6 +38,7 @@ traceAst lbl x
     doTrace = unsafePerformIO $ do
         u <- U.newUnique
         let htmlDumpFileName = printf "/tmp/hls/%s-%s-%d.html" (show timestamp) lbl (U.hashUnique u)
+        createDirectoryIfMissing True "/tmp/hls"
         writeFile htmlDumpFileName $ renderDump htmlDump
         return $ unlines
             [prettyCallStack callStack ++ ":"

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -3045,7 +3045,7 @@ addFunctionConstraintTests = let
 
     [ "module Testing where"
     , "foo "
-    , "    :: (" <> constraint <> ") =>"
+    , "    :: ("<> constraint <> ") =>"
     , "    -- This is a comment"
     , "    m ()"
     , "foo = pure ()"
@@ -3098,7 +3098,7 @@ addFunctionConstraintTests = let
     "preexisting constraint, with haddock comment in type signature"
     "Add `Applicative m` to the context of the type signature for `foo`"
     (incompleteConstraintSourceCodeWithCommentInTypeSignature "")
-    (incompleteConstraintSourceCodeWithCommentInTypeSignature "Applicative m")
+    (incompleteConstraintSourceCodeWithCommentInTypeSignature " Applicative m")
   , checkCodeAction
     "missing Monad constraint"
     "Add `Monad m` to the context of the type signature for `f`"

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -3036,6 +3036,21 @@ addFunctionConstraintTests = let
     , "eq (Pair x y) (Pair x' y') = x == x' && y == y'"
     ]
 
+  -- See https://github.com/haskell/haskell-language-server/issues/4648
+  -- When haddock comment appears after the =>, code action was introducing the
+  -- new constraint in the comment
+  incompleteConstraintSourceCodeWithCommentInTypeSignature :: T.Text -> T.Text
+  incompleteConstraintSourceCodeWithCommentInTypeSignature constraint =
+    T.unlines
+
+    [ "module Testing where"
+    , "foo "
+    , "    :: (" <> constraint <> ") =>"
+    , "    -- This is a comment"
+    , "    m ()"
+    , "foo = pure ()"
+    ]
+
   missingMonadConstraint constraint = T.unlines
     [ "module Testing where"
     , "f :: " <> constraint <> "m ()"
@@ -3079,6 +3094,11 @@ addFunctionConstraintTests = let
     "Add `Eq b` to the context of the type signature for `eq`"
     (incompleteConstraintSourceCodeWithNewlinesInTypeSignature "Eq a")
     (incompleteConstraintSourceCodeWithNewlinesInTypeSignature "Eq a, Eq b")
+  , checkCodeAction
+    "preexisting constraint, with haddock comment in type signature"
+    "Add `Applicative m` to the context of the type signature for `foo`"
+    (incompleteConstraintSourceCodeWithCommentInTypeSignature "")
+    (incompleteConstraintSourceCodeWithCommentInTypeSignature "Applicative m")
   , checkCodeAction
     "missing Monad constraint"
     "Add `Monad m` to the context of the type signature for `f`"


### PR DESCRIPTION
For now it is just a repro for #4648

Tested with ghc 9.12.2, it seems to fail as expected:

```
[guillaume@gecko:~/srcs/haskell-language-server]$ cabal run hls-refactor-plugin-tests -- -p haddock
Configuration is affected by the following files:
- cabal.project
refactor
  code actions
    add function constraint
      preexisting constraint, with haddock comment in type signature: FAIL (0.84s)
        plugins/hls-refactor-plugin/test/Main.hs:3122:
        expected: "module Testing where\ndata Pair a b = Pair a b\neq \n    :: (Eq a, Eq b)\n    =>\n   -- This is the first argument\n   Pair a b ->\n   -- And this is the second\n   Pair a b ->\n   -- And this is the result\n   Bool\neq (Pair x y) (Pair x' y') = x == x' && y == y'\n"
         but got: "module Testing where\ndata Pair a b = Pair a b\neq \n    :: (Eq a,\n\n   -- This is the first argument Eq b)\n    =>\n\n   Pair a b ->\n   -- And this is the second\n   Pair a b ->\n   -- And this is the result\n   Bool\neq (Pair x y) (Pair x' y') = x == x' && y == y'\n"

1 out of 1 tests failed (0.84s)
```

(see how `Eq b)` is introduced inside the haddock comment `This is the first argument`.

I'm pushing the branch for reference and to test with other GHC version (I'm too lazy to build that locally, cabal cache was hot for ghc 9.12.2).