### PR TITLE
Use Server side Diagnostics

### DIFF
--- a/ghcide/src/Development/IDE/Core/PluginUtils.hs
+++ b/ghcide/src/Development/IDE/Core/PluginUtils.hs
@@ -225,16 +225,14 @@ activeDiagnosticsInRange :: MonadIO m => Shake.ShakeExtras -> NormalizedFilePath
 activeDiagnosticsInRange ide nfp range = runMaybeT (activeDiagnosticsInRangeMT ide nfp range)
 
 -- Prefer server-side diagnostics if available; they are authoritative.
--- Fall back to client-supplied diagnostics when none are found.
 injectServerDiagnostics :: IdeState -> CodeActionParams -> IO CodeActionParams
-injectServerDiagnostics ide params@LSP.CodeActionParams{_textDocument=LSP.TextDocumentIdentifier{_uri}, _range, _context=context} = do
-  let clientDiags = context ^. LSP.diagnostics
+injectServerDiagnostics ide params@LSP.CodeActionParams{_textDocument=LSP.TextDocumentIdentifier{_uri}, _range} = do
   serverDiags <- case LSP.uriToNormalizedFilePath (LSP.toNormalizedUri _uri) of
-    Nothing  -> pure clientDiags
+    Nothing  -> pure []
     Just nfp -> do
       mDiags <- activeDiagnosticsInRange (shakeExtras ide) nfp _range
       case mDiags of
-        Nothing    -> pure clientDiags
+        Nothing    -> pure []
         Just diags -> pure $ diags ^.. traverse . fdLspDiagnosticL
   pure $ params & LSP.context . LSP.diagnostics .~ serverDiags
 

--- a/ghcide/src/Development/IDE/Plugin/HLS.hs
+++ b/ghcide/src/Development/IDE/Plugin/HLS.hs
@@ -48,12 +48,12 @@ import           Language.LSP.Protocol.Message
 import           Language.LSP.Protocol.Types
 import qualified Language.LSP.Server              as LSP
 import           Language.LSP.VFS
-import           Prettyprinter.Render.String   (renderString)
-import           Text.Regex.TDFA.Text          ()
-import           UnliftIO                      (MonadUnliftIO, liftIO,
-                                                readTVarIO)
-import           UnliftIO.Async                (forConcurrently)
-import           UnliftIO.Exception            (catchAny)
+import           Prettyprinter.Render.String      (renderString)
+import           Text.Regex.TDFA.Text             ()
+import           UnliftIO                         (MonadUnliftIO, liftIO,
+                                                   readTVarIO)
+import           UnliftIO.Async                   (forConcurrently)
+import           UnliftIO.Exception               (catchAny)
 
 -- ---------------------------------------------------------------------
 --

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -218,8 +218,8 @@ suggestionsTests =
         doc <- openDoc "TwoHints.hs" "haskell"
         _ <- hlintCaptureKick
 
-        firstLine <- map fromAction <$> getCodeActions doc (mkRange 0 0 0 0)
-        secondLine <- map fromAction <$> getCodeActions doc (mkRange 1 0 1 0)
+        firstLine <- map fromAction <$> getCodeActions doc (mkRange 0 0 1 0)
+        secondLine <- map fromAction <$> getCodeActions doc (mkRange 1 0 2 0)
         thirdLine <- map fromAction <$> getCodeActions doc (mkRange 2 0 2 0)
         multiLine <- map fromAction <$> getCodeActions doc (mkRange 0 0 2 0)
 


### PR DESCRIPTION
Fixes #4805 

This PR aims to deliver server-side diagnostics to codeactions. 
The Comment below linked issue by @fendor  stated 
> Ideally, we come up with some API or API changes to the plugin handlers that allow us to omit the step of manually calling activeDiagnosticsInRange* and automatically do the right thing... But I don't know right away how.

This is the approach i followed, hopefully it aligns with the expectations : 

- exposed a new API named `mkCodeActionHandlerWithDiagnostics`
- previously users called ` mkPluginHandler SMethod_TextDocumentCodeAction`
- now users need to call this API instead, 
- internally `activeDiagnosticsInRange` is used to fetch server-side diagnostics
- if file not published / server-side diagnostics inaccessible then use client side diagnostics 
- call `mkPluginHandler SMethod_TextDocumentCodeAction` with this fresh diagnostics ( if available ). 

Edit : 
the above mentioned approach has been discarded. The new approach follows : 

- making an injectDiagnostics function that uses activeDiagnosticsinRange to fetch server side diagnostics. 
- if no server side diagnostics are found then return an empty list. 
- this function is later used after intercepting codeactions requests and used to inject server diagnostics.