### PR TITLE
Show LaTeX math expressions in haddockToMarkdown

### DIFF
--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -191,9 +191,9 @@ haddockToMarkdown (H.DocDefList things)
   = '\n' : (unlines $ map (\(term, defn) -> "+ **" ++ haddockToMarkdown term ++ "**: " ++ haddockToMarkdown defn) things)
 
 haddockToMarkdown (H.DocMathInline s)
-  = "$" ++ s ++ "$"
+  = "`" ++ s ++ "`"
 haddockToMarkdown (H.DocMathDisplay s)
-  = "\n$$\n" ++ s ++ "\n$$\n"
+  = "\n```latex\n" ++ s ++ "\n```\n"
 
 -- TODO: render tables
 haddockToMarkdown (H.DocTable _t)

--- a/ghcide/src/Development/IDE/Spans/Common.hs
+++ b/ghcide/src/Development/IDE/Spans/Common.hs
@@ -190,11 +190,10 @@ haddockToMarkdown (H.DocOrderedList things) =
 haddockToMarkdown (H.DocDefList things)
   = '\n' : (unlines $ map (\(term, defn) -> "+ **" ++ haddockToMarkdown term ++ "**: " ++ haddockToMarkdown defn) things)
 
--- we cannot render math by default
-haddockToMarkdown (H.DocMathInline _)
-  = "*cannot render inline math formula*"
-haddockToMarkdown (H.DocMathDisplay _)
-  = "\n\n*cannot render display math formula*\n\n"
+haddockToMarkdown (H.DocMathInline s)
+  = "$" ++ s ++ "$"
+haddockToMarkdown (H.DocMathDisplay s)
+  = "\n$$\n" ++ s ++ "\n$$\n"
 
 -- TODO: render tables
 haddockToMarkdown (H.DocTable _t)


### PR DESCRIPTION
- Replace fallback messages with raw LaTeX math expressions using `$...$` and `$$...$$`.
- This lets editors display the original math content even if they don't render LaTeX.
- No sanitization is performed, raw LaTeX is output as-is.
- Related to #201 