### PR TITLE
Use edit-distance to fix typos in cabal fields

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -60,6 +60,7 @@ library
     , Diff                         ^>=0.5 || ^>=1.0.0
     , directory
     , dlist
+    , edit-distance
     , enummapset
     , exceptions
     , extra                        >=1.7.14
@@ -83,7 +84,6 @@ library
     , list-t
     , lsp                          ^>=2.7
     , lsp-types                    ^>=2.3
-    , MemoTrie
     , mtl
     , opentelemetry                >=0.6.1
     , optparse-applicative

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -83,6 +83,7 @@ library
     , list-t
     , lsp                          ^>=2.7
     , lsp-types                    ^>=2.3
+    , MemoTrie
     , mtl
     , opentelemetry                >=0.6.1
     , optparse-applicative
@@ -196,6 +197,7 @@ library
     Development.IDE.Types.Shake
     Generics.SYB.GHC
     Text.Fuzzy.Parallel
+    Text.Fuzzy.Levenshtein
 
   other-modules:
     Development.IDE.Core.FileExists

--- a/ghcide/src/Text/Fuzzy/Levenshtein.hs
+++ b/ghcide/src/Text/Fuzzy/Levenshtein.hs
@@ -1,36 +1,16 @@
 module Text.Fuzzy.Levenshtein where
 
-import           Data.Function       (fix)
 import           Data.List           (sortOn)
-import           Data.MemoTrie
+import           Data.Text           (Text)
 import qualified Data.Text           as T
-import qualified Data.Text.Array     as T
-import           Data.Text.Internal  (Text (..))
+import           Text.EditDistance
 import           Text.Fuzzy.Parallel
