### PR TITLE
Draft: Cabal rename module

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,7 +5,6 @@ packages:
          ./ghcide
          ./hls-plugin-api
          ./hls-test-utils
-         ../lsp/lsp
 
 index-state: 2026-02-24T00:00:00Z
 

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ packages:
          ./ghcide
          ./hls-plugin-api
          ./hls-test-utils
+         ../lsp/lsp
 
 index-state: 2026-02-24T00:00:00Z
 

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -262,8 +262,8 @@ getVersionedTextDocForNormalizedFilePath :: NormalizedFilePath -> Action Version
 getVersionedTextDocForNormalizedFilePath nfp = do
   mvf <- getVirtualFile nfp
   let ver = case mvf of
-        Just (VirtualFile lspver _ _) -> lspver
-        Nothing                       -> 0
+        Just (VirtualFile lspver _ _ _) -> lspver
+        Nothing                         -> 0
   return (VersionedTextDocumentIdentifier (fromNormalizedUri $ filePathToUri' nfp) ver)
 
 fileStoreRules :: Recorder (WithPriority Log) -> (NormalizedFilePath -> Action Bool) -> Rules ()

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -7,6 +7,7 @@ module Development.IDE.Core.FileStore(
     getFileContents,
     getUriContents,
     getVersionedTextDoc,
+    getVersionedTextDocForNormalizedFilePath,
     setFileModified,
     setSomethingModified,
     fileStoreRules,
@@ -256,6 +257,14 @@ getVersionedTextDoc doc = do
         Just (VirtualFile lspver _ _ _) -> lspver
         Nothing                         -> 0
   return (VersionedTextDocumentIdentifier uri ver)
+
+getVersionedTextDocForNormalizedFilePath :: NormalizedFilePath -> Action VersionedTextDocumentIdentifier
+getVersionedTextDocForNormalizedFilePath nfp = do
+  mvf <- getVirtualFile nfp
+  let ver = case mvf of
+        Just (VirtualFile lspver _ _) -> lspver
+        Nothing                       -> 0
+  return (VersionedTextDocumentIdentifier (fromNormalizedUri $ filePathToUri' nfp) ver)
 
 fileStoreRules :: Recorder (WithPriority Log) -> (NormalizedFilePath -> Action Bool) -> Rules ()
 fileStoreRules recorder isWatched = do

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE RecursiveDo           #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
 
 -- | A Shake implementation of the compiler service.
 --
@@ -29,6 +30,9 @@ module Development.IDE.Core.Shake(
     GetModificationTime(GetModificationTime, GetModificationTime_, missingFileDiagnostics),
     shakeOpen, shakeShut,
     shakeEnqueue,
+    shakeRestart,
+    updateFileDiagnostics,
+    UpdateFileDiagnostics(..),
     newSession,
     use, useNoFile, uses, useWithStaleFast, useWithStaleFast', delayedAction,
     useWithSeparateFingerprintRule,
@@ -130,7 +134,6 @@ import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Types.Options          as Options
 import qualified Language.LSP.Protocol.Message          as LSP
 import qualified Language.LSP.Server                    as LSP
-import qualified Language.LSP.VFS                       as VFS
 
 import           Development.IDE.Core.Tracing
 import           Development.IDE.Core.WorkerThread
@@ -1207,7 +1210,7 @@ defineEarlyCutoff recorder (Rule op) = addRule $ \(Q (key, file)) (old :: Maybe 
     extras <- getShakeExtras
     let diagnostics ver diags = do
             traceDiagnostics diags
-            updateFileDiagnostics recorder file ver (newKey key) extras diags
+            updateFileDiagnostics recorder extras file $ Update ver (newKey key) diags
     defineEarlyCutoff' diagnostics (==) key file old mode $ const $ op key file
 defineEarlyCutoff recorder (RuleNoDiagnostics op) = addRule $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file mode traceA $ \traceDiagnostics -> do
     let diagnostics _ver diags = do
@@ -1226,7 +1229,7 @@ defineEarlyCutoff recorder (RuleWithOldValue op) = addRule $ \(Q (key, file)) (o
     extras <- getShakeExtras
     let diagnostics ver diags = do
             traceDiagnostics diags
-            updateFileDiagnostics recorder file ver (newKey key) extras diags
+            updateFileDiagnostics recorder extras file $ Update ver (newKey key) diags
     defineEarlyCutoff' diagnostics (==) key file old mode $ op key file
 
 defineNoFile :: IdeRule k v => Recorder (WithPriority Log) -> (k -> Action v) -> Rules ()
@@ -1357,32 +1360,60 @@ traceA (A Failed{})    = "Failed"
 traceA (A Stale{})     = "Stale"
 traceA (A Succeeded{}) = "Success"
 
+data UpdateFileDiagnostics
+    = Update
+        (Maybe Int32)
+        Key
+        [FileDiagnostic]
+        -- ^ current results
+    | Delete
+
+getUpdateVersion :: UpdateFileDiagnostics -> Maybe Int32
+getUpdateVersion = \ case
+    Update ver _ _ -> ver
+    Delete -> Nothing
+
+getKey :: UpdateFileDiagnostics -> Maybe Key
+getKey = \ case
+    Update _ key _ -> Just key
+    Delete -> Nothing
+
+data Tagger = Tagger (forall a . String -> String -> a -> a)
+
 updateFileDiagnostics :: MonadIO m
   => Recorder (WithPriority Log)
-  -> NormalizedFilePath
-  -> Maybe Int32
-  -> Key
   -> ShakeExtras
-  -> [FileDiagnostic] -- ^ current results
+  -> NormalizedFilePath
+  -> UpdateFileDiagnostics
   -> m ()
-updateFileDiagnostics recorder fp ver k ShakeExtras{diagnostics, hiddenDiagnostics, publishedDiagnostics, debouncer, lspEnv, ideTesting} current0 = do
+updateFileDiagnostics recorder ShakeExtras{diagnostics, hiddenDiagnostics, publishedDiagnostics, debouncer, lspEnv, ideTesting} fp updateOp = do
   liftIO $ withTrace ("update diagnostics " <> fromString(fromNormalizedFilePath fp)) $ \ addTag -> do
-    addTag "key" (show k)
-    let (currentShown, currentHidden) = partition ((== ShowDiag) . fdShouldShowDiagnostic) current
-        uri = filePathToUri' fp
+    let
         addTagUnsafe :: String -> String -> String -> a -> a
         addTagUnsafe msg t x v = unsafePerformIO(addTag (msg <> t) x) `seq` v
-        update :: (forall a. String -> String -> a -> a) -> [FileDiagnostic] -> STMDiagnosticStore -> STM [FileDiagnostic]
-        update addTagUnsafeMethod new store = addTagUnsafeMethod "count" (show $ Prelude.length new) $ setStageDiagnostics addTagUnsafeMethod uri ver (renderKey k) new store
-        current = map (fdLspDiagnosticL %~ diagsFromRule) current0
-    addTag "version" (show ver)
+        uri = filePathToUri' fp
+    (update, currentShown, currentHidden) <- case updateOp of
+        Update ver key current0 -> do
+            let (currentShown, currentHidden) = partition ((== ShowDiag) . fdShouldShowDiagnostic) current
+                update :: Tagger -> [FileDiagnostic] -> STMDiagnosticStore -> STM [FileDiagnostic]
+                update (Tagger addTagUnsafeMethod) new store = addTagUnsafeMethod "count" (show $ Prelude.length new) $ setStageDiagnostics addTagUnsafeMethod uri ver (renderKey key) new store
+                current = map (fdLspDiagnosticL %~ diagsFromRule) current0
+            addTag "key" (show key)
+            addTag "version" (show ver)
+            pure (update, currentShown, currentHidden)
+        Delete -> do
+            let delete :: Tagger -> [FileDiagnostic] -> STMDiagnosticStore -> STM [FileDiagnostic]
+                delete (Tagger addTagUnsafeMethod) _ store = do
+                    deleteStageDiagnostics addTagUnsafeMethod uri store
+                    pure []
+            pure (delete, [], [])
     mask_ $ do
         -- Mask async exceptions to ensure that updated diagnostics are always
         -- published. Otherwise, we might never publish certain diagnostics if
         -- an exception strikes between modifyVar but before
         -- publishDiagnosticsNotification.
-        newDiags <- liftIO $ atomicallyNamed "diagnostics - update" $ update (addTagUnsafe "shown ") currentShown diagnostics
-        _ <- liftIO $ atomicallyNamed "diagnostics - hidden" $ update (addTagUnsafe "hidden ") currentHidden hiddenDiagnostics
+        newDiags <- liftIO $ atomicallyNamed "diagnostics - update" $ update (Tagger $ addTagUnsafe "shown ") currentShown diagnostics
+        _ <- liftIO $ atomicallyNamed "diagnostics - hidden" $ update (Tagger $ addTagUnsafe "hidden ") currentHidden hiddenDiagnostics
         let uri' = filePathToUri' fp
         let delay = if null newDiags then 0.1 else 0
         registerEvent debouncer delay uri' $ withTrace ("report diagnostics " <> fromString (fromNormalizedFilePath fp)) $ \tag -> do
@@ -1393,14 +1424,16 @@ updateFileDiagnostics recorder fp ver k ShakeExtras{diagnostics, hiddenDiagnosti
                             logWith recorder Info $ LogDiagsDiffButNoLspEnv newDiags
                         Just env -> LSP.runLspT env $ do
                             liftIO $ tag "count" (show $ Prelude.length newDiags)
-                            liftIO $ tag "key" (show k)
+                            liftIO $ tag "key" (show $ getKey updateOp)
+                            let ver = fmap fromIntegral $ getUpdateVersion updateOp
                             LSP.sendNotification SMethod_TextDocumentPublishDiagnostics $
-                                LSP.PublishDiagnosticsParams (fromNormalizedUri uri') (fmap fromIntegral ver) (map fdLspDiagnostic newDiags)
+                                LSP.PublishDiagnosticsParams (fromNormalizedUri uri') ver (map fdLspDiagnostic newDiags)
                 return action
     where
         diagsFromRule :: Diagnostic -> Diagnostic
         diagsFromRule c@Diagnostic{_range}
-            | coerce ideTesting = c & L.relatedInformation ?~
+            | coerce ideTesting,
+              Just k <- getKey updateOp = c & L.relatedInformation ?~
                         [ DiagnosticRelatedInformation
                             (Location
                                 (filePathToUri $ fromNormalizedFilePath fp)
@@ -1441,6 +1474,20 @@ updateSTMDiagnostics addTag store uri mv newDiagsBySource =
       | mvs == mv = Just (StoreItem' mv (newDiagsBySource <> dbs))
     update _ = Just (StoreItem' mv newDiagsBySource)
 
+deleteSTMDiagnostics ::
+  (forall a. String -> String -> a -> a) ->
+  STMDiagnosticStore ->
+  NormalizedUri ->
+  STM ()
+deleteSTMDiagnostics addTag store uri =
+    STM.focus (Focus.alter delete) uri store
+  where
+    delete (Just(StoreItem' mv dbs))
+      | addTag "previous version" (show mv) $
+      addTag "previous count" (show $ Prelude.length $ filter (not.null) $ Map.elems dbs) False = undefined
+      | otherwise = Nothing
+    delete storeItem = storeItem
+
 -- | Sets the diagnostics for a file and compilation step
 --   if you want to clear the diagnostics call this with an empty list
 setStageDiagnostics
@@ -1454,6 +1501,16 @@ setStageDiagnostics
 setStageDiagnostics addTag uri ver stage diags ds = updateSTMDiagnostics addTag ds uri ver updatedDiags
   where
     !updatedDiags = Map.singleton (Just stage) $! SL.toSortedList diags
+
+-- | Sets the diagnostics for a file and compilation step
+--   if you want to clear the diagnostics call this with an empty list
+deleteStageDiagnostics
+    :: (forall a. String -> String -> a -> a)
+    -> NormalizedUri
+    -> STMDiagnosticStore
+    -> STM ()
+deleteStageDiagnostics addTag uri ds = deleteSTMDiagnostics addTag ds uri
+
 
 getAllDiagnostics ::
     STMDiagnosticStore ->

--- a/ghcide/src/Development/IDE/GHC/Compat/Core.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Core.hs
@@ -187,6 +187,7 @@ module Development.IDE.GHC.Compat.Core (
     unLocA,
     LocatedAn,
     GHC.LocatedA,
+    -- GHC.SrcSpanAnnA,
     GHC.AnnListItem(..),
     GHC.NameAnn(..),
     SrcLoc.RealLocated,

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -15,7 +15,7 @@ import qualified Language.LSP.Protocol.Message         as LSP
 import           Language.LSP.Protocol.Types
 import qualified Language.LSP.Protocol.Types           as LSP
 
-import           Control.Concurrent.STM.Stats          (atomically)
+import           Control.Concurrent.STM.Stats          (atomically, atomicallyNamed)
 import           Control.Monad.Extra
 import           Control.Monad.IO.Class
 import qualified Data.HashMap.Strict                   as HM
@@ -33,10 +33,17 @@ import           Development.IDE.Core.OfInterest       hiding (Log, LogShake)
 import           Development.IDE.Core.Service          hiding (Log, LogShake)
 import           Development.IDE.Core.Shake            hiding (Log)
 import qualified Development.IDE.Core.Shake            as Shake
+import qualified Development.IDE.Types.Shake           as Shake
 import           Development.IDE.Types.Location
 import           Ide.Logger
 import           Ide.Types
 import           Numeric.Natural
+import Development.IDE.Core.RuleTypes (GhcSessionIO(..))
+import GHC.IO.Unsafe (unsafePerformIO)
+import Development.IDE.Core.Tracing (withTrace)
+import Control.Lens ((^.))
+import qualified Language.LSP.Protocol.Lens as FD
+import Data.Foldable (traverse_)
 
 data Log
   = LogShake Shake.Log
@@ -46,6 +53,7 @@ data Log
   | LogSavedTextDocument !Uri
   | LogClosedTextDocument !Uri
   | LogWatchedFileEvents !Text.Text
+  | LogSessionRestart
   | LogWarnNoWatchedFilesSupport
   deriving Show
 
@@ -59,6 +67,7 @@ instance Pretty Log where
     LogClosedTextDocument uri -> "Closed text document:" <+> pretty (getUri uri)
     LogWatchedFileEvents msg -> "Watched file events:" <+> pretty msg
     LogWarnNoWatchedFilesSupport -> "Client does not support watched files. Falling back to OS polling"
+    LogSessionRestart ->  "Restarting shake session globally"
 
 whenUriFile :: Uri -> (NormalizedFilePath -> IO ()) -> IO ()
 whenUriFile uri act = whenJust (LSP.uriToFilePath uri) $ act . toNormalizedFilePath'
@@ -147,6 +156,24 @@ descriptor recorder plId = (defaultPluginDescriptor plId desc) { pluginNotificat
       success <- registerFileWatches globs
       unless success $
         liftIO $ logWith recorder Warning LogWarnNoWatchedFilesSupport
+  , mkPluginNotificationHandler LSP.SMethod_WorkspaceDidDeleteFiles $
+      \ide vfs _ (DeleteFilesParams (fileDeletes)) ->
+        traverse_
+        (\fd -> do
+          let uri = fd ^. FD.uri
+          --TODO delete from diagnostics
+          updateFileDiagnostics (cmapWithPrio LogShake recorder) (shakeExtras ide) (toNormalizedFilePath $ Text.unpack uri) Delete
+          logWith recorder Debug LogSessionRestart
+          liftIO $ Shake.shakeRestart (cmapWithPrio LogShake recorder) ide (VFSModified vfs) "" [] $ do
+            return [Shake.toNoFileKey GhcSessionIO]
+        )
+        fileDeletes
+  , mkPluginNotificationHandler LSP.SMethod_WorkspaceDidRenameFiles $
+              \ide vfs _ _ -> liftIO $ do
+                logWith recorder Debug LogSessionRestart
+                Shake.shakeRestart (cmapWithPrio LogShake recorder) ide (VFSModified vfs) "" [] $ do
+                  return [Shake.toNoFileKey GhcSessionIO]
+                pure ()
   ],
 
     -- The ghcide descriptors should come last'ish so that the notification handlers

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -129,6 +129,7 @@ import           System.Process                           (readProcessWithExitCo
 import           System.Random                            (newStdGen)
 import           System.Time.Extra                        (Seconds, offsetTime,
                                                            showDuration)
+import qualified Language.LSP.Protocol.Types as LSP
 
 data Log
   = LogHeapStats !HeapStats.Log
@@ -300,7 +301,87 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
     let hlsPlugin = asGhcIdePlugin (cmapWithPrio LogPluginHLS recorder) argsHlsPlugins
         hlsCommands = allLspCmdIds' pid argsHlsPlugins
         plugins = hlsPlugin <> argsGhcidePlugin
-        options = argsLspOptions { LSP.optExecuteCommandCommands = LSP.optExecuteCommandCommands argsLspOptions <> Just hlsCommands }
+        options = argsLspOptions {
+          LSP.optExecuteCommandCommands = LSP.optExecuteCommandCommands argsLspOptions <> Just hlsCommands,
+          LSP.optWorkspaceWillRenameFileOperationRegistrationOptions = Just $
+            LSP.FileOperationRegistrationOptions
+              [LSP.FileOperationFilter
+              {_scheme= Just "file", _pattern = LSP.FileOperationPattern
+                  { {-|
+                  The glob pattern to match. Glob patterns can have the following syntax:
+                  - `*` to match one or more characters in a path segment
+                  - `?` to match on one character in a path segment
+                  - `**` to match any number of path segments, including none
+                  - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+                  - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+                  - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+                  -}
+                  _glob = "**/*.hs"
+                  , {-|
+                  Whether to match files or folders with this pattern.
+
+                  Matches both if undefined.
+                  -}
+                  _matches = Nothing
+                  , {-|
+                  Additional options used during matching.
+                  -}
+                  _options = Nothing
+                }
+              }],
+          LSP.optWorkspaceDidRenameFileOperationRegistrationOptions = Just $
+           LSP.FileOperationRegistrationOptions
+              [LSP.FileOperationFilter
+              {_scheme= Just "file", _pattern = LSP.FileOperationPattern
+                  { {-|
+                  The glob pattern to match. Glob patterns can have the following syntax:
+                  - `*` to match one or more characters in a path segment
+                  - `?` to match on one character in a path segment
+                  - `**` to match any number of path segments, including none
+                  - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+                  - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+                  - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+                  -}
+                  _glob = "**/*.hs"
+                  , {-|
+                  Whether to match files or folders with this pattern.
+
+                  Matches both if undefined.
+                  -}
+                  _matches = Nothing
+                  , {-|
+                  Additional options used during matching.
+                  -}
+                  _options = Nothing
+                }
+              }],
+          LSP.optWorkspaceDidDeleteFileOperationRegistrationOptions = Just $
+           LSP.FileOperationRegistrationOptions
+              [LSP.FileOperationFilter
+              {_scheme= Just "file", _pattern = LSP.FileOperationPattern
+                  { {-|
+                  The glob pattern to match. Glob patterns can have the following syntax:
+                  - `*` to match one or more characters in a path segment
+                  - `?` to match on one character in a path segment
+                  - `**` to match any number of path segments, including none
+                  - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+                  - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+                  - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+                  -}
+                  _glob = "**/*.hs"
+                  , {-|
+                  Whether to match files or folders with this pattern.
+
+                  Matches both if undefined.
+                  -}
+                  _matches = Nothing
+                  , {-|
+                  Additional options used during matching.
+                  -}
+                  _options = Nothing
+                }
+              }]
+          } --TODO extract commonalities
         argsParseConfig = getConfigFromNotification argsHlsPlugins
         rules = do
             argsRules

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -261,6 +261,7 @@ library hls-cabal-plugin
     Ide.Plugin.Cabal.CabalAdd.Command
     Ide.Plugin.Cabal.CabalAdd.CodeAction
     Ide.Plugin.Cabal.CabalAdd.Types
+    Ide.Plugin.Cabal.CabalAdd.Rename
     Ide.Plugin.Cabal.Orphans
     Ide.Plugin.Cabal.Outline
     Ide.Plugin.Cabal.Parse

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -597,9 +597,12 @@ library hls-rename-plugin
   exposed-modules:
     Ide.Plugin.Rename
     Ide.Plugin.Rename.ModuleName
+    Ide.Plugin.Rename.ModuleRename
   hs-source-dirs:   plugins/hls-rename-plugin/src
   build-depends:
+    , extra ^>=1.8.1
     , aeson
+    , text-rope ^>=0.3
     , containers
     , filepath
     , ghc

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -614,7 +614,7 @@ instance PluginMethod Request (Method_CustomMethod m) where
   handlesRequest _ _ _ _ _ = HandlesRequest
 
 instance PluginMethod Request Method_WorkspaceWillRenameFiles where
-  handlesRequest _ _ desc conf = pluginEnabledGlobally desc conf
+  handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
 
 -- Plugin Notifications
 
@@ -638,13 +638,17 @@ instance PluginMethod Notification Method_WorkspaceDidChangeConfiguration where
   -- This method has no URI parameter, thus no call to 'pluginResponsible'.
   handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
 
-instance PluginMethod Notification Method_WorkspaceDidRenameFiles where
-  handlesRequest :: SMethod Method_WorkspaceDidRenameFiles
-    -> MessageParams Method_WorkspaceDidRenameFiles
+instance PluginMethod Notification Method_WorkspaceDidDeleteFiles where
+  handlesRequest :: VFS
+    -> SMethod Method_WorkspaceDidDeleteFiles
+    -> MessageParams Method_WorkspaceDidDeleteFiles
     -> PluginDescriptor c
     -> Config
     -> HandleRequestResult
-  handlesRequest _ _ desc conf = pluginEnabledGlobally desc conf
+  handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
+
+instance PluginMethod Notification Method_WorkspaceDidRenameFiles where
+  handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
 
 instance PluginMethod Notification Method_Initialized where
   -- This method has no URI parameter, thus no call to 'pluginResponsible'.
@@ -927,6 +931,8 @@ instance PluginNotificationMethod Method_WorkspaceDidChangeWorkspaceFolders wher
 instance PluginNotificationMethod Method_WorkspaceDidChangeConfiguration where
 
 instance PluginNotificationMethod Method_Initialized where
+
+instance PluginNotificationMethod Method_WorkspaceDidDeleteFiles where
 
 instance PluginNotificationMethod Method_WorkspaceDidRenameFiles where
 
@@ -1261,6 +1267,7 @@ instance HasTracing DocumentLink
 instance HasTracing InlayHint
 instance HasTracing WorkspaceSymbol
 instance HasTracing RenameFilesParams
+instance HasTracing DeleteFilesParams
 -- ---------------------------------------------------------------------
 --Experimental resolve refactoring
 {-# NOINLINE pROCESS_ID #-}

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -635,6 +635,14 @@ instance PluginMethod Notification Method_WorkspaceDidChangeConfiguration where
   -- This method has no URI parameter, thus no call to 'pluginResponsible'.
   handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
 
+instance PluginMethod Notification Method_WorkspaceDidRenameFiles where
+  handlesRequest :: SMethod Method_WorkspaceDidRenameFiles
+    -> MessageParams Method_WorkspaceDidRenameFiles
+    -> PluginDescriptor c
+    -> Config
+    -> HandleRequestResult
+  handlesRequest _ _ desc conf = pluginEnabledGlobally desc conf
+
 instance PluginMethod Notification Method_Initialized where
   -- This method has no URI parameter, thus no call to 'pluginResponsible'.
   handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
@@ -914,6 +922,8 @@ instance PluginNotificationMethod Method_WorkspaceDidChangeWorkspaceFolders wher
 instance PluginNotificationMethod Method_WorkspaceDidChangeConfiguration where
 
 instance PluginNotificationMethod Method_Initialized where
+
+instance PluginNotificationMethod Method_WorkspaceDidRenameFiles where
 
 -- ---------------------------------------------------------------------
 
@@ -1245,6 +1255,7 @@ instance HasTracing CompletionItem
 instance HasTracing DocumentLink
 instance HasTracing InlayHint
 instance HasTracing WorkspaceSymbol
+instance HasTracing RenameFilesParams
 -- ---------------------------------------------------------------------
 --Experimental resolve refactoring
 {-# NOINLINE pROCESS_ID #-}

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -613,6 +613,9 @@ instance PluginMethod Request Method_WorkspaceExecuteCommand where
 instance PluginMethod Request (Method_CustomMethod m) where
   handlesRequest _ _ _ _ _ = HandlesRequest
 
+instance PluginMethod Request Method_WorkspaceWillRenameFiles where
+  handlesRequest _ _ desc conf = pluginEnabledGlobally desc conf
+
 -- Plugin Notifications
 
 instance PluginMethod Notification Method_TextDocumentDidOpen where
@@ -851,6 +854,8 @@ instance PluginRequestMethod Method_TextDocumentSemanticTokensFullDelta where
 
 instance PluginRequestMethod Method_TextDocumentInlayHint where
   combineResponses _ _ _ _ x = sconcat x
+
+instance PluginRequestMethod Method_WorkspaceWillRenameFiles where
 
 takeLefts :: [a |? b] -> [a]
 takeLefts = mapMaybe (\x -> [res | (InL res) <- Just x])

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -16,10 +16,15 @@ import qualified Data.List                                     as List
 import qualified Data.Maybe                                    as Maybe
 import qualified Data.Text                                     ()
 import qualified Data.Text                                     as T
+import           Data.Text.Utf16.Rope.Mixed                    as Rope
+
+import           Control.Monad.Except                          (runExceptT)
 import           Development.IDE                               as D
-import           Development.IDE.Core.FileStore                (getVersionedTextDoc)
+import           Development.IDE.Core.FileStore                (getVersionedTextDoc,
+                                                                getVersionedTextDocForNormalizedFilePath)
 import           Development.IDE.Core.PluginUtils
-import           Development.IDE.Core.Shake                    (restartShakeSession)
+import           Development.IDE.Core.Shake                    (getIdeGlobalState,
+                                                                restartShakeSession)
 import           Development.IDE.Graph                         (Key)
 import           Development.IDE.LSP.HoverDefinition           (foundHover)
 import qualified Development.IDE.Plugin.Completions.Logic      as Ghcide
@@ -33,6 +38,7 @@ import           Distribution.PackageDescription.Configuration (flattenPackageDe
 import qualified Distribution.Parsec.Position                  as Syntax
 import qualified Ide.Plugin.Cabal.CabalAdd.CodeAction          as CabalAdd
 import qualified Ide.Plugin.Cabal.CabalAdd.Command             as CabalAdd
+import qualified Ide.Plugin.Cabal.CabalAdd.Rename              as Rename
 import           Ide.Plugin.Cabal.Completion.CabalFields       as CabalFields
 import qualified Ide.Plugin.Cabal.Completion.Completer.Types   as CompleterTypes
 import qualified Ide.Plugin.Cabal.Completion.Completions       as Completions
@@ -53,10 +59,16 @@ import           Ide.Types
 import qualified Language.LSP.Protocol.Lens                    as JL
 import qualified Language.LSP.Protocol.Message                 as LSP
 import           Language.LSP.Protocol.Types
+import           Language.LSP.Server                           (LspM,
+                                                                getClientCapabilities,
+                                                                getConfig)
+import qualified Language.LSP.Server                           as LSP
 import qualified Language.LSP.VFS                              as VFS
 import qualified Text.Fuzzy.Levenshtein                        as Fuzzy
 import qualified Text.Fuzzy.Parallel                           as Fuzzy
 import           Text.Regex.TDFA
+import Data.Text.Encoding (encodeUtf8)
+import Debug.Trace (traceShowM)
 
 data Log
   = LogModificationTime NormalizedFilePath FileVersion
@@ -70,6 +82,7 @@ data Log
   | LogCompletionContext Types.Context Position
   | LogCompletions Types.Log
   | LogCabalAdd CabalAdd.Log
+  | LogDidRename Rename.Log
   deriving (Show)
 
 instance Pretty Log where
@@ -95,6 +108,7 @@ instance Pretty Log where
         <+> pretty position
     LogCompletions logs -> pretty logs
     LogCabalAdd logs -> pretty logs
+    LogDidRename logs -> pretty logs
 
 {- | Some actions in cabal files can be triggered from haskell files.
 This descriptor allows us to hook into the diagnostics of haskell source files and
@@ -155,6 +169,11 @@ descriptor recorder plId =
                   log' Debug $ LogDocClosed _uri
                   restartCabalShakeSession (shakeExtras ide) vfs file "(closed)" $
                     OfInterest.deleteFileOfInterest ofInterestRecorder ide file
+          , mkPluginNotificationHandler LSP.SMethod_WorkspaceDidRenameFiles $
+            \ide vfs _ (RenameFilesParams (renames)) -> do
+              case renames of
+                (fileRename:_) -> renameModuleHandler recorder ide fileRename
+                _ -> error "cannot handle multiple file renames"
           ]
     , pluginConfigDescriptor =
         defaultConfigDescriptor
@@ -299,6 +318,36 @@ cabalAddModuleCodeAction recorder state plId (CodeActionParams _ _ (TextDocument
                 uri
             pure $ InL $ fmap InR actions
     Nothing -> pure $ InL []
+
+renameModuleHandler :: Recorder (WithPriority Log) -> IdeState -> FileRename -> LspM Config ()
+renameModuleHandler recorder ide (FileRename oldUri newUri) = do
+    caps <- getClientCapabilities
+    renameResult <- runExceptT $ do
+      oldHaskellFilePath <- uriToFilePathE $ Uri oldUri
+      newHaskellFilePath <- uriToFilePathE $ Uri newUri
+      mbCabalFile <- liftIO $ CabalAdd.findResponsibleCabalFile oldHaskellFilePath
+      case mbCabalFile of
+          Nothing -> pure undefined -- log this maybe
+          Just cabalFilePath -> do
+            mCabalInfo <- runActionE "cabal-plugin.getUriContents" ide $ do
+              let nuri = toNormalizedUri $ filePathToUri cabalFilePath
+                  nfp = toNormalizedFilePath cabalFilePath
+              mcontent <- lift $ getUriContents nuri
+              verTextDocId <- lift $ getVersionedTextDocForNormalizedFilePath nfp
+              (fields, _) <- useWithStaleE ParseCabalFields nfp
+              (gpd, _) <- useWithStaleE ParseCabalFile nfp
+              pure (mcontent, fields, gpd, verTextDocId)
+            case mCabalInfo of
+              (Just contents, fields, gpd, verTextDocId) ->
+                Rename.renameHandler (cmapWithPrio LogDidRename recorder) ide (caps, verTextDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath (encodeUtf8 $ Rope.toText contents) fields gpd
+              _ -> undefined
+
+    case renameResult of
+      Left err -> do
+        traceShowM ("BANANA", pretty err) --todo better error handling pls
+      Right edit -> do
+        _ <- LSP.sendRequest LSP.SMethod_WorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing edit) (\_ -> pure ())
+        pure ()
 
 {- | Handler for hover messages.
 

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -69,6 +69,7 @@ import qualified Text.Fuzzy.Parallel                           as Fuzzy
 import           Text.Regex.TDFA
 import Data.Text.Encoding (encodeUtf8)
 import Debug.Trace (traceShowM)
+import Control.Monad.Trans.Except (ExceptT)
 
 data Log
   = LogModificationTime NormalizedFilePath FileVersion
@@ -142,6 +143,11 @@ descriptor recorder plId =
           , mkPluginHandler LSP.SMethod_TextDocumentCodeAction $ fieldSuggestCodeAction recorder
           , mkPluginHandler LSP.SMethod_TextDocumentDefinition gotoDefinition
           , mkPluginHandler LSP.SMethod_TextDocumentHover hover
+          , mkPluginHandler LSP.SMethod_WorkspaceWillRenameFiles $
+            \ide _ (RenameFilesParams (renames)) -> do
+              case renames of
+                (fileRename:_) -> renameModuleHandler recorder ide fileRename
+                _ -> error "cannot handle multiple file renames"
           ]
     , pluginNotificationHandlers =
         mconcat
@@ -169,11 +175,6 @@ descriptor recorder plId =
                   log' Debug $ LogDocClosed _uri
                   restartCabalShakeSession (shakeExtras ide) vfs file "(closed)" $
                     OfInterest.deleteFileOfInterest ofInterestRecorder ide file
-          , mkPluginNotificationHandler LSP.SMethod_WorkspaceDidRenameFiles $
-            \ide vfs _ (RenameFilesParams (renames)) -> do
-              case renames of
-                (fileRename:_) -> renameModuleHandler recorder ide fileRename
-                _ -> error "cannot handle multiple file renames"
           ]
     , pluginConfigDescriptor =
         defaultConfigDescriptor
@@ -319,9 +320,9 @@ cabalAddModuleCodeAction recorder state plId (CodeActionParams _ _ (TextDocument
             pure $ InL $ fmap InR actions
     Nothing -> pure $ InL []
 
-renameModuleHandler :: Recorder (WithPriority Log) -> IdeState -> FileRename -> LspM Config ()
-renameModuleHandler recorder ide (FileRename oldUri newUri) = do
-    caps <- getClientCapabilities
+renameModuleHandler :: Recorder (WithPriority Log) -> IdeState -> FileRename -> ExceptT PluginError (HandlerM Config) (WorkspaceEdit |? Null)
+renameModuleHandler recorder state (FileRename oldUri newUri) = do
+    caps <- lift pluginGetClientCapabilities
     renameResult <- runExceptT $ do
       oldHaskellFilePath <- uriToFilePathE $ Uri oldUri
       newHaskellFilePath <- uriToFilePathE $ Uri newUri
@@ -329,7 +330,7 @@ renameModuleHandler recorder ide (FileRename oldUri newUri) = do
       case mbCabalFile of
           Nothing -> pure undefined -- log this maybe
           Just cabalFilePath -> do
-            mCabalInfo <- runActionE "cabal-plugin.getUriContents" ide $ do
+            mCabalInfo <- runActionE "cabal-plugin.getUriContents" state $ do
               let nuri = toNormalizedUri $ filePathToUri cabalFilePath
                   nfp = toNormalizedFilePath cabalFilePath
               mcontent <- lift $ getUriContents nuri
@@ -339,15 +340,15 @@ renameModuleHandler recorder ide (FileRename oldUri newUri) = do
               pure (mcontent, fields, gpd, verTextDocId)
             case mCabalInfo of
               (Just contents, fields, gpd, verTextDocId) ->
-                Rename.renameHandler (cmapWithPrio LogDidRename recorder) ide (caps, verTextDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath (encodeUtf8 $ Rope.toText contents) fields gpd
+                Rename.renameHandler (cmapWithPrio LogDidRename recorder) state (caps, verTextDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath (encodeUtf8 $ Rope.toText contents) fields gpd
               _ -> undefined
 
     case renameResult of
       Left err -> do
         traceShowM ("BANANA", pretty err) --todo better error handling pls
+        pure $ InR Null
       Right edit -> do
-        _ <- LSP.sendRequest LSP.SMethod_WorkspaceApplyEdit (ApplyWorkspaceEditParams Nothing edit) (\_ -> pure ())
-        pure ()
+        pure $ InL edit
 
 {- | Handler for hover messages.
 

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -18,13 +18,17 @@ import qualified Data.Text                                     ()
 import qualified Data.Text                                     as T
 import           Data.Text.Utf16.Rope.Mixed                    as Rope
 
-import           Control.Monad.Except                          (runExceptT)
+import           Control.Monad.Except                          (runExceptT, MonadError (..))
+import           Control.Monad.Trans.Except                    (ExceptT)
+import           Data.Text.Encoding                            (encodeUtf8)
+import qualified Data.Text.IO                                  as Text
+import           Debug.Trace                                   (traceShowM)
 import           Development.IDE                               as D
 import           Development.IDE.Core.FileStore                (getVersionedTextDoc,
                                                                 getVersionedTextDocForNormalizedFilePath)
 import           Development.IDE.Core.PluginUtils
-import           Development.IDE.Core.Shake                    (getIdeGlobalState,
-                                                                restartShakeSession)
+import           Development.IDE.Core.Shake                    (restartShakeSession)
+import qualified Development.IDE.Core.Shake                    as Shake
 import           Development.IDE.Graph                         (Key)
 import           Development.IDE.LSP.HoverDefinition           (foundHover)
 import qualified Development.IDE.Plugin.Completions.Logic      as Ghcide
@@ -59,17 +63,13 @@ import           Ide.Types
 import qualified Language.LSP.Protocol.Lens                    as JL
 import qualified Language.LSP.Protocol.Message                 as LSP
 import           Language.LSP.Protocol.Types
-import           Language.LSP.Server                           (LspM,
-                                                                getClientCapabilities,
-                                                                getConfig)
-import qualified Language.LSP.Server                           as LSP
 import qualified Language.LSP.VFS                              as VFS
 import qualified Text.Fuzzy.Levenshtein                        as Fuzzy
 import qualified Text.Fuzzy.Parallel                           as Fuzzy
 import           Text.Regex.TDFA
-import Data.Text.Encoding (encodeUtf8)
-import Debug.Trace (traceShowM)
-import Control.Monad.Trans.Except (ExceptT)
+import qualified Data.Map.Strict as Map
+import Control.Applicative ((<|>))
+import Data.Foldable (foldl')
 
 data Log
   = LogModificationTime NormalizedFilePath FileVersion
@@ -84,6 +84,8 @@ data Log
   | LogCompletions Types.Log
   | LogCabalAdd CabalAdd.Log
   | LogDidRename Rename.Log
+  | LogShake Shake.Log
+  | LogSessionRestart
   deriving (Show)
 
 instance Pretty Log where
@@ -110,6 +112,8 @@ instance Pretty Log where
     LogCompletions logs -> pretty logs
     LogCabalAdd logs -> pretty logs
     LogDidRename logs -> pretty logs
+    LogSessionRestart -> "Restarting shake session globally"
+    LogShake logs -> pretty logs
 
 {- | Some actions in cabal files can be triggered from haskell files.
 This descriptor allows us to hook into the diagnostics of haskell source files and
@@ -143,11 +147,7 @@ descriptor recorder plId =
           , mkPluginHandler LSP.SMethod_TextDocumentCodeAction $ fieldSuggestCodeAction recorder
           , mkPluginHandler LSP.SMethod_TextDocumentDefinition gotoDefinition
           , mkPluginHandler LSP.SMethod_TextDocumentHover hover
-          , mkPluginHandler LSP.SMethod_WorkspaceWillRenameFiles $
-            \ide _ (RenameFilesParams (renames)) -> do
-              case renames of
-                (fileRename:_) -> renameModuleHandler recorder ide fileRename
-                _ -> error "cannot handle multiple file renames"
+          , mkPluginHandler LSP.SMethod_WorkspaceWillRenameFiles $ renameModulesHandler recorder
           ]
     , pluginNotificationHandlers =
         mconcat
@@ -185,7 +185,6 @@ descriptor recorder plId =
   log' = logWith recorder
   ruleRecorder = cmapWithPrio LogRule recorder
   ofInterestRecorder = cmapWithPrio LogOfInterest recorder
-
   whenUriFile :: Uri -> (NormalizedFilePath -> IO ()) -> IO ()
   whenUriFile uri act = whenJust (uriToFilePath uri) $ act . toNormalizedFilePath'
 
@@ -320,35 +319,41 @@ cabalAddModuleCodeAction recorder state plId (CodeActionParams _ _ (TextDocument
             pure $ InL $ fmap InR actions
     Nothing -> pure $ InL []
 
-renameModuleHandler :: Recorder (WithPriority Log) -> IdeState -> FileRename -> ExceptT PluginError (HandlerM Config) (WorkspaceEdit |? Null)
-renameModuleHandler recorder state (FileRename oldUri newUri) = do
+renameModulesHandler :: Recorder (WithPriority Log) -> PluginMethodHandler IdeState LSP.Method_WorkspaceWillRenameFiles
+renameModulesHandler recorder ideState _plId (RenameFilesParams renames) = do
+  renamedEdits <- traverse (renameModuleHelper recorder ideState) renames
+  pure $ InL $ foldl' combineTextEdits (WorkspaceEdit mempty mempty mempty) renamedEdits
+
+
+renameModuleHelper :: Recorder (WithPriority Log) -> IdeState -> FileRename -> ExceptT PluginError (HandlerM Config) WorkspaceEdit
+renameModuleHelper recorder ideState (FileRename oldUri newUri) = do
     caps <- lift pluginGetClientCapabilities
     renameResult <- runExceptT $ do
       oldHaskellFilePath <- uriToFilePathE $ Uri oldUri
       newHaskellFilePath <- uriToFilePathE $ Uri newUri
       mbCabalFile <- liftIO $ CabalAdd.findResponsibleCabalFile oldHaskellFilePath
       case mbCabalFile of
-          Nothing -> pure undefined -- log this maybe
+          Nothing -> pure undefined -- todo log this maybe
           Just cabalFilePath -> do
-            mCabalInfo <- runActionE "cabal-plugin.getUriContents" state $ do
+            (contents, fields, gpd, verTextDocId) <- runActionE "cabal-plugin.getUriContents" ideState $ do -- todo mv to handler
               let nuri = toNormalizedUri $ filePathToUri cabalFilePath
                   nfp = toNormalizedFilePath cabalFilePath
-              mcontent <- lift $ getUriContents nuri
+              mContent <- lift $ getUriContents nuri
+              content <- case mContent of
+                Just content -> pure content
+                Nothing -> liftIO $ Rope.fromText <$> Text.readFile cabalFilePath
               verTextDocId <- lift $ getVersionedTextDocForNormalizedFilePath nfp
               (fields, _) <- useWithStaleE ParseCabalFields nfp
               (gpd, _) <- useWithStaleE ParseCabalFile nfp
-              pure (mcontent, fields, gpd, verTextDocId)
-            case mCabalInfo of
-              (Just contents, fields, gpd, verTextDocId) ->
-                Rename.renameHandler (cmapWithPrio LogDidRename recorder) state (caps, verTextDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath (encodeUtf8 $ Rope.toText contents) fields gpd
-              _ -> undefined
+              pure (content, fields, gpd, verTextDocId)
+            Rename.renameHandler (cmapWithPrio LogDidRename recorder) ideState (caps, verTextDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath (encodeUtf8 $ Rope.toText contents) fields gpd
 
     case renameResult of
       Left err -> do
         traceShowM ("BANANA", pretty err) --todo better error handling pls
-        pure $ InR Null
+        throwError undefined
       Right edit -> do
-        pure $ InL edit
+        pure edit
 
 {- | Handler for hover messages.
 
@@ -460,3 +465,14 @@ computeCompletionsAt recorder ide prefInfo fp fields matcher = do
   pos = Types.completionCursorPosition prefInfo
   context fields = Completions.getContext completerRecorder prefInfo fields
   completerRecorder = cmapWithPrio LogCompletions recorder
+
+combineTextEdits :: WorkspaceEdit  -> WorkspaceEdit -> WorkspaceEdit
+combineTextEdits (WorkspaceEdit c1 dc1 ca1) (WorkspaceEdit c2 dc2 ca2) =
+  WorkspaceEdit c dc ca
+ where
+  c = liftA2 (Map.unionWith (<>)) c1 c2 <|> c1 <|> c2
+  dc = dc1 <> dc2
+  -- We know this might result in information loss due to the monad instance of map,
+  -- but we do not expect our use of workspacedit combination to contain two changeAnnotations
+  -- for the same edit.
+  ca = ca1 <> ca2

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/CodeAction.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/CodeAction.hs
@@ -248,7 +248,7 @@ addDependencySuggestCodeAction ::
   GenericPackageDescription ->
   IO [J.CodeAction]
 addDependencySuggestCodeAction plId verTxtDocId suggestions haskellFilePath cabalFilePath gpd = do
-  buildTargets <- liftIO $ getBuildTargets gpd cabalFilePath haskellFilePath
+  buildTargets <- liftIO $ getBuildTargets (flattenPackageDescription gpd) cabalFilePath haskellFilePath
   case buildTargets of
     -- If there are no build targets found, run the `cabal-add` command with default behaviour
     [] -> pure $ mkCodeActionForDependency cabalFilePath Nothing <$> suggestions
@@ -266,17 +266,6 @@ addDependencySuggestCodeAction plId verTxtDocId suggestions haskellFilePath caba
    It will be used as the input for `cabal-add`'s `executeConfig`.
   -}
   buildTargetToStringRepr target = render $ CabalPretty.pretty $ buildTargetComponentName target
-
-  {- | Finds the build targets that are used in `cabal-add`.
-   Note the unorthodox usage of `readBuildTargets`:
-   If the relative path to the haskell file is provided,
-   `readBuildTargets` will return the build targets, this
-   module is mentioned in (either exposed-modules or other-modules).
-  -}
-  getBuildTargets :: GenericPackageDescription -> FilePath -> FilePath -> IO [BuildTarget]
-  getBuildTargets gpd cabalFilePath haskellFilePath = do
-    let haskellFileRelativePath = makeRelative (dropFileName cabalFilePath) haskellFilePath
-    readBuildTargets (verboseNoStderr silent) (flattenPackageDescription gpd) [haskellFileRelativePath]
 
   mkCodeActionForDependency :: FilePath -> Maybe String -> (T.Text, T.Text) -> J.CodeAction
   mkCodeActionForDependency cabalFilePath target (suggestedDep, suggestedVersion) =
@@ -299,6 +288,17 @@ addDependencySuggestCodeAction plId verTxtDocId suggestions haskellFilePath caba
       command = mkLspCommand plId (CommandId cabalAddDependencyCommandId) "Add dependency" (Just [toJSON params])
      in
       J.CodeAction title (Just CodeActionKind_QuickFix) (Just []) Nothing Nothing Nothing (Just command) Nothing
+
+{- | Finds the build targets that are used in `cabal-add`.
+  Note the unorthodox usage of `readBuildTargets`:
+  If the relative path to the haskell file is provided,
+  `readBuildTargets` will return the build targets, this
+  module is mentioned in (either exposed-modules or other-modules).
+-}
+getBuildTargets :: PackageDescription -> FilePath -> FilePath -> IO [BuildTarget]
+getBuildTargets pd cabalFilePath haskellFilePath = do
+  let haskellFileRelativePath = makeRelative (dropFileName cabalFilePath) haskellFilePath
+  readBuildTargets (verboseNoStderr silent) pd [haskellFileRelativePath]
 
 {- | Gives a mentioned number of @(dependency, version)@ pairs
 found in the "hidden package" diagnostic message.

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/Rename.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/Rename.hs
@@ -97,16 +97,12 @@ renameHandler recorder ideState (caps, verTxtDocId) oldHaskellFilePath newHaskel
 
 renameModuleDeclaration :: MonadIO m => Recorder (WithPriority Log) -> IdeState -> FilePath -> FilePath -> T.Text -> ExceptT PluginError m WorkspaceEdit
 renameModuleDeclaration recorder ideState oldHaskellFilePath newHaskellFilePath newModulePath = do
-  traceShowM ("BANANA in rename decl")
-  verTextDocId <- runActionE "cabal-plugin.getUriContents" ideState $ lift $ getVersionedTextDocForNormalizedFilePath $ toNormalizedFilePath newHaskellFilePath
-  traceShowM ("BANANA textdocid", verTextDocId)
+  verTextDocId <- runActionE "cabal-plugin.getUriContents" ideState $ lift $ getVersionedTextDocForNormalizedFilePath $ toNormalizedFilePath oldHaskellFilePath
   rangeToRename <- maybeToExceptT PluginStaleResolve $
       MaybeT $ liftIO $ moduleNameRange ideState $ toNormalizedFilePath oldHaskellFilePath
-  traceShowM ("BANANA rangetorename", rangeToRename)
   let diff = TextEdit rangeToRename newModulePath
       renameEdit = TextDocumentEdit (verTextDocId  ^. re _versionedTextDocumentIdentifier) $ fmap InL [diff]
-  pure $ WorkspaceEdit Nothing (Just [InL renameEdit]) Nothing-- [Replace uri nameRange ("Set module name to " <> bestName) bestName]
-
+  pure $ WorkspaceEdit Nothing (Just [InL renameEdit]) Nothing
 
 applyModuleRenameToCabalFile ::
   forall m.
@@ -228,11 +224,8 @@ findFieldForModule modulePath compName pd buildInfo =
 moduleNameRange :: Shake.IdeState -> NormalizedFilePath -> IO (Maybe Range)
 moduleNameRange state nfp = runMaybeT $ do
   (pm, mp) <- MaybeT . runAction "ModuleName.GetParsedModule" state $ Shake.useWithStale GetParsedModule nfp
-  traceShowM ("BANANA 1")
   L (locA -> (RealSrcSpan l _)) _ <- MaybeT . pure . hsmodName . unLoc $ GHC.pm_parsed_source pm
-  traceShowM ("BANANA 2")
   range <- MaybeT . pure $ toCurrentRange mp (realSrcSpanToRange l)
-  traceShowM ("BANANA 3")
   pure range
 
 

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/Rename.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/Rename.hs
@@ -1,0 +1,248 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+
+module Ide.Plugin.Cabal.CabalAdd.Rename (
+  renameHandler,
+  Log,
+)
+where
+import           Control.Lens                                  (re)
+import           Control.Lens.Getter                           ((^.))
+import           Control.Monad.IO.Class                        (MonadIO, liftIO)
+import           Control.Monad.Trans
+import           Control.Monad.Trans.Except                    (ExceptT, throwE)
+import           Control.Monad.Trans.Maybe
+import           Data.ByteString                               (ByteString)
+import qualified Data.Maybe                                    as Maybe
+import qualified Data.Text                                     as T
+import qualified Data.Text.Encoding                            as T
+import           Debug.Trace                                   (traceShowId, traceShowM)
+import           Development.IDE.Core.PositionMapping          (toCurrentRange)
+import           Development.IDE.Core.Rules                    hiding (Log)
+import qualified Development.IDE.Core.Shake                    as Shake
+import qualified Development.IDE.GHC.Compat                    as GHC
+import           Development.IDE.GHC.Compat.Core
+import           Development.IDE.GHC.Error                     (realSrcSpanToRange)
+import qualified Distribution.Client.Add                       as Add
+import           Distribution.Client.Rename                    (RenameConfig (..),
+                                                                executeRenameConfig)
+import           Distribution.Fields                           (Field)
+import qualified Distribution.ModuleName                       as Cabal
+import           Distribution.PackageDescription
+import           Distribution.PackageDescription.Configuration (flattenPackageDescription)
+import           Distribution.Parsec.Position                  (Position)
+import           Distribution.Simple.BuildTarget               (buildTargetComponentName)
+import           Ide.Logger
+import           Ide.Plugin.Cabal.CabalAdd.CodeAction          (buildInfoToHsSourceDirs,
+                                                                getBuildTargets,
+                                                                mkRelativeModulePathM)
+import           Ide.Plugin.Cabal.Definition                   (lookupBuildTargetPackageDescription)
+import           Ide.Plugin.Error
+import           Ide.PluginUtils                               (WithDeletions (IncludeDeletions),
+                                                                diffText)
+import           Language.LSP.Protocol.Types                   (ClientCapabilities,
+                                                                NormalizedFilePath,
+                                                                Range,
+                                                                TextDocumentEdit (..),
+                                                                VersionedTextDocumentIdentifier,
+                                                                WorkspaceEdit (WorkspaceEdit),
+                                                                _versionedTextDocumentIdentifier,
+                                                                toNormalizedFilePath,
+                                                                type (|?) (InL), TextEdit (..))
+import Control.Applicative
+import qualified Data.Map.Strict as Map
+import Development.IDE.Core.FileStore (getVersionedTextDocForNormalizedFilePath)
+import Development.IDE.Core.PluginUtils (runActionE)
+
+data Log =
+  LogDidRename FilePath FilePath
+  deriving (Show)
+
+instance Pretty Log where
+  pretty = \case
+    LogDidRename oldFp newFp -> "Received rename info from:" <+> pretty oldFp <+> "to:" <+> pretty newFp
+
+--------------------------------------------
+-- Rename module in cabal file
+--------------------------------------------
+
+renameHandler ::
+  forall m.
+  (MonadIO m) =>
+  Recorder (WithPriority Log) ->
+  Shake.IdeState ->
+  (ClientCapabilities, VersionedTextDocumentIdentifier) ->
+  -- | the old file path before the rename
+  FilePath ->
+  -- | the new file path after the rename
+  FilePath ->
+  -- | the path to the cabal file, responsible for the renamed module
+  FilePath ->
+  -- | the responsible cabal file's contents
+  ByteString ->
+  -- | the responsible cabal file's fields
+  [Field Position] ->
+  GenericPackageDescription ->
+  ExceptT PluginError m WorkspaceEdit
+renameHandler recorder ideState (caps, verTxtDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath cnfOrigContents fields gpd = do
+  let pd = flattenPackageDescription gpd
+  compName <- resolveFileTargetE pd cabalFilePath oldHaskellFilePath
+  buildInfo <- resolveBuildInfoE pd compName
+  newModulePath <- toRelativeModulePathE (buildInfoToHsSourceDirs buildInfo) cabalFilePath newHaskellFilePath
+  cabalFileEdit <- applyModuleRenameToCabalFile recorder (caps, verTxtDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath cnfOrigContents fields gpd
+  modDeclEdit <- renameModuleDeclaration recorder ideState oldHaskellFilePath newHaskellFilePath newModulePath
+  pure $ traceShowId $ combineTextEdits (traceShowId cabalFileEdit) $ traceShowId modDeclEdit
+
+renameModuleDeclaration :: MonadIO m => Recorder (WithPriority Log) -> IdeState -> FilePath -> FilePath -> T.Text -> ExceptT PluginError m WorkspaceEdit
+renameModuleDeclaration recorder ideState oldHaskellFilePath newHaskellFilePath newModulePath = do
+  traceShowM ("BANANA in rename decl")
+  verTextDocId <- runActionE "cabal-plugin.getUriContents" ideState $ lift $ getVersionedTextDocForNormalizedFilePath $ toNormalizedFilePath newHaskellFilePath
+  traceShowM ("BANANA textdocid", verTextDocId)
+  rangeToRename <- maybeToExceptT PluginStaleResolve $
+      MaybeT $ liftIO $ moduleNameRange ideState $ toNormalizedFilePath oldHaskellFilePath
+  traceShowM ("BANANA rangetorename", rangeToRename)
+  let diff = TextEdit rangeToRename newModulePath
+      renameEdit = TextDocumentEdit (verTextDocId  ^. re _versionedTextDocumentIdentifier) $ fmap InL [diff]
+  pure $ WorkspaceEdit Nothing (Just [InL renameEdit]) Nothing-- [Replace uri nameRange ("Set module name to " <> bestName) bestName]
+
+
+applyModuleRenameToCabalFile ::
+  forall m.
+  (MonadIO m) =>
+  Recorder (WithPriority Log) ->
+  (ClientCapabilities, VersionedTextDocumentIdentifier) ->
+  -- | the old file path before the rename
+  FilePath ->
+  -- | the new file path after the rename
+  FilePath ->
+  -- | the path to the cabal file, responsible for the renamed module
+  FilePath ->
+  -- | the responsible cabal file's contents
+  ByteString ->
+  -- | the responsible cabal file's fields
+  [Field Position] ->
+  GenericPackageDescription ->
+  ExceptT PluginError m WorkspaceEdit
+applyModuleRenameToCabalFile recorder (caps, verTxtDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath cnfOrigContents fields gpd = do
+  logWith recorder Info $ LogDidRename oldHaskellFilePath newHaskellFilePath
+  let pd = flattenPackageDescription gpd
+
+  compName <- resolveFileTargetE pd cabalFilePath oldHaskellFilePath
+  buildInfo <- resolveBuildInfoE pd compName
+  newModulePath <- toRelativeModulePathE (buildInfoToHsSourceDirs buildInfo) cabalFilePath newHaskellFilePath
+  oldModulePath <- toRelativeModulePathE (buildInfoToHsSourceDirs buildInfo) cabalFilePath oldHaskellFilePath
+  targetField <- resolveTargetFieldForComponentE oldModulePath compName pd buildInfo
+
+  newContents <- maybeToExceptT PluginStaleResolve $ hoistMaybe $
+    executeRenameConfig (Add.validateChanges gpd) (renameConfig (Right $ compName) targetField oldModulePath newModulePath)
+  pure $ diffText caps (verTxtDocId, T.decodeUtf8 cnfOrigContents) (T.decodeUtf8 newContents) IncludeDeletions
+
+  where
+    -- define renameConfig to pass to cabal-add
+    renameConfig compName targetField from to = RenameConfig
+      { cnfOrigContents = cnfOrigContents
+      , cnfFields = fields
+      , cnfComponent = compName
+      , cnfTargetField = targetField
+      , cnfRenameFrom = T.encodeUtf8 from
+      , cnfRenameTo = T.encodeUtf8 to
+      }
+
+-- | Returns the `BuildInfo` for the given component name.
+-- If the build info cannot be resolved, throws a PluginError.
+resolveBuildInfoE :: Applicative m => PackageDescription -> ComponentName -> ExceptT PluginError m BuildInfo
+resolveBuildInfoE pd compName =
+  maybeToExceptT PluginStaleResolve $ hoistMaybe $ lookupBuildTargetPackageDescription pd (Just compName)
+
+-- | Determines the `ComponentName` of the given file target.
+-- Tries to resolve the file target's component name within the given cabal file.
+-- If the component name cannot be uniquely resolved, throws a PluginError,
+resolveFileTargetE :: MonadIO m => PackageDescription -> FilePath -> FilePath -> ExceptT PluginError m ComponentName
+resolveFileTargetE pd cabalFilePath fileTarget = do
+  buildTargets <- liftIO $ getBuildTargets pd cabalFilePath fileTarget
+  case buildTargets of
+    [buildTarget] -> pure $ buildTargetComponentName buildTarget
+    []            -> throwE PluginStaleResolve -- todo maybe handle these two cases differently
+    _             -> throwE PluginStaleResolve
+
+-- | Takes a list of source subdirectories, a cabal source path and a haskell filepath
+-- and returns a path to the module in exposed module syntax.
+-- The path will be relative to one of the subdirectories, in case the module is contained within one of them.
+-- If no module path can be resolved, throws a PluginError.
+toRelativeModulePathE :: Applicative m => [FilePath] -> FilePath -> FilePath -> ExceptT PluginError m T.Text
+toRelativeModulePathE sourceDirs cabalFilePath oldHaskellFilePath =
+  maybeToExceptT PluginStaleResolve $
+    hoistMaybe $ mkRelativeModulePathM sourceDirs cabalFilePath oldHaskellFilePath
+
+-- | Returns the field, a module name is contained in.
+-- Takes a module name and a component name and returns whether the module name is in exposed- or other-modules of that component.
+-- If the module name cannot be found in either field, throws a PluginError.
+resolveTargetFieldForComponentE :: Applicative m => T.Text -> ComponentName -> PackageDescription -> BuildInfo -> ExceptT PluginError m Add.TargetField
+resolveTargetFieldForComponentE oldModulePath compName pd buildInfo =
+  maybeToExceptT PluginStaleResolve $
+    hoistMaybe $ findFieldForModule oldModulePath compName pd buildInfo
+
+-- | Determine the `TargetField` of the given module path
+--
+-- Takes a module path and which component the module is a part of and returns whether the module is in the
+-- exposed- or the other-modules field of the component.
+-- If the module is in neither of the fields, returns Nothing.
+findFieldForModule :: T.Text -> ComponentName -> PackageDescription -> BuildInfo -> Maybe Add.TargetField
+findFieldForModule modulePath compName pd buildInfo =
+  case compName of
+    CLibName name ->
+      case name of
+        LMainLibName ->
+          if moduleName `elem` (Maybe.maybe [] exposedModules $ library pd)
+            then Just Add.ExposedModules
+            else
+              if moduleName `elem` (otherModules buildInfo)
+                then Just Add.OtherModules
+                else Nothing
+        LSubLibName _ ->
+          if moduleName `elem` (concat $ Maybe.mapMaybe (getExposedModulesForLib compName) $ subLibraries pd)
+            then Just Add.ExposedModules
+            else
+              if moduleName `elem` (otherModules buildInfo) -- todo deduplicate
+                then Just Add.OtherModules
+                else Nothing
+    _ ->
+      if moduleName `elem` (otherModules buildInfo)
+        then Just Add.OtherModules
+        else Nothing
+  where
+    moduleName = Cabal.fromString (T.unpack modulePath)
+    getExposedModulesForLib :: ComponentName -> Library -> Maybe [Cabal.ModuleName]
+    getExposedModulesForLib compName library =
+      case libName library of
+        LSubLibName lName ->
+          case componentNameString compName of
+            Just unqualCompName -> if lName == unqualCompName then Just $ exposedModules library else Nothing
+            _ -> Nothing
+        _ -> Nothing
+
+-- | The module declaration range of the given file path
+-- inspired by `codeModuleName` in the hls-module-name-plugin
+moduleNameRange :: Shake.IdeState -> NormalizedFilePath -> IO (Maybe Range)
+moduleNameRange state nfp = runMaybeT $ do
+  (pm, mp) <- MaybeT . runAction "ModuleName.GetParsedModule" state $ Shake.useWithStale GetParsedModule nfp
+  traceShowM ("BANANA 1")
+  L (locA -> (RealSrcSpan l _)) _ <- MaybeT . pure . hsmodName . unLoc $ GHC.pm_parsed_source pm
+  traceShowM ("BANANA 2")
+  range <- MaybeT . pure $ toCurrentRange mp (realSrcSpanToRange l)
+  traceShowM ("BANANA 3")
+  pure range
+
+
+combineTextEdits :: WorkspaceEdit -> WorkspaceEdit -> WorkspaceEdit
+combineTextEdits (WorkspaceEdit c1 dc1 ca1) (WorkspaceEdit c2 dc2 ca2) =
+    WorkspaceEdit c dc ca
+  where
+    c = liftA2 (Map.unionWith (<>)) c1 c2 <|> c1 <|> c2
+    dc = dc1 <> dc2
+    -- We know this might result in information loss due to the monad instance of map,
+    -- but we do not expect our use of workspacedit combination to contain two changeAnnotations
+    -- for the same edit.
+    ca = ca1 <> ca2

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/Rename.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/CabalAdd/Rename.hs
@@ -8,9 +8,9 @@ module Ide.Plugin.Cabal.CabalAdd.Rename (
   Log,
 )
 where
-import           Control.Lens                                  (re)
-import           Control.Lens.Getter                           ((^.))
-import           Control.Monad.IO.Class                        (MonadIO, liftIO)
+import           Control.Applicative
+import           Control.Monad                                 (guard)
+import qualified Control.Monad.Extra                           as Maybe
 import           Control.Monad.Trans
 import           Control.Monad.Trans.Except                    (ExceptT, throwE)
 import           Control.Monad.Trans.Maybe
@@ -18,13 +18,7 @@ import           Data.ByteString                               (ByteString)
 import qualified Data.Maybe                                    as Maybe
 import qualified Data.Text                                     as T
 import qualified Data.Text.Encoding                            as T
-import           Debug.Trace                                   (traceShowId, traceShowM)
-import           Development.IDE.Core.PositionMapping          (toCurrentRange)
-import           Development.IDE.Core.Rules                    hiding (Log)
 import qualified Development.IDE.Core.Shake                    as Shake
-import qualified Development.IDE.GHC.Compat                    as GHC
-import           Development.IDE.GHC.Compat.Core
-import           Development.IDE.GHC.Error                     (realSrcSpanToRange)
 import qualified Distribution.Client.Add                       as Add
 import           Distribution.Client.Rename                    (RenameConfig (..),
                                                                 executeRenameConfig)
@@ -43,26 +37,17 @@ import           Ide.Plugin.Error
 import           Ide.PluginUtils                               (WithDeletions (IncludeDeletions),
                                                                 diffText)
 import           Language.LSP.Protocol.Types                   (ClientCapabilities,
-                                                                NormalizedFilePath,
-                                                                Range,
-                                                                TextDocumentEdit (..),
                                                                 VersionedTextDocumentIdentifier,
-                                                                WorkspaceEdit (WorkspaceEdit),
-                                                                _versionedTextDocumentIdentifier,
-                                                                toNormalizedFilePath,
-                                                                type (|?) (InL), TextEdit (..))
-import Control.Applicative
-import qualified Data.Map.Strict as Map
-import Development.IDE.Core.FileStore (getVersionedTextDocForNormalizedFilePath)
-import Development.IDE.Core.PluginUtils (runActionE)
-
-data Log =
-  LogDidRename FilePath FilePath
+                                                                WorkspaceEdit)
+data Log
+  = LogDidRename FilePath FilePath
+  | CabalRenameLog T.Text T.Text
   deriving (Show)
 
 instance Pretty Log where
   pretty = \case
     LogDidRename oldFp newFp -> "Received rename info from:" <+> pretty oldFp <+> "to:" <+> pretty newFp
+    CabalRenameLog oldModulePath newModulePath -> "Executing rename of module from" <+> pretty oldModulePath <+> "to" <+> pretty newModulePath <+> "in cabal file."
 
 --------------------------------------------
 -- Rename module in cabal file
@@ -74,9 +59,9 @@ renameHandler ::
   Recorder (WithPriority Log) ->
   Shake.IdeState ->
   (ClientCapabilities, VersionedTextDocumentIdentifier) ->
-  -- | the old file path before the rename
+  -- | the old file path, before the rename
   FilePath ->
-  -- | the new file path after the rename
+  -- | the new file path, after the rename
   FilePath ->
   -- | the path to the cabal file, responsible for the renamed module
   FilePath ->
@@ -86,24 +71,17 @@ renameHandler ::
   [Field Position] ->
   GenericPackageDescription ->
   ExceptT PluginError m WorkspaceEdit
-renameHandler recorder ideState (caps, verTxtDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath cnfOrigContents fields gpd = do
-  let pd = flattenPackageDescription gpd
-  compName <- resolveFileTargetE pd cabalFilePath oldHaskellFilePath
-  buildInfo <- resolveBuildInfoE pd compName
-  newModulePath <- toRelativeModulePathE (buildInfoToHsSourceDirs buildInfo) cabalFilePath newHaskellFilePath
+renameHandler recorder _ (caps, verTxtDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath cnfOrigContents fields gpd = do
+  logWith recorder Info $ LogDidRename oldHaskellFilePath newHaskellFilePath
   cabalFileEdit <- applyModuleRenameToCabalFile recorder (caps, verTxtDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath cnfOrigContents fields gpd
-  modDeclEdit <- renameModuleDeclaration recorder ideState oldHaskellFilePath newHaskellFilePath newModulePath
-  pure $ traceShowId $ combineTextEdits (traceShowId cabalFileEdit) $ traceShowId modDeclEdit
+  pure cabalFileEdit
 
-renameModuleDeclaration :: MonadIO m => Recorder (WithPriority Log) -> IdeState -> FilePath -> FilePath -> T.Text -> ExceptT PluginError m WorkspaceEdit
-renameModuleDeclaration recorder ideState oldHaskellFilePath newHaskellFilePath newModulePath = do
-  verTextDocId <- runActionE "cabal-plugin.getUriContents" ideState $ lift $ getVersionedTextDocForNormalizedFilePath $ toNormalizedFilePath oldHaskellFilePath
-  rangeToRename <- maybeToExceptT PluginStaleResolve $
-      MaybeT $ liftIO $ moduleNameRange ideState $ toNormalizedFilePath oldHaskellFilePath
-  let diff = TextEdit rangeToRename newModulePath
-      renameEdit = TextDocumentEdit (verTextDocId  ^. re _versionedTextDocumentIdentifier) $ fmap InL [diff]
-  pure $ WorkspaceEdit Nothing (Just [InL renameEdit]) Nothing
-
+-- | Apply rename to the given cabal file
+--
+-- Replaces the module name corresponding to the old file path with the
+-- module name corresponding to the new file path in the given cabal file.
+-- Fails if the cabal file cannot be parsed, the file paths cannot be parsed to module names
+-- or no occurence of the module can be found in the cabal file.
 applyModuleRenameToCabalFile ::
   forall m.
   (MonadIO m) =>
@@ -122,19 +100,16 @@ applyModuleRenameToCabalFile ::
   GenericPackageDescription ->
   ExceptT PluginError m WorkspaceEdit
 applyModuleRenameToCabalFile recorder (caps, verTxtDocId) oldHaskellFilePath newHaskellFilePath cabalFilePath cnfOrigContents fields gpd = do
-  logWith recorder Info $ LogDidRename oldHaskellFilePath newHaskellFilePath
   let pd = flattenPackageDescription gpd
-
   compName <- resolveFileTargetE pd cabalFilePath oldHaskellFilePath
   buildInfo <- resolveBuildInfoE pd compName
   newModulePath <- toRelativeModulePathE (buildInfoToHsSourceDirs buildInfo) cabalFilePath newHaskellFilePath
   oldModulePath <- toRelativeModulePathE (buildInfoToHsSourceDirs buildInfo) cabalFilePath oldHaskellFilePath
-  targetField <- resolveTargetFieldForComponentE oldModulePath compName pd buildInfo
-
+  targetField <- resolveTargetFieldForComponentE pd oldModulePath compName buildInfo
   newContents <- maybeToExceptT PluginStaleResolve $ hoistMaybe $
     executeRenameConfig (Add.validateChanges gpd) (renameConfig (Right $ compName) targetField oldModulePath newModulePath)
+  logWith recorder Info $ CabalRenameLog oldModulePath newModulePath
   pure $ diffText caps (verTxtDocId, T.decodeUtf8 cnfOrigContents) (T.decodeUtf8 newContents) IncludeDeletions
-
   where
     -- define renameConfig to pass to cabal-add
     renameConfig compName targetField from to = RenameConfig
@@ -145,6 +120,50 @@ applyModuleRenameToCabalFile recorder (caps, verTxtDocId) oldHaskellFilePath new
       , cnfRenameFrom = T.encodeUtf8 from
       , cnfRenameTo = T.encodeUtf8 to
       }
+
+-- | Determine the `TargetField` of the given module path
+--
+-- Takes a module path and which component the module is a part of and returns whether the module is in the
+-- exposed- or the other-modules field of the component.
+-- If the module is in neither of the fields, returns Nothing.
+findFieldForModule :: T.Text -> ComponentName -> PackageDescription -> BuildInfo -> Maybe Add.TargetField
+findFieldForModule modulePath compName pd buildInfo =
+  let
+    exposedMods = case compName of
+        CLibName name ->
+          case name of
+            LMainLibName ->
+              Maybe.maybe [] exposedModules $ library pd
+            LSubLibName _ ->
+              concat $ Maybe.concatMapM (getExposedModulesForLib compName) $ subLibraries pd
+        _ -> []
+  in
+    findInExposedModules exposedMods <|> findInOtherModules (otherModules buildInfo)
+  where
+    moduleName = Cabal.fromString (T.unpack modulePath)
+
+    findInOtherModules mods =
+      Add.OtherModules <$ findInModules mods
+
+    findInExposedModules mods =
+      Add.ExposedModules <$ findInModules mods
+
+    findInModules mods =
+      guard $ moduleName `elem` mods
+
+    getExposedModulesForLib :: ComponentName -> Library -> Maybe [Cabal.ModuleName]
+    getExposedModulesForLib compName lib =
+      case libName lib of
+        LSubLibName lName ->
+          case componentNameString compName of
+            Just unqualCompName -> if lName == unqualCompName then Just $ exposedModules lib else Nothing
+            _ -> Nothing
+        _ -> Nothing
+
+
+---------------------------------------------------------
+-- Rule applications with shortcuts to plugin errors
+---------------------------------------------------------
 
 -- | Returns the `BuildInfo` for the given component name.
 -- If the build info cannot be resolved, throws a PluginError.
@@ -163,79 +182,20 @@ resolveFileTargetE pd cabalFilePath fileTarget = do
     []            -> throwE PluginStaleResolve -- todo maybe handle these two cases differently
     _             -> throwE PluginStaleResolve
 
+-- | Returns the field a module name is contained in.
+--
+-- Takes a module name and a component name and returns whether the module name is in exposed- or other-modules of that component.
+-- If the module name cannot be found in either field, throws a PluginError.
+resolveTargetFieldForComponentE :: Applicative m => PackageDescription -> T.Text -> ComponentName -> BuildInfo -> ExceptT PluginError m Add.TargetField
+resolveTargetFieldForComponentE pd oldModulePath compName buildInfo =
+  maybeToExceptT PluginStaleResolve $
+    hoistMaybe $ findFieldForModule oldModulePath compName pd buildInfo
+
 -- | Takes a list of source subdirectories, a cabal source path and a haskell filepath
 -- and returns a path to the module in exposed module syntax.
+--
 -- The path will be relative to one of the subdirectories, in case the module is contained within one of them.
 -- If no module path can be resolved, throws a PluginError.
 toRelativeModulePathE :: Applicative m => [FilePath] -> FilePath -> FilePath -> ExceptT PluginError m T.Text
 toRelativeModulePathE sourceDirs cabalFilePath oldHaskellFilePath =
-  maybeToExceptT PluginStaleResolve $
-    hoistMaybe $ mkRelativeModulePathM sourceDirs cabalFilePath oldHaskellFilePath
-
--- | Returns the field, a module name is contained in.
--- Takes a module name and a component name and returns whether the module name is in exposed- or other-modules of that component.
--- If the module name cannot be found in either field, throws a PluginError.
-resolveTargetFieldForComponentE :: Applicative m => T.Text -> ComponentName -> PackageDescription -> BuildInfo -> ExceptT PluginError m Add.TargetField
-resolveTargetFieldForComponentE oldModulePath compName pd buildInfo =
-  maybeToExceptT PluginStaleResolve $
-    hoistMaybe $ findFieldForModule oldModulePath compName pd buildInfo
-
--- | Determine the `TargetField` of the given module path
---
--- Takes a module path and which component the module is a part of and returns whether the module is in the
--- exposed- or the other-modules field of the component.
--- If the module is in neither of the fields, returns Nothing.
-findFieldForModule :: T.Text -> ComponentName -> PackageDescription -> BuildInfo -> Maybe Add.TargetField
-findFieldForModule modulePath compName pd buildInfo =
-  case compName of
-    CLibName name ->
-      case name of
-        LMainLibName ->
-          if moduleName `elem` (Maybe.maybe [] exposedModules $ library pd)
-            then Just Add.ExposedModules
-            else
-              if moduleName `elem` (otherModules buildInfo)
-                then Just Add.OtherModules
-                else Nothing
-        LSubLibName _ ->
-          if moduleName `elem` (concat $ Maybe.mapMaybe (getExposedModulesForLib compName) $ subLibraries pd)
-            then Just Add.ExposedModules
-            else
-              if moduleName `elem` (otherModules buildInfo) -- todo deduplicate
-                then Just Add.OtherModules
-                else Nothing
-    _ ->
-      if moduleName `elem` (otherModules buildInfo)
-        then Just Add.OtherModules
-        else Nothing
-  where
-    moduleName = Cabal.fromString (T.unpack modulePath)
-    getExposedModulesForLib :: ComponentName -> Library -> Maybe [Cabal.ModuleName]
-    getExposedModulesForLib compName library =
-      case libName library of
-        LSubLibName lName ->
-          case componentNameString compName of
-            Just unqualCompName -> if lName == unqualCompName then Just $ exposedModules library else Nothing
-            _ -> Nothing
-        _ -> Nothing
-
--- | The module declaration range of the given file path
--- inspired by `codeModuleName` in the hls-module-name-plugin
-moduleNameRange :: Shake.IdeState -> NormalizedFilePath -> IO (Maybe Range)
-moduleNameRange state nfp = runMaybeT $ do
-  (pm, mp) <- MaybeT . runAction "ModuleName.GetParsedModule" state $ Shake.useWithStale GetParsedModule nfp
-  L (locA -> (RealSrcSpan l _)) _ <- MaybeT . pure . hsmodName . unLoc $ GHC.pm_parsed_source pm
-  range <- MaybeT . pure $ toCurrentRange mp (realSrcSpanToRange l)
-  pure range
-
-
-combineTextEdits :: WorkspaceEdit -> WorkspaceEdit -> WorkspaceEdit
-combineTextEdits (WorkspaceEdit c1 dc1 ca1) (WorkspaceEdit c2 dc2 ca2) =
-    WorkspaceEdit c dc ca
-  where
-    c = liftA2 (Map.unionWith (<>)) c1 c2 <|> c1 <|> c2
-    dc = dc1 <> dc2
-    -- We know this might result in information loss due to the monad instance of map,
-    -- but we do not expect our use of workspacedit combination to contain two changeAnnotations
-    -- for the same edit.
-    ca = ca1 <> ca2
+  maybeToExceptT PluginStaleResolve $ hoistMaybe $ mkRelativeModulePathM sourceDirs cabalFilePath oldHaskellFilePath

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/CabalFields.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/CabalFields.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings     #-}
+
 module Ide.Plugin.Cabal.Completion.CabalFields
   ( findStanzaForColumn
   , getModulesNames
@@ -28,6 +30,8 @@ import qualified Distribution.Fields               as Syntax
 import qualified Distribution.Parsec.Position      as Syntax
 import           Ide.Plugin.Cabal.Completion.Types
 import qualified Language.LSP.Protocol.Types       as LSP
+import Distribution.Types.ComponentName (ComponentName (CLibName, CTestName, CBenchName, CExeName, CFLibName))
+import Distribution.PackageDescription (mkUnqualComponentName, LibraryName (LSubLibName))
 
 -- ----------------------------------------------------------------
 -- Cabal-syntax utilities I don't really want to write myself
@@ -155,7 +159,6 @@ getOptionalSectionName (x:xs) = case x of
     Syntax.SecArgName _ name -> Just (T.decodeUtf8 name)
     _                        -> getOptionalSectionName xs
 
-type BuildTargetName = T.Text
 type ModuleName      = T.Text
 
 -- | Given a cabal AST returns pairs of all respective target names
@@ -186,18 +189,28 @@ type ModuleName      = T.Text
 -- * @getModulesNames@ output:
 --
 -- >   [([Just "first-target", Just "second-target"], "Config")]
-getModulesNames :: [Syntax.Field any] -> [([Maybe BuildTargetName], ModuleName)]
+getModulesNames :: [Syntax.Field any] -> [([Maybe ComponentName], ModuleName)]
 getModulesNames fields = map swap $ groupSort rawModuleTargetPairs
   where
     rawModuleTargetPairs = concatMap getSectionModuleNames sections
     sections = getSectionsWithModules fields
 
-    getSectionModuleNames :: Syntax.Field any -> [(ModuleName, Maybe BuildTargetName)]
-    getSectionModuleNames (Syntax.Section _ secArgs fields) = map (, getArgsName secArgs) $ concatMap getFieldModuleNames fields
+    getSectionModuleNames :: Syntax.Field any -> [(ModuleName, Maybe ComponentName)]
+    getSectionModuleNames (Syntax.Section secName secArgs fields) = map (, getArgsName secName secArgs) $ concatMap getFieldModuleNames fields
     getSectionModuleNames _ = []
 
-    getArgsName [Syntax.SecArgName _ name] = Just $ T.decodeUtf8 name
-    getArgsName _                          = Nothing -- Can be only a main library, that has no name
+    getArgsName (Syntax.Name _ secName) [Syntax.SecArgName _ nameBs] =
+      let
+        name = mkUnqualComponentName $ T.unpack $ T.decodeUtf8 nameBs
+      in
+        case secName of
+          "library" -> Just $ CLibName $ LSubLibName name
+          "test-suite" -> Just $ CTestName name
+          "benchmark" -> Just $ CBenchName name
+          "executable" -> Just $ CExeName name
+          "foreign-library" -> Just $ CFLibName name
+          _ -> Nothing
+    getArgsName _ _                          = Nothing -- Can be only a main library, that has no name
                                                      -- since it's impossible to have multiple names for a build target
 
     getFieldModuleNames field@(Syntax.Field _ modules) = if getFieldName field == T.pack "exposed-modules" ||

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Definition.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Definition.hs
@@ -45,6 +45,9 @@ import           System.Directory                              (doesFileExist)
 import           System.FilePath                               (joinPath,
                                                                 takeDirectory,
                                                                 (<.>), (</>))
+import Distribution.Types.ComponentName (ComponentName)
+import Data.Foldable (asum)
+import Distribution.Types.ComponentName (ComponentName(..))
 
 -- | Handler for going to definitions.
 --
@@ -142,50 +145,48 @@ gotoModulesDefinition nfp gpd cursor fieldsOfInterest = do
     isModuleName (Just name) (_,  moduleName) = name == moduleName
     isModuleName _ _                          = False
 
--- | Gives all `buildInfo`s given a target name.
+-- | Gives all 'BuildInfo's given a target name.
 --
--- `Maybe buildTargetName` is provided, and if it's
--- Nothing we assume, that it's a main library.
--- Otherwise looks for the provided name.
-lookupBuildTargetPackageDescription :: PackageDescription -> Maybe T.Text -> [BuildInfo]
+-- Takes a @'Maybe' 'ComponentName'@ and looks for the coresponding Buildinfo if it is Just.
+-- If Nothing is passed we assume that we are looking for a main library.
+-- If no main library can be found, returns Nothing.
+lookupBuildTargetPackageDescription :: PackageDescription -> Maybe ComponentName -> Maybe BuildInfo
 lookupBuildTargetPackageDescription (PackageDescription {..}) Nothing =
   case library of
-    Nothing                       -> [] -- Target is a main library but no main library was found
-    Just (Library {libBuildInfo}) -> [libBuildInfo]
+    Nothing                       -> Nothing -- Target is a main library but no main library was found
+    Just (Library {libBuildInfo}) -> Just libBuildInfo
 lookupBuildTargetPackageDescription (PackageDescription {..}) (Just buildTargetName) =
-  Maybe.catMaybes $
+    asum $
+    foldMap libraryNameLookup library :
     map executableNameLookup executables <>
-    map subLibraryNameLookup subLibraries <>
+    map libraryNameLookup subLibraries <>
     map foreignLibsNameLookup foreignLibs <>
     map testSuiteNameLookup testSuites <>
     map benchmarkNameLookup benchmarks
   where
     executableNameLookup :: Executable -> Maybe BuildInfo
     executableNameLookup (Executable {exeName, buildInfo}) =
-      if T.pack (unUnqualComponentName exeName) == buildTargetName
+      if CExeName exeName == buildTargetName
         then Just buildInfo
         else Nothing
-    subLibraryNameLookup :: Library -> Maybe BuildInfo
-    subLibraryNameLookup (Library {libName, libBuildInfo}) =
-      case libName of
-        (LSubLibName name) ->
-          if T.pack (unUnqualComponentName name) == buildTargetName
-            then Just libBuildInfo
-            else Nothing
-        LMainLibName -> Nothing
+    libraryNameLookup :: Library -> Maybe BuildInfo
+    libraryNameLookup (Library {libName, libBuildInfo}) =
+      if CLibName libName == buildTargetName
+        then Just libBuildInfo
+        else Nothing
     foreignLibsNameLookup :: ForeignLib -> Maybe BuildInfo
     foreignLibsNameLookup (ForeignLib {foreignLibName, foreignLibBuildInfo}) =
-        if T.pack (unUnqualComponentName foreignLibName) == buildTargetName
+      if CFLibName foreignLibName == buildTargetName
         then Just foreignLibBuildInfo
         else Nothing
     testSuiteNameLookup :: TestSuite -> Maybe BuildInfo
     testSuiteNameLookup (TestSuite {testName, testBuildInfo}) =
-      if T.pack (unUnqualComponentName testName) == buildTargetName
+      if CTestName testName == buildTargetName
         then Just testBuildInfo
         else Nothing
     benchmarkNameLookup :: Benchmark -> Maybe BuildInfo
     benchmarkNameLookup (Benchmark {benchmarkName, benchmarkBuildInfo}) =
-        if T.pack (unUnqualComponentName benchmarkName) == buildTargetName
+      if CBenchName benchmarkName == buildTargetName
         then Just benchmarkBuildInfo
         else Nothing
 

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Definition.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Definition.hs
@@ -9,25 +9,24 @@ module Ide.Plugin.Cabal.Definition where
 import           Control.Lens                                  ((^.))
 import           Control.Monad.Extra
 import           Control.Monad.IO.Class
+import           Data.Foldable                                 (asum)
 import           Data.List                                     (find)
 import qualified Data.Maybe                                    as Maybe
 import qualified Data.Text                                     as T
 import           Development.IDE                               as D
 import           Development.IDE.Core.PluginUtils
 import qualified Distribution.Fields                           as Syntax
-import           Distribution.PackageDescription               (Benchmark (..),
-                                                                BuildInfo (..),
-                                                                Executable (..),
-                                                                ForeignLib (..),
+import           Distribution.PackageDescription               (Benchmark (Benchmark, benchmarkBuildInfo, benchmarkName),
+                                                                BuildInfo (hsSourceDirs),
+                                                                Executable (Executable, buildInfo, exeName),
+                                                                ForeignLib (ForeignLib, foreignLibBuildInfo, foreignLibName),
                                                                 GenericPackageDescription,
-                                                                Library (..),
-                                                                LibraryName (LMainLibName, LSubLibName),
+                                                                Library (Library, libBuildInfo, libName),
                                                                 PackageDescription (..),
-                                                                TestSuite (..),
-                                                                library,
-                                                                unUnqualComponentName)
+                                                                TestSuite (TestSuite, testBuildInfo, testName))
 import           Distribution.PackageDescription.Configuration (flattenPackageDescription)
 import qualified Distribution.Parsec.Position                  as Syntax
+import           Distribution.Types.ComponentName              (ComponentName (..))
 import           Distribution.Utils.Generic                    (safeHead)
 import           Distribution.Utils.Path                       (getSymbolicPath)
 import           Ide.Plugin.Cabal.Completion.CabalFields       as CabalFields
@@ -45,9 +44,6 @@ import           System.Directory                              (doesFileExist)
 import           System.FilePath                               (joinPath,
                                                                 takeDirectory,
                                                                 (<.>), (</>))
-import Distribution.Types.ComponentName (ComponentName)
-import Data.Foldable (asum)
-import Distribution.Types.ComponentName (ComponentName(..))
 
 -- | Handler for going to definitions.
 --

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -6,30 +6,38 @@
 {-# LANGUAGE RecordWildCards   #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Ide.Plugin.Rename (descriptor, Log) where
 
+import           Control.Applicative                   ((<|>))
 import           Control.Lens                          ((^.))
 import           Control.Monad
 import           Control.Monad.Except                  (ExceptT, throwError)
 import           Control.Monad.IO.Class                (MonadIO, liftIO)
 import           Control.Monad.Trans.Class             (lift)
+import           Control.Monad.Trans.Except            (mapExceptT)
+import           Control.Monad.Trans.Maybe             (hoistMaybe,
+                                                        maybeToExceptT)
 import           Data.Either                           (rights)
-import           Data.Foldable                         (fold)
+import           Data.Foldable                         (fold, minimumBy)
 import           Data.Generics
 import           Data.Hashable
 import           Data.HashSet                          (HashSet)
 import qualified Data.HashSet                          as HS
+import           Data.List                             (foldl')
 import           Data.List.NonEmpty                    (NonEmpty ((:|)),
                                                         groupWith)
+import qualified Data.List.NonEmpty                    as NE
 import qualified Data.Map                              as M
+import qualified Data.Map.Strict                       as Map
 import           Data.Maybe
 import           Data.Mod.Word
+import           Data.Ord                              (comparing)
 import qualified Data.Text                             as T
-import           Development.IDE                       (Recorder, WithPriority,
-                                                        usePropertyAction)
 import           Development.IDE.Core.FileStore        (getVersionedTextDoc)
 import           Development.IDE.Core.PluginUtils
+import           Development.IDE.Core.Rules            (usePropertyAction)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Service          hiding (Log)
 import           Development.IDE.Core.Shake            hiding (Log)
@@ -38,8 +46,10 @@ import           Development.IDE.GHC.Compat.ExactPrint
 import           Development.IDE.GHC.Error
 import           Development.IDE.GHC.ExactPrint        hiding (Log)
 import qualified Development.IDE.GHC.ExactPrint        as E
+import           Development.IDE.GHC.Util              (evalGhcEnv)
 import           Development.IDE.Plugin.CodeAction
 import           Development.IDE.Spans.AtPoint
+import           Development.IDE.Types.HscEnvEq        (HscEnvEq (hscEnv))
 import           Development.IDE.Types.Location
 import           GHC.Iface.Ext.Types                   (HieAST (..),
                                                         HieASTs (..),
@@ -49,11 +59,11 @@ import           GHC.Iface.Ext.Utils                   (generateReferencesMap)
 import           HieDb                                 ((:.) (..))
 import           HieDb.Query
 import           HieDb.Types                           (RefRow (refIsGenerated))
-import           Ide.Logger                            (Pretty (..),
-                                                        cmapWithPrio)
+import           Ide.Logger
 import           Ide.Plugin.Error
 import           Ide.Plugin.Properties
 import qualified Ide.Plugin.Rename.ModuleName          as ModuleName
+import qualified Ide.Plugin.Rename.ModuleRename        as ModuleRename
 import           Ide.PluginUtils
 import           Ide.Types
 import qualified Language.LSP.Protocol.Lens            as L
@@ -65,11 +75,13 @@ instance Hashable (Mod a) where hash n = hash (unMod n)
 data Log
     = LogExactPrint E.Log
     | LogModuleName ModuleName.Log
+    | LogModuleRename ModuleRename.Log
 
 instance Pretty Log where
     pretty = \ case
         LogExactPrint msg -> pretty msg
         LogModuleName msg -> pretty msg
+        LogModuleRename msg -> pretty msg
 
 descriptor :: Recorder (WithPriority Log) -> PluginId -> PluginDescriptor IdeState
 descriptor recorder pluginId = mkExactprintPluginDescriptor exactPrintRecorder $
@@ -78,6 +90,7 @@ descriptor recorder pluginId = mkExactprintPluginDescriptor exactPrintRecorder $
               [ mkPluginHandler SMethod_TextDocumentRename renameProvider
               , mkPluginHandler SMethod_TextDocumentPrepareRename prepareRenameProvider
               , mkPluginHandler SMethod_TextDocumentCodeLens (ModuleName.codeLens moduleNameRecorder)
+              , mkPluginHandler SMethod_WorkspaceWillRenameFiles (renameModuleProvider recorder)
               ]
         , pluginCommands = [PluginCommand ModuleName.updateModuleNameCommand "Set name of module to match with file path" (ModuleName.command moduleNameRecorder)]
         , pluginConfigDescriptor = defaultConfigDescriptor
@@ -100,6 +113,34 @@ prepareRenameProvider state _pluginId (PrepareRenameParams (TextDocumentIdentifi
     -- so that the full rename handler can give more informative error about them.
     let renameValid = not $ null namesUnderCursor
     pure $ InL $ PrepareRenameResult $ InR $ InR $ PrepareRenameDefaultBehavior renameValid
+
+renameModuleProvider :: Recorder (WithPriority Log)-> PluginMethodHandler IdeState Method_WorkspaceWillRenameFiles
+renameModuleProvider recorder state pluginId (RenameFilesParams renames) = do
+    renameResults <- mapM renameFile renames
+    pure $ InL $ foldl' combineTextEdits (WorkspaceEdit mempty mempty mempty) $ catMaybes renameResults
+    where
+        recorder' = cmapWithPrio LogModuleRename recorder
+        renameFile (FileRename oldUri newUri) = do
+            oldNfp <- fmap toNormalizedFilePath $ uriToFilePathE $ Uri oldUri
+            newNfp <- fmap toNormalizedFilePath $ uriToFilePathE $ Uri newUri
+            pm <- runActionE "Rename.GetParsedModule" state
+                (useE GetParsedModule oldNfp)
+            let oldModuleNameM = moduleNameString . unLoc <$> (hsmodName $ unLoc $ pm_parsed_source pm)
+            newModulePathM <- guessModuleName newNfp oldNfp
+            case (oldModuleNameM, newModulePathM) of
+                (Just oldModulePath, Just newModulePath) -> do
+                    modDeclEdit <- ModuleRename.renameModuleDeclaration recorder' state oldNfp newModulePath
+                    importEdits <- ModuleRename.applyRenameToImports recorder' state (T.pack oldModulePath) newModulePath $ oldNfp
+                    pure $ Just $ combineTextEdits modDeclEdit importEdits
+                _ -> do
+                    logWith  recorder' Info $ ModuleRename.NoModuleName newNfp
+                    pure Nothing
+
+        guessModuleName newNfp oldNfp = do
+            (session, _) <- runActionE "ModuleName.ghcSession" state $ useWithStaleE GhcSession oldNfp
+            srcPaths <- liftIO $ evalGhcEnv (hscEnv session) $ importPaths <$> getSessionDynFlags
+            correctNames <- mapExceptT liftIO $ ModuleName.potentialModuleNames (cmapWithPrio LogModuleName recorder) state (fromNormalizedFilePath newNfp) srcPaths
+            pure $ minimumBy (comparing T.length) <$> NE.nonEmpty correctNames
 
 renameProvider :: PluginMethodHandler IdeState Method_TextDocumentRename
 renameProvider state pluginId (RenameParams _prog (TextDocumentIdentifier uri) pos newNameText) = do
@@ -254,6 +295,25 @@ handleGetHieAst state nfp =
     -- the module compiles, otherwise we can't guarantee that we'll rename everything,
     -- which is bad (see https://github.com/haskell/haskell-language-server/issues/3799)
     fmap removeGenerated $ runActionE "Rename.GetHieAst" state $ useE GetHieAst nfp
+
+-- | Takes a haskell filepath
+-- and returns a path to the module in exposed module syntax.
+toRelativeModulePathE :: MonadIO m => IdeState -> NormalizedFilePath -> ExceptT PluginError m T.Text
+toRelativeModulePathE state fp = do
+    (hsc_dflags . hscEnv -> df) <- runActionE "renamePlugin.renameModule.GhcSessionDeps" state $ useE GhcSessionDeps fp
+    maybeToExceptT PluginStaleResolve $ hoistMaybe $ fmap T.pack $ workingDirectory df
+
+combineTextEdits :: WorkspaceEdit -> WorkspaceEdit -> WorkspaceEdit
+combineTextEdits (WorkspaceEdit c1 dc1 ca1) (WorkspaceEdit c2 dc2 ca2) =
+  WorkspaceEdit c dc ca
+ where
+  c = liftA2 (Map.unionWith (<>)) c1 c2 <|> c1 <|> c2
+  dc = dc1 <> dc2
+  -- We know this might result in information loss due to the monad instance of map,
+  -- but we do not expect our use of workspacedit combination to contain two changeAnnotations
+  -- for the same edit.
+  ca = ca1 <> ca2
+
 
 {- Note [Generated references]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename/ModuleName.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename/ModuleName.hs
@@ -15,6 +15,8 @@ module Ide.Plugin.Rename.ModuleName (
     codeLens,
     updateModuleNameCommand,
     command,
+    potentialModuleNames,
+    codeModuleName,
 ) where
 
 import           Control.Monad                        (forM_, void)
@@ -102,12 +104,11 @@ data Action = Replace
 action :: Recorder (WithPriority Log) -> IdeState -> Uri -> ExceptT PluginError (HandlerM c) [Action]
 action recorder state uri = do
     nfp <- getNormalizedFilePathE  uri
-    fp <- uriToFilePathE uri
 
     contents <- liftIO $ runAction "ModuleName.getFileContents" state $ getFileContents nfp
     let emptyModule = maybe True (T.null . T.strip . Rope.toText) contents
 
-    correctNames <- mapExceptT liftIO $ pathModuleNames recorder state nfp fp
+    correctNames <- mapExceptT liftIO $ pathModuleNames recorder state nfp
     logWith recorder Debug (CorrectNames correctNames)
     let bestName = minimumBy (comparing T.length) <$> NE.nonEmpty correctNames
     logWith recorder Debug (BestName bestName)
@@ -127,33 +128,34 @@ action recorder state uri = do
 -- | Possible module names, as derived by the position of the module in the
 -- source directories.  There may be more than one possible name, if the source
 -- directories are nested inside each other.
-pathModuleNames :: Recorder (WithPriority Log) -> IdeState -> NormalizedFilePath -> FilePath -> ExceptT PluginError IO [T.Text]
-pathModuleNames recorder state normFilePath filePath
+pathModuleNames :: Recorder (WithPriority Log) -> IdeState -> NormalizedFilePath -> ExceptT PluginError IO [T.Text]
+pathModuleNames recorder state nfp
   | firstLetter isLower $ takeFileName filePath = return ["Main"]
   | otherwise = do
-      (session, _) <- runActionE "ModuleName.ghcSession" state $ useWithStaleE GhcSession normFilePath
+      (session, _) <- runActionE "ModuleName.ghcSession" state $ useWithStaleE GhcSession nfp
       srcPaths <- liftIO $ evalGhcEnv (hscEnv session) $ importPaths <$> getSessionDynFlags
       logWith recorder Debug (SrcPaths srcPaths)
-
+      potentialModuleNames recorder state filePath srcPaths
       -- Append a `pathSeparator` to make the path looks like a directory,
       --   and then we can drop it uniformly.
       -- See https://github.com/haskell/haskell-language-server/pull/3092 for details.
-      let paths = map (normalise . (<> pure pathSeparator)) srcPaths
-      logWith recorder Debug (NormalisedPaths paths)
-
-      -- TODO, this can be avoid if the filePath is already absolute,
-      -- we can avoid the toAbsolute call in the future.
-      -- see Note [Root Directory]
-      let mdlPath = (toAbsolute $ rootDir state) filePath
-      logWith recorder Debug (AbsoluteFilePath mdlPath)
-
-      let suffixes = mapMaybe (`stripPrefix` mdlPath) paths
-      pure (map moduleNameFrom suffixes)
   where
-    firstLetter :: (Char -> Bool) -> FilePath -> Bool
-    firstLetter _ []       = False
-    firstLetter pred (c:_) = pred c
+    filePath = fromNormalizedFilePath nfp
 
+potentialModuleNames :: Recorder (WithPriority Log) -> IdeState -> [Char] -> [FilePath] -> ExceptT PluginError IO [T.Text]
+potentialModuleNames recorder state filePath srcPaths = do
+    let paths = map (normalise . (<> pure pathSeparator)) srcPaths
+    logWith recorder Debug (NormalisedPaths paths)
+
+    -- TODO, this can be avoid if the filePath is already absolute,
+    -- we can avoid the toAbsolute call in the future.
+    -- see Note [Root Directory]
+    let mdlPath = (toAbsolute $ rootDir state) filePath
+    logWith recorder Debug (AbsoluteFilePath mdlPath)
+
+    let suffixes = mapMaybe (`stripPrefix` mdlPath) paths
+    pure (map moduleNameFrom suffixes)
+  where
     moduleNameFrom =
       T.pack
         . intercalate "."
@@ -162,6 +164,10 @@ pathModuleNames recorder state normFilePath filePath
         . filter (firstLetter isUpper)
         . splitDirectories
         . dropExtension
+
+firstLetter :: (Char -> Bool) -> FilePath -> Bool
+firstLetter _ []       = False
+firstLetter pred (c:_) = pred c
 
 -- | The module name, as stated in the module
 codeModuleName :: IdeState -> NormalizedFilePath -> IO (Maybe (Range, T.Text))

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename/ModuleRename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename/ModuleRename.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Ide.Plugin.Rename.ModuleRename (renameModuleDeclaration, applyRenameToImports, Log(..)) where
+
+import Control.Lens (re)
+import Control.Lens.Getter ((^.))
+import Control.Monad (guard, (<=<))
+import Control.Monad.Extra qualified as Maybe
+import Control.Monad.Trans
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Maybe
+import Data.Maybe qualified as Maybe
+import Data.Text qualified as T
+import Development.IDE (NormalizedFilePath)
+import Development.IDE.Core.FileStore (getVersionedTextDocForNormalizedFilePath)
+import Development.IDE.Core.PluginUtils (runActionE)
+import Development.IDE.Core.PositionMapping (toCurrentRange)
+import Development.IDE.Core.RuleTypes (GetModuleGraph (..))
+import Development.IDE.Core.Rules hiding (Log)
+import Development.IDE.Core.Rules qualified as Shake
+import Development.IDE.Core.Shake qualified as Shake
+import Development.IDE.GHC.Compat qualified as GHC
+import Development.IDE.GHC.Compat.Core
+import Development.IDE.GHC.Error (
+  realSrcSpanToRange,
+  srcSpanToRange,
+ )
+import Development.IDE.Import.DependencyInformation (immediateReverseDependencies)
+import Ide.Logger
+import Ide.Plugin.Error
+import Language.LSP.Protocol.Types (
+  Range,
+  TextDocumentEdit (..),
+  TextEdit (..),
+  VersionedTextDocumentIdentifier,
+  WorkspaceEdit (..),
+  fromNormalizedFilePath,
+  _versionedTextDocumentIdentifier,
+  type (|?) (InL),
+ )
+import Debug.Trace (traceShowM)
+
+data Log
+  = CorrectNames [T.Text]
+  | LogRenameDependencies T.Text [NormalizedFilePath]
+  | NoModuleName NormalizedFilePath
+  deriving (Show)
+
+instance Pretty Log where
+  pretty log =
+    "ModuleRename." <> case log of
+      CorrectNames log -> "CorrectNames" <> colon <+> pretty log
+      LogRenameDependencies oldName fps -> "Rename of" <+> pretty oldName <+> "in" <+> (pretty $ map fromNormalizedFilePath fps)
+      NoModuleName nfp -> "Could not execute rename of" <+> pretty (fromNormalizedFilePath nfp) <+> "as no module path could be determined."
+-- | Apply rename to the given module's declaration
+--
+-- Rename the module in the given file's module declaration.
+-- Fails if .
+renameModuleDeclaration :: (MonadIO m) => Recorder (WithPriority Log) -> IdeState -> NormalizedFilePath -> T.Text -> ExceptT PluginError m WorkspaceEdit
+renameModuleDeclaration recorder ideState oldHaskellFilePath newModulePath = do
+  verTextDocId <- runActionE "cabal-plugin.getUriContents" ideState $ lift $ getVersionedTextDocForNormalizedFilePath $ oldHaskellFilePath
+  rangeToRename <-
+    maybeToExceptT PluginStaleResolve $
+      MaybeT $
+        liftIO $
+          moduleNameRange ideState $
+            oldHaskellFilePath
+  let
+    edit = mkTextEditInRange newModulePath verTextDocId rangeToRename
+  pure $ WorkspaceEdit Nothing (Just [InL edit]) Nothing
+
+-- | Apply rename to all imports of the given module
+--
+-- Replaces all imports of the given old module name with the given new module name.
+applyRenameToImports ::
+  (MonadIO m) =>
+  Recorder (WithPriority Log) ->
+  IdeState ->
+  -- | The module name before the rename.
+  T.Text ->
+  -- | The new module name after the rename.
+  T.Text ->
+  -- | The old path to the renamed haskell file.
+  NormalizedFilePath ->
+  ExceptT e m WorkspaceEdit
+applyRenameToImports recorder ideState oldModulePath newModulePath oldHaskellFilePath = do
+  moduleGraph <- runActionE "applyRenameToImports" ideState $ lift $ Shake.useNoFile_ GetModuleGraph
+  let
+    invertedDepsM = immediateReverseDependencies oldHaskellFilePath moduleGraph
+  case invertedDepsM of
+    Just depFilePaths -> do
+      logWith recorder Debug $ LogRenameDependencies oldModulePath depFilePaths
+      modImportRanges <- liftIO $ Maybe.mapMaybeM (getRangesForModuleImports ideState oldModulePath) depFilePaths
+      let
+        textEdits = concatMap (\(verTextDocId, ranges) -> map (mkTextEditInRange newModulePath verTextDocId) ranges) modImportRanges
+      pure $ WorkspaceEdit Nothing (Just $ map InL textEdits) Nothing
+    Nothing -> pure $ WorkspaceEdit Nothing Nothing Nothing
+
+-- | The module declaration range of the given file path
+
+-- | Determines all ranges in the given file where the module name is imported
+--
+-- Returns the identifier of the file and a list of ranges of the imports if none of the rule applications fail.
+-- Otherwise will return Nothing.
+getRangesForModuleImports :: IdeState -> T.Text -> NormalizedFilePath -> IO (Maybe (VersionedTextDocumentIdentifier, [Range]))
+getRangesForModuleImports state moduleName nfp = runMaybeT $ do
+  verTextDocId <- MaybeT . fmap Just $ runAction "cabal-plugin.getUriContents" state $ getVersionedTextDocForNormalizedFilePath nfp
+  (pm, mp) <- MaybeT . runAction "ModuleName.GetParsedModule" state $ Shake.useWithStale GetParsedModule nfp
+  let
+    allImports = hsmodImports . unLoc $ GHC.pm_parsed_source pm
+    modNameImports =
+      Maybe.mapMaybe
+        (\imp -> GHC.getLoc (ideclName $ GHC.unLoc imp) <$ guard ((== (mkModuleName $ T.unpack moduleName)) . GHC.unLoc . ideclName $ GHC.unLoc imp))
+        allImports
+  pure $ (verTextDocId, Maybe.mapMaybe (toCurrentRange mp <=< srcSpanToRange) modNameImports)
+
+--
+-- Inspired by `codeModuleName` in the hls-module-name-plugin.
+moduleNameRange :: Shake.IdeState -> NormalizedFilePath -> IO (Maybe Range)
+moduleNameRange state nfp = runMaybeT $ do
+  (pm, mp) <- MaybeT . runAction "ModuleName.GetParsedModule" state $ Shake.useWithStale GetParsedModule nfp
+  L (locA -> (RealSrcSpan l _)) _ <- MaybeT . pure . hsmodName . unLoc $ GHC.pm_parsed_source pm
+  range <- MaybeT . pure $ toCurrentRange mp (realSrcSpanToRange l)
+  pure range
+
+mkTextEditInRange :: T.Text -> VersionedTextDocumentIdentifier -> Range -> TextDocumentEdit
+mkTextEditInRange newText verTextDocId range =
+  TextDocumentEdit (verTextDocId ^. re _versionedTextDocumentIdentifier) $ fmap InL [TextEdit range newText]


### PR DESCRIPTION
Adds handling of renaming of modules.

The plan is for a rename notification to trigger a rename of the respective module in the cabal file, the module's header and all relevant imports. 
Also a complete session reloading is triggered after a rename action has taken place.

All of this works as of now but i need to split up the implementation to the relevant places in HLS, right now it all takes place in the cabal plugin, while ideally only the renaming in the `.cabal` file should.

Closes #713