### PR TITLE
Capture output of `eval` plugin and some girls scout changes

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Logger.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Logger.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
--- | Compat module for GHC 9.2 Logger infrastructure.
+-- | Compat module for logger infrastructure.
 module Development.IDE.GHC.Compat.Logger (
     putLogHook,
     Logger.pushLogHook,

--- a/ghcide/src/Development/IDE/Spans/AtPoint.hs
+++ b/ghcide/src/Development/IDE/Spans/AtPoint.hs
@@ -25,7 +25,8 @@ module Development.IDE.Spans.AtPoint (
   ) where
 
 
-import           GHC.Data.FastString                  (lengthFS)
+import           GHC.Data.FastString                  (LexicalFastString (..),
+                                                       lengthFS)
 import qualified GHC.Utils.Outputable                 as O
 
 import           Development.IDE.GHC.Error
@@ -50,7 +51,6 @@ import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
-import           Data.Coerce                          (coerce)
 import qualified Data.HashMap.Strict                  as HM
 import qualified Data.Map.Strict                      as M
 import           Data.Maybe
@@ -669,18 +669,8 @@ defRowToSymbolInfo _ = Nothing
 
 pointCommand :: HieASTs t -> Position -> (HieAST t -> a) -> [a]
 pointCommand hf pos k =
-    M.elems $ flip M.mapMaybeWithKey (getAsts hf) $ \fs ast ->
-      -- Since GHC 9.2:
-      -- getAsts :: Map HiePath (HieAst a)
-      -- type HiePath = LexicalFastString
-      --
-      -- but before:
-      -- getAsts :: Map HiePath (HieAst a)
-      -- type HiePath = FastString
-      --
-      -- 'coerce' here to avoid an additional function for maintaining
-      -- backwards compatibility.
-      case selectSmallestContaining (sp $ coerce fs) ast of
+    M.elems $ flip M.mapMaybeWithKey (getAsts hf) $ \(LexicalFastString fs) ast ->
+      case selectSmallestContaining (sp fs) ast of
         Nothing   -> Nothing
         Just ast' -> Just $ k ast'
  where

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -479,6 +479,7 @@ library hls-eval-plugin
     , deepseq
     , Diff                  ^>=0.5 || ^>=1.0.0
     , dlist
+    , exceptions
     , extra
     , filepath
     , ghc

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -487,7 +487,7 @@ library hls-eval-plugin
     , hls-graph
     , hls-plugin-api        == 2.14.0.0
     , lens
-    , lsp
+    , lsp                   ^>=2.8
     , lsp-types
     , megaparsec            >=9.0
     , mtl

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1392,7 +1392,7 @@ library hls-fourmolu-plugin
     , ghcide          == 2.14.0.0
     , hls-plugin-api  == 2.14.0.0
     , lens
-    , lsp
+    , lsp             ^>= 2.8
     , mtl
     , process-extras  >= 0.7.1
     , text

--- a/plugins/hls-eval-plugin/README.md
+++ b/plugins/hls-eval-plugin/README.md
@@ -259,40 +259,18 @@ This is a problem if you want, for example, to pretty print a value (in this cas
 "[ 1\n, 2\n, 3\n]"
 ```
 
-We could try to print the pretty-print output, but stdout is not captured so we get just a ():
-
+Instead, we can do
 ```
->>> print $ pShowNoColor [1..7]
-()
+>>> mapM_ putStrLn $ lines pShowNoColor [1..7]
+-- [ 1
+-- , 2
+-- , 3
+-- ]
 ```
-
-To display it properly, we can exploit the fact that the output of an error is displayed as a multi-line text:
-
-```
->>> import qualified Data.Text.Lazy as TL
->>> import Text.Pretty.Simple
->>> prettyPrint v = error (TL.unpack $ pShowNoColor v) :: IO String
->>> prettyPrint [1..3]
-[ 1
-, 2
-, 3
-]
-```
-
-This assumes you did not turn on exception marking (see [Marking exceptions](#marking-exceptions) below).
 
 # Differences with doctest
 
 Though the Eval plugin functionality is quite similar to that of [doctest](https://hackage.haskell.org/package/doctest), some doctest's features are not supported.
-
-### Capturing Stdout
-
-Only the value of an IO expression is spliced in, not its output:
-
-```
->>> print "foo"
-()
-```
 
 ###  Marking exceptions
 

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
@@ -68,12 +68,20 @@ showDiff (Second w) = "NOW " <> w
 showDiff (Both w _) = w
 
 -- | Compare the expected output recorded in the 'EvalExpr' with the actual
--- output @out@. When diffing is enabled and there is a recorded output, return
--- a line-by-line diff (see 'showDiffs'); otherwise return @out@ unchanged.
+-- output @out@, returning the result as one 'T.Text' per line. When diffing is
+-- enabled and there is a recorded output, return a line-by-line diff (see
+-- 'showDiffs'); otherwise return @out@ unchanged.
+--
+-- @out@ is normalised to one element per line first: a multi-line result
+-- arrives here as a single element with embedded newlines, whereas the recorded
+-- output is already split per line, and 'getDiff' compares element-wise. Without
+-- this, identical multi-line results would be reported as entirely changed.
 evalExprCheck :: Bool -> (Section, EvalExpr) -> [T.Text] -> [T.Text]
 evalExprCheck diff (section, evalExpr) out
-    | not diff || null (evalExprOutput evalExpr) || sectionLanguage section == Plain = out
-    | otherwise = showDiffs $ getDiff (map T.pack $ evalExprOutput evalExpr) out
+    | not diff || null (evalExprOutput evalExpr) || sectionLanguage section == Plain = outLines
+    | otherwise = showDiffs $ getDiff (map T.pack $ evalExprOutput evalExpr) outLines
+  where
+    outLines = concatMap T.lines out
 
 -- | The number of (expression lines, result lines) an 'EvalExpr' occupies.
 evalExprLengths :: EvalExpr -> (Int, Int)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
@@ -72,11 +72,15 @@ showDiff (First w)  = "WAS " <> w
 showDiff (Second w) = "NOW " <> w
 showDiff (Both w _) = w
 
+-- | Compare the expected output recorded in the test with the actual output
+-- @out@. When diffing is enabled and there is a recorded output, return a
+-- line-by-line diff (see 'showDiffs'); otherwise return @out@ unchanged.
 testCheck :: Bool -> (Section, Test) -> [T.Text] -> [T.Text]
 testCheck diff (section, test) out
     | not diff || null (testOutput test) || sectionLanguage section == Plain = out
     | otherwise = showDiffs $ getDiff (map T.pack $ testOutput test) out
 
+-- | The number of (expression lines, result lines) a test occupies.
 testLengths :: Test -> (Int, Int)
 testLengths (Example e r _)  = (NE.length e, length r)
 testLengths (Property _ r _) = (1, length r)
@@ -84,9 +88,13 @@ testLengths (Property _ r _) = (1, length r)
 -- |A one-line Haskell statement
 type Statement = Loc String
 
+-- | The Haskell statements to feed to GHCi for a test, each tagged with its
+-- source line so evaluation errors can be located.
 asStatements :: Test -> [Statement]
 asStatements lt = locate $ Located (fromIntegral $ testRange lt ^. L.start . L.line) (asStmts lt)
 
+-- | The raw statement lines of a test. A 'Property' is wrapped so its result
+-- is evaluated through 'propEvaluation' (see 'propSetup').
 asStmts :: Test -> [Txt]
 asStmts (Example e _ _) = NE.toList e
 asStmts (Property t _ _) =

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
@@ -17,6 +17,7 @@ import           Control.Lens                ((^.))
 import           Control.Monad.Catch         (MonadMask, bracket)
 import           Control.Monad.IO.Class
 import           Data.Algorithm.Diff         (Diff, PolyDiff (..), getDiff)
+import           Data.List                   (dropWhileEnd)
 import qualified Data.List.NonEmpty          as NE
 import           Data.Maybe                  (listToMaybe)
 import           Data.String                 (IsString)
@@ -45,7 +46,6 @@ evalExprRanges tst =
         resLine = startLine + exprLines
      in ( Range
             (Position startLine 0)
-            --(Position (startLine + exprLines + resultLines) 0),
             (Position resLine 0)
         , Range (Position resLine 0) (Position (resLine + resultLines) 0)
         )
@@ -54,16 +54,15 @@ evalExprRanges tst =
 resultRange :: EvalExpr -> Range
 resultRange = snd . evalExprRanges
 
--- TODO: handle BLANKLINE
-{-
->>> showDiffs $  getDiff ["abc","def","ghi","end"] ["abc","def","Z","ZZ","end"]
+{- |
+>>> showDiffs $ getDiff ["abc" :: String,"def","ghi","end"] ["abc","def","Z","ZZ","end"]
 ["abc","def","WAS ghi","NOW Z","NOW ZZ","end"]
 -}
 showDiffs :: (Semigroup a, IsString a) => [Diff a] -> [a]
 showDiffs = map showDiff
 
 showDiff :: (Semigroup a, IsString a) => Diff a -> a
-showDiff (First w)  = "WAS " <> w
+showDiff (First  w) = "WAS " <> w
 showDiff (Second w) = "NOW " <> w
 showDiff (Both w _) = w
 
@@ -78,8 +77,13 @@ showDiff (Both w _) = w
 -- this, identical multi-line results would be reported as entirely changed.
 evalExprCheck :: Bool -> (Section, EvalExpr) -> [T.Text] -> [T.Text]
 evalExprCheck diff (section, evalExpr) out
-    | not diff || null (evalExprOutput evalExpr) || sectionLanguage section == Plain = outLines
-    | otherwise = showDiffs $ getDiff (map T.pack $ evalExprOutput evalExpr) outLines
+    |  not diff
+    || null (evalExprOutput evalExpr)
+    || sectionLanguage section == Plain =
+        outLines
+    | otherwise =
+        showDiffs $
+          getDiff (map T.pack $ evalExprOutput evalExpr) outLines
   where
     outLines = concatMap T.lines out
 
@@ -88,7 +92,7 @@ evalExprLengths :: EvalExpr -> (Int, Int)
 evalExprLengths (Example e r _)  = (NE.length e, length r)
 evalExprLengths (Property _ r _) = (1, length r)
 
--- |A one-line Haskell statement
+-- | A one-line Haskell statement
 type Statement = Loc String
 
 -- | The Haskell statements to feed to GHCi for an 'EvalExpr', each tagged with
@@ -121,13 +125,26 @@ execStmtCaptureResult recorder stmt opts = do
       Right (ExecComplete (Left err) _) ->
         pure $ Left $ show err
       Right (ExecComplete (Right _) _) -> do
-        pure $ Right $ toMaybe (output <> result)
+        pure $ Right $ toMaybe (combine output result)
       Right ExecBreak{} ->
         pure $ Right $ Just "breakpoints are not supported"
   where
     toMaybe :: String -> Maybe String
     toMaybe x | null x    = Nothing
               | otherwise = Just x
+
+    -- Join the captured stdout/stderr output with the result value. GHC
+    -- diagnostics (e.g. warnings) written to stderr end with a trailing blank
+    -- line; drop trailing newlines so output and result are separated by a
+    -- single newline rather than a spurious blank line (which would otherwise
+    -- surface unexpectedly in the rendered result).
+    combine :: String -> String -> String
+    combine output result
+        | null trimmed = result
+        | null result = trimmed
+        | otherwise    = trimmed <> "\n" <> result
+      where
+        trimmed = dropWhileEnd (== '\n') output
 
 -- 'System.IO.Extra.withTempFile' is specialized to 'IO'.
 withTempFile :: (MonadIO m, MonadMask m) => (FilePath -> m b) -> m (String, b)
@@ -219,10 +236,10 @@ captureTeardown = unwords
 Example:
 
 prop> \(l::[Bool]) -> reverse (reverse l) == l
-+++ OK, passed 100 evalExprs.
++++ OK, passed 100 tests.
 
 prop> \(l::[Bool]) -> reverse l == l
-*** Failed! Falsified (after 6 evalExprs and 2 shrinks):
+*** Failed! Falsified (after 4 tests and 1 shrink):
 [True,False]
 -}
 propSetup :: [Loc [Char]]

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
@@ -5,10 +5,10 @@
 -- | Expression execution
 module Ide.Plugin.Eval.Code (
     Statement
-  , testRanges
+  , evalExprRanges
   , resultRange
   , propSetup
-  , testCheck
+  , evalExprCheck
   , asStatements
   , execStmtCaptureResult
   ) where
@@ -27,21 +27,21 @@ import           GHC                         (ExecOptions, ExecResult (..),
 import           Ide.Logger                  (Recorder, WithPriority, logWith)
 import qualified Ide.Logger                  as Log
 
-import           Ide.Plugin.Eval.Types       (Language (Plain), Loc,
-                                              Located (..), Log (..),
-                                              Section (sectionLanguage),
-                                              Test (..), Txt, locate, locate0)
+import           Ide.Plugin.Eval.Types       (EvalExpr (..), Language (Plain),
+                                              Loc, Located (..), Log (..),
+                                              Section (sectionLanguage), Txt,
+                                              locate, locate0)
 import           Ide.Plugin.Eval.Util        (gStrictTry)
 import qualified Language.LSP.Protocol.Lens  as L
 import           Language.LSP.Protocol.Types (Position (Position),
                                               Range (Range))
 import           System.IO.Extra             (newTempFile, readFile')
 
--- | Return the ranges of the expression and result parts of the given test
-testRanges :: Test -> (Range, Range)
-testRanges tst =
-    let startLine = testRange tst ^. L.start . L.line
-        (fromIntegral -> exprLines, fromIntegral -> resultLines) = testLengths tst
+-- | Return the ranges of the expression and result parts of the given 'EvalExpr'.
+evalExprRanges :: EvalExpr -> (Range, Range)
+evalExprRanges tst =
+    let startLine = evalExprRange tst ^. L.start . L.line
+        (fromIntegral -> exprLines, fromIntegral -> resultLines) = evalExprLengths tst
         resLine = startLine + exprLines
      in ( Range
             (Position startLine 0)
@@ -50,14 +50,9 @@ testRanges tst =
         , Range (Position resLine 0) (Position (resLine + resultLines) 0)
         )
 
-{- |The document range where a test is defined
- testRange :: Loc Test -> Range
- testRange = fst . testRanges
--}
-
--- |The document range where the result of the test is defined
-resultRange :: Test -> Range
-resultRange = snd . testRanges
+-- | The document range where the result of the 'EvalExpr' is defined.
+resultRange :: EvalExpr -> Range
+resultRange = snd . evalExprRanges
 
 -- TODO: handle BLANKLINE
 {-
@@ -72,30 +67,31 @@ showDiff (First w)  = "WAS " <> w
 showDiff (Second w) = "NOW " <> w
 showDiff (Both w _) = w
 
--- | Compare the expected output recorded in the test with the actual output
--- @out@. When diffing is enabled and there is a recorded output, return a
--- line-by-line diff (see 'showDiffs'); otherwise return @out@ unchanged.
-testCheck :: Bool -> (Section, Test) -> [T.Text] -> [T.Text]
-testCheck diff (section, test) out
-    | not diff || null (testOutput test) || sectionLanguage section == Plain = out
-    | otherwise = showDiffs $ getDiff (map T.pack $ testOutput test) out
+-- | Compare the expected output recorded in the 'EvalExpr' with the actual
+-- output @out@. When diffing is enabled and there is a recorded output, return
+-- a line-by-line diff (see 'showDiffs'); otherwise return @out@ unchanged.
+evalExprCheck :: Bool -> (Section, EvalExpr) -> [T.Text] -> [T.Text]
+evalExprCheck diff (section, evalExpr) out
+    | not diff || null (evalExprOutput evalExpr) || sectionLanguage section == Plain = out
+    | otherwise = showDiffs $ getDiff (map T.pack $ evalExprOutput evalExpr) out
 
--- | The number of (expression lines, result lines) a test occupies.
-testLengths :: Test -> (Int, Int)
-testLengths (Example e r _)  = (NE.length e, length r)
-testLengths (Property _ r _) = (1, length r)
+-- | The number of (expression lines, result lines) an 'EvalExpr' occupies.
+evalExprLengths :: EvalExpr -> (Int, Int)
+evalExprLengths (Example e r _)  = (NE.length e, length r)
+evalExprLengths (Property _ r _) = (1, length r)
 
 -- |A one-line Haskell statement
 type Statement = Loc String
 
--- | The Haskell statements to feed to GHCi for a test, each tagged with its
--- source line so evaluation errors can be located.
-asStatements :: Test -> [Statement]
-asStatements lt = locate $ Located (fromIntegral $ testRange lt ^. L.start . L.line) (asStmts lt)
+-- | The Haskell statements to feed to GHCi for an 'EvalExpr', each tagged with
+-- its source line so evaluation errors can be located.
+asStatements :: EvalExpr -> [Statement]
+asStatements lt =
+  locate $ Located (fromIntegral $ evalExprRange lt ^. L.start . L.line) (asStmts lt)
 
--- | The raw statement lines of a test. A 'Property' is wrapped so its result
--- is evaluated through 'propEvaluation' (see 'propSetup').
-asStmts :: Test -> [Txt]
+-- | The raw statement lines of an 'EvalExpr'. A 'Property' is wrapped so its
+-- result is evaluated through 'propEvaluation' (see 'propSetup').
+asStmts :: EvalExpr -> [Txt]
 asStmts (Example e _ _) = NE.toList e
 asStmts (Property t _ _) =
     ["prop11 = " ++ t, "(propEvaluation prop11 :: IO String)"]
@@ -210,15 +206,15 @@ captureTeardown = unwords
     , "  }"
     ]
 
-{- |GHC declarations required to execute test properties
+{- | GHC declarations required to evaluate property 'EvalExprs'
 
 Example:
 
 prop> \(l::[Bool]) -> reverse (reverse l) == l
-+++ OK, passed 100 tests.
++++ OK, passed 100 evalExprs.
 
 prop> \(l::[Bool]) -> reverse l == l
-*** Failed! Falsified (after 6 tests and 2 shrinks):
+*** Failed! Falsified (after 6 evalExprs and 2 shrinks):
 [True,False]
 -}
 propSetup :: [Loc [Char]]

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Code.hs
@@ -1,24 +1,37 @@
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
 {-# OPTIONS_GHC -Wwarn #-}
 
 -- | Expression execution
-module Ide.Plugin.Eval.Code (Statement, testRanges, resultRange, propSetup, testCheck, asStatements,myExecStmt) where
+module Ide.Plugin.Eval.Code (
+    Statement
+  , testRanges
+  , resultRange
+  , propSetup
+  , testCheck
+  , asStatements
+  , execStmtCaptureResult
+  ) where
 
 import           Control.Lens                ((^.))
+import           Control.Monad.Catch         (MonadMask, bracket)
 import           Control.Monad.IO.Class
 import           Data.Algorithm.Diff         (Diff, PolyDiff (..), getDiff)
 import qualified Data.List.NonEmpty          as NE
+import           Data.Maybe                  (listToMaybe)
 import           Data.String                 (IsString)
 import qualified Data.Text                   as T
 import           Development.IDE.GHC.Compat
 import           GHC                         (ExecOptions, ExecResult (..),
                                               execStmt)
+import           Ide.Logger                  (Recorder, WithPriority, logWith)
+import qualified Ide.Logger                  as Log
+
 import           Ide.Plugin.Eval.Types       (Language (Plain), Loc,
-                                              Located (..),
+                                              Located (..), Log (..),
                                               Section (sectionLanguage),
                                               Test (..), Txt, locate, locate0)
+import           Ide.Plugin.Eval.Util        (gStrictTry)
 import qualified Language.LSP.Protocol.Lens  as L
 import           Language.LSP.Protocol.Types (Position (Position),
                                               Range (Range))
@@ -79,20 +92,115 @@ asStmts (Example e _ _) = NE.toList e
 asStmts (Property t _ _) =
     ["prop11 = " ++ t, "(propEvaluation prop11 :: IO String)"]
 
-
-
 -- | A wrapper of 'InteractiveEval.execStmt', capturing the execution result
-myExecStmt :: String -> ExecOptions -> Ghc (Either String (Maybe String))
-myExecStmt stmt opts = do
-    (temp, purge) <- liftIO newTempFile
-    evalPrint <- head <$> runDecls ("evalPrint x = P.writeFile " <> show temp <> " (P.show x)")
-    modifySession $ \hsc -> hsc {hsc_IC = setInteractivePrintName (hsc_IC hsc) evalPrint}
-    result <- execStmt stmt opts >>= \case
-              ExecComplete (Left err) _ -> pure $ Left $ show err
-              ExecComplete (Right _) _ -> liftIO $ Right . (\x -> if null x then Nothing else Just x) <$> readFile' temp
-              ExecBreak{} -> pure $ Right $ Just "breakpoints are not supported"
-    liftIO purge
-    pure result
+execStmtCaptureResult ::
+     Recorder (WithPriority Log)
+  -> String
+  -> ExecOptions
+  -> Ghc (Either String (Maybe String))
+execStmtCaptureResult recorder stmt opts = do
+    (result, (output, execResultE)) <-
+      withCaptureResult recorder $
+        withCaptureStdHandles opts $
+           gStrictTry (execStmt stmt opts)
+    case execResultE of
+      Left exc ->
+        pure $ Left exc
+      Right (ExecComplete (Left err) _) ->
+        pure $ Left $ show err
+      Right (ExecComplete (Right _) _) -> do
+        pure $ Right $ toMaybe (output <> result)
+      Right ExecBreak{} ->
+        pure $ Right $ Just "breakpoints are not supported"
+  where
+    toMaybe :: String -> Maybe String
+    toMaybe x | null x    = Nothing
+              | otherwise = Just x
+
+-- 'System.IO.Extra.withTempFile' is specialized to 'IO'.
+withTempFile :: (MonadIO m, MonadMask m) => (FilePath -> m b) -> m (String, b)
+withTempFile k = do
+    bracket
+      (liftIO newTempFile)
+      (\(_, purgeTempFile) -> liftIO purgeTempFile)
+      (\(tempFile, _) -> do
+        r <- k tempFile
+        o <- liftIO $ readFile' tempFile
+        pure (o, r))
+
+-- | Capture the value the statement evaluates to (printed by GHCi via the
+-- interactive print function) by writing it to a temporary file.
+withCaptureResult :: Recorder (WithPriority Log) -> Ghc a -> Ghc (String, a)
+withCaptureResult recorder action = withTempFile $ \resultTemp -> do
+    mEvalPrint <-
+      listToMaybe <$>
+        runDecls
+          ("evalPrint x = P.writeFile " <> show resultTemp <> " (P.show x)")
+    case mEvalPrint of
+      Nothing ->
+        logWith recorder Log.Warning $ LogEvalFailedSettingInteractivePrintFunction
+      Just evalPrint ->
+        modifySession $
+          \hsc -> hsc {hsc_IC = setInteractivePrintName (hsc_IC hsc) evalPrint}
+    action
+
+-- | Capture output written to @stdout@ and @stderr@ as a side effect of
+-- evaluating the statement.
+--
+-- We redirect the handles from *within* the interpreted program, because the
+-- statement writes to the interpreted standard handles, which are not the host
+-- handles that 'System.IO.Silently' would redirect -- HLS has already
+-- redirected the latter to protect the LSP channel (see
+-- 'Development.IDE.Main').
+--
+-- NB: This redirection is process global, so output written concurrently to
+-- @stdout@/@stderr@ from another thread may be captured here, or eval output
+-- may leak. base provides no per-thread standard handles, so this is
+-- unavoidable with this approach.
+withCaptureStdHandles ::
+     ExecOptions
+  -> Ghc a
+  -> Ghc (String, a)
+withCaptureStdHandles opts action = withTempFile $ \outputTemp -> do
+    bracket
+      (execStmt (captureSetup outputTemp) opts)
+      -- Restore the handles no matter how the statement terminated.
+      (\_ -> execStmt captureTeardown opts)
+      (\_ -> action)
+
+-- Open a temporary file and redirect the interpreted @stdout@/@stderr@ to
+-- it, saving the original handles in interactive bindings so 'captureTeardown'
+-- can restore them. Bound to a tuple (rather than evaluated as a bare
+-- expression) so GHCi does not pass it to the interactive print function.
+captureSetup :: FilePath -> String
+-- Squeeze into one line (executed by GHCi).
+captureSetup outputTemp = unwords
+    [ "(__hls_captureHandle, __hls_savedStdout, __hls_savedStderr) <- do {"
+    , "  __hls_h <- System.IO.openFile", show outputTemp, "System.IO.WriteMode;"
+    , "  System.IO.hSetBuffering __hls_h System.IO.LineBuffering;"
+    , "  __hls_o <- GHC.IO.Handle.hDuplicate System.IO.stdout;"
+    , "  __hls_e <- GHC.IO.Handle.hDuplicate System.IO.stderr;"
+    , "  GHC.IO.Handle.hDuplicateTo __hls_h System.IO.stdout;"
+    , "  GHC.IO.Handle.hDuplicateTo __hls_h System.IO.stderr;"
+    , "  P.return (__hls_h, __hls_o, __hls_e);"
+    , "  }"
+    ]
+
+-- Flush, restore the original handles and close the temporary file so the
+-- host can read back the captured output.
+captureTeardown :: String
+-- Squeeze into one line (executed by GHCi).
+captureTeardown = unwords
+    [ "__hls_restored <- do {"
+    , "  System.IO.hFlush System.IO.stdout;"
+    , "  System.IO.hFlush System.IO.stderr;"
+    , "  GHC.IO.Handle.hDuplicateTo __hls_savedStdout System.IO.stdout;"
+    , "  GHC.IO.Handle.hDuplicateTo __hls_savedStderr System.IO.stderr;"
+    , "  System.IO.hClose __hls_savedStdout;"
+    , "  System.IO.hClose __hls_savedStderr;"
+    , "  System.IO.hClose __hls_captureHandle;"
+    , "  }"
+    ]
 
 {- |GHC declarations required to execute test properties
 

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/GHC.hs
@@ -30,41 +30,12 @@ import           GHC                             (setTopSessionDynFlags,
 import           GHC.Driver.Env
 import           GHC.Driver.Session              (getDynFlags)
 
-{- $setup
->>> import GHC
->>> import GHC.Paths
->>> run act = runGhc (Just libdir) (getInteractiveDynFlags >>= act)
->>> libdir
-"/Users/titto/.ghcup/ghc/8.8.4/lib/ghc-8.8.4"
--}
-
-{- | True if specified package is present in DynFlags
-
--- >>> hasPackageTst pkg = run $ \df -> return (hasPackage df pkg)
->>> hasPackageTst pkg = run $ \_ -> addPackages [pkg] >>= return . either Left (\df -> Right (hasPackage df pkg))
-
->>> hasPackageTst "base"
-Right True
-
->>> hasPackageTst "ghc"
-Right True
-
->>> hasPackageTst "extra"
-Left "<command line>: cannot satisfy -package extra\n    (use -v for more information)"
-
->>> hasPackageTst "QuickCheck"
-Left "<command line>: cannot satisfy -package QuickCheck\n    (use -v for more information)"
--}
 hasPackage :: DynFlags -> String -> Bool
 hasPackage df = hasPackage_ (packageFlags df)
 
 hasPackage_ :: [PackageFlag] -> [Char] -> Bool
 hasPackage_ pkgFlags name = any (name `isPrefixOf`) (pkgNames_ pkgFlags)
 
-{- |
->>> run (return . pkgNames)
-[]
--}
 pkgNames :: DynFlags -> [String]
 pkgNames = pkgNames_ . packageFlags
 
@@ -77,27 +48,6 @@ pkgNames_ =
             _                                 -> Nothing
         )
 
-{- | Expose a list of packages.
->>> addPackagesTest pkgs = run (\_ -> (packageFlags <$>) <$> addPackages pkgs)
-
->>> addPackagesTest []
-Right []
-
->>> addPackagesTest ["base","base","array"]
-Right [-package base{package base True ([])},-package array{package array True ([])}]
-
->>> addPackagesTest ["Cabal"]
-Right [-package Cabal{package Cabal True ([])}]
-
->>> addPackagesTest ["QuickCheck"]
-Left "<command line>: cannot satisfy -package QuickCheck\n    (use -v for more information)"
-
->>> addPackagesTest ["base","notThere"]
-Left "<command line>: cannot satisfy -package notThere\n    (use -v for more information)"
-
-prop> \(x::Int) -> x + x == 2 * x
-+++ OK, passed 100 tests.
--}
 addPackages :: [String] -> Ghc (Either String DynFlags)
 addPackages pkgNames = gStrictTry $
     modifyFlags $ \df ->
@@ -111,37 +61,15 @@ modifyFlags f = do
     _ <- setSessionDynFlags (f df)
     getSessionDynFlags
 
--- modifyFlags f = do
---         modifyDynFlags f
---         getSessionDynFlags
-
-{- | Add import to evaluation context
-
->>> run $ \_ -> addImport "import Data.Maybe"
-Could not find module ‘Data.Maybe’
-Use -v (or `:set -v` in ghci) to see a list of the files searched for.
-
->>> run $ \df -> addPackages ["base"] >> addImport "import Data.Maybe"
-[import Data.Maybe]
-
->>> run $ \df -> addPackages ["base"] >> addImport "import qualified Data.Maybe as M"
-[import qualified Data.Maybe as M]
--}
+-- | Add import to evaluation context
 addImport :: GhcMonad m => String -> m [InteractiveImport]
 addImport i = do
     ctx <- getContext
-    -- dbgO "CONTEXT" ctx
     idecl <- parseImportDecl i
     setContext $ IIDecl idecl : ctx
-    -- ctx' <- getContext
-    -- dbg "CONTEXT'" ctx'
     getContext
 
-{- | Add extension to interactive evaluation session
->>> import GHC.LanguageExtensions.Type(Extension(..))
->>> run $ \_ -> addExtension DeriveGeneric
-()
--}
+-- | Add extension to interactive evaluation session
 addExtension :: GhcMonad m => Extension -> m ()
 addExtension ext =
     modifySession $ \hsc -> hsc{hsc_IC = setExtension (hsc_IC hsc) ext}
@@ -151,7 +79,7 @@ setExtension ic ext = ic{ic_dflags = xopt_set (ic_dflags ic) ext}
 
 deriving instance Read Extension
 
--- Partial display of DynFlags contents, for testing purposes
+-- | Partial display of DynFlags contents, for testing purposes
 showDynFlags :: DynFlags -> String
 showDynFlags df =
     T.unpack . printOutputable . vcat . map (\(n, d) -> text (n ++ ": ") <+> d) $
@@ -159,12 +87,8 @@ showDynFlags df =
         , ("extensionFlags", ppr . EnumSet.toList . extensionFlags $ df)
         , ("importPaths", vList $ importPaths df)
         , ("generalFlags", pprHsString . fromString . show . EnumSet.toList . generalFlags $ df)
-        , -- , ("includePaths", text . show $ includePaths df)
-          -- ("packageEnv", ppr $ packageEnv df)
-          ("pkgNames", vcat . map text $ pkgNames df)
+        , ("pkgNames", vcat . map text $ pkgNames df)
         , ("packageFlags", vcat . map ppr $ packageFlags df)
-        -- ,("pkgDatabase",(map) (ppr . installedPackageId) . pkgDatabase $ df)
-        -- ("pkgDatabase", text . show <$> pkgDatabase $ df)
         ]
 
 vList :: [String] -> SDoc

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -150,6 +150,9 @@ codeLens recorder st plId CodeLensParams{_textDocument} = do
             | (range, command) <- rangeCommands
             ]
 
+-- | Find every test in the document and pair its source range with the
+-- 'Command' that evaluates it. Shared by the code action and code lens
+-- providers.
 mkRangeCommands :: Recorder (WithPriority Log) -> IdeState -> PluginId -> TextDocumentIdentifier -> ExceptT PluginError (HandlerM Config) [(Range, Command)]
 mkRangeCommands recorder st plId textDocument =
     let dbg = logWith recorder Debug
@@ -309,6 +312,9 @@ initialiseSessionForEval needs_quickcheck st nfp = do
             getSession
   return env2
 
+-- | Convert the typechecker's import specs into the interface representation,
+-- so the reconstructed iface for the current module records what it imports
+-- (needed when re-adding the rdr env, see 'initialiseSessionForEval').
 #if MIN_VERSION_ghc(9,13,0)
 mkIfaceImports :: [ImportUserSpec] -> [IfaceImport]
 mkIfaceImports = map go
@@ -325,12 +331,15 @@ mkIfaceImports = map go
     go (ImpUserSpec decl (ImpUserEverythingBut ns)) = IfaceImport decl (ImpIfaceEverythingBut ns)
 #endif
 
+-- | Prepend an edit adding a trailing newline when the module does not end in
+-- one, so the appended results land on their own line.
 addFinalReturn :: Text -> [TextEdit] -> [TextEdit]
 addFinalReturn mdlText edits
     | not (null edits) && not (T.null mdlText) && T.last mdlText /= '\n' =
         finalReturn mdlText : edits
     | otherwise = edits
 
+-- | An empty edit at the very end of the module that inserts a newline.
 finalReturn :: Text -> TextEdit
 finalReturn txt =
     let ls = T.lines txt
@@ -339,6 +348,7 @@ finalReturn txt =
         p = Position l c
      in TextEdit (Range p p) "\n"
 
+-- | The current (possibly unsaved) contents of the module as seen by the IDE.
 moduleText :: IdeState -> Uri -> ExceptT PluginError (HandlerM config) Text
 moduleText state uri = do
     contents <-
@@ -349,6 +359,8 @@ moduleText state uri = do
                         toNormalizedUri uri
     pure $ Rope.toText contents
 
+-- | Flatten sections into their individual tests, tagging each with the index
+-- ('EvalId') of its containing section.
 testsBySection :: [Section] -> [(Section, EvalId, Test)]
 testsBySection sections =
     [(section, ident, test)
@@ -370,6 +382,9 @@ evalSetup = do
     context <- getContext
     setContext (IIDecl preludeAsP : IIDecl systemIO : IIDecl ghcIOHandle : context)
 
+-- | Evaluate every test and produce the 'TextEdit's that write the results
+-- back into the document, prefixing/padding each result line as the section's
+-- format requires.
 runTests :: Recorder (WithPriority Log) -> EvalConfig -> TEnv -> [(Section, Test)] -> Ghc [TextEdit]
 runTests recorder EvalConfig{..} e tests = do
     df <- getInteractiveDynFlags
@@ -400,6 +415,10 @@ runTests recorder EvalConfig{..} e tests = do
                     "Add QuickCheck to your cabal dependencies to run this test."
     runTest e df test = evals recorder (eval_cfg_exception && not (isProperty test)) e df (asStatements test)
 
+-- | Build the edit that replaces a test's old result with @resultLines@. For a
+-- test that sits on the closing @-}@ line of a block comment, the result is
+-- inserted before @-}@ on fresh lines; otherwise it simply overwrites the
+-- existing result range.
 asEdit :: Format -> Test -> [Text] -> TextEdit
 asEdit (MultiLine commRange) test resultLines
     -- A test in a block comment, ending with @-\}@ without newline in-between.
@@ -618,6 +637,9 @@ ghciLikeCommands =
     , ("type", doTypeCmd)
     ]
 
+-- | Dispatch a GHCi-like command (e.g. @:type@, @:kind@, @:info@) to its
+-- handler, matching by exact name or unique prefix. Throws if no command
+-- matches.
 evalGhciLikeCmd :: Text -> Text -> Ghc (Maybe [Text])
 evalGhciLikeCmd cmd arg = do
     df <- getSessionDynFlags
@@ -630,6 +652,8 @@ evalGhciLikeCmd cmd arg = do
                 <$> hndler df arg
         _ -> E.throw $ GhciLikeCmdNotImplemented cmd arg
 
+-- | Implement @:info@ / @:info!@: show the definition, fixity and instances of
+-- each named thing. The 'Bool' is the @!@ variant, including all instances.
 doInfoCmd :: Bool -> DynFlags -> Text -> Ghc (Maybe Text)
 doInfoCmd allInfo dflags s = do
     sdocs <- mapM infoThing (T.words s)
@@ -675,6 +699,8 @@ doInfoCmd allInfo dflags s = do
                 = ppr fixity <+> pprInfixName (GHC.getName thing)
             | otherwise = empty
 
+-- | Implement @:kind@ / @:kind!@: show a type's kind. The 'Bool' is the @!@
+-- variant, additionally normalising and showing the type itself.
 doKindCmd :: Bool -> DynFlags -> Text -> Ghc (Maybe Text)
 doKindCmd False df arg = do
     let input = T.strip arg
@@ -688,6 +714,8 @@ doKindCmd True df arg = do
         tyDoc = "=" <+> pprSigmaType ty
     pure $ Just $ T.pack (showSDoc df $ kindDoc $$ tyDoc)
 
+-- | Implement @:type@: show the type of an expression. Accepts a leading
+-- @+d@ to request the defaulted type (see 'parseExprMode').
 doTypeCmd :: DynFlags -> Text -> Ghc (Maybe Text)
 doTypeCmd dflags arg = do
     let (emod, expr) = parseExprMode arg
@@ -704,6 +732,8 @@ doTypeCmd dflags arg = do
                                 $$ nest 2 ("::" <+> pprSigmaType ty)
                 else expr <> " :: " <> rawType <> "\n"
 
+-- | Split a @:type@ argument into its mode and expression: a leading @+d@
+-- selects defaulting ('TM_Default'), anything else the plain type ('TM_Inst').
 parseExprMode :: Text -> (TcRnExprMode, T.Text)
 parseExprMode rawArg = case T.break isSpace rawArg of
     ("+d", rest) -> (TM_Default, T.strip rest)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -400,8 +400,7 @@ runEvalExprs recorder EvalConfig{..} e evalExprs = do
         rs <- runEvalExpr e df evalExpr
         dbg $ LogRunEvalExprResults rs
 
-        let checkedResult = evalExprCheck eval_cfg_diff (section, evalExpr) rs
-        let resultLines = concatMap T.lines checkedResult
+        let resultLines = evalExprCheck eval_cfg_diff (section, evalExpr) rs
 
         let edit = asEdit (sectionFormat section) evalExpr (map pad resultLines)
         dbg $ LogRunEvalExprEdits edit

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -372,31 +372,40 @@ type TEnv = String
 -- |GHC declarations required for expression evaluation
 evalSetup :: Ghc ()
 evalSetup = do
-    preludeAsP <- parseImportDecl "import qualified Prelude as P"
+    preludeAsP  <- parseImportDecl "import qualified Prelude as P"
     -- 'myExecStmt' redirects the interpreted @stdout@ and @stderr@ to a temporary
     -- file in order to capture output produced as a side effect of evaluating a
     -- statement. The setup and teardown statements it injects need these modules
     -- in scope.
-    systemIO <- parseImportDecl "import qualified System.IO"
+    systemIO    <- parseImportDecl "import qualified System.IO"
     ghcIOHandle <- parseImportDecl "import qualified GHC.IO.Handle"
-    context <- getContext
+    context     <- getContext
     setContext (IIDecl preludeAsP : IIDecl systemIO : IIDecl ghcIOHandle : context)
 
 -- | Evaluate every 'EvalExpr' and produce the 'TextEdit's that write the results
 -- back into the document, prefixing/padding each result line as the section's
 -- format requires.
-runEvalExprs :: Recorder (WithPriority Log) -> EvalConfig -> TEnv -> [(Section, EvalExpr)] -> Ghc [TextEdit]
+runEvalExprs ::
+     Recorder (WithPriority Log)
+  -> EvalConfig
+  -> TEnv
+  -> [(Section, EvalExpr)]
+  -> Ghc [TextEdit]
 runEvalExprs recorder EvalConfig{..} e evalExprs = do
     df <- getInteractiveDynFlags
     evalSetup
-    when (hasQuickCheck df && needsQuickCheck evalExprs) $ void $ evals recorder True e df propSetup
+    when (hasQuickCheck df && needsQuickCheck evalExprs) $
+      void $ evals recorder True e df propSetup
 
     mapM (processEvalExpr e df) evalExprs
   where
     processEvalExpr :: TEnv -> DynFlags -> (Section, EvalExpr) -> Ghc TextEdit
     processEvalExpr fp df (section, evalExpr) = do
         let dbg = logWith recorder Debug
-        let pad = pad_ $ (if isLiterate fp then ("> " `T.append`) else id) $ padPrefix (sectionFormat section)
+            pre =
+              (if isLiterate fp then ("> " `T.append`) else id) $
+                padPrefix (sectionFormat section)
+            pad = T.append pre
         rs <- runEvalExpr e df evalExpr
         dbg $ LogRunEvalExprResults rs
 
@@ -406,13 +415,19 @@ runEvalExprs recorder EvalConfig{..} e evalExprs = do
         dbg $ LogRunEvalExprEdits edit
         return edit
 
-    -- runEvalExpr :: String -> DynFlags -> Loc EvalExpr -> Ghc [Text]
-    runEvalExpr _ df evalExpr
+    runEvalExpr :: String -> DynFlags -> EvalExpr -> Ghc [Text]
+    runEvalExpr e df evalExpr
         | not (hasQuickCheck df) && isProperty evalExpr =
             return $
                 singleLine
                     "Add QuickCheck to your cabal dependencies to run this property."
-    runEvalExpr e df evalExpr = evals recorder (eval_cfg_exception && not (isProperty evalExpr)) e df (asStatements evalExpr)
+        | otherwise =
+            evals
+              recorder
+              (eval_cfg_exception && not (isProperty evalExpr))
+              e
+              df
+              (asStatements evalExpr)
 
 -- | Build the edit that replaces the old result of an 'EvalExpr' with
 -- @resultLines@. For an 'EvalExpr' that sits on the closing @-}@ line of a
@@ -608,13 +623,6 @@ exceptionLines = (ix 0 %~ ("*** Exception: " <>)) . errorLines
 >>> map (pad_ (T.pack "--")) (map T.pack ["2+2",""])
 ["--2+2","--<BLANKLINE>"]
 -}
-pad_ :: Text -> Text -> Text
-pad_ prefix = (prefix `T.append`) . convertBlank
-
-convertBlank :: Text -> Text
-convertBlank x
-    | T.null x = "<BLANKLINE>"
-    | otherwise = x
 
 padPrefix :: IsString p => Format -> p
 padPrefix SingleLine = "-- "

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -102,8 +102,8 @@ import           Ide.Plugin.Eval.Code                         (Statement,
                                                                execStmtCaptureResult,
                                                                propSetup,
                                                                resultRange,
-                                                               testCheck,
-                                                               testRanges)
+                                                               evalExprCheck,
+                                                               evalExprRanges)
 import           Ide.Plugin.Eval.Config                       (EvalConfig (..),
                                                                getEvalConfig)
 import           Ide.Plugin.Eval.GHC                          (addImport,
@@ -134,8 +134,8 @@ codeAction recorder st plId CodeActionParams{_textDocument,_range} = do
     pure
         $ InL
             [ InL command
-            | (testRange, command) <- rangeCommands
-            , _range `isSubrangeOf` testRange
+            | (evalExprRange, command) <- rangeCommands
+            , _range `isSubrangeOf` evalExprRange
             ]
 
 {- | Code Lens provider
@@ -150,7 +150,7 @@ codeLens recorder st plId CodeLensParams{_textDocument} = do
             | (range, command) <- rangeCommands
             ]
 
--- | Find every test in the document and pair its source range with the
+-- | Find every eval-expr in the document and pair its source range with the
 -- 'Command' that evaluates it. Shared by the code action and code lens
 -- providers.
 mkRangeCommands :: Recorder (WithPriority Log) -> IdeState -> PluginId -> TextDocumentIdentifier -> ExceptT PluginError (HandlerM Config) [(Range, Command)]
@@ -168,14 +168,14 @@ mkRangeCommands recorder st plId textDocument =
                     runActionE "eval.GetParsedModuleWithComments" st $ useWithStaleE GetEvalComments nfp
                 dbg $ LogCodeLensComments comments
 
-                -- Extract tests from source code
+                -- Extract 'EvalExpr's from source code
                 let Sections{..} = commentsToSections isLHS comments
-                    tests = testsBySection nonSetupSections
+                    evalExprs = evalExprsBySection nonSetupSections
                     cmd = mkLspCommand plId evalCommandName "Evaluate=..." (Just [])
                 let rangeCommands =
-                        [ (testRange, cmd')
-                        | (section, ident, test) <- tests
-                        , let (testRange, resultRange) = testRanges test
+                        [ (evalExprRange, cmd')
+                        | (section, ident, evalExpr) <- evalExprs
+                        , let (evalExprRange, resultRange) = evalExprRanges evalExpr
                               args = EvalParams (setupSections ++ [section]) textDocument ident
                               cmd' =
                                 (cmd :: Command)
@@ -187,9 +187,9 @@ mkRangeCommands recorder st plId textDocument =
                                     }
                         ]
 
-                perf "tests" $
-                    dbg $ LogTests
-                            (length tests)
+                perf "evalExprs" $
+                    dbg $ LogEvalExprs
+                            (length evalExprs)
                             (length nonSetupSections)
                             (length setupSections)
                             (length rangeCommands)
@@ -212,7 +212,7 @@ runEvalCmd recorder plId st mtoken EvalParams{..} =
         perf = timed (\lbl duration -> dbg $ LogExecutionTime lbl duration)
         cmd :: ExceptT PluginError (HandlerM Config) WorkspaceEdit
         cmd = do
-            let tests = map (\(a,_,b) -> (a,b)) $ testsBySection sections
+            let evalExprs = map (\(a,_,b) -> (a,b)) $ evalExprsBySection sections
 
             let TextDocumentIdentifier{_uri} = module_
             fp <- uriToFilePathE _uri
@@ -229,7 +229,7 @@ runEvalCmd recorder plId st mtoken EvalParams{..} =
                 unqueueForEvaluation st nfp
                 return [toKey IsEvaluating nfp]
                 )
-              (initialiseSessionForEval (needsQuickCheck tests) st nfp)
+              (initialiseSessionForEval (needsQuickCheck evalExprs) st nfp)
 
             evalCfg <- liftIO $ runAction "eval: config" st $ getEvalConfig plId
 
@@ -238,7 +238,7 @@ runEvalCmd recorder plId st mtoken EvalParams{..} =
                 perf "edits" $
                     liftIO $
                         evalGhcEnv final_hscEnv $ do
-                            runTests recorder evalCfg fp tests
+                            runEvalExprs recorder evalCfg fp evalExprs
 
             let workspaceEditsMap = Map.singleton _uri (addFinalReturn mdlText edits)
             let workspaceEdits = WorkspaceEdit (Just workspaceEditsMap) Nothing Nothing
@@ -359,13 +359,13 @@ moduleText state uri = do
                         toNormalizedUri uri
     pure $ Rope.toText contents
 
--- | Flatten sections into their individual tests, tagging each with the index
+-- | Flatten sections into their individual 'EvalExpr's, tagging each with the index
 -- ('EvalId') of its containing section.
-testsBySection :: [Section] -> [(Section, EvalId, Test)]
-testsBySection sections =
-    [(section, ident, test)
+evalExprsBySection :: [Section] -> [(Section, EvalId, EvalExpr)]
+evalExprsBySection sections =
+    [(section, ident, evalExpr)
     | (ident, section) <- zip [0..] sections
-    , test <- sectionTests section
+    , evalExpr <- sectionEvalExprs section
     ]
 
 type TEnv = String
@@ -382,59 +382,59 @@ evalSetup = do
     context <- getContext
     setContext (IIDecl preludeAsP : IIDecl systemIO : IIDecl ghcIOHandle : context)
 
--- | Evaluate every test and produce the 'TextEdit's that write the results
+-- | Evaluate every 'EvalExpr' and produce the 'TextEdit's that write the results
 -- back into the document, prefixing/padding each result line as the section's
 -- format requires.
-runTests :: Recorder (WithPriority Log) -> EvalConfig -> TEnv -> [(Section, Test)] -> Ghc [TextEdit]
-runTests recorder EvalConfig{..} e tests = do
+runEvalExprs :: Recorder (WithPriority Log) -> EvalConfig -> TEnv -> [(Section, EvalExpr)] -> Ghc [TextEdit]
+runEvalExprs recorder EvalConfig{..} e evalExprs = do
     df <- getInteractiveDynFlags
     evalSetup
-    when (hasQuickCheck df && needsQuickCheck tests) $ void $ evals recorder True e df propSetup
+    when (hasQuickCheck df && needsQuickCheck evalExprs) $ void $ evals recorder True e df propSetup
 
-    mapM (processTest e df) tests
+    mapM (processEvalExpr e df) evalExprs
   where
-    processTest :: TEnv -> DynFlags -> (Section, Test) -> Ghc TextEdit
-    processTest fp df (section, test) = do
+    processEvalExpr :: TEnv -> DynFlags -> (Section, EvalExpr) -> Ghc TextEdit
+    processEvalExpr fp df (section, evalExpr) = do
         let dbg = logWith recorder Debug
         let pad = pad_ $ (if isLiterate fp then ("> " `T.append`) else id) $ padPrefix (sectionFormat section)
-        rs <- runTest e df test
-        dbg $ LogRunTestResults rs
+        rs <- runEvalExpr e df evalExpr
+        dbg $ LogRunEvalExprResults rs
 
-        let checkedResult = testCheck eval_cfg_diff (section, test) rs
+        let checkedResult = evalExprCheck eval_cfg_diff (section, evalExpr) rs
         let resultLines = concatMap T.lines checkedResult
 
-        let edit = asEdit (sectionFormat section) test (map pad resultLines)
-        dbg $ LogRunTestEdits edit
+        let edit = asEdit (sectionFormat section) evalExpr (map pad resultLines)
+        dbg $ LogRunEvalExprEdits edit
         return edit
 
-    -- runTest :: String -> DynFlags -> Loc Test -> Ghc [Text]
-    runTest _ df test
-        | not (hasQuickCheck df) && isProperty test =
+    -- runEvalExpr :: String -> DynFlags -> Loc EvalExpr -> Ghc [Text]
+    runEvalExpr _ df evalExpr
+        | not (hasQuickCheck df) && isProperty evalExpr =
             return $
                 singleLine
-                    "Add QuickCheck to your cabal dependencies to run this test."
-    runTest e df test = evals recorder (eval_cfg_exception && not (isProperty test)) e df (asStatements test)
+                    "Add QuickCheck to your cabal dependencies to run this property."
+    runEvalExpr e df evalExpr = evals recorder (eval_cfg_exception && not (isProperty evalExpr)) e df (asStatements evalExpr)
 
--- | Build the edit that replaces a test's old result with @resultLines@. For a
--- test that sits on the closing @-}@ line of a block comment, the result is
--- inserted before @-}@ on fresh lines; otherwise it simply overwrites the
--- existing result range.
-asEdit :: Format -> Test -> [Text] -> TextEdit
-asEdit (MultiLine commRange) test resultLines
-    -- A test in a block comment, ending with @-\}@ without newline in-between.
-    | testRange test ^. L.end . L.line == commRange ^. L.end . L.line
+-- | Build the edit that replaces the old result of an 'EvalExpr' with
+-- @resultLines@. For an 'EvalExpr' that sits on the closing @-}@ line of a
+-- block comment, the result is inserted before @-}@ on fresh lines; otherwise
+-- it simply overwrites the existing result range.
+asEdit :: Format -> EvalExpr -> [Text] -> TextEdit
+asEdit (MultiLine commRange) evalExpr resultLines
+    -- An 'EvalExpr' in a block comment, ending with @-\}@ without newline in-between.
+    | evalExprRange evalExpr ^. L.end . L.line == commRange ^. L.end . L.line
     =
     TextEdit
         (Range
-            (testRange test ^. L.end)
-            (resultRange test ^. L.end)
+            (evalExprRange evalExpr ^. L.end)
+            (resultRange evalExpr ^. L.end)
         )
         ("\n" <> T.unlines (resultLines <> ["-}"]))
-asEdit _ test resultLines =
-    TextEdit (resultRange test) (T.unlines resultLines)
+asEdit _ evalExpr resultLines =
+    TextEdit (resultRange evalExpr) (T.unlines resultLines)
 
 {- |
-The result of evaluating a test line can be:
+The result of evaluating an eval-expr line can be:
 * a value
 * nothing
 * a (possibly multiline) error message
@@ -576,7 +576,7 @@ evals recorder mark_exception fp df stmts = do
         let opts = execOptions{execSourceFile = fp, execLineNumber = l}
          in execStmtCaptureResult recorder stmt opts
 
-needsQuickCheck :: [(Section, Test)] -> Bool
+needsQuickCheck :: [(Section, EvalExpr)] -> Bool
 needsQuickCheck = any (isProperty . snd)
 
 hasQuickCheck :: DynFlags -> Bool

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE ViewPatterns              #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 
--- | -- A plugin inspired by the REPLoid feature of
+-- | A plugin inspired by the REPLoid feature of
 -- [Dante](https://github.com/jyp/dante),
 -- [Haddock examples and properties](https://haskell-haddock.readthedocs.io/latest/markup.html#examples),
 -- and [Doctest](https://hackage.haskell.org/package/doctest).
@@ -99,7 +99,7 @@ import           Ide.Plugin.Error                             (PluginError (Plug
                                                                handleMaybeM)
 import           Ide.Plugin.Eval.Code                         (Statement,
                                                                asStatements,
-                                                               myExecStmt,
+                                                               execStmtCaptureResult,
                                                                propSetup,
                                                                resultRange,
                                                                testCheck,
@@ -361,8 +361,14 @@ type TEnv = String
 evalSetup :: Ghc ()
 evalSetup = do
     preludeAsP <- parseImportDecl "import qualified Prelude as P"
+    -- 'myExecStmt' redirects the interpreted @stdout@ and @stderr@ to a temporary
+    -- file in order to capture output produced as a side effect of evaluating a
+    -- statement. The setup and teardown statements it injects need these modules
+    -- in scope.
+    systemIO <- parseImportDecl "import qualified System.IO"
+    ghcIOHandle <- parseImportDecl "import qualified GHC.IO.Handle"
     context <- getContext
-    setContext (IIDecl preludeAsP : context)
+    setContext (IIDecl preludeAsP : IIDecl systemIO : IIDecl ghcIOHandle : context)
 
 runTests :: Recorder (WithPriority Log) -> EvalConfig -> TEnv -> [(Section, Test)] -> Ghc [TextEdit]
 runTests recorder EvalConfig{..} e tests = do
@@ -420,9 +426,12 @@ Either a pure value:
 >>> 'h' : "askell"
 "haskell"
 
-Or an 'IO a' (output on stdout/stderr is ignored):
->>> print "OK" >> return "ABC"
-"ABC"
+Or an 'IO a' (output on stdout/stderr is captured):
+>>> putStrLn "Hello," >> pure "World!"
+Hello,
+"World!"
+
+Note the quotes around @World!@, which are a result of using 'show'.
 
 Nothing is returned for a correct directive:
 
@@ -446,11 +455,15 @@ A, possibly multi line, error is returned for a wrong declaration, directive or 
 Some flags have not been recognized: -XNonExistent
 
 >>> cls C
-Variable not in scope: cls :: t0 -> t
-Data constructor not in scope: C
+Illegal term-level use of the class `C'
+  defined at <interactive>:1:2
+In the first argument of `cls', namely `C'
+In the expression: cls C
+In an equation for `it_a1kSJ': it_a1kSJ = cls C
+Variable not in scope: cls :: t0_a1kU9[tau:1] -> t1_a1kUb[tau:1]
 
 >>> "A
-lexical error in string/character literal at end of input
+lexical error at end of input
 
 Exceptions are shown as if printed, but it can be configured to include prefix like
 in GHCi or doctest. This allows it to be used as a hack to simulate print until we
@@ -466,7 +479,8 @@ bad times
 Or for a value that does not have a Show instance and can therefore not be displayed:
 >>> data V = V
 >>> V
-No instance for (Show V) arising from a use of ‘evalPrint’
+No instance for `Show V' arising from a use of `evalPrint'
+In a stmt of an interactive GHCi command: evalPrint it_a1l4V
 -}
 evals :: Recorder (WithPriority Log) -> Bool -> TEnv -> DynFlags -> [Statement] -> Ghc [Text]
 evals recorder mark_exception fp df stmts = do
@@ -475,7 +489,7 @@ evals recorder mark_exception fp df stmts = do
         Left err -> errorLines err
         Right rs -> concat . catMaybes $ rs
   where
-    dbg = logWith recorder Debug
+    dbg  = logWith recorder Debug
     eval :: Statement -> Ghc (Maybe [Text])
     eval (Located l stmt)
         | -- GHCi flags
@@ -541,7 +555,7 @@ evals recorder mark_exception fp df stmts = do
     unhelpfulReason = UnhelpfulInteractive
     exec stmt l =
         let opts = execOptions{execSourceFile = fp, execLineNumber = l}
-         in myExecStmt stmt opts
+         in execStmtCaptureResult recorder stmt opts
 
 needsQuickCheck :: [(Section, Test)] -> Bool
 needsQuickCheck = any (isProperty . snd)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -7,11 +7,10 @@
 {-# LANGUAGE ViewPatterns              #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 
-{- |
-A plugin inspired by the REPLoid feature of <https://github.com/jyp/dante Dante>, <https://www.haskell.org/haddock/doc/html/ch03s08.html#idm140354810775744 Haddock>'s Examples and Properties and <https://hackage.haskell.org/package/doctest Doctest>.
-
-For a full example see the "Ide.Plugin.Eval.Tutorial" module.
--}
+-- | -- A plugin inspired by the REPLoid feature of
+-- [Dante](https://github.com/jyp/dante),
+-- [Haddock examples and properties](https://haskell-haddock.readthedocs.io/latest/markup.html#examples),
+-- and [Doctest](https://hackage.haskell.org/package/doctest).
 module Ide.Plugin.Eval.Handlers (
     codeAction,
     codeLens,
@@ -418,7 +417,7 @@ The result of evaluating a test line can be:
 A value is returned for a correct expression.
 
 Either a pure value:
->>> 'h' :"askell"
+>>> 'h' : "askell"
 "haskell"
 
 Or an 'IO a' (output on stdout/stderr is ignored):

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Parse/Comments.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Parse/Comments.hs
@@ -90,16 +90,16 @@ newtype PropLine = PropLine {getPropLine :: String}
 newtype ExampleLine = ExampleLine {getExampleLine :: String}
     deriving (Show)
 
-data TestComment
+data EvalExprComment
     = AProp
-        { testCommentRange :: Range
-        , lineProp         :: PropLine
-        , propResults      :: [String]
+        { evalExprCommentRange :: Range
+        , lineProp             :: PropLine
+        , propResults          :: [String]
         }
     | AnExample
-        { testCommentRange :: Range
-        , lineExamples     :: NonEmpty ExampleLine
-        , exampleResults   :: [String]
+        { evalExprCommentRange :: Range
+        , lineExamples         :: NonEmpty ExampleLine
+        , exampleResults       :: [String]
         }
     deriving (Show)
 
@@ -174,19 +174,19 @@ commentsToSections isLHS Comments {..} =
                 -- block comment body.
                 $ Map.toList blockComments
         lineSections =
-            lineSectionSeeds <&> uncurry (testsToSection Line)
+            lineSectionSeeds <&> uncurry (evalExprsToSection Line)
         multilineSections =
             Map.mapWithKey
-                (uncurry . testsToSection . Block)
+                (uncurry . evalExprsToSection . Block)
                 blockSeed
         setupSections =
             -- Setups doesn't need Dummy position
             map
-                ( \(style, tests) ->
-                    testsToSection
+                ( \(style, evalExprs) ->
+                    evalExprsToSection
                         style
                         (Named "setup")
-                        tests
+                        evalExprs
                 )
                 $ DL.toList $
                     F.fold $
@@ -214,12 +214,12 @@ type CommentRange = Range
 
 type SectionRange = Range
 
-testsToSection ::
+evalExprsToSection ::
     CommentStyle ->
     CommentFlavour ->
-    [TestComment] ->
+    [EvalExprComment] ->
     Section
-testsToSection style flav tests =
+evalExprsToSection style flav evalExprs =
     let sectionName
             | Named name <- flav = name
             | otherwise = ""
@@ -227,25 +227,25 @@ testsToSection style flav tests =
             HaddockNext -> Haddock
             HaddockPrev -> Haddock
             _           -> Plain
-        sectionTests = map fromTestComment tests
+        sectionEvalExprs = map fromEvalExprComment evalExprs
         sectionFormat =
             case style of
                 Line      -> SingleLine
                 Block ran -> MultiLine ran
      in Section {..}
 
-fromTestComment :: TestComment -> Test
-fromTestComment AProp {..} =
-    Property
-        { testline = getPropLine lineProp
-        , testOutput = propResults
-        , testRange = testCommentRange
+fromEvalExprComment :: EvalExprComment -> EvalExpr
+fromEvalExprComment AProp {..} =
+    Property {
+          evalExprLine   = getPropLine lineProp
+        , evalExprOutput = propResults
+        , evalExprRange  = evalExprCommentRange
         }
-fromTestComment AnExample {..} =
-    Example
-        { testLines = getExampleLine <$> lineExamples
-        , testOutput = exampleResults
-        , testRange = testCommentRange
+fromEvalExprComment AnExample {..} =
+    Example {
+          evalExprLines  = getExampleLine <$> lineExamples
+        , evalExprOutput = exampleResults
+        , evalExprRange  = evalExprCommentRange
         }
 
 -- * Block comment parser
@@ -256,11 +256,11 @@ fromTestComment AnExample {..} =
 -}
 
 -- >>> parseE (blockCommentBP True dummyPos) "{- |\n  >>> 5+5\n  11\n  -}"
--- (HaddockNext,[AnExample {testCommentRange = Position {_line = 1, _character = 0}, lineExamples = ExampleLine {getExampleLine = " 5+5"} :| [], exampleResults = ["  11"]}])
+-- (HaddockNext,[AnExample {evalExprCommentRange = Position {_line = 1, _character = 0}, lineExamples = ExampleLine {getExampleLine = " 5+5"} :| [], exampleResults = ["  11"]}])
 
 blockCommentBP ::
     -- | True if Literate Haskell
-    BlockCommentParser (CommentFlavour, [TestComment])
+    BlockCommentParser (CommentFlavour, [EvalExprComment])
 blockCommentBP = do
     skipCount 2 anySingle -- "{-"
     void $ optional $ char ' '
@@ -281,10 +281,10 @@ skipNormalCommentBlock = do
     BlockEnv {..} <- ask
     skipManyTill (normalLineP isLhs $ Block blockRange) $
         False <$ try (optional (chunk "-}") *> eof)
-            <|> True <$ lookAhead (try $ testSymbol isLhs $ Block blockRange)
+            <|> True <$ lookAhead (try $ evalExprSymbol isLhs $ Block blockRange)
 
-testSymbol :: Bool -> CommentStyle -> LineParser ()
-testSymbol isLHS style =
+evalExprSymbol :: Bool -> CommentStyle -> LineParser ()
+evalExprSymbol isLHS style =
     -- FIXME: To comply with existing Extended Eval Plugin Behaviour;
     -- it must skip one space after a comment!
     -- This prevents Eval Plugin from working on
@@ -297,7 +297,7 @@ eob = eof <|> try (optional (chunk "-}") *> eof) <|> void eol
 
 blockExamples
     , blockProp ::
-        BlockCommentParser TestComment
+        BlockCommentParser EvalExprComment
 blockExamples = do
     BlockEnv {..} <- ask
     (ran, examples) <- withRange $ NE.some $ exampleLineStrP isLhs $ Block blockRange
@@ -340,10 +340,10 @@ sourcePosToPosition SourcePos {..} =
 
 -- * Line Group Parser
 
-{- |
-Result: a tuple of ordinary line tests and setting sections.
+{- | Result: a tuple of ordinary line evaluation expressions and setting
+sections.
 
-TODO: Haddock comment can adjacent to vanilla comment:
+TODO: Haddock comment can be adjacent to a vanilla comment:
 
     @
         -- Vanilla comment
@@ -351,12 +351,12 @@ TODO: Haddock comment can adjacent to vanilla comment:
         -- | This parses as Haddock comment as GHC
     @
 
-This behaviour is not yet handled correctly in Eval Plugin;
+This behaviour is not yet handled correctly in the Eval Plugin;
 but for future extension for this, we use a tuple here instead of 'Either'.
 -}
 lineGroupP ::
     LineGroupParser
-        (Maybe (CommentFlavour, [TestComment]), [TestComment])
+        (Maybe (CommentFlavour, [EvalExprComment]), [EvalExprComment])
 lineGroupP = do
     (_, flav) <- lookAhead $ parseLine (commentFlavourP <* takeRest)
     case flav of
@@ -386,7 +386,7 @@ lineCommentHeadP = do
     void $ optional $ char ' '
 
 lineCommentSectionsP ::
-    LineGroupParser [TestComment]
+    LineGroupParser [EvalExprComment]
 lineCommentSectionsP = do
     skipMany normalLineCommentP
     many $
@@ -411,7 +411,7 @@ nonEmptyLGP =
             parseLine $
                 fst <$ commentFlavourP <*> nonEmptyNormalLineP False Line
 
-exampleLinesGP :: LineGroupParser TestComment
+exampleLinesGP :: LineGroupParser EvalExprComment
 exampleLinesGP =
     lexemeLine $
         uncurry AnExample . first convexHullRange . NE.unzip
@@ -485,7 +485,7 @@ normalLineP ::
     LineParser (String, Position)
 normalLineP isLHS style = do
     notFollowedBy
-        (try $ testSymbol isLHS style)
+        (try $ evalExprSymbol isLHS style)
     when (isLHS && is _Block style) $
         void $ count' 0 2 $ char ' '
     consume style
@@ -499,10 +499,10 @@ consume style =
 getPosition :: (Ord v, TraversableStream s) => ParsecT v s m Position
 getPosition = sourcePosToPosition <$> getSourcePos
 
--- | Parses example test line.
+-- | Parses example line.
 exampleLineStrP ::
-    -- | True if Literate Haskell
     Bool ->
+    -- ^ True if Literate Haskell
     CommentStyle ->
     LineParser (ExampleLine, Position)
 exampleLineStrP isLHS style =
@@ -522,10 +522,10 @@ exampleSymbol =
 propSymbol :: LineParser ()
 propSymbol = chunk "prop>" *> P.notFollowedBy (char '>')
 
--- | Parses prop test line.
+-- | Parses property line.
 propLineStrP ::
-    -- | True if Literate HAskell
     Bool ->
+    -- ^ True if Literate Haskell
     CommentStyle ->
     LineParser (PropLine, Position)
 propLineStrP isLHS style =

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
@@ -156,17 +156,17 @@ hasPropertyEvalExpr = any isProperty . sectionEvalExprs
 splitSections :: [Section] -> ([Section], [Section])
 splitSections = partition ((== "setup") . sectionName)
 
-data EvalExpr
-    = Example {
+data EvalExpr =
+      Example {
           evalExprLines  :: NonEmpty Txt
         , evalExprOutput :: [Txt]
         , evalExprRange  :: Range
         }
     | Property {
-        evalExprLine   :: Txt
-      , evalExprOutput :: [Txt]
-      , evalExprRange  :: Range
-      }
+          evalExprLine   :: Txt
+        , evalExprOutput :: [Txt]
+        , evalExprRange  :: Range
+        }
     deriving (Eq, Show, Generic, FromJSON, ToJSON, NFData)
 
 data IsEvaluating = IsEvaluating

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
@@ -75,6 +75,7 @@ data Log
     | LogEvalStmtResult (Maybe [T.Text])
     | LogEvalImport String
     | LogEvalDeclaration String
+    | LogEvalFailedSettingInteractivePrintFunction
 
 instance Pretty Log where
     pretty = \case
@@ -103,6 +104,9 @@ instance Pretty Log where
         LogEvalStmtResult result -> "STMT}" <+> pretty result
         LogEvalImport stmt -> "{IMPORT" <+> pretty stmt
         LogEvalDeclaration stmt -> "{DECL" <+> pretty stmt
+        LogEvalFailedSettingInteractivePrintFunction -> pretty $
+               "Return value will not be captured: "
+            ++ "Failed setting the interactive print function."
 
 -- | A thing with a location attached.
 data Located l a = Located {location :: l, located :: a}

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Types.hs
@@ -12,14 +12,14 @@ module Ide.Plugin.Eval.Types
     ( Log(..),
       locate,
       locate0,
-      Test (..),
+      EvalExpr (..),
       isProperty,
       Format (..),
       Language (..),
       Section (..),
       Sections (..),
-      hasTests,
-      hasPropertyTest,
+      hasEvalExprs,
+      hasPropertyEvalExpr,
       splitSections,
       Loc,
       Located (..),
@@ -61,9 +61,9 @@ data Log
     | LogCodeLensFp FilePath
     | LogCodeLensComments Comments
     | LogExecutionTime T.Text Extra.Seconds
-    | LogTests !Int !Int !Int !Int
-    | LogRunTestResults [T.Text]
-    | LogRunTestEdits TextEdit
+    | LogEvalExprs !Int !Int !Int !Int
+    | LogRunEvalExprResults [T.Text]
+    | LogRunEvalExprEdits TextEdit
     | LogEvalFlags [String]
     | LogEvalPreSetDynFlags Core.DynFlags
     | LogEvalParsedFlags
@@ -83,9 +83,10 @@ instance Pretty Log where
         LogCodeLensFp fp -> "fp" <+> pretty fp
         LogCodeLensComments comments -> "comments" <+> viaShow comments
         LogExecutionTime lbl duration -> pretty lbl <> ":" <+> pretty (Extra.showDuration duration)
-        LogTests nTests nNonSetupSections nSetupSections nLenses -> "Tests" <+> fillSep
-            [ pretty nTests
-            , "tests in"
+        LogEvalExprs nEvalExprs nNonSetupSections nSetupSections nLenses ->
+          "EvalExprs" <+> fillSep [
+              pretty nEvalExprs
+            , "expressions to evaluate in"
             , pretty nNonSetupSections
             , "sections"
             , pretty nSetupSections
@@ -93,8 +94,8 @@ instance Pretty Log where
             , pretty nLenses
             , "lenses."
             ]
-        LogRunTestResults results ->  "TEST RESULTS" <+> viaShow results
-        LogRunTestEdits edits -> "TEST EDIT" <+> viaShow edits
+        LogRunEvalExprResults results ->  "EVAL EXPR RESULTS" <+> viaShow results
+        LogRunEvalExprEdits edits -> "EVAL EXPR EDIT" <+> viaShow edits
         LogEvalFlags flags -> "{:SET" <+> pretty flags
         LogEvalPreSetDynFlags dynFlags -> "pre set" <+> pretty (showDynFlags dynFlags)
         LogEvalParsedFlags eans -> "parsed flags" <+> viaShow (eans
@@ -138,26 +139,34 @@ data Sections = Sections
     deriving (Show, Eq, Generic)
 
 data Section = Section
-    { sectionName     :: Txt
-    , sectionTests    :: [Test]
-    , sectionLanguage :: Language
-    , sectionFormat   :: Format
+    { sectionName      :: Txt
+    , sectionEvalExprs :: [EvalExpr]
+    , sectionLanguage  :: Language
+    , sectionFormat    :: Format
     }
     deriving (Eq, Show, Generic, FromJSON, ToJSON, NFData)
 
-hasTests :: Section -> Bool
-hasTests = not . null . sectionTests
+hasEvalExprs :: Section -> Bool
+hasEvalExprs = not . null . sectionEvalExprs
 
-hasPropertyTest :: Section -> Bool
-hasPropertyTest = any isProperty . sectionTests
+hasPropertyEvalExpr :: Section -> Bool
+hasPropertyEvalExpr = any isProperty . sectionEvalExprs
 
 -- |Split setup and normal sections
 splitSections :: [Section] -> ([Section], [Section])
 splitSections = partition ((== "setup") . sectionName)
 
-data Test
-    = Example {testLines :: NonEmpty Txt, testOutput :: [Txt], testRange :: Range}
-    | Property {testline :: Txt, testOutput :: [Txt], testRange :: Range}
+data EvalExpr
+    = Example {
+          evalExprLines  :: NonEmpty Txt
+        , evalExprOutput :: [Txt]
+        , evalExprRange  :: Range
+        }
+    | Property {
+        evalExprLine   :: Txt
+      , evalExprOutput :: [Txt]
+      , evalExprRange  :: Range
+      }
     deriving (Eq, Show, Generic, FromJSON, ToJSON, NFData)
 
 data IsEvaluating = IsEvaluating
@@ -214,14 +223,14 @@ instance Semigroup Comments where
 instance Monoid Comments where
     mempty = Comments mempty mempty
 
-isProperty :: Test -> Bool
+isProperty :: EvalExpr -> Bool
 isProperty Property {} = True
 isProperty _           = False
 
 data Format
     = SingleLine
     | -- | @Range@ is that of surrounding entire block comment, not section.
-      -- Used for detecting no-newline test commands.
+      -- Used for detecting no-newline eval-expr commands.
       MultiLine Range
     deriving (Eq, Show, Ord, Generic, FromJSON, ToJSON, NFData)
 
@@ -241,10 +250,10 @@ instance IsString LineChunk where
 
 type EvalId = Int
 
--- | Specify the test section to execute
+-- | Specify the eval-expr sections to execute
 data EvalParams = EvalParams
     { sections :: [Section]
     , module_  :: !TextDocumentIdentifier
-    , evalId   :: !EvalId -- ^ unique group id; for test uses
+    , evalId   :: !EvalId -- ^ unique group id; for eval-expr uses
     }
     deriving (Eq, Show, Generic, FromJSON, ToJSON)

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Util.hs
@@ -48,19 +48,26 @@ timed out name op = do
 isLiterate :: FilePath -> Bool
 isLiterate x = takeExtension x `elem` [".lhs", ".lhs-boot"]
 
-response' :: ExceptT PluginError (HandlerM c) WorkspaceEdit -> ExceptT PluginError (HandlerM c) (Value |? Null)
+response' ::
+     ExceptT PluginError (HandlerM c) WorkspaceEdit
+  -> ExceptT PluginError (HandlerM c) (Value |? Null)
 response' act = do
     res <-  ExceptT (runExceptT act
              `catchAny` \e -> do
                 res <- showErr e
                 pure . Left  . PluginInternalError $ fromString res)
-    _ <- lift $ pluginSendRequest SMethod_WorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing res) (\_ -> pure ())
+    _ <-
+      lift $
+        pluginSendRequest
+          SMethod_WorkspaceApplyEdit
+          (ApplyWorkspaceEditParams Nothing res)
+          (\_ -> pure ())
     pure $ InR Null
 
 gStrictTry :: (MonadIO m, MonadCatch m) => m b -> m (Either String b)
-gStrictTry op =
+gStrictTry action =
     catch
-        (op >>= fmap Right . gevaluate)
+        (action >>= fmap Right . gevaluate)
         (fmap Left . showErr)
 
 gevaluate :: MonadIO m => a -> m a

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -144,7 +144,7 @@ tests =
   , goldenWithEval "Test on last line insert results correctly" "TLastLine" "hs"
   , testGroup "with preprocessors"
     [ knownBrokenInEnv [HostOS Windows]
-        "CPP eval on Windows and/or GHC <= 8.6 fails for some reasons" $
+        "CPP eval on Windows fails for some reasons" $
         goldenWithEval "CPP support" "TCPP" "hs"
     , goldenWithEval "Literate Haskell Bird Style" "TLHS" "lhs"
     ]

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -153,6 +153,7 @@ tests =
   , goldenWithEval "Variable 'it' works" "TIt" "hs"
   , testGroup "configuration"
     [ goldenWithEval' "Give 'WAS' by default" "TDiff" "hs" "expected.default"
+    , goldenWithEval "Refreshing an identical multi-line result is a no-op" "TDiffMultiline" "hs"
     , goldenWithEvalConfig' "Give the result only if diff is off" "TDiff" "hs" "expected.no-diff" diffOffConfig
     , goldenWithEvalConfig' "Evaluates to exception (not marked)" "TException" "hs" "expected.nomark" (exceptionConfig False)
     , goldenWithEvalConfig' "Evaluates to exception (with mark)" "TException" "hs" "expected.marked" (exceptionConfig True)

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -20,7 +20,7 @@ import           Ide.Plugin.Config          (Config)
 import qualified Ide.Plugin.Config          as Plugin
 import qualified Ide.Plugin.Eval            as Eval
 import           Ide.Plugin.Eval.Types      (EvalParams (..), Section (..),
-                                             testOutput)
+                                             evalExprOutput)
 import           Language.LSP.Protocol.Lens (command, range, title)
 import           System.FilePath            ((<.>), (</>))
 import           Test.Hls
@@ -290,8 +290,8 @@ codeLensTestOutput codeLens = do
   CodeLens { _command = Just command } <- [codeLens]
   Command { _arguments = Just args } <- [command]
   Success EvalParams { sections = sections } <- fromJSON @EvalParams <$> args
-  Section { sectionTests = sectionTests } <- sections
-  testOutput =<< sectionTests
+  Section { sectionEvalExprs = sectionEvalExprs } <- sections
+  evalExprOutput =<< sectionEvalExprs
 
 testDataDir :: FilePath
 testDataDir = "plugins" </> "hls-eval-plugin" </> "test" </> "testdata"

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -128,7 +128,8 @@ tests =
       evalInFile "T8.hs" "-- >>> :t id" "-- id :: a -> a"
       evalInFile "T8.hs" "-- >>> :set -fprint-explicit-foralls\n-- >>> :t id" "-- id :: forall a. a -> a"
   , goldenWithEval "The default language extensions for the eval plugin are the same as those for ghci" "TSameDefaultLanguageExtensionsAsGhci" "hs"
-  , goldenWithEval "IO expressions are supported, stdout/stderr output is ignored" "TIO" "hs"
+  , goldenWithEval "Support IO expressions, capture and show stdout/stderr output" "TIO" "hs"
+  , goldenWithEval "Support IO expressions, close handles on errors" "TIOError" "hs"
   , goldenWithEvalAndFs "Property checking" cabalProjectFS "TProperty" "hs"
   , knownBrokenInWindowsBeforeGHC912 "The output has path separators in it, which on Windows look different. Just skip it there" $
       goldenWithEvalAndFs' "Property checking with exception" cabalProjectFS "TPropertyError" "hs" $

--- a/plugins/hls-eval-plugin/test/testdata/TDiffMultiline.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TDiffMultiline.expected.hs
@@ -1,0 +1,6 @@
+module TDiffMultiline where
+
+-- |
+-- >>> putStrLn "Hello," >> pure "World!"
+-- Hello,
+-- "World!"

--- a/plugins/hls-eval-plugin/test/testdata/TDiffMultiline.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TDiffMultiline.hs
@@ -1,0 +1,6 @@
+module TDiffMultiline where
+
+-- |
+-- >>> putStrLn "Hello," >> pure "World!"
+-- Hello,
+-- "World!"

--- a/plugins/hls-eval-plugin/test/testdata/TIO.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TIO.expected.hs
@@ -1,12 +1,15 @@
--- IO expressions are supported, stdout/stderr output is ignored
+-- 1. Support IO expressions
+--
+-- 2. Capture and show stdout
 module TIO where
 
-import Control.Concurrent (threadDelay)
+import           Control.Concurrent (threadDelay)
 
-{-
-Does not capture stdout, returns value.
+{- Capture stdout, returns value.
+
 Has a delay in order to show progress reporting.
 
 >>> threadDelay 2000000 >> print "ABC" >> return "XYZ"
+"ABC"
 "XYZ"
 -}

--- a/plugins/hls-eval-plugin/test/testdata/TIO.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TIO.hs
@@ -1,12 +1,13 @@
--- IO expressions are supported, stdout/stderr output is ignored
+-- 1. Support IO expressions
+--
+-- 2. Capture and show stdout
 module TIO where
 
-import Control.Concurrent (threadDelay)
+import           Control.Concurrent (threadDelay)
 
-{-
-Does not capture stdout, returns value.
+{- Capture stdout, returns value.
+
 Has a delay in order to show progress reporting.
 
 >>> threadDelay 2000000 >> print "ABC" >> return "XYZ"
-"XYZ"
 -}

--- a/plugins/hls-eval-plugin/test/testdata/TIOError.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TIOError.expected.hs
@@ -1,0 +1,11 @@
+-- 1. Support IO expressions
+--
+-- 2. Capture and show stderr
+module TIOError where
+
+import           Control.Exception
+
+{-
+>>> throwIO (TypeError "Doh")
+Doh
+-}

--- a/plugins/hls-eval-plugin/test/testdata/TIOError.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TIOError.hs
@@ -1,0 +1,10 @@
+-- 1. Support IO expressions
+--
+-- 2. Capture and show stderr
+module TIOError where
+
+import           Control.Exception
+
+{-
+>>> throwIO (TypeError "Doh")
+-}

--- a/plugins/hls-gadt-plugin/test/Main.hs
+++ b/plugins/hls-gadt-plugin/test/Main.hs
@@ -34,12 +34,12 @@ tests = testGroup "GADT"
     , runTest "ConstructorContext" "ConstructorContext" 2 0 2 38
     , runTest "Context" "Context" 2 0 4 41
     , runTest "Pragma" "Pragma" 2 0 3 29
-    , runTest "SingleDerivingGHC92" "SingleDerivingGHC92" 2 0 3 14
-    , gadtPragmaTest "ghc-9.2 don't need to insert GADTs pragma" False
+    , runTest "SingleDeriving" "SingleDeriving" 2 0 3 14
+    , gadtPragmaTest "no need to insert GADTs pragma"
     ]
 
-gadtPragmaTest :: TestName -> Bool -> TestTree
-gadtPragmaTest title hasGADT = testCase title
+gadtPragmaTest :: TestName -> TestTree
+gadtPragmaTest title = testCase title
     $ withCanonicalTempDir
     $ \dir -> runSessionWithServer def gadtPlugin dir $ do
         doc <- createDoc "A.hs" "haskell" (T.unlines ["module A where", "data Foo = Bar"])
@@ -47,7 +47,6 @@ gadtPragmaTest title hasGADT = testCase title
         (act:_) <- findGADTAction <$> getCodeActions doc (Range (Position 1 0) (Position 1 1))
         executeCodeAction act
         let expected = T.unlines $
-                ["{-# LANGUAGE GADTs #-}" | hasGADT] ++
                 ["module A where", "data Foo where", "  Bar :: Foo"]
         contents <- skipManyTill anyMessage (getDocumentEdit doc)
         liftIO $ contents @?= expected

--- a/plugins/hls-gadt-plugin/test/testdata/SingleDeriving.expected.hs
+++ b/plugins/hls-gadt-plugin/test/testdata/SingleDeriving.expected.hs
@@ -2,4 +2,4 @@ module SingleDeriving where
 
 data Foo a b where
   Bar :: b -> a -> Foo a b
-  deriving Eq
+  deriving (Eq)

--- a/plugins/hls-gadt-plugin/test/testdata/SingleDerivingGHC92.expected.hs
+++ b/plugins/hls-gadt-plugin/test/testdata/SingleDerivingGHC92.expected.hs
@@ -1,5 +1,0 @@
-module SingleDerivingGHC92 where
-
-data Foo a b where
-  Bar :: b -> a -> Foo a b
-  deriving (Eq)

--- a/plugins/hls-gadt-plugin/test/testdata/SingleDerivingGHC92.hs
+++ b/plugins/hls-gadt-plugin/test/testdata/SingleDerivingGHC92.hs
@@ -1,4 +1,0 @@
-module SingleDerivingGHC92 where
-
-data Foo a b = Bar b a
- deriving (Eq)


### PR DESCRIPTION
This PR contains some girl-scout changes as well as changes to how the `eval` plugin treats `stdout` and `stderr`.

#### Eval plugin

We now capture output to `stdout` and `stderr` induced as a possible side effect by the statement being evaluated. This is fragile because the output may be scrambled in a concurrent setting when HLS is writing to one of these file handles from a different thread.

Fixes #1977, most likely also #4390 (although this is debatable, we could do something more sophisticated).

```haskell
-- >>> putStrLn "Hello"
-- Hello

-- >>> hPutStrLn stderr "Hello"
-- Hello

-- >>> putStrLn "Hello," >> pure "World!"
-- Hello,
-- "World!"
```

#### Girl scout changes

- Docs: Fix some links in `eval` plugin in-source documentation
- Clarify documentation of expected test failure
- Update Nix Flake (Darwin issues seem to be solved)
- Update some tests and avoid mentioning GHC 9.2
- Remove comment referring to GHC 9.2 and fix code
