### PR TITLE
Pin version of extra to 1.8.1 for stack

### DIFF
--- a/stack-lts22.yaml
+++ b/stack-lts22.yaml
@@ -17,6 +17,7 @@ allow-newer-deps:
   - directory-ospath-streaming
 
 extra-deps:
+  - extra-1.8.1
   - Diff-0.5
   - hiedb-0.8.0.0
   - hie-bios-0.18.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,6 +19,7 @@ allow-newer-deps:
   - directory-ospath-streaming
 
 extra-deps:
+  - extra-1.8.1
   - hiedb-0.8.0.0
   - hie-compat-0.3.1.2
   - implicit-hie-0.1.4.0


### PR DESCRIPTION
Fix CircleCI on master.
We really need to address #4373 and drop circleci :)
