### PR TITLE
Remove overly chatty log message

### DIFF
--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -183,7 +183,6 @@ data Log
   | LogLoadingHieFileFail !FilePath !SomeException
   | LogLoadingHieFileSuccess !FilePath
   | LogTypecheckedFOI !NormalizedFilePath
-  | LogDependencies !NormalizedFilePath [FilePath]
   deriving Show
 
 instance Pretty Log where
@@ -208,11 +207,6 @@ instance Pretty Log where
         <+> "the HLS version being used, the plugins enabled, and if possible the codebase and file which"
         <+> "triggered this warning."
       ]
-    LogDependencies nfp deps ->
-      vcat
-         [ "Add dependency" <+> pretty (fromNormalizedFilePath nfp)
-         , nest 2 $ pretty deps
-         ]
 
 templateHaskellInstructions :: T.Text
 templateHaskellInstructions = "https://haskell-language-server.readthedocs.io/en/latest/troubleshooting.html#static-binaries"
@@ -722,7 +716,7 @@ loadGhcSession recorder ghcSessionDepsConfig = do
                 itExists <- getFileExists nfp
                 when itExists $ void $ do
                   use_ GetPhysicalModificationTime nfp
-        logWith recorder Logger.Info $ LogDependencies file deps
+
         mapM_ addDependency deps
 
         let cutoffHash = LBS.toStrict $ B.encode (hash (snd val))


### PR DESCRIPTION
Since the latest HLS release, I am getting spammed with log messages such as: 
```
2025-10-06T11:16:14.121738Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/PreProcess.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.121891Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/ShowBuildInfo.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.122021Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Backpack/UnifyM.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.122345Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Utils.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.122668Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Types/ComponentLocalBuildInfo.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.122901Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Backpack/PreExistingComponent.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.123088Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Compat/Async.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.123294Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Backpack/LinkedComponent.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.123452Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Compat/SnocList.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.123620Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/GHC/EnvironmentParser.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.123810Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Install.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.123974Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Setup/Test.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.124171Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Program/Ar.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.124336Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/ZinzaPrelude.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.124512Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Utils/IOData.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.124686Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Types/LocalBuildInfo.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.124989Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.125169Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/GHC/Build/Link.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.125486Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Test/Log.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.125713Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Program/Strip.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.128454Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Program/Builtin.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.128630Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/GHC/ImplInfo.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.128783Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Build.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.128955Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/PackageDescription.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.129110Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Configure.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.129704Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Test.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.129902Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Setup/Hscolour.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.130074Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/PackageDescription/Check/Warning.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.130292Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Backpack/DescribeUnitId.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.130417Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/CCompiler.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.130568Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/SetupHooks/Rule.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
2025-10-06T11:16:14.130723Z | Info | Add dependency /home/hugin/Documents/haskell/cabal/Cabal/src/Distribution/Simple/Program/Ld.hs
[ /home/hugin/Documents/haskell/cabal/Cabal/Cabal.cabal
, /home/hugin/Documents/haskell/cabal/cabal.project
, /home/hugin/Documents/haskell/cabal/cabal.project.local
, /home/hugin/Documents/haskell/cabal/hie.yaml ]
```

This log message was semi-accidentaly introduced by me, and I think it is save to remove it again.