### PR TITLE
fix spacing issues while refactor-reduce

### DIFF
--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -3288,7 +3288,7 @@ removeRedundantConstraintsTests = let
     ]
 
   typeSignatureLined3 = T.unlines $ header <>
-    [ "foo :: ( Eq a"
+    [ "foo :: (Eq a"
     , "       , Show a"
     , "       )"
     , "    => a -> Bool"
@@ -3296,7 +3296,7 @@ removeRedundantConstraintsTests = let
     ]
 
   typeSignatureLined3' = T.unlines $ header <>
-    [ "foo :: ( Eq a"
+    [ "foo :: (Eq a"
     , "       )"
     , "    => a -> Bool"
     , "foo x = x == x"


### PR DESCRIPTION
Fixes #4825 

In the previous implementation `resetEntryDP ` function was triggered when reduction code action removed any leading constraint from the context. This lead to inconsistent spacing for this scenario. 

fixes this by 
1) not using the `resetEndtryDP` function ( fixes removal of space after => )
2) add a normalization function that trims leading spaces