### PR TITLE
Fix cache clearing job

### DIFF
--- a/.github/workflows/clear-cache.yaml
+++ b/.github/workflows/clear-cache.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Cleanup caches for closed PR
         # remove all cache entries for this PR
@@ -16,7 +18,7 @@ jobs:
         # other PRs / master cannot reuse them
         # so clear them when the PR is closed or merged
         run: |
-          gh cache list --ref ${{ github.ref }} --json id \
+          gh cache list --ref refs/pull/${{ github.event.pull_request.number }}/merge --json id \
             | jq -r '.[].id' \
             | xargs -I{} gh cache delete {}
         env:


### PR DESCRIPTION
PR #4865 introduced a cache clearing job. 

The purpose of this job is to clear cache entries of PR that are closed / merged saving space. 
But from the logs, it seems that github.refs resolves to master branch. 

This PR tries to fix this by properly pointing to expected PR and give write access to clear cache entries. 

logs : 
```
Run gh cache list --ref refs/heads/master --json id \
  gh cache list --ref refs/heads/master --json id \
    | jq -r '.[].id' \
    | xargs -I{} gh cache delete {}
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
    GH_REPO: haskell/haskell-language-server
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117420053)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117265713)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117249614)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117306351)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117536723)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117080153)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/2998970676)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117678958)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117500479)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117431541)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117278309)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117324130)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117396725)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3175739411)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117366147)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3175740006)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117355129)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3175741184)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117219783)
X Failed to delete cache: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/haskell/haskell-language-server/actions/caches/3117406912)
```