### PR TITLE
fix notes crashing and leaking single comments notes

### DIFF
--- a/plugins/hls-notes-plugin/test/NotesTest.hs
+++ b/plugins/hls-notes-plugin/test/NotesTest.hs
@@ -144,4 +144,18 @@ hoverNoteTests = testGroup "Hover Notes"
               (Just (Range (Position 27 3) (Position 27 36)))
 
         liftIO $ hover @?= expected
+
+  , testCase "hover single-comment leak" $ runSessionWithServer' testDataDir $ \_dir -> do
+        let file = "NoteDef.hs"
+            pos  = Position 5 69
+        doc <- openDoc file "haskell"
+        waitForKickDone
+        hover <- getHover doc pos
+
+        let expected =
+              Just $ Hover (InL $ MarkupContent MarkupKind_Markdown
+              "Single line comments\n\nGHC's notes script only allows multiline comments to define notes, but in the\nHLS codebase this single line style can be found as well.\n\n")
+              (Just (Range (Position 5 61) (Position 5 88)))
+
+        liftIO $ hover @?= expected
   ]


### PR DESCRIPTION
This PR fixes : 
1) Issue #4763 
2) Leaking Single Comment Notes Declaration 
<img width="841" height="77" alt="singleLine Leak" src="https://github.com/user-attachments/assets/b30628f8-4185-45f2-8888-d65d961b6823" />

here the definatination declaration is : 
<img width="665" height="233" alt="singleLine Leak Def" src="https://github.com/user-attachments/assets/7631e148-0d52-4c1e-a149-9ee827b43df8" />
