### PR TITLE
Also add max-backjumps to caching job

### DIFF
--- a/.github/workflows/caching.yml
+++ b/.github/workflows/caching.yml
@@ -52,7 +52,7 @@ on:
 # We can't set the `--builddir` via `v2-configure` as cabal doesn't support this.
 # https://github.com/haskell/cabal/issues/5271
 env:
-  cabalBuild: "v2-build --keep-going --builddir b"
+  cabalBuild: "v2-build --keep-going --builddir b --max-backjumps 10000"
 
 jobs:
   pre_job:


### PR DESCRIPTION
Followup on https://github.com/haskell/haskell-language-server/pull/4821/files#diff-edf8d072d22b634e9d3c3f80927c2b045a37621129baee9ecea6bb51a560ccc7R99-R102 where this had to be included because of build failures on ghc 9.6.7 + windows. After merging that PR we got failure on master which runs additional cabal build in caching job (and is failing with the same error: https://github.com/haskell/haskell-language-server/actions/runs/21674519345/job/62490997356)