### PR TITLE
getLocatedImportsRule: "Simplify" some bogus logic

### DIFF
--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -328,8 +328,7 @@ getLocatedImportsRule recorder =
                     return $ if itExists then Just nfp' else Nothing
                 | Just tt <- HM.lookup (TargetModule modName) targets = do
                     -- reuse the existing NormalizedFilePath in order to maximize sharing
-                    let ttmap = HM.mapWithKey const (HashSet.toMap tt)
-                        nfp' = HM.lookupDefault nfp nfp ttmap
+                    let nfp' = nfp
                     itExists <- getFileExists nfp'
                     return $ if itExists then Just nfp' else Nothing
                 | otherwise = do

--- a/ghcide/src/Development/IDE/Types/KnownTargets.hs
+++ b/ghcide/src/Development/IDE/Types/KnownTargets.hs
@@ -21,7 +21,7 @@ import           GHC.Generics
 -- | A mapping of module name to known files
 data KnownTargets = KnownTargets
   { targetMap      :: !(HashMap Target (HashSet NormalizedFilePath))
-  -- | 'normalisingMap' is a cached copy of `HMap.mapKey const targetMap`
+  -- | 'normalisingMap' is a cached copy of `HMap.mapWithKey const targetMap`
   --
   -- At startup 'GetLocatedImports' is called on all known files. Say you have 10000
   -- modules in your project then this leads to 10000 calls to 'GetLocatedImports'


### PR DESCRIPTION
This PR could have been an issue, but I wanted to use your CI to check whether my understanding of this code is correct.

* `ttmap` is a `HashMap` that maps each `NormalizedFilePath` key to itself.
* So if `nfp` is a member of `ttmap`, we find the same `nfp` in the map, and have `nfp' = nfp`.
* If `nfp` isn't a member, we fall back to the default, which is also `nfp`.
* So in both cases we end up with `nfp' = nfp`.

I don't actually know what this code was meant to do! It was introduced in https://github.com/haskell/haskell-language-server/commit/0e642b3a35d150b8e4ca743a78f7048db15d1562.