### PR TITLE
Produce structured error for unknown module

### DIFF
--- a/ghcide/session-loader/Development/IDE/Session/Diagnostics.hs
+++ b/ghcide/session-loader/Development/IDE/Session/Diagnostics.hs
@@ -18,23 +18,22 @@ import           System.FilePath
 
 data CradleErrorDetails =
   CradleErrorDetails
-    { cabalProjectFiles :: [FilePath]
+    { cradleDependencies    :: [FilePath]
     -- ^ files related to the cradle error
     -- i.e. .cabal, cabal.project, etc.
-    , structuredError   :: Maybe StructuredErrors
-    -- ^ errors related to cradle error
+    , structuredCradleError :: Maybe StructuredCradleError
+    -- ^ structured information about the cradle error
     -- i.e. unknownModules error
     } deriving (Show, Eq, Ord, Read, Generic, Aeson.ToJSON, Aeson.FromJSON)
 
-data StructuredErrors =
-  StructuredErrors
-    { unknownModule :: Maybe UnknownModuleDetails
-    } deriving (Show, Eq, Ord, Read, Generic, Aeson.ToJSON, Aeson.FromJSON)
+data StructuredCradleError
+  = UnknownModuleError UnknownModuleDetails
+  deriving (Show, Eq, Ord, Read, Generic, Aeson.ToJSON, Aeson.FromJSON)
 
 data UnknownModuleDetails =
   UnknownModuleDetails
-    { moduleFilePath   :: FilePath
-    , suggestedModName :: String
+    { moduleFilePath      :: FilePath
+    , suggestedModuleName :: String
     } deriving (Show, Eq, Ord, Read, Generic, Aeson.ToJSON, Aeson.FromJSON)
 
 {- | Takes a cradle error, the corresponding cradle and the file path where
@@ -49,11 +48,8 @@ renderCradleError cradleError cradle nfp =
   if HieBios.isCabalCradle cradle
      then noDetails & fdLspDiagnosticL %~ \diag -> diag
             { _data_ = Just $ Aeson.toJSON CradleErrorDetails
-                { cabalProjectFiles = absDeps
-                , structuredError   =
-                    case mkUnknownModuleDetails of
-                      Nothing -> Nothing
-                      Just u  -> Just (StructuredErrors (Just u))
+                { cradleDependencies = absDeps
+                , structuredCradleError = fmap UnknownModuleError mkUnknownModuleDetails
                 }
             }
      else noDetails
@@ -66,14 +62,14 @@ renderCradleError cradleError cradle nfp =
       | HieBios.isCabalCradle cradle = fromMaybe ms $ fileMissingMessage <|> (unknownModuleMessage (fromNormalizedFilePath nfp) <$ mkUnknownModuleDetails)
       | otherwise = ms
 
-    -- Produce structured details when unknown module error detected;
+    -- Produce structured details when unknown module error is detected
     mkUnknownModuleDetails :: Maybe UnknownModuleDetails
     mkUnknownModuleDetails
       | any (isInfixOf "Failed extracting script block:") ms =
           let fp = fromNormalizedFilePath nfp
           in Just UnknownModuleDetails
                { moduleFilePath   = fp
-               , suggestedModName = dropExtension (takeFileName fp)
+               , suggestedModuleName = dropExtension (takeFileName fp)
                }
       | otherwise = Nothing
 

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/CodeAction.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/CodeAction.hs
@@ -152,14 +152,13 @@ isUnknownModuleDiagnostic :: J.Diagnostic -> Bool
 isUnknownModuleDiagnostic diag =
   case diag ^. JL.data_ of
     Nothing -> False
-    Just v  ->
+    Just v ->
       case Aeson.fromJSON v of
-        Aeson.Error _ -> False
-        Aeson.Success (details :: CradleErrorDetails) ->
-          case structuredError details of
-            Just (StructuredErrors { unknownModule = Just _ }) -> True
-            _                                                  -> False
-
+        Aeson.Success details ->
+          case structuredCradleError details of
+            Just (UnknownModuleError _) -> True
+            _                           -> False
+        _ -> False
 --------------------------
 -- Below are several utility functions which create a StanzaItem for each of the possible Stanzas,
 -- these all have specific constructors we need to match, so we can't generalise this process well.


### PR DESCRIPTION
Fixes #4684

This PR does 2 things : 

1) introduce a new Data Type called `StructuredErrors` and `UnknownModuleDetails`. StructuredErrors are then added inside `CradleErrorDetails`. 

This helps us make sure that we can easily extend `StructuredErrors` later with more details without changing cradleErrorDetials. 

i.e 

```haskell
data CradleErrorDetails =
  CradleErrorDetails
    { cabalProjectFiles :: [FilePath]
    , structuredError   :: Maybe StructuredErrors
    } deriving (Show, Eq, Ord, Read, Generic, Aeson.ToJSON, Aeson.FromJSON)

data StructuredErrors =
  StructuredErrors
    { unknownModule :: Maybe UnknownModuleDetails
    } deriving (Show, Eq, Ord, Read, Generic, Aeson.ToJSON, Aeson.FromJSON)

data UnknownModuleDetails =
  UnknownModuleDetails
    { moduleFilePath   :: FilePath
    , suggestedModName :: String
    } deriving (Show, Eq, Ord, Read, Generic, Aeson.ToJSON, Aeson.FromJSON)

```

Note : i am not 100% sure if these are the perfect names to use, any suggestions here will help a lot !!

2) change `isUnknownModuleDiagnostic` used in hls-cabal-plugin. Previously it used regex matching return Bool values if unknownModule error exists. Now we pattern match on our structuredError to find this detail.  

Note : i could not find any other callers where we are regex matching on the error string (for unknown modules). i am not sure if there are any more ? 