-
--- | Same caveats apply w.r.t. ASCII as in 'Text.Fuzzy.Parallel'.
--- Might be worth optimizing this at some point, but it's good enoughᵗᵐ for now
-levenshtein :: Text -> Text -> Int
-levenshtein a b | T.null a = T.length b
-levenshtein a b | T.null b = T.length a
-levenshtein (Text aBuf aOff aLen) (Text bBuf bOff bLen) = do
-  let aTot = aOff + aLen
-      bTot = bOff + bLen
-      go' _ (!aIx, !bIx) | aIx >= aTot || bIx >= bTot = max (aTot - aIx) (bTot - bIx)
-      go' f (!aIx, !bIx) | T.unsafeIndex aBuf aIx == T.unsafeIndex bBuf bIx = f (aIx + 1, bIx + 1)
-      go' f (!aIx, !bIx) =
-        minimum
-          [ 2 + f (aIx + 1, bIx + 1), -- Give substitutions a heavier cost, so multiple typos cost more
-            1 + f (aIx + 1, bIx),
-            1 + f (aIx, bIx + 1)
-          ]
-      go = fix (memo . go')
-  go (aOff, bOff)
 
 -- | Sort the given list according to it's levenshtein distance relative to the
 -- given string.
 levenshteinScored :: Int -> Text -> [Text] -> [Scored Text]
-levenshteinScored chunkSize needle haystack =
+levenshteinScored chunkSize needle haystack = do
+  let levenshtein = levenshteinDistance $ defaultEditCosts {substitutionCosts=ConstantCost 2}
   sortOn score $
     matchPar chunkSize needle haystack id $
-      \a b -> Just $ levenshtein a b
+      \a b -> Just $ levenshtein (T.unpack a) (T.unpack b)

--- a/ghcide/src/Text/Fuzzy/Levenshtein.hs
+++ b/ghcide/src/Text/Fuzzy/Levenshtein.hs
@@ -1,0 +1,36 @@
+module Text.Fuzzy.Levenshtein where
+
+import           Data.Function       (fix)
+import           Data.List           (sortOn)
+import           Data.MemoTrie
+import qualified Data.Text           as T
+import qualified Data.Text.Array     as T
+import           Data.Text.Internal  (Text (..))
+import           Text.Fuzzy.Parallel
+
+-- | Same caveats apply w.r.t. ASCII as in 'Text.Fuzzy.Parallel'.
+-- Might be worth optimizing this at some point, but it's good enoughᵗᵐ for now
+levenshtein :: Text -> Text -> Int
+levenshtein a b | T.null a = T.length b
+levenshtein a b | T.null b = T.length a
+levenshtein (Text aBuf aOff aLen) (Text bBuf bOff bLen) = do
+  let aTot = aOff + aLen
+      bTot = bOff + bLen
+      go' _ (!aIx, !bIx) | aIx >= aTot || bIx >= bTot = max (aTot - aIx) (bTot - bIx)
+      go' f (!aIx, !bIx) | T.unsafeIndex aBuf aIx == T.unsafeIndex bBuf bIx = f (aIx + 1, bIx + 1)
+      go' f (!aIx, !bIx) =
+        minimum
+          [ 2 + f (aIx + 1, bIx + 1), -- Give substitutions a heavier cost, so multiple typos cost more
+            1 + f (aIx + 1, bIx),
+            1 + f (aIx, bIx + 1)
+          ]
+      go = fix (memo . go')
+  go (aOff, bOff)
+
+-- | Sort the given list according to it's levenshtein distance relative to the
+-- given string.
+levenshteinScored :: Int -> Text -> [Text] -> [Scored Text]
+levenshteinScored chunkSize needle haystack =
+  sortOn score $
+    matchPar chunkSize needle haystack id $
+      \a b -> Just $ levenshtein a b

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -1,10 +1,10 @@
 -- | Parallel versions of 'filter' and 'simpleFilter'
 
 module Text.Fuzzy.Parallel
-(   filter, filter',
+(   filter, filter', matchPar,
     simpleFilter, simpleFilter',
     match, defChunkSize, defMaxResults,
-    Scored(..)
+    Scored(..), Matcher (..)
 ) where
 
 import           Control.Parallel.Strategies (evalList, parList, rseq, using)
@@ -17,6 +17,8 @@ import           Prelude                     hiding (filter)
 
 data Scored a = Scored {score :: !Int, original:: !a}
   deriving (Functor, Show)
+
+newtype Matcher a = Matcher { runMatcher :: T.Text -> [T.Text] -> [Scored a] }
 
 -- | Returns the rendered output and the
 -- matching score for a pattern and a text.
@@ -103,15 +105,29 @@ filter' :: Int           -- ^ Chunk size. 1000 works well.
        -- ^ Custom scoring function to use for calculating how close words are
        -- When the function returns Nothing, this means the values are incomparable.
        -> [Scored t]    -- ^ The list of results, sorted, highest score first.
-filter' chunkSize maxRes pat ts extract match' = partialSortByAscScore maxRes perfectScore (concat vss)
+filter' chunkSize maxRes pat ts extract match' = partialSortByAscScore maxRes perfectScore $
+    matchPar chunkSize pat' ts extract match'
   where
-      -- Preserve case for the first character, make all others lowercase
-      pat' = case T.uncons pat of
+    perfectScore = fromMaybe (error $ T.unpack pat) $ match' pat pat
+    -- Preserve case for the first character, make all others lowercase
+    pat' = case T.uncons pat of
         Just (c, rest) -> T.cons c (T.toLower rest)
         _              -> pat
-      vss = map (mapMaybe (\t -> flip Scored t <$> match' pat' (extract t))) (chunkList chunkSize ts)
+
+matchPar
+    :: Int           -- ^ Chunk size. 1000 works well.
+    -> T.Text        -- ^ Pattern.
+    -> [t]           -- ^ The list of values containing the text to search in.
+    -> (t -> T.Text) -- ^ The function to extract the text from the container.
+    -> (T.Text -> T.Text -> Maybe Int)
+    -- ^ Custom scoring function to use for calculating how close words are
+    -- When the function returns Nothing, this means the values are incomparable.
+    -> [Scored t]    -- ^ The list of results, sorted, highest score first.
+{-# INLINABLE matchPar #-}
+matchPar chunkSize pat ts extract match' = concat vss
+  where
+    vss = map (mapMaybe (\t -> flip Scored t <$> match' pat (extract t))) (chunkList chunkSize ts)
         `using` parList (evalList rseq)
-      perfectScore = fromMaybe (error $ T.unpack pat) $ match' pat' pat'
 
 -- | The function to filter a list of values by fuzzy search on the text extracted from them,
 -- using a custom matching function which determines how close words are.

--- a/ghcide/src/Text/Fuzzy/Parallel.hs
+++ b/ghcide/src/Text/Fuzzy/Parallel.hs
@@ -4,7 +4,7 @@ module Text.Fuzzy.Parallel
 (   filter, filter', matchPar,
     simpleFilter, simpleFilter',
     match, defChunkSize, defMaxResults,
-    Scored(..), Matcher (..)
+    Scored(..)
 ) where
 
 import           Control.Parallel.Strategies (evalList, parList, rseq, using)
@@ -17,8 +17,6 @@ import           Prelude                     hiding (filter)
 
 data Scored a = Scored {score :: !Int, original:: !a}
   deriving (Functor, Show)
-
-newtype Matcher a = Matcher { runMatcher :: T.Text -> [T.Text] -> [Scored a] }
 
 -- | Returns the rendered output and the
 -- matching score for a pattern and a text.

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -55,6 +55,8 @@ import qualified Language.LSP.Protocol.Lens                    as JL
 import qualified Language.LSP.Protocol.Message                 as LSP
 import           Language.LSP.Protocol.Types
 import qualified Language.LSP.VFS                              as VFS
+import qualified Text.Fuzzy.Levenshtein                        as Fuzzy
+import qualified Text.Fuzzy.Parallel                           as Fuzzy
 import           Text.Regex.TDFA
 
 data Log
@@ -234,7 +236,9 @@ fieldSuggestCodeAction recorder ide _ (CodeActionParams _ _ (TextDocumentIdentif
       fakeLspCursorPosition = Position lineNr (col + fromIntegral (T.length fieldName))
       lspPrefixInfo = Ghcide.getCompletionPrefixFromRope fakeLspCursorPosition fileContents
       cabalPrefixInfo = Completions.getCabalPrefixInfo fp lspPrefixInfo
-    completions <- liftIO $ computeCompletionsAt recorder ide cabalPrefixInfo fp cabalFields
+    completions <- liftIO $ computeCompletionsAt recorder ide cabalPrefixInfo fp cabalFields $
+      Fuzzy.Matcher $
+        Fuzzy.levenshteinScored Fuzzy.defChunkSize
     let completionTexts = fmap (^. JL.label) completions
     pure $ FieldSuggest.fieldErrorAction uri fieldName completionTexts _range
 
@@ -365,12 +369,21 @@ completion recorder ide _ complParams = do
         Just (fields, _) -> do
           let lspPrefInfo = Ghcide.getCompletionPrefixFromRope position cnts
               cabalPrefInfo = Completions.getCabalPrefixInfo path lspPrefInfo
-          let res = computeCompletionsAt recorder ide cabalPrefInfo path fields
+              res = computeCompletionsAt recorder ide cabalPrefInfo path fields $
+                Fuzzy.Matcher $
+                  Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
           liftIO $ fmap InL res
     Nothing -> pure . InR $ InR Null
 
-computeCompletionsAt :: Recorder (WithPriority Log) -> IdeState -> Types.CabalPrefixInfo -> FilePath -> [Syntax.Field Syntax.Position] -> IO [CompletionItem]
-computeCompletionsAt recorder ide prefInfo fp fields = do
+computeCompletionsAt
+  :: Recorder (WithPriority Log)
+  -> IdeState
+  -> Types.CabalPrefixInfo
+  -> FilePath
+  -> [Syntax.Field Syntax.Position]
+  -> Fuzzy.Matcher T.Text
+  -> IO [CompletionItem]
+computeCompletionsAt recorder ide prefInfo fp fields matcher = do
   runMaybeT (context fields) >>= \case
     Nothing -> pure []
     Just ctx -> do
@@ -390,6 +403,7 @@ computeCompletionsAt recorder ide prefInfo fp fields = do
                   case fst ctx of
                     Types.Stanza _ name -> name
                     _                   -> Nothing
+              , matcher = matcher
               }
       completions <- completer completerRecorder completerData
       pure completions

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE TypeFamilies          #-}
 
 module Ide.Plugin.Cabal (descriptor, haskellInteractionDescriptor, Log (..)) where
@@ -237,7 +236,7 @@ fieldSuggestCodeAction recorder ide _ (CodeActionParams _ _ (TextDocumentIdentif
       lspPrefixInfo = Ghcide.getCompletionPrefixFromRope fakeLspCursorPosition fileContents
       cabalPrefixInfo = Completions.getCabalPrefixInfo fp lspPrefixInfo
     completions <- liftIO $ computeCompletionsAt recorder ide cabalPrefixInfo fp cabalFields $
-      Fuzzy.Matcher $
+      CompleterTypes.Matcher $
         Fuzzy.levenshteinScored Fuzzy.defChunkSize
     let completionTexts = fmap (^. JL.label) completions
     pure $ FieldSuggest.fieldErrorAction uri fieldName completionTexts _range
@@ -370,7 +369,7 @@ completion recorder ide _ complParams = do
           let lspPrefInfo = Ghcide.getCompletionPrefixFromRope position cnts
               cabalPrefInfo = Completions.getCabalPrefixInfo path lspPrefInfo
               res = computeCompletionsAt recorder ide cabalPrefInfo path fields $
-                Fuzzy.Matcher $
+                CompleterTypes.Matcher $
                   Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
           liftIO $ fmap InL res
     Nothing -> pure . InR $ InR Null
@@ -381,7 +380,7 @@ computeCompletionsAt
   -> Types.CabalPrefixInfo
   -> FilePath
   -> [Syntax.Field Syntax.Position]
-  -> Fuzzy.Matcher T.Text
+  -> CompleterTypes.Matcher T.Text
   -> IO [CompletionItem]
 computeCompletionsAt recorder ide prefInfo fp fields matcher = do
   runMaybeT (context fields) >>= \case

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Module.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Module.hs
@@ -33,8 +33,7 @@ modulesCompleter extractionFunction recorder cData = do
   case mGPD of
     Just gpd -> do
       let sourceDirs = extractionFunction sName gpd
-      filePathCompletions <-
-        filePathsForExposedModules recorder sourceDirs prefInfo
+      filePathCompletions <- filePathsForExposedModules recorder sourceDirs prefInfo (matcher cData)
       pure $ map (\compl -> mkSimpleCompletionItem (completionRange prefInfo) compl) filePathCompletions
     Nothing -> do
       logWith recorder Debug LogUseWithStaleFastNoResult
@@ -45,8 +44,13 @@ modulesCompleter extractionFunction recorder cData = do
 
 -- | Takes a list of source directories and returns a list of path completions
 --  relative to any of the passed source directories which fit the passed prefix info.
-filePathsForExposedModules :: Recorder (WithPriority Log) -> [FilePath] -> CabalPrefixInfo -> IO [T.Text]
-filePathsForExposedModules recorder srcDirs prefInfo = do
+filePathsForExposedModules
+  :: Recorder (WithPriority Log)
+  -> [FilePath]
+  -> CabalPrefixInfo
+  -> Fuzzy.Matcher T.Text
+  -> IO [T.Text]
+filePathsForExposedModules recorder srcDirs prefInfo matcher = do
   concatForM
     srcDirs
     ( \dir' -> do
@@ -55,9 +59,8 @@ filePathsForExposedModules recorder srcDirs prefInfo = do
         completions <- listFileCompletions recorder pathInfo
         validExposedCompletions <- filterM (isValidExposedModulePath pathInfo) completions
         let toMatch = pathSegment pathInfo
-            scored = Fuzzy.simpleFilter
-              Fuzzy.defChunkSize
-              Fuzzy.defMaxResults
+            scored = Fuzzy.runMatcher
+              matcher
               toMatch
               (map T.pack validExposedCompletions)
         forM

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Module.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Module.hs
@@ -48,7 +48,7 @@ filePathsForExposedModules
   :: Recorder (WithPriority Log)
   -> [FilePath]
   -> CabalPrefixInfo
-  -> Fuzzy.Matcher T.Text
+  -> Matcher T.Text
   -> IO [T.Text]
 filePathsForExposedModules recorder srcDirs prefInfo matcher = do
   concatForM
@@ -59,7 +59,7 @@ filePathsForExposedModules recorder srcDirs prefInfo matcher = do
         completions <- listFileCompletions recorder pathInfo
         validExposedCompletions <- filterM (isValidExposedModulePath pathInfo) completions
         let toMatch = pathSegment pathInfo
-            scored = Fuzzy.runMatcher
+            scored = runMatcher
               matcher
               toMatch
               (map T.pack validExposedCompletions)

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Simple.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Simple.hs
@@ -41,7 +41,7 @@ errorNoopCompleter l recorder _ = do
 constantCompleter :: [T.Text] -> Completer
 constantCompleter completions _ cData = do
   let prefInfo = cabalPrefixInfo cData
-      scored = Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults (completionPrefix prefInfo) completions
+      scored = Fuzzy.runMatcher (matcher cData) (completionPrefix prefInfo) completions
       range = completionRange prefInfo
   pure $ map (mkSimpleCompletionItem range . Fuzzy.original) scored
 
@@ -68,7 +68,7 @@ importCompleter l cData = do
 -- it is just forbidden on hackage.
 nameCompleter :: Completer
 nameCompleter _ cData = do
-  let scored = Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults (completionPrefix prefInfo) [completionFileName prefInfo]
+  let scored = Fuzzy.runMatcher (matcher cData) (completionPrefix prefInfo) [completionFileName prefInfo]
       prefInfo = cabalPrefixInfo cData
       range = completionRange prefInfo
   pure $ map (mkSimpleCompletionItem range . Fuzzy.original) scored
@@ -85,6 +85,7 @@ weightedConstantCompleter completions weights _ cData = do
   let scored =
         if perfectScore > 0
           then
+            -- TODO: Would be nice to use to be able to use the matcher in `cData`
             fmap Fuzzy.original $
               Fuzzy.simpleFilter' Fuzzy.defChunkSize Fuzzy.defMaxResults prefix completions customMatch
           else topTenByWeight

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Simple.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Simple.hs
@@ -41,7 +41,7 @@ errorNoopCompleter l recorder _ = do
 constantCompleter :: [T.Text] -> Completer
 constantCompleter completions _ cData = do
   let prefInfo = cabalPrefixInfo cData
-      scored = Fuzzy.runMatcher (matcher cData) (completionPrefix prefInfo) completions
+      scored = runMatcher (matcher cData) (completionPrefix prefInfo) completions
       range = completionRange prefInfo
   pure $ map (mkSimpleCompletionItem range . Fuzzy.original) scored
 
@@ -68,7 +68,7 @@ importCompleter l cData = do
 -- it is just forbidden on hackage.
 nameCompleter :: Completer
 nameCompleter _ cData = do
-  let scored = Fuzzy.runMatcher (matcher cData) (completionPrefix prefInfo) [completionFileName prefInfo]
+  let scored = runMatcher (matcher cData) (completionPrefix prefInfo) [completionFileName prefInfo]
       prefInfo = cabalPrefixInfo cData
       range = completionRange prefInfo
   pure $ map (mkSimpleCompletionItem range . Fuzzy.original) scored

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Types.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Types.hs
@@ -2,12 +2,14 @@
 
 module Ide.Plugin.Cabal.Completion.Completer.Types where
 
+import           Data.Text                         (Text)
 import           Development.IDE                   as D
 import qualified Distribution.Fields               as Syntax
 import           Distribution.PackageDescription   (GenericPackageDescription)
 import qualified Distribution.Parsec.Position      as Syntax
 import           Ide.Plugin.Cabal.Completion.Types
 import           Language.LSP.Protocol.Types       (CompletionItem)
+import qualified Text.Fuzzy.Parallel               as Fuzzy
 
 -- | Takes information needed to build possible completion items
 -- and returns the list of possible completion items
@@ -24,5 +26,7 @@ data CompleterData = CompleterData
     -- | Prefix info to be used for constructing completion items
     cabalPrefixInfo        :: CabalPrefixInfo,
     -- | The name of the stanza in which the completer is applied
-    stanzaName             :: Maybe StanzaName
+    stanzaName             :: Maybe StanzaName,
+    -- | The matcher that'll be used to rank the texts against the pattern.
+    matcher                :: Fuzzy.Matcher Text
   }

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Types.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/Types.hs
@@ -3,17 +3,21 @@
 module Ide.Plugin.Cabal.Completion.Completer.Types where
 
 import           Data.Text                         (Text)
+import qualified Data.Text                         as T
 import           Development.IDE                   as D
 import qualified Distribution.Fields               as Syntax
 import           Distribution.PackageDescription   (GenericPackageDescription)
 import qualified Distribution.Parsec.Position      as Syntax
 import           Ide.Plugin.Cabal.Completion.Types
 import           Language.LSP.Protocol.Types       (CompletionItem)
-import qualified Text.Fuzzy.Parallel               as Fuzzy
+import           Text.Fuzzy.Parallel
 
 -- | Takes information needed to build possible completion items
 -- and returns the list of possible completion items
 type Completer = Recorder (WithPriority Log) -> CompleterData -> IO [CompletionItem]
+
+-- | Type signature of completion functions ranking texts against a pattern.
+newtype Matcher a = Matcher { runMatcher :: T.Text -> [T.Text] -> [Scored a] }
 
 -- | Contains information to be used by completers.
 data CompleterData = CompleterData
@@ -28,5 +32,5 @@ data CompleterData = CompleterData
     -- | The name of the stanza in which the completer is applied
     stanzaName             :: Maybe StanzaName,
     -- | The matcher that'll be used to rank the texts against the pattern.
-    matcher                :: Fuzzy.Matcher Text
+    matcher                :: Matcher Text
   }

--- a/plugins/hls-cabal-plugin/test/Completer.hs
+++ b/plugins/hls-cabal-plugin/test/Completer.hs
@@ -21,7 +21,8 @@ import           Ide.Plugin.Cabal.Completion.Completer.FilePath
 import           Ide.Plugin.Cabal.Completion.Completer.Module
 import           Ide.Plugin.Cabal.Completion.Completer.Paths
 import           Ide.Plugin.Cabal.Completion.Completer.Simple   (importCompleter)
-import           Ide.Plugin.Cabal.Completion.Completer.Types    (CompleterData (..))
+import           Ide.Plugin.Cabal.Completion.Completer.Types    (CompleterData (..),
+                                                                 Matcher (..))
 import           Ide.Plugin.Cabal.Completion.Completions
 import           Ide.Plugin.Cabal.Completion.Types              (CabalPrefixInfo (..),
                                                                  StanzaName)
@@ -271,7 +272,7 @@ filePathExposedModulesTests =
     callFilePathsForExposedModules :: [FilePath] -> IO [T.Text]
     callFilePathsForExposedModules srcDirs = do
       let prefInfo = simpleCabalPrefixInfoFromFp "" exposedTestDir
-      filePathsForExposedModules mempty srcDirs prefInfo $ Fuzzy.Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
+      filePathsForExposedModules mempty srcDirs prefInfo $ Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
 
 exposedModuleCompleterTests :: TestTree
 exposedModuleCompleterTests =
@@ -368,7 +369,7 @@ simpleCompleterData sName dir pref = do
         pure $ parseGenericPackageDescriptionMaybe cabalContents,
       getCabalCommonSections = undefined,
       stanzaName = sName,
-      matcher = Fuzzy.Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
+      matcher = Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
     }
 
 mkCompleterData :: CabalPrefixInfo -> CompleterData
@@ -378,7 +379,7 @@ mkCompleterData prefInfo =
       getCabalCommonSections = undefined,
       cabalPrefixInfo = prefInfo,
       stanzaName = Nothing,
-      matcher = Fuzzy.Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
+      matcher = Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
     }
 
 exposedTestDir :: FilePath

--- a/plugins/hls-cabal-plugin/test/Completer.hs
+++ b/plugins/hls-cabal-plugin/test/Completer.hs
@@ -28,6 +28,7 @@ import           Ide.Plugin.Cabal.Completion.Types              (CabalPrefixInfo
 import qualified Language.LSP.Protocol.Lens                     as L
 import           System.FilePath
 import           Test.Hls
+import qualified Text.Fuzzy.Parallel                            as Fuzzy
 import           Utils
 
 completerTests :: TestTree
@@ -270,7 +271,7 @@ filePathExposedModulesTests =
     callFilePathsForExposedModules :: [FilePath] -> IO [T.Text]
     callFilePathsForExposedModules srcDirs = do
       let prefInfo = simpleCabalPrefixInfoFromFp "" exposedTestDir
-      filePathsForExposedModules mempty srcDirs prefInfo
+      filePathsForExposedModules mempty srcDirs prefInfo $ Fuzzy.Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
 
 exposedModuleCompleterTests :: TestTree
 exposedModuleCompleterTests =
@@ -366,11 +367,19 @@ simpleCompleterData sName dir pref = do
         cabalContents <- ByteString.readFile $ testDataDir </> "exposed.cabal"
         pure $ parseGenericPackageDescriptionMaybe cabalContents,
       getCabalCommonSections = undefined,
-      stanzaName = sName
+      stanzaName = sName,
+      matcher = Fuzzy.Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
     }
 
 mkCompleterData :: CabalPrefixInfo -> CompleterData
-mkCompleterData prefInfo = CompleterData {getLatestGPD = undefined, getCabalCommonSections = undefined, cabalPrefixInfo = prefInfo, stanzaName = Nothing}
+mkCompleterData prefInfo =
+  CompleterData
+    { getLatestGPD = undefined,
+      getCabalCommonSections = undefined,
+      cabalPrefixInfo = prefInfo,
+      stanzaName = Nothing,
+      matcher = Fuzzy.Matcher $ Fuzzy.simpleFilter Fuzzy.defChunkSize Fuzzy.defMaxResults
+    }
 
 exposedTestDir :: FilePath
 exposedTestDir = addTrailingPathSeparator $ testDataDir </> "src-modules"

--- a/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestions.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestions.cabal
@@ -21,9 +21,8 @@ source-repository head
   loc: fake
 
 library
-    default-lang: Haskell2010
-    -- Import isn't supported right now.
     impor: warnings
+    default-lang: Haskell2010
     build-dep: base
 
 executable my-exe

--- a/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestions.golden.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestions.golden.cabal
@@ -21,9 +21,8 @@ source-repository head
   location: fake
 
 library
-    default-language: Haskell2010
-    -- Import isn't supported right now.
     import: warnings
+    default-language: Haskell2010
     build-depends: base
 
 executable my-exe

--- a/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestionsTypos.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestionsTypos.cabal
@@ -21,9 +21,8 @@ source-repository head
   locqt: fake
 
 library
-    qqjfault-lang: Haskell2010
-    -- Import isn't supported right now.
     iqqor: warnings
+    qqjfault-lang: Haskell2010
     bqqld-dep: base
 
 executable my-exe

--- a/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestionsTypos.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestionsTypos.cabal
@@ -1,0 +1,36 @@
+cabal-version: 3.0
+name: FieldSuggestions
+version: 0.1.0
+liqns:            BSD-3-Clause
+
+quil-type: Simple
+
+qqxtra-doc-fils:
+    ChangeLog
+
+-- Default warnings in HLS
+common warnings
+  ghq-option: -Wall
+               -Wredundant-constraints
+               -Wunused-packages
+               -Wno-name-shadowing
+               -Wno-unticked-promoted-constructors
+
+source-repository head
+  type:     git
+  locqt: fake
+
+library
+    qqjfault-lang: Haskell2010
+    -- Import isn't supported right now.
+    iqqor: warnings
+    bqqld-dep: base
+
+executable my-exe
+    mbn-is: Main.hs
+
+test-suite Test
+    type: exitcode-stdio-1.0
+    main-is: Test.hs
+    hqqqsource-drs:
+

--- a/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestionsTypos.golden.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestionsTypos.golden.cabal
@@ -21,9 +21,8 @@ source-repository head
   location: fake
 
 library
-    default-language: Haskell2010
-    -- Import isn't supported right now.
     import: warnings
+    default-language: Haskell2010
     build-depends: base
 
 executable my-exe

--- a/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestionsTypos.golden.cabal
+++ b/plugins/hls-cabal-plugin/test/testdata/code-actions/FieldSuggestionsTypos.golden.cabal
@@ -1,0 +1,36 @@
+cabal-version: 3.0
+name: FieldSuggestions
+version: 0.1.0
+license:            BSD-3-Clause
+
+build-type: Simple
+
+extra-doc-files:
+    ChangeLog
+
+-- Default warnings in HLS
+common warnings
+  ghc-options: -Wall
+               -Wredundant-constraints
+               -Wunused-packages
+               -Wno-name-shadowing
+               -Wno-unticked-promoted-constructors
+
+source-repository head
+  type:     git
+  location: fake
+
+library
+    default-language: Haskell2010
+    -- Import isn't supported right now.
+    import: warnings
+    build-depends: base
+
+executable my-exe
+    main-is: Main.hs
+
+test-suite Test
+    type: exitcode-stdio-1.0
+    main-is: Test.hs
+    hs-source-dirs:
+


### PR DESCRIPTION
Closes #4357.

This adds a pretty simple function for calculating the edit distance between two strings and uses it to score suggestions in completion lists. Some 
- I increased the cost of substitutions, otherwise the suggestions would very often lean towards nonsense.
- Kind of hackily injected the `Matcher` that's used in scoring texts into `CompleterData`. Couldn't really massage that into the `weightedConstantCompleter` that's used for licenses.
- This new scoring function doesn't do any filtering, so I had to adjust the cabal codeaction golden test to pick the top action per diagnostic.