### PR TITLE
Process shake restarts asynchronously

### DIFF
--- a/ghcide-test/exe/Main.hs
+++ b/ghcide-test/exe/Main.hs
@@ -63,6 +63,7 @@ import           ReferenceTests
 import           ResolveTests
 import           RootUriTests
 import           SafeTests
+import           ShakeRestartTests
 import           SymlinkTests
 import           THTests
 import           UnitTests
@@ -105,4 +106,5 @@ main = do
     , GarbageCollectionTests.tests
     , HieDbRetry.tests
     , ExceptionTests.tests
+    , ShakeRestartTests.tests
     ]

--- a/ghcide-test/exe/ShakeRestartTests.hs
+++ b/ghcide-test/exe/ShakeRestartTests.hs
@@ -21,7 +21,7 @@ tests = testGroup "shake restart merging"
         newestVFSModified VFSUnmodified vfs1 @?= vfs1
 
     , testCase "mergePendingRestart Nothing" $ do
-        let p = PendingRestart VFSUnmodified (pure []) ["reason"] [] []
+        let p = PendingRestart VFSUnmodified [] ["reason"] [] []
         if mergePendingRestart p Nothing == p
           then pure ()
           else assertFailure "merging with nothing should get new"
@@ -31,18 +31,18 @@ tests = testGroup "shake restart merging"
         done2 <- newEmptyTMVarIO
         let key1 = newKey ("1" :: String)
             key2 = newKey ("2" :: String)
-            p1 = PendingRestart VFSUnmodified (pure [key1]) ["r1"] [] [done1]
-            p2 = PendingRestart VFSUnmodified (pure [key2]) ["r2"] [] [done2]
+            p1 = PendingRestart VFSUnmodified [pure [key1]] ["r1"] [] [done1]
+            p2 = PendingRestart VFSUnmodified [pure [key2]] ["r2"] [] [done2]
             merged = mergePendingRestart p1 (Just p2)
 
         pendingRestartReasons merged @?= ["r1", "r2"]
-        keys <- pendingRestartActionBetweenSessions merged
-        keys @?= [key2, key1]
+        keys <- sequence $ pendingRestartActionBetweenSessions merged
+        concat keys @?= [key2, key1]
 
     , testCase "RestartSlot coalescing" $ do
         slot <- newRestartSlot
-        let p1 = PendingRestart VFSUnmodified (pure []) ["r1"] [] []
-            p2 = PendingRestart VFSUnmodified (pure []) ["r2"] [] []
+        let p1 = PendingRestart VFSUnmodified [] ["r1"] [] []
+            p2 = PendingRestart VFSUnmodified [] ["r2"] [] []
 
         atomicModifyIORef'_ (queuedRestart slot) $ Just . mergePendingRestart p1
         atomicModifyIORef'_ (queuedRestart slot) $ Just . mergePendingRestart p2

--- a/ghcide-test/exe/ShakeRestartTests.hs
+++ b/ghcide-test/exe/ShakeRestartTests.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module ShakeRestartTests (tests) where
+
+import           Control.Concurrent.STM
+import           Data.IORef
+import           Data.IORef.Extra           (atomicModifyIORef'_)
+import           Development.IDE.Core.Shake
+import           Development.IDE.Graph      (newKey)
+import           Language.LSP.VFS
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "shake restart merging"
+    [ testCase "newestVFSModified" $ do
+        let vfs1 = VFSModified (VFS mempty)
+        newestVFSModified VFSUnmodified VFSUnmodified @?= VFSUnmodified
+        newestVFSModified vfs1 VFSUnmodified @?= vfs1
+        newestVFSModified VFSUnmodified vfs1 @?= vfs1
+
+    , testCase "mergePendingRestart Nothing" $ do
+        let p = PendingRestart VFSUnmodified (pure []) ["reason"] [] []
+        if mergePendingRestart p Nothing == p
+          then pure ()
+          else assertFailure "merging with nothing should get new"
+
+    , testCase "mergePendingRestart Just" $ do
+        done1 <- newEmptyTMVarIO
+        done2 <- newEmptyTMVarIO
+        let key1 = newKey ("1" :: String)
+            key2 = newKey ("2" :: String)
+            p1 = PendingRestart VFSUnmodified (pure [key1]) ["r1"] [] [done1]
+            p2 = PendingRestart VFSUnmodified (pure [key2]) ["r2"] [] [done2]
+            merged = mergePendingRestart p1 (Just p2)
+
+        pendingRestartReasons merged @?= ["r1", "r2"]
+        keys <- pendingRestartActionBetweenSessions merged
+        keys @?= [key2, key1]
+
+    , testCase "RestartSlot coalescing" $ do
+        slot <- newRestartSlot
+        let p1 = PendingRestart VFSUnmodified (pure []) ["r1"] [] []
+            p2 = PendingRestart VFSUnmodified (pure []) ["r2"] [] []
+
+        atomicModifyIORef'_ (queuedRestart slot) $ Just . mergePendingRestart p1
+        atomicModifyIORef'_ (queuedRestart slot) $ Just . mergePendingRestart p2
+
+        res <- atomicModifyIORef' (queuedRestart slot) (Nothing,)
+        case res of
+            Nothing -> assertFailure "Should have a pending restart"
+            Just p  -> pendingRestartReasons p @?= ["r2", "r1"]
+    ]
+
+instance Eq VFSModified where
+    VFSUnmodified == VFSUnmodified             = True
+    VFSModified (VFS _) == VFSModified (VFS _) = True
+    _ == _                                     = False
+
+instance Eq PendingRestart where
+    p1 == p2 = pendingRestartVFS p1 == pendingRestartVFS p2 &&
+               pendingRestartReasons p1 == pendingRestartReasons p2

--- a/ghcide-test/exe/ShakeRestartTests.hs
+++ b/ghcide-test/exe/ShakeRestartTests.hs
@@ -36,7 +36,7 @@ tests = testGroup "shake restart merging"
             merged = mergePendingRestart p1 (Just p2)
 
         pendingRestartReasons merged @?= ["r1", "r2"]
-        keys <- sequence $ pendingRestartActionBetweenSessions merged
+        keys <- sequence $ reverse $ pendingRestartActionBetweenSessions merged
         concat keys @?= [key2, key1]
 
     , testCase "RestartSlot coalescing" $ do

--- a/ghcide-test/exe/ShakeRestartTests.hs
+++ b/ghcide-test/exe/ShakeRestartTests.hs
@@ -3,9 +3,9 @@
 
 module ShakeRestartTests (tests) where
 
-import           Control.Concurrent.STM
+import qualified Data.Map.Lazy               as Map
 import           Development.IDE.Core.Shake
-import           Development.IDE.Graph      (newKey)
+import           Language.LSP.Protocol.Types (Uri (..), toNormalizedUri)
 import           Language.LSP.VFS
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -18,18 +18,22 @@ tests = testGroup "shake restart merging"
         newestVFSModified vfs1 VFSUnmodified @?= vfs1
         newestVFSModified VFSUnmodified vfs1 @?= vfs1
 
-    , testCase "<>" $ do
-        done1 <- newEmptyTMVarIO
-        done2 <- newEmptyTMVarIO
-        let key1 = newKey ("1" :: String)
-            key2 = newKey ("2" :: String)
-            p1 = PendingRestart VFSUnmodified [pure [key1]] ["r1"] [] [done1]
-            p2 = PendingRestart VFSUnmodified [pure [key2]] ["r2"] [] [done2]
-            merged = p1 <> p2
+    , testCase "<> appends reasons in chronological order" $ do
+        let p1 = PendingRestart VFSUnmodified mempty ["r1"] [] []
+            p2 = PendingRestart VFSUnmodified mempty ["r2"] [] []
+        pendingRestartReasons (p1 <> p2) @?= ["r1", "r2"]
 
-        pendingRestartReasons merged @?= ["r1", "r2"]
-        keys <- sequence $ reverse $ pendingRestartActionBetweenSessions merged
-        concat keys @?= [key2, key1]
+    , testCase "<> takes VFS from the right operand" $ do
+        let olderUri  = toNormalizedUri (Uri "older")
+            newerUri  = toNormalizedUri (Uri "newer")
+            unforced  = error "VFS payload should not be forced by Map.keys"
+            olderVfs  = VFSModified (VFS (Map.singleton olderUri unforced))
+            newerVfs  = VFSModified (VFS (Map.singleton newerUri unforced))
+            older     = PendingRestart olderVfs mempty ["older"] [] []
+            newer     = PendingRestart newerVfs mempty ["newer"] [] []
+        case pendingRestartVFS (older <> newer) of
+            VFSModified (VFS m) -> Map.keys m @?= [newerUri]
+            VFSUnmodified       -> assertFailure "expected VFSModified"
     ]
 
 instance Eq VFSModified where

--- a/ghcide-test/exe/ShakeRestartTests.hs
+++ b/ghcide-test/exe/ShakeRestartTests.hs
@@ -12,16 +12,16 @@ import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "shake restart merging"
-    [ testCase "newestVFSModified" $ do
+    [ testCase "succeedVFS" $ do
         let vfs1 = VFSModified (VFS mempty)
-        newestVFSModified VFSUnmodified VFSUnmodified @?= VFSUnmodified
-        newestVFSModified vfs1 VFSUnmodified @?= vfs1
-        newestVFSModified VFSUnmodified vfs1 @?= vfs1
+        succeedVFS VFSUnmodified VFSUnmodified @?= VFSUnmodified
+        succeedVFS VFSUnmodified vfs1 @?= vfs1
+        succeedVFS vfs1 VFSUnmodified @?= vfs1
 
     , testCase "<> appends reasons in chronological order" $ do
         let p1 = PendingRestart VFSUnmodified mempty ["r1"] [] []
             p2 = PendingRestart VFSUnmodified mempty ["r2"] [] []
-        pendingRestartReasons (p1 <> p2) @?= ["r1", "r2"]
+        pendingRestartReasons (succeedPendingRestart p1 p2) @?= ["r1", "r2"]
 
     , testCase "<> takes VFS from the right operand" $ do
         let olderUri  = toNormalizedUri (Uri "older")
@@ -31,7 +31,7 @@ tests = testGroup "shake restart merging"
             newerVfs  = VFSModified (VFS (Map.singleton newerUri unforced))
             older     = PendingRestart olderVfs mempty ["older"] [] []
             newer     = PendingRestart newerVfs mempty ["newer"] [] []
-        case pendingRestartVFS (older <> newer) of
+        case pendingRestartVFS (succeedPendingRestart older newer) of
             VFSModified (VFS m) -> Map.keys m @?= [newerUri]
             VFSUnmodified       -> assertFailure "expected VFSModified"
     ]

--- a/ghcide-test/exe/ShakeRestartTests.hs
+++ b/ghcide-test/exe/ShakeRestartTests.hs
@@ -4,8 +4,6 @@
 module ShakeRestartTests (tests) where
 
 import           Control.Concurrent.STM
-import           Data.IORef
-import           Data.IORef.Extra           (atomicModifyIORef'_)
 import           Development.IDE.Core.Shake
 import           Development.IDE.Graph      (newKey)
 import           Language.LSP.VFS
@@ -20,37 +18,18 @@ tests = testGroup "shake restart merging"
         newestVFSModified vfs1 VFSUnmodified @?= vfs1
         newestVFSModified VFSUnmodified vfs1 @?= vfs1
 
-    , testCase "mergePendingRestart Nothing" $ do
-        let p = PendingRestart VFSUnmodified [] ["reason"] [] []
-        if mergePendingRestart p Nothing == p
-          then pure ()
-          else assertFailure "merging with nothing should get new"
-
-    , testCase "mergePendingRestart Just" $ do
+    , testCase "<>" $ do
         done1 <- newEmptyTMVarIO
         done2 <- newEmptyTMVarIO
         let key1 = newKey ("1" :: String)
             key2 = newKey ("2" :: String)
             p1 = PendingRestart VFSUnmodified [pure [key1]] ["r1"] [] [done1]
             p2 = PendingRestart VFSUnmodified [pure [key2]] ["r2"] [] [done2]
-            merged = mergePendingRestart p1 (Just p2)
+            merged = p1 <> p2
 
         pendingRestartReasons merged @?= ["r1", "r2"]
         keys <- sequence $ reverse $ pendingRestartActionBetweenSessions merged
         concat keys @?= [key2, key1]
-
-    , testCase "RestartSlot coalescing" $ do
-        slot <- newRestartSlot
-        let p1 = PendingRestart VFSUnmodified [] ["r1"] [] []
-            p2 = PendingRestart VFSUnmodified [] ["r2"] [] []
-
-        atomicModifyIORef'_ (queuedRestart slot) $ Just . mergePendingRestart p1
-        atomicModifyIORef'_ (queuedRestart slot) $ Just . mergePendingRestart p2
-
-        res <- atomicModifyIORef' (queuedRestart slot) (Nothing,)
-        case res of
-            Nothing -> assertFailure "Should have a pending restart"
-            Just p  -> pendingRestartReasons p @?= ["r2", "r1"]
     ]
 
 instance Eq VFSModified where

--- a/ghcide-test/exe/ShakeRestartTests.hs
+++ b/ghcide-test/exe/ShakeRestartTests.hs
@@ -18,10 +18,10 @@ tests = testGroup "shake restart merging"
         succeedVFS VFSUnmodified vfs1 @?= vfs1
         succeedVFS vfs1 VFSUnmodified @?= vfs1
 
-    , testCase "<> appends reasons in chronological order" $ do
+    , testCase "<> appends reasons in reverse chronological order" $ do
         let p1 = PendingRestart VFSUnmodified mempty ["r1"] [] []
             p2 = PendingRestart VFSUnmodified mempty ["r2"] [] []
-        pendingRestartReasons (succeedPendingRestart p1 p2) @?= ["r1", "r2"]
+        reverse (pendingRestartReasons (succeedPendingRestart p1 p2)) @?= ["r1", "r2"]
 
     , testCase "<> takes VFS from the right operand" $ do
         let olderUri  = toNormalizedUri (Uri "older")

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -729,7 +729,7 @@ checkInCache sessionState ncfp = runMaybeT $ do
 
 -- | Modify the shake state.
 data SessionShake = SessionShake
-  { restartSession :: VFSModified -> String -> [DelayedAction ()] -> IO [Key] -> IO ()
+  { restartSession :: VFSModified -> T.Text -> [DelayedAction ()] -> IO [Key] -> IO ()
   , invalidateCache :: IO Key
   , enqueueActions :: DelayedAction () -> IO (IO ())
   }

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -90,6 +90,7 @@ import           Data.HashMap.Strict                 (HashMap)
 import           Data.HashSet                        (HashSet)
 import qualified Data.HashSet                        as Set
 import           Database.SQLite.Simple
+import qualified Development.IDE.Core.Shake          as Shake
 import           Development.IDE.Core.Tracing        (withTrace)
 import           Development.IDE.Core.WorkerThread
 import           Development.IDE.Session.Dependency
@@ -136,6 +137,7 @@ data Log
   | LogLookupSessionCache !FilePath
   | LogTime !String
   | LogSessionGhc Ghc.Log
+  | LogShake Shake.Log
 deriving instance Show Log
 
 instance Pretty Log where
@@ -209,6 +211,7 @@ instance Pretty Log where
     LogSessionGhc msg -> pretty msg
     LogSessionLoadingChanged ->
       "Session Loading config changed, reloading the full session."
+    LogShake msg -> pretty msg
 
 -- | Bump this version number when making changes to the format of the data stored in hiedb
 hiedbDataVersion :: String
@@ -633,7 +636,7 @@ newSessionState = do
 -- components mapping to the same hie.yaml file are mapped to the same
 -- HscEnv which is updated as new components are discovered.
 
-loadSessionWithOptions :: Recorder (WithPriority Log) -> SessionLoadingOptions -> FilePath -> TaskQueue (IO ()) -> IO (Action IdeGhcSession)
+loadSessionWithOptions :: Recorder (WithPriority Log) -> SessionLoadingOptions -> FilePath -> WorkerTasks STM (IO ()) -> IO (Action IdeGhcSession)
 loadSessionWithOptions recorder SessionLoadingOptions{..} rootDir que = do
   let toAbsolutePath = toAbsolute rootDir -- see Note [Root Directory]
 
@@ -663,7 +666,7 @@ loadSessionWithOptions recorder SessionLoadingOptions{..} rootDir que = do
     -- see Note [Serializing runs in separate thread]
     -- Start the 'getOptionsLoop' if the queue is empty
     liftIO $ atomically $
-      Extra.whenM (isEmptyTaskQueue que) $ do
+      Extra.whenM (nullWorkerTasks que) $ do
         let newSessionLoadingOptions = SessionLoadingOptions
               { findCradle = cradleLoc
               , ..
@@ -683,7 +686,7 @@ loadSessionWithOptions recorder SessionLoadingOptions{..} rootDir que = do
               , sessionLoadingOptions = newSessionLoadingOptions
               }
 
-        writeTaskQueue que (runReaderT (getOptionsLoop recorder sessionShake sessionState knownTargetsVar) sessionEnv)
+        addWorkerTask que (runReaderT (getOptionsLoop recorder sessionShake sessionState knownTargetsVar) sessionEnv)
 
     -- Each one of deps will be registered as a FileSystemWatcher in the GhcSession action
     -- so that we can get a workspace/didChangeWatchedFiles notification when a dep changes.

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -641,6 +641,7 @@ loadSessionWithOptions recorder SessionLoadingOptions{..} rootDir que = do
   let toAbsolutePath = toAbsolute rootDir -- see Note [Root Directory]
 
   sessionState <- newSessionState
+  sharedInterp <- newVar Nothing
   let returnWithVersion fun = IdeGhcSession fun <$> liftIO (readVar (version sessionState))
 
   -- This caches the mapping from Mod.hs -> hie.yaml
@@ -684,6 +685,7 @@ loadSessionWithOptions recorder SessionLoadingOptions{..} rootDir que = do
               , sessionClientConfig = clientConfig
               , sessionSharedNameCache = ideNc
               , sessionLoadingOptions = newSessionLoadingOptions
+              , sessionSharedInterp = sharedInterp
               }
 
         addWorkerTask que (runReaderT (getOptionsLoop recorder sessionShake sessionState knownTargetsVar) sessionEnv)
@@ -746,6 +748,8 @@ data SessionEnv = SessionEnv
   , sessionClientConfig    :: Config
   , sessionSharedNameCache :: NameCache
   , sessionLoadingOptions  :: SessionLoadingOptions
+  , sessionSharedInterp    :: Var (Maybe Interp)
+    -- ^ Shared interpreter for all sessions. See Note [TH interpreter loader reuse].
   }
 
 type SessionM = ReaderT SessionEnv IO
@@ -1074,7 +1078,12 @@ cradleToOptsAndLibDir recorder loadConfig cradle file old_fps = do
 emptyHscEnvM :: FilePath -> SessionM HscEnv
 emptyHscEnvM libDir = do
   nc <- asks sessionSharedNameCache
-  liftIO $ Ghc.emptyHscEnv nc libDir
+  sharedInterpVar <- asks sessionSharedInterp
+  env <- liftIO $ Ghc.emptyHscEnv nc libDir
+  liftIO $ modifyVar sharedInterpVar $ \cached ->
+    case (cached, hscInterpMaybe env) of
+      (Nothing, mFresh) -> pure (mFresh, env)
+      (mCached, _)      -> pure (mCached, withHscInterp mCached env)
 
 toFlagsMap :: TargetDetails -> [(NormalizedFilePath, (IdeResult HscEnvEq, DependencyInfo))]
 toFlagsMap TargetDetails{..} =

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -342,7 +342,6 @@ captureSplicesAndDeps TypecheckHelpers{..} env k = do
 #else
            ; let hsc_env' = loadModulesHome (map linkableHomeMod lbs) hsc_env
 #endif
-
              {- load it -}
 #if MIN_VERSION_ghc(9,11,0)
            ; bco_time <- getCurrentTime
@@ -1487,6 +1486,21 @@ As we always generate Linkables from core files, we use the core file hash
 as a (hopefully) deterministic measure of whether the Linkable has changed.
 This is better than using the object file hash (if we have one) because object
 file generation is not deterministic.
+-}
+
+{- Note [TH interpreter loader reuse]
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'loadDecls' (called per TH splice) consults the interpreter's
+'bcos_loaded :: ModuleEnv Linkable': a module with a matching timestamp is
+reused, otherwise it is loaded fresh from the HUG. 'loadModulesHome' only
+updates the HUG, so stale 'bcos_loaded' entries must be evicted via 'unload'.
+
+'getLinkableRule' calls 'unload' on every new linkable. For this to reach
+'loadDecls', all sessions must share the same 'Interp' IORef. 'emptyHscEnvM'
+ensures this by caching the first 'Interp' and overwrites 'hsc_interp' on every
+subsequent call.
+
+See also: Note [Recompilation avoidance in the presence of TH]
 -}
 
 data RecompilationInfo m

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -75,7 +75,7 @@ import           Development.IDE.Core.Preprocessor
 import           Development.IDE.Core.ProgressReporting       (progressUpdate)
 import           Development.IDE.Core.RuleTypes
 import           Development.IDE.Core.Shake
-import           Development.IDE.Core.WorkerThread            (writeTaskQueue)
+import           Development.IDE.Core.WorkerThread            (WorkerTasks (..))
 import           Development.IDE.Core.Tracing                 (withTrace)
 import qualified Development.IDE.GHC.Compat                   as Compat
 import qualified Development.IDE.GHC.Compat                   as GHC
@@ -942,7 +942,7 @@ indexHieFile se mod_summary srcPath !hash hf = do
       -- hiedb doesn't use the Haskell src, so we clear it to avoid unnecessarily keeping it around
       let !hf' = hf{hie_hs_src = mempty}
       modifyTVar' indexPending $ HashMap.insert srcPath hash
-      writeTaskQueue indexQueue $ \withHieDb -> do
+      addWorkerTask indexQueue $ \withHieDb -> do
         -- We are now in the worker thread
         -- Check if a newer index of this file has been scheduled, and if so skip this one
         newerScheduled <- atomically $ do

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -279,7 +279,7 @@ setFileModified recorder vfs state saved nfp actionBefore = do
           AlwaysCheck -> True
           CheckOnSave -> saved
           _           -> False
-    restartShakeSession (shakeExtras state) vfs (fromNormalizedFilePath nfp ++ " (modified)") [] $ do
+    restartShakeSession (shakeExtras state) vfs (T.pack (fromNormalizedFilePath nfp ++ " (modified)")) [] $ do
         keys<-actionBefore
         return (toKey GetModificationTime nfp:keys)
     when checkParents $
@@ -301,7 +301,7 @@ typecheckParentsAction recorder nfp = do
 -- | Note that some keys have been modified and restart the session
 --   Only valid if the virtual file system was initialised by LSP, as that
 --   independently tracks which files are modified.
-setSomethingModified :: VFSModified -> IdeState -> String -> IO [Key] -> IO ()
+setSomethingModified :: VFSModified -> IdeState -> T.Text -> IO [Key] -> IO ()
 setSomethingModified vfs state reason actionBetweenSession = do
     -- Update database to remove any files that might have been renamed/deleted
     atomically $ writeTaskQueue (indexQueue $ hiedbWriter $ shakeExtras state) (\withHieDb -> withHieDb deleteMissingRealFiles)

--- a/ghcide/src/Development/IDE/Core/FileStore.hs
+++ b/ghcide/src/Development/IDE/Core/FileStore.hs
@@ -304,7 +304,8 @@ typecheckParentsAction recorder nfp = do
 setSomethingModified :: VFSModified -> IdeState -> T.Text -> IO [Key] -> IO ()
 setSomethingModified vfs state reason actionBetweenSession = do
     -- Update database to remove any files that might have been renamed/deleted
-    atomically $ writeTaskQueue (indexQueue $ hiedbWriter $ shakeExtras state) (\withHieDb -> withHieDb deleteMissingRealFiles)
+    let indexQueue' = indexQueue $ hiedbWriter $ shakeExtras state
+    atomically $ addWorkerTask indexQueue' (\withHieDb -> withHieDb deleteMissingRealFiles)
     void $ restartShakeSession (shakeExtras state) vfs reason [] actionBetweenSession
 
 registerFileWatches :: [String] -> LSP.LspT Config IO Bool

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -140,6 +140,13 @@ import qualified Development.IDE.Types.Shake                  as Shake
 import           GHC.Iface.Ext.Types                          (HieASTs (..))
 import           GHC.Iface.Ext.Utils                          (generateReferencesMap)
 import qualified GHC.LanguageExtensions                       as LangExt
+#if MIN_VERSION_ghc(9,11,0)
+import           GHC.ByteCode.Types                           (CompiledByteCode (..))
+import           GHC.Data.FlatBag                             (emptyFlatBag)
+#endif
+#if MIN_VERSION_ghc(9,11,0) && !MIN_VERSION_ghc(9,13,0)
+import           GHC.Types.Name.Env                           (emptyNameEnv)
+#endif
 #if MIN_VERSION_ghc(9,13,0)
 import           GHC.Types.PkgQual                            (PkgQual (NoPkgQual))
 import           GHC.Types.Basic                              (ImportLevel (..))
@@ -1115,6 +1122,33 @@ usePropertyByPathAction path plId p = do
 
 -- ---------------------------------------------------------------------
 
+-- | Argument order matches 'moduleEnvToList'. See Note [TH interpreter loader reuse].
+fakeKeepLinkable :: Module -> UTCTime -> Linkable
+#if MIN_VERSION_ghc(9,13,0)
+fakeKeepLinkable m t = Linkable t m (pure (BCOs emptyCompiledByteCode))
+  where
+    emptyCompiledByteCode = CompiledByteCode
+      { bc_bcos = emptyFlatBag
+      , bc_itbls = []
+      , bc_strs = []
+      , bc_breaks = Nothing
+      , bc_spt_entries = []
+      }
+#elif MIN_VERSION_ghc(9,11,0)
+fakeKeepLinkable m t = Linkable t m (pure (BCOs emptyCompiledByteCode))
+  where
+    emptyCompiledByteCode = CompiledByteCode
+      { bc_bcos = emptyFlatBag
+      , bc_itbls = emptyNameEnv
+      , bc_ffis = []
+      , bc_strs = emptyNameEnv
+      , bc_breaks = Nothing
+      , bc_spt_entries = []
+      }
+#else
+fakeKeepLinkable m t = LM t m [LoadedBCOs []]
+#endif
+
 getLinkableRule :: Recorder (WithPriority Log) -> Rules ()
 getLinkableRule recorder =
   defineEarlyCutoff (cmapWithPrio LogShake recorder) $ Rule $ \GetLinkable f -> do
@@ -1175,9 +1209,8 @@ getLinkableRule recorder =
               --just before returning it to be loaded. This has a substantial effect on recompile
               --times as the number of loaded modules and splices increases.
               --
-              --We use a dummy DotA linkable part to fake a NativeCode linkable.
-              --The unload function doesn't care about the exact linkable parts.
-              unload (hscEnv session) (map (\(mod', time') -> mkLinkable time' mod' (DotA "dummy")) $ moduleEnvToList to_keep)
+              -- See Note [TH interpreter loader reuse]
+              unload (hscEnv session) (map (uncurry fakeKeepLinkable) $ moduleEnvToList to_keep)
               return (to_keep, ())
         return (fileHash <$ hmi, (warns, LinkableResult <$> hmi <*> pure fileHash))
 

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -813,6 +813,7 @@ delayedAction a = do
   extras <- ask
   liftIO $ shakeEnqueue extras a
 
+-- | NB: The lists in this datatype are with reverse chronological appends.
 data PendingRestart = PendingRestart
     { pendingRestartVFS          :: !VFSModified
     , pendingRestartDirtyActions :: ![IO [Key]]
@@ -895,9 +896,9 @@ processPendingRestart :: Recorder (WithPriority Log) -> MVar IdeState -> Pending
 processPendingRestart recorder ideMVar pendingRestart = do
   processPendingRestart' recorder ideMVar pendingRestart
     `catch` \(e :: SomeException) ->
-        case fromException e of
-            Just AsyncCancelled -> throwIO e
-            _ -> logWith recorder Error (LogRestartWorkerException e)
+      case fromException e of
+        Just AsyncCancelled -> throwIO e
+        _ -> logWith recorder Error (LogRestartWorkerException e)
 
 processPendingRestart' :: Recorder (WithPriority Log) -> MVar IdeState -> PendingRestart -> IO ()
 processPendingRestart' recorder ideMVar PendingRestart{..} = do

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -889,7 +889,9 @@ withRestartWorker ide@IdeState{..} action =
     withAsync (forever $
         processPendingRestart (shakeRecorder shakeExtras) ide
             `catch` \(e :: SomeException) ->
-                logWith (shakeRecorder shakeExtras) Error (LogRestartWorkerException e)) $
+                case fromException e of
+                  Just AsyncCancelled -> throwIO e
+                  _ -> logWith (shakeRecorder shakeExtras) Error (LogRestartWorkerException e)) $
         \_ -> action
 
 processPendingRestart :: Recorder (WithPriority Log) -> IdeState -> IO ()

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -819,11 +819,11 @@ delayedAction a = do
   liftIO $ shakeEnqueue extras a
 
 data PendingRestart = PendingRestart
-    { pendingRestartVFS                   :: VFSModified
-    , pendingRestartActionBetweenSessions :: IO [Key]
-    , pendingRestartReasons               :: [T.Text]
-    , pendingRestartActions               :: [DelayedActionInternal]
-    , pendingRestartDoneSignals           :: [TMVar ()]
+    { pendingRestartVFS                   :: !VFSModified
+    , pendingRestartActionBetweenSessions :: ![IO [Key]]
+    , pendingRestartReasons               :: ![T.Text]
+    , pendingRestartActions               :: ![DelayedActionInternal]
+    , pendingRestartDoneSignals           :: ![TMVar ()]
     }
 
 newestVFSModified :: VFSModified -> VFSModified -> VFSModified
@@ -834,34 +834,51 @@ mergePendingRestart :: PendingRestart -> Maybe PendingRestart -> PendingRestart
 mergePendingRestart new Nothing = new
 mergePendingRestart new (Just old) = PendingRestart
     { pendingRestartVFS = newestVFSModified (pendingRestartVFS new) (pendingRestartVFS old)
-    , pendingRestartReasons = pendingRestartReasons new <> pendingRestartReasons old
-    -- TODO: Contains a quadratic list append on the number of accumulated shake restarts.
-    , pendingRestartActions = pendingRestartActions old <> pendingRestartActions new
-    , pendingRestartActionBetweenSessions = pendingRestartActionBetweenSessions old <> pendingRestartActionBetweenSessions new
-    , pendingRestartDoneSignals = pendingRestartDoneSignals new <> pendingRestartDoneSignals old    }
+    , pendingRestartReasons = pendingRestartReasons new ++ pendingRestartReasons old
+    , pendingRestartActions = pendingRestartActions new ++ pendingRestartActions old
+    , pendingRestartActionBetweenSessions = pendingRestartActionBetweenSessions new ++ pendingRestartActionBetweenSessions old
+    , pendingRestartDoneSignals = pendingRestartDoneSignals new ++ pendingRestartDoneSignals old
+    }
 
 data RestartSlot = RestartSlot
-    { queuedRestart :: IORef (Maybe (PendingRestart))
-    , restartSignal :: MVar ()
+    { queuedRestart      :: IORef (Maybe PendingRestart)
+    , restartSignal      :: MVar ()
+    , lastRestartBarrier :: TVar (TMVar ())
+    -- ^ A barrier that is filled when the most recent shake restart completes.
+    --
+    -- Each call to 'shakeRestart' replaces this with a fresh empty TMVar. The
+    -- restart worker fills it when the restart finishes. Dependents on the
+    -- restart can then wait on this.
     }
 
 newRestartSlot :: IO RestartSlot
-newRestartSlot = RestartSlot <$> newIORef Nothing <*> newEmptyMVar
+newRestartSlot = do
+    initialBarrier <- newTMVarIO ()  -- starts filled (no pending restart)
+    RestartSlot <$> newIORef Nothing <*> newEmptyMVar <*> newTVarIO initialBarrier
 
 -- | Restart the current 'ShakeSession' with the given system actions.
---   Any actions running in the current session will be aborted,
---   but actions added via 'shakeEnqueue' will be requeued.
+--
+-- Any actions running in the current session will be aborted, but actions added
+-- via 'shakeEnqueue' will be requeued.
 shakeRestart :: IdeState -> VFSModified -> T.Text -> [DelayedAction ()] -> IO [Key] -> IO ()
 shakeRestart IdeState{..} vfs reason acts ioActionBetweenShakeSession = do
     restartDone <- newEmptyTMVarIO
-    atomicModifyIORef'_ (queuedRestart (restartSlot shakeExtras)) $ Just . mergePendingRestart PendingRestart
+    let slot = restartSlot shakeExtras
+    -- Publish this restart's barrier, that dependents LSP requests can wait on.
+    atomically $ writeTVar (lastRestartBarrier slot) restartDone
+    atomicModifyIORef'_ (queuedRestart slot) $ Just . mergePendingRestart PendingRestart
         { pendingRestartVFS = vfs
-        , pendingRestartActionBetweenSessions = ioActionBetweenShakeSession
+        , pendingRestartActionBetweenSessions = [ioActionBetweenShakeSession]
         , pendingRestartReasons = [reason]
         , pendingRestartActions = acts
         , pendingRestartDoneSignals = [restartDone]
         }
-    void $ tryPutMVar (restartSignal (restartSlot shakeExtras)) ()
+    void $ tryPutMVar (restartSignal slot) ()
+    -- Block until the restart (including ioActionBetweenShakeSession) completes.
+    -- This preserves the invariant from the original synchronous shakeRestart:
+    -- callers (e.g. the session loader) must not proceed until their
+    -- between-session actions have run, otherwise downstream rules can observe
+    -- stale results (see Note at Session.hs restartSession call site).
     atomically $ readTMVar restartDone
 
 -- | Run a worker that asynchronously processes shake restart requests. Will
@@ -880,10 +897,10 @@ processPendingRestart recorder IdeState{..} = do
     takeMVar (restartSignal (restartSlot shakeExtras))
     pendingRestart <- atomicModifyIORef' (queuedRestart (restartSlot shakeExtras)) (Nothing,)
     void $ forM pendingRestart $ \PendingRestart {..} -> do
-        flip finally (atomically $ traverse (flip tryPutTMVar ()) pendingRestartDoneSignals) $ do
+        flip finally (atomically $ traverse (flip tryPutTMVar ()) (reverse pendingRestartDoneSignals)) $ do
             let sessionAction runner = do
                     (stopTime,()) <- duration $ logErrorAfter 10 $ cancelShakeSession runner
-                    keys <- pendingRestartActionBetweenSessions
+                    keys <- fmap concat (sequence (reverse pendingRestartActionBetweenSessions))
                     -- it is every important to update the dirty keys after we enter the critical section
                     -- see Note [Housekeeping rule cache and dirty key outside of hls-graph]
                     atomically $ modifyTVar' (dirtyKeys shakeExtras) $ \x -> foldl' (flip insertKeySet) x keys
@@ -892,13 +909,15 @@ processPendingRestart recorder IdeState{..} = do
                     queue <- atomicallyNamed "actionQueue - peek" $ peekInProgress $ actionQueue shakeExtras
 
                     -- this log is required by tests
-                    logWith recorder Debug $ LogBuildSessionRestart pendingRestartReasons queue backlog stopTime res
+                    logWith recorder Debug $ LogBuildSessionRestart (reverse pendingRestartReasons) queue backlog stopTime res
 
             withMVar' shakeSession sessionAction $ \() ->
                 -- It is crucial to be masked here, otherwise we can get killed
                 -- between spawning the new thread and updating shakeSession.
                 -- See https://github.com/haskell/ghcide/issues/79
-                (,()) <$> newSession recorder shakeExtras pendingRestartVFS shakeDb pendingRestartActions pendingRestartReasons
+                (,()) <$> newSession recorder shakeExtras pendingRestartVFS shakeDb
+                    (reverse pendingRestartActions)
+                    (reverse pendingRestartReasons)
     pure ()
   where
     logErrorAfter :: Seconds -> IO () -> IO ()

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -26,10 +26,10 @@ module Development.IDE.Core.Shake(
     IdeState, shakeSessionInit, shakeExtras, shakeDb, rootDir,
     ShakeExtras(..), getShakeExtras, getShakeExtrasRules,
     KnownTargets(..), Target(..), toKnownFiles, unionKnownTargets, mkKnownTargets,
-    IdeRule, IdeResult, RestartQueue,
+    IdeRule, IdeResult,
     GetModificationTime(GetModificationTime, GetModificationTime_, missingFileDiagnostics),
     shakeOpen, shakeShut,
-    withRestartWorker, newRestartSlot,
+    newRestartSlot,
     shakeEnqueue,
     newSession,
     use, useNoFile, uses, useWithStaleFast, useWithStaleFast', delayedAction,
@@ -76,14 +76,14 @@ module Development.IDE.Core.Shake(
     RestartSlot(..),
     addPersistentRule,
     newestVFSModified,
-    mergePendingRestart,
     garbageCollectDirtyKeys,
     garbageCollectDirtyKeysOlderThan,
     Log(..),
     VFSModified(..), getClientConfigAction,
     ThreadQueue(..),
     runWithSignal,
-    askShake
+    askShake,
+    processPendingRestart
     ) where
 
 import           Control.Concurrent.Async
@@ -149,7 +149,6 @@ import           Development.IDE.GHC.Compat             (NameCache,
                                                          initNameCache,
                                                          knownKeyNames)
 #endif
-import           Data.IORef.Extra                       (atomicModifyIORef'_)
 import qualified Data.Text.Encoding                     as T
 import           Development.IDE.GHC.Orphans            ()
 import           Development.IDE.Graph                  hiding (ShakeValue,
@@ -192,10 +191,7 @@ import qualified StmContainers.Map                      as STM
 import           System.FilePath                        hiding (makeRelative)
 import           System.IO.Unsafe                       (unsafePerformIO)
 import           System.Time.Extra
-import           UnliftIO                               (IORef,
-                                                         MonadUnliftIO (withRunInIO),
-                                                         atomicModifyIORef',
-                                                         newIORef)
+import           UnliftIO                               (MonadUnliftIO (..))
 
 
 data Log
@@ -277,16 +273,15 @@ data HieDbWriter
 -- | Actions to queue up on the index worker thread
 -- The inner `(HieDb -> IO ()) -> IO ()` wraps `HieDb -> IO ()`
 -- with (currently) retry functionality
-type IndexQueue = TaskQueue (((HieDb -> IO ()) -> IO ()) -> IO ())
-type RestartQueue = TaskQueue (IO ())
-type LoaderQueue = TaskQueue (IO ())
+type IndexQueue = WorkerTasks STM (((HieDb -> IO ()) -> IO ()) -> IO ())
+type RestartRef = WorkerTasks STM PendingRestart
+type LoaderQueue = WorkerTasks STM (IO ())
 
-
-data ThreadQueue = ThreadQueue {
-    tIndexQueue    :: IndexQueue
-    , tRestartSlot :: RestartSlot
-    , tLoaderQueue :: LoaderQueue
-}
+data ThreadQueue = ThreadQueue
+  { tIndexQueue  :: IndexQueue
+  , tRestartSlot :: RestartSlot
+  , tLoaderQueue :: LoaderQueue
+  }
 
 -- Note [Semantic Tokens Cache Location]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -826,13 +821,8 @@ data PendingRestart = PendingRestart
     , pendingRestartDoneSignals           :: ![TMVar ()]
     }
 
-newestVFSModified :: VFSModified -> VFSModified -> VFSModified
-newestVFSModified VFSUnmodified old     = old
-newestVFSModified new@(VFSModified _) _ = new
-
-mergePendingRestart :: PendingRestart -> Maybe PendingRestart -> PendingRestart
-mergePendingRestart new Nothing = new
-mergePendingRestart new (Just old) = PendingRestart
+instance Semigroup PendingRestart where
+  new <> old = PendingRestart
     { pendingRestartVFS = newestVFSModified (pendingRestartVFS new) (pendingRestartVFS old)
     , pendingRestartReasons = pendingRestartReasons new ++ pendingRestartReasons old
     , pendingRestartActions = pendingRestartActions new ++ pendingRestartActions old
@@ -840,9 +830,12 @@ mergePendingRestart new (Just old) = PendingRestart
     , pendingRestartDoneSignals = pendingRestartDoneSignals new ++ pendingRestartDoneSignals old
     }
 
+newestVFSModified :: VFSModified -> VFSModified -> VFSModified
+newestVFSModified VFSUnmodified old     = old
+newestVFSModified new@(VFSModified _) _ = new
+
 data RestartSlot = RestartSlot
-    { queuedRestart      :: IORef (Maybe PendingRestart)
-    , restartSignal      :: MVar ()
+    { restartRef         :: WorkerTasks STM PendingRestart
     , lastRestartBarrier :: TVar (TMVar ())
     -- ^ A barrier that is filled when the most recent shake restart completes.
     --
@@ -851,10 +844,10 @@ data RestartSlot = RestartSlot
     -- restart can then wait on this.
     }
 
-newRestartSlot :: IO RestartSlot
-newRestartSlot = do
+newRestartSlot :: RestartRef -> IO RestartSlot
+newRestartSlot queuedRestart = do
     initialBarrier <- newTMVarIO ()  -- starts filled (no pending restart)
-    RestartSlot <$> newIORef Nothing <*> newEmptyMVar <*> newTVarIO initialBarrier
+    RestartSlot <$> pure queuedRestart <*> newTVarIO initialBarrier
 
 -- | Restart the current 'ShakeSession' with the given system actions.
 --
@@ -862,66 +855,51 @@ newRestartSlot = do
 -- via 'shakeEnqueue' will be requeued.
 shakeRestart :: IdeState -> VFSModified -> T.Text -> [DelayedAction ()] -> IO [Key] -> IO ()
 shakeRestart IdeState{..} vfs reason acts ioActionBetweenShakeSession = do
-    restartDone <- newEmptyTMVarIO
-    let slot = restartSlot shakeExtras
-    -- Publish this restart's barrier, that dependents LSP requests can wait on.
-    atomically $ writeTVar (lastRestartBarrier slot) restartDone
-    atomicModifyIORef'_ (queuedRestart slot) $ Just . mergePendingRestart PendingRestart
-        { pendingRestartVFS = vfs
-        , pendingRestartActionBetweenSessions = [ioActionBetweenShakeSession]
-        , pendingRestartReasons = [reason]
-        , pendingRestartActions = acts
-        , pendingRestartDoneSignals = [restartDone]
-        }
-    void $ tryPutMVar (restartSignal slot) ()
-    -- Block until the restart (including ioActionBetweenShakeSession) completes.
-    -- This preserves the invariant from the original synchronous shakeRestart:
-    -- callers (e.g. the session loader) must not proceed until their
-    -- between-session actions have run, otherwise downstream rules can observe
-    -- stale results (see Note at Session.hs restartSession call site).
-    atomically $ readTMVar restartDone
+  restartDone <- newEmptyTMVarIO
+  let RestartSlot {..} = restartSlot shakeExtras
+  -- Publish this restart's barrier, that dependents LSP requests can wait on.
+  atomically $ do
+    writeTVar lastRestartBarrier restartDone
+    addWorkerTask restartRef $ PendingRestart
+      { pendingRestartVFS = vfs
+      , pendingRestartActionBetweenSessions = [ioActionBetweenShakeSession]
+      , pendingRestartReasons = [reason]
+      , pendingRestartActions = acts
+      , pendingRestartDoneSignals = [restartDone]
+      }
 
--- | Run a worker that asynchronously processes shake restart requests. Will
--- only ever queue upto 1 additional restart, accumulating data while processing
--- any restart.
-withRestartWorker :: MVar IdeState -> IO r -> IO r
-withRestartWorker ideMVar action = do
-    let restartWorkerAction = do
-          ide@IdeState{..} <- readMVar ideMVar
-          forever (processPendingRestart (shakeRecorder shakeExtras) ide)
-            `catch` \(e :: SomeException) ->
-                case fromException e of
-                    Just AsyncCancelled -> throwIO e
-                    _ -> logWith (shakeRecorder shakeExtras) Error (LogRestartWorkerException e)
+processPendingRestart :: Recorder (WithPriority Log) -> MVar IdeState -> PendingRestart -> IO ()
+processPendingRestart recorder ideMVar pendingRestart = do
+  processPendingRestart' recorder ideMVar pendingRestart
+    `catch` \(e :: SomeException) ->
+        case fromException e of
+            Just AsyncCancelled -> throwIO e
+            _ -> logWith recorder Error (LogRestartWorkerException e)
 
-    withAsync restartWorkerAction $ \_ -> action
+processPendingRestart' :: Recorder (WithPriority Log) -> MVar IdeState -> PendingRestart -> IO ()
+processPendingRestart' recorder ideMVar PendingRestart{..} = do
+    IdeState{..} <- readMVar ideMVar
+    flip finally (atomically $ traverse (flip tryPutTMVar ()) (reverse pendingRestartDoneSignals)) $ do
+        let sessionAction runner = do
+                (stopTime,()) <- duration $ logErrorAfter 10 $ cancelShakeSession runner
+                keys <- fmap concat (sequence (reverse pendingRestartActionBetweenSessions))
+                -- it is every important to update the dirty keys after we enter the critical section
+                -- see Note [Housekeeping rule cache and dirty key outside of hls-graph]
+                atomically $ modifyTVar' (dirtyKeys shakeExtras) $ \x -> foldl' (flip insertKeySet) x keys
+                res <- shakeDatabaseProfile shakeDb
+                backlog <- readTVarIO $ dirtyKeys shakeExtras
+                queue <- atomicallyNamed "actionQueue - peek" $ peekInProgress $ actionQueue shakeExtras
 
-processPendingRestart :: Recorder (WithPriority Log) -> IdeState -> IO ()
-processPendingRestart recorder IdeState{..} = do
-    takeMVar (restartSignal (restartSlot shakeExtras))
-    pendingRestart <- atomicModifyIORef' (queuedRestart (restartSlot shakeExtras)) (Nothing,)
-    void $ forM pendingRestart $ \PendingRestart {..} -> do
-        flip finally (atomically $ traverse (flip tryPutTMVar ()) (reverse pendingRestartDoneSignals)) $ do
-            let sessionAction runner = do
-                    (stopTime,()) <- duration $ logErrorAfter 10 $ cancelShakeSession runner
-                    keys <- fmap concat (sequence (reverse pendingRestartActionBetweenSessions))
-                    -- it is every important to update the dirty keys after we enter the critical section
-                    -- see Note [Housekeeping rule cache and dirty key outside of hls-graph]
-                    atomically $ modifyTVar' (dirtyKeys shakeExtras) $ \x -> foldl' (flip insertKeySet) x keys
-                    res <- shakeDatabaseProfile shakeDb
-                    backlog <- readTVarIO $ dirtyKeys shakeExtras
-                    queue <- atomicallyNamed "actionQueue - peek" $ peekInProgress $ actionQueue shakeExtras
+                -- this log is required by tests
+                logWith recorder Debug $ LogBuildSessionRestart (reverse pendingRestartReasons) queue backlog stopTime res
 
-                    -- this log is required by tests
-                    logWith recorder Debug $ LogBuildSessionRestart (reverse pendingRestartReasons) queue backlog stopTime res
-
-            withMVar' shakeSession sessionAction $ \() ->
-                -- It is crucial to be masked here, otherwise we can get killed
-                -- between spawning the new thread and updating shakeSession.
-                -- See https://github.com/haskell/ghcide/issues/79
-                (,()) <$> newSession recorder shakeExtras pendingRestartVFS shakeDb
-                    (reverse pendingRestartActions)
-                    (reverse pendingRestartReasons)
+        withMVar' shakeSession sessionAction $ \() ->
+            -- It is crucial to be masked here, otherwise we can get killed
+            -- between spawning the new thread and updating shakeSession.
+            -- See https://github.com/haskell/ghcide/issues/79
+            (,()) <$> newSession recorder shakeExtras pendingRestartVFS shakeDb
+                (reverse pendingRestartActions)
+                (reverse pendingRestartReasons)
   where
     logErrorAfter :: Seconds -> IO () -> IO ()
     logErrorAfter seconds action = flip withAsync (const action) $ do

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -75,11 +75,12 @@ module Development.IDE.Core.Shake(
     PendingRestart(..),
     RestartSlot(..),
     addPersistentRule,
-    newestVFSModified,
+    succeedPendingRestart, succeedVFS,
     garbageCollectDirtyKeys,
     garbageCollectDirtyKeysOlderThan,
     Log(..),
     VFSModified(..), getClientConfigAction,
+    waitForLastRestart,
     ThreadQueue(..),
     runWithSignal,
     askShake,
@@ -820,20 +821,18 @@ data PendingRestart = PendingRestart
     , pendingRestartDoneSignals :: ![TMVar ()]
     }
 
--- | TODO(crtschin): This isn't commutative because of VFS ordering. Make this a
--- proper function.
-instance Semigroup PendingRestart where
-  older <> newer = PendingRestart
-    { pendingRestartVFS = newestVFSModified (pendingRestartVFS newer) (pendingRestartVFS older)
+succeedPendingRestart :: PendingRestart -> PendingRestart -> PendingRestart
+succeedPendingRestart older newer = PendingRestart
+    { pendingRestartVFS = succeedVFS (pendingRestartVFS older) (pendingRestartVFS newer)
     , pendingRestartDirtyKeys = pendingRestartDirtyKeys older <> pendingRestartDirtyKeys newer
     , pendingRestartReasons = pendingRestartReasons older ++ pendingRestartReasons newer
     , pendingRestartActions = pendingRestartActions older ++ pendingRestartActions newer
     , pendingRestartDoneSignals = pendingRestartDoneSignals older ++ pendingRestartDoneSignals newer
     }
 
-newestVFSModified :: VFSModified -> VFSModified -> VFSModified
-newestVFSModified VFSUnmodified old     = old
-newestVFSModified new@(VFSModified _) _ = new
+succeedVFS :: VFSModified -> VFSModified -> VFSModified
+succeedVFS old VFSUnmodified     = old
+succeedVFS _ new@(VFSModified _) = new
 
 data RestartSlot = RestartSlot
     { restartRef         :: WorkerTasks STM PendingRestart
@@ -849,6 +848,28 @@ newRestartSlot :: RestartRef -> IO RestartSlot
 newRestartSlot queuedRestart = do
     initialBarrier <- newTMVarIO ()  -- starts filled (no pending restart)
     RestartSlot <$> pure queuedRestart <*> newTVarIO initialBarrier
+
+-- | Block until the most recently enqueued restart has started its new session.
+--
+-- Needed by request handlers, not notification handlers,
+--   (See Note [Notification vs request restart ordering])
+-- that call @shakeRestart@ and then run a @runAction@ depending on a rule
+-- cached in the old session. Without this, the rule's cached result survives
+-- because hls-graph's @isDirty@ check ignores @alwaysRerun@ within a
+-- session, see #4697.
+waitForLastRestart :: IdeState -> IO ()
+waitForLastRestart IdeState{shakeExtras} =
+    atomically $ readTVar (lastRestartBarrier (restartSlot shakeExtras)) >>= readTMVar
+
+-- Note [Notification vs request restart ordering]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- @shakeRestart@ is non-blocking. @restartDone@ delays any notification's
+-- @done@ barrier until its restart completes, so any subsequent request waiting
+-- on @notificationLocks@ observes the new session.
+--
+-- Request handlers that call @shakeRestart@ themselves are not covered.
+-- They must call @waitForLastRestart@ before any @runAction@ that needs a
+-- rule to be recomputed in the new session.
 
 -- | Restart the current 'ShakeSession' with the given system actions.
 --

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -114,8 +114,7 @@ import           Data.Hashable
 import qualified Data.HashMap.Strict                    as HMap
 import           Data.HashSet                           (HashSet)
 import qualified Data.HashSet                           as HSet
-import           Data.List.Extra                        (foldl', partition,
-                                                         takeEnd)
+import           Data.List.Extra                        (partition, takeEnd)
 import qualified Data.Map.Strict                        as Map
 import           Data.Maybe
 import qualified Data.SortedList                        as SL
@@ -814,20 +813,22 @@ delayedAction a = do
   liftIO $ shakeEnqueue extras a
 
 data PendingRestart = PendingRestart
-    { pendingRestartVFS                   :: !VFSModified
-    , pendingRestartActionBetweenSessions :: ![IO [Key]]
-    , pendingRestartReasons               :: ![T.Text]
-    , pendingRestartActions               :: ![DelayedActionInternal]
-    , pendingRestartDoneSignals           :: ![TMVar ()]
+    { pendingRestartVFS         :: !VFSModified
+    , pendingRestartDirtyKeys   :: !KeySet
+    , pendingRestartReasons     :: ![T.Text]
+    , pendingRestartActions     :: ![DelayedActionInternal]
+    , pendingRestartDoneSignals :: ![TMVar ()]
     }
 
+-- | TODO(crtschin): This isn't commutative because of VFS ordering. Make this a
+-- proper function.
 instance Semigroup PendingRestart where
-  new <> old = PendingRestart
-    { pendingRestartVFS = newestVFSModified (pendingRestartVFS new) (pendingRestartVFS old)
-    , pendingRestartReasons = pendingRestartReasons new ++ pendingRestartReasons old
-    , pendingRestartActions = pendingRestartActions new ++ pendingRestartActions old
-    , pendingRestartActionBetweenSessions = pendingRestartActionBetweenSessions new ++ pendingRestartActionBetweenSessions old
-    , pendingRestartDoneSignals = pendingRestartDoneSignals new ++ pendingRestartDoneSignals old
+  older <> newer = PendingRestart
+    { pendingRestartVFS = newestVFSModified (pendingRestartVFS newer) (pendingRestartVFS older)
+    , pendingRestartDirtyKeys = pendingRestartDirtyKeys older <> pendingRestartDirtyKeys newer
+    , pendingRestartReasons = pendingRestartReasons older ++ pendingRestartReasons newer
+    , pendingRestartActions = pendingRestartActions older ++ pendingRestartActions newer
+    , pendingRestartDoneSignals = pendingRestartDoneSignals older ++ pendingRestartDoneSignals newer
     }
 
 newestVFSModified :: VFSModified -> VFSModified -> VFSModified
@@ -857,12 +858,20 @@ shakeRestart :: IdeState -> VFSModified -> T.Text -> [DelayedAction ()] -> IO [K
 shakeRestart IdeState{..} vfs reason acts ioActionBetweenShakeSession = do
   restartDone <- newEmptyTMVarIO
   let RestartSlot {..} = restartSlot shakeExtras
-  -- Publish this restart's barrier, that dependents LSP requests can wait on.
+  -- Run the between-session action here (not on the worker) so notification
+  -- side effects are visible by the time the LSP notification handler returns.
+  --
+  -- If not here, then it would be hard to determine exactly where to place
+  -- these side-effects when shake restarts are merged. While these side-effects
+  -- do need to occur here, the keys they invalidate need to propagate to the
+  -- worker so it can be used during the concrete restart.
+  -- See Note [Housekeeping rule cache and dirty key outside of hls-graph].
+  !newDirty <- fromListKeySet <$> ioActionBetweenShakeSession
   atomically $ do
     writeTVar lastRestartBarrier restartDone
     addWorkerTask restartRef $ PendingRestart
       { pendingRestartVFS = vfs
-      , pendingRestartActionBetweenSessions = [ioActionBetweenShakeSession]
+      , pendingRestartDirtyKeys = newDirty
       , pendingRestartReasons = [reason]
       , pendingRestartActions = acts
       , pendingRestartDoneSignals = [restartDone]
@@ -882,10 +891,11 @@ processPendingRestart' recorder ideMVar PendingRestart{..} = do
     flip finally (atomically $ traverse (flip tryPutTMVar ()) (reverse pendingRestartDoneSignals)) $ do
         let sessionAction runner = do
                 (stopTime,()) <- duration $ logErrorAfter 10 $ cancelShakeSession runner
-                keys <- fmap concat (sequence (reverse pendingRestartActionBetweenSessions))
-                -- it is every important to update the dirty keys after we enter the critical section
-                -- see Note [Housekeeping rule cache and dirty key outside of hls-graph]
-                atomically $ modifyTVar' (dirtyKeys shakeExtras) $ \x -> foldl' (flip insertKeySet) x keys
+                -- Apply dirty keys after the dying session's work thread is dead
+                -- (cancelShakeSession is synchronous). This is the only placement
+                -- immune to concern 1.2 in
+                --   Note [Housekeeping rule cache and dirty key outside of hls-graph]
+                atomically $ modifyTVar' (dirtyKeys shakeExtras) (<> pendingRestartDirtyKeys)
                 res <- shakeDatabaseProfile shakeDb
                 backlog <- readTVarIO $ dirtyKeys shakeExtras
                 queue <- atomicallyNamed "actionQueue - peek" $ peekInProgress $ actionQueue shakeExtras

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -72,7 +72,11 @@ module Development.IDE.Core.Shake(
     IndexQueue,
     HieDb,
     HieDbWriter(..),
+    PendingRestart(..),
+    RestartSlot(..),
     addPersistentRule,
+    newestVFSModified,
+    mergePendingRestart,
     garbageCollectDirtyKeys,
     garbageCollectDirtyKeysOlderThan,
     Log(..),
@@ -135,7 +139,6 @@ import qualified Language.LSP.Protocol.Message          as LSP
 import qualified Language.LSP.Server                    as LSP
 
 import           Development.IDE.Core.Tracing
-import           Development.IDE.Core.WorkerThread
 #if MIN_VERSION_ghc(9,13,0)
 import           Development.IDE.GHC.Compat             (NameCache,
                                                          NameCacheUpdater,
@@ -831,15 +834,10 @@ mergePendingRestart :: PendingRestart -> Maybe PendingRestart -> PendingRestart
 mergePendingRestart new Nothing = new
 mergePendingRestart new (Just old) = PendingRestart
     { pendingRestartVFS = newestVFSModified (pendingRestartVFS new) (pendingRestartVFS old)
-    , pendingRestartActions = do
-        old' <- pendingRestartActions old
-        new' <- pendingRestartActions new
-        pure $ new' <> old'
     , pendingRestartReasons = pendingRestartReasons new <> pendingRestartReasons old
-    , pendingRestartActionBetweenSessions = do
-        old' <- pendingRestartActionBetweenSessions old
-        new' <- pendingRestartActionBetweenSessions new
-        pure $ new' <> old'
+    -- TODO: Contains a quadratic list append on the number of accumulated shake restarts.
+    , pendingRestartActions = pendingRestartActions old <> pendingRestartActions new
+    , pendingRestartActionBetweenSessions = pendingRestartActionBetweenSessions old <> pendingRestartActionBetweenSessions new
     , pendingRestartDoneSignals = pendingRestartDoneSignals new <> pendingRestartDoneSignals old    }
 
 data RestartSlot = RestartSlot
@@ -932,6 +930,7 @@ shakeEnqueue ShakeExtras{actionQueue, shakeRecorder} act = do
     return (wait' b >>= either throwIO return)
 
 data VFSModified = VFSUnmodified | VFSModified !VFS
+    deriving Show
 
 -- | Set up a new 'ShakeSession' with a set of initial actions
 --   Will crash if there is an existing 'ShakeSession' running.

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -814,20 +814,20 @@ delayedAction a = do
   liftIO $ shakeEnqueue extras a
 
 data PendingRestart = PendingRestart
-    { pendingRestartVFS         :: !VFSModified
-    , pendingRestartDirtyKeys   :: !KeySet
-    , pendingRestartReasons     :: ![T.Text]
-    , pendingRestartActions     :: ![DelayedActionInternal]
-    , pendingRestartDoneSignals :: ![TMVar ()]
+    { pendingRestartVFS          :: !VFSModified
+    , pendingRestartDirtyActions :: ![IO [Key]]
+    , pendingRestartReasons      :: ![T.Text]
+    , pendingRestartActions      :: ![DelayedActionInternal]
+    , pendingRestartDoneSignals  :: ![TMVar ()]
     }
 
 succeedPendingRestart :: PendingRestart -> PendingRestart -> PendingRestart
 succeedPendingRestart older newer = PendingRestart
     { pendingRestartVFS = succeedVFS (pendingRestartVFS older) (pendingRestartVFS newer)
-    , pendingRestartDirtyKeys = pendingRestartDirtyKeys older <> pendingRestartDirtyKeys newer
-    , pendingRestartReasons = pendingRestartReasons older ++ pendingRestartReasons newer
-    , pendingRestartActions = pendingRestartActions older ++ pendingRestartActions newer
-    , pendingRestartDoneSignals = pendingRestartDoneSignals older ++ pendingRestartDoneSignals newer
+    , pendingRestartDirtyActions = pendingRestartDirtyActions newer ++ pendingRestartDirtyActions older
+    , pendingRestartReasons = pendingRestartReasons newer ++ pendingRestartReasons older
+    , pendingRestartActions = pendingRestartActions newer ++ pendingRestartActions older
+    , pendingRestartDoneSignals = pendingRestartDoneSignals newer ++ pendingRestartDoneSignals older
     }
 
 succeedVFS :: VFSModified -> VFSModified -> VFSModified
@@ -863,9 +863,9 @@ waitForLastRestart IdeState{shakeExtras} =
 
 -- Note [Notification vs request restart ordering]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--- @shakeRestart@ is non-blocking. @restartDone@ delays any notification's
+-- @shakeRestart@ is non-blocking, @restartDone@ delays any notification's
 -- @done@ barrier until its restart completes, so any subsequent request waiting
--- on @notificationLocks@ observes the new session.
+-- on @notificationLocks@ observes the side effects and the new session.
 --
 -- Request handlers that call @shakeRestart@ themselves are not covered.
 -- They must call @waitForLastRestart@ before any @runAction@ that needs a
@@ -875,24 +875,17 @@ waitForLastRestart IdeState{shakeExtras} =
 --
 -- Any actions running in the current session will be aborted, but actions added
 -- via 'shakeEnqueue' will be requeued.
+--
+-- NB: the @ioActionBetweenShakeSession@ is deferred to the restart worker.
 shakeRestart :: IdeState -> VFSModified -> T.Text -> [DelayedAction ()] -> IO [Key] -> IO ()
 shakeRestart IdeState{..} vfs reason acts ioActionBetweenShakeSession = do
   restartDone <- newEmptyTMVarIO
   let RestartSlot {..} = restartSlot shakeExtras
-  -- Run the between-session action here (not on the worker) so notification
-  -- side effects are visible by the time the LSP notification handler returns.
-  --
-  -- If not here, then it would be hard to determine exactly where to place
-  -- these side-effects when shake restarts are merged. While these side-effects
-  -- do need to occur here, the keys they invalidate need to propagate to the
-  -- worker so it can be used during the concrete restart.
-  -- See Note [Housekeeping rule cache and dirty key outside of hls-graph].
-  !newDirty <- fromListKeySet <$> ioActionBetweenShakeSession
   atomically $ do
     writeTVar lastRestartBarrier restartDone
     addWorkerTask restartRef $ PendingRestart
       { pendingRestartVFS = vfs
-      , pendingRestartDirtyKeys = newDirty
+      , pendingRestartDirtyActions = [ioActionBetweenShakeSession]
       , pendingRestartReasons = [reason]
       , pendingRestartActions = acts
       , pendingRestartDoneSignals = [restartDone]
@@ -910,13 +903,19 @@ processPendingRestart' :: Recorder (WithPriority Log) -> MVar IdeState -> Pendin
 processPendingRestart' recorder ideMVar PendingRestart{..} = do
     IdeState{..} <- readMVar ideMVar
     flip finally (atomically $ traverse (flip tryPutTMVar ()) (reverse pendingRestartDoneSignals)) $ do
-        let sessionAction runner = do
+        let runDirtyAction io = try @SomeException io >>= \case
+                Right ks -> pure ks
+                Left  e  -> [] <$ logWith recorder Error (LogRestartWorkerException e)
+            sessionAction runner = do
                 (stopTime,()) <- duration $ logErrorAfter 10 $ cancelShakeSession runner
-                -- Apply dirty keys after the dying session's work thread is dead
-                -- (cancelShakeSession is synchronous). This is the only placement
-                -- immune to concern 1.2 in
-                --   Note [Housekeeping rule cache and dirty key outside of hls-graph]
-                atomically $ modifyTVar' (dirtyKeys shakeExtras) (<> pendingRestartDirtyKeys)
+                -- Run the queued IO actions and apply dirty keys after the
+                -- dying session's work thread is dead so no inflight rule can
+                -- observe these mutations.
+                --
+                -- See Note [Housekeeping rule cache and dirty key outside of hls-graph]
+                newDirtyLists <- traverse runDirtyAction $ reverse pendingRestartDirtyActions
+                let newDirty = fromListKeySet (concat newDirtyLists)
+                atomically $ modifyTVar' (dirtyKeys shakeExtras) (<> newDirty)
                 res <- shakeDatabaseProfile shakeDb
                 backlog <- readTVarIO $ dirtyKeys shakeExtras
                 queue <- atomicallyNamed "actionQueue - peek" $ peekInProgress $ actionQueue shakeExtras

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -884,15 +884,17 @@ shakeRestart IdeState{..} vfs reason acts ioActionBetweenShakeSession = do
 -- | Run a worker that asynchronously processes shake restart requests. Will
 -- only ever queue upto 1 additional restart, accumulating data while processing
 -- any restart.
-withRestartWorker :: IdeState -> IO r -> IO r
-withRestartWorker ide@IdeState{..} action =
-    withAsync (forever $
-        processPendingRestart (shakeRecorder shakeExtras) ide
+withRestartWorker :: MVar IdeState -> IO r -> IO r
+withRestartWorker ideMVar action = do
+    let restartWorkerAction = do
+          ide@IdeState{..} <- readMVar ideMVar
+          forever (processPendingRestart (shakeRecorder shakeExtras) ide)
             `catch` \(e :: SomeException) ->
                 case fromException e of
-                  Just AsyncCancelled -> throwIO e
-                  _ -> logWith (shakeRecorder shakeExtras) Error (LogRestartWorkerException e)) $
-        \_ -> action
+                    Just AsyncCancelled -> throwIO e
+                    _ -> logWith (shakeRecorder shakeExtras) Error (LogRestartWorkerException e)
+
+    withAsync restartWorkerAction $ \_ -> action
 
 processPendingRestart :: Recorder (WithPriority Log) -> IdeState -> IO ()
 processPendingRestart recorder IdeState{..} = do
@@ -920,7 +922,6 @@ processPendingRestart recorder IdeState{..} = do
                 (,()) <$> newSession recorder shakeExtras pendingRestartVFS shakeDb
                     (reverse pendingRestartActions)
                     (reverse pendingRestartReasons)
-    pure ()
   where
     logErrorAfter :: Seconds -> IO () -> IO ()
     logErrorAfter seconds action = flip withAsync (const action) $ do

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE RecursiveDo           #-}
 {-# LANGUAGE TypeFamilies          #-}
@@ -28,6 +29,7 @@ module Development.IDE.Core.Shake(
     IdeRule, IdeResult, RestartQueue,
     GetModificationTime(GetModificationTime, GetModificationTime_, missingFileDiagnostics),
     shakeOpen, shakeShut,
+    withRestartWorker, newRestartSlot,
     shakeEnqueue,
     newSession,
     use, useNoFile, uses, useWithStaleFast, useWithStaleFast', delayedAction,
@@ -127,6 +129,7 @@ import           Development.IDE.Core.FileUtils         (getModTime)
 import           Development.IDE.Core.PositionMapping
 import           Development.IDE.Core.ProgressReporting
 import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.WorkerThread
 import           Development.IDE.Types.Options          as Options
 import qualified Language.LSP.Protocol.Message          as LSP
 import qualified Language.LSP.Server                    as LSP
@@ -143,6 +146,8 @@ import           Development.IDE.GHC.Compat             (NameCache,
                                                          initNameCache,
                                                          knownKeyNames)
 #endif
+import           Data.IORef.Extra                       (atomicModifyIORef'_)
+import qualified Data.Text.Encoding                     as T
 import           Development.IDE.GHC.Orphans            ()
 import           Development.IDE.Graph                  hiding (ShakeValue,
                                                          action)
@@ -184,13 +189,16 @@ import qualified StmContainers.Map                      as STM
 import           System.FilePath                        hiding (makeRelative)
 import           System.IO.Unsafe                       (unsafePerformIO)
 import           System.Time.Extra
-import           UnliftIO                               (MonadUnliftIO (withRunInIO))
+import           UnliftIO                               (IORef,
+                                                         MonadUnliftIO (withRunInIO),
+                                                         atomicModifyIORef',
+                                                         newIORef)
 
 
 data Log
   = LogCreateHieDbExportsMapStart
   | LogCreateHieDbExportsMapFinish !Int
-  | LogBuildSessionRestart !String ![DelayedActionInternal] !KeySet !Seconds !(Maybe FilePath)
+  | LogBuildSessionRestart ![T.Text] ![DelayedActionInternal] !KeySet !Seconds !(Maybe FilePath)
   | LogBuildSessionRestartTakingTooLong !Seconds
   | LogDelayedAction !(DelayedAction ()) !Seconds
   | LogBuildSessionFinish !(Maybe SomeException)
@@ -203,6 +211,7 @@ data Log
   | LogShakeGarbageCollection !T.Text !Int !Seconds
   -- * OfInterest Log messages
   | LogSetFilesOfInterest ![(NormalizedFilePath, FileOfInterestStatus)]
+  | LogRestartWorkerException !SomeException
   deriving Show
 
 instance Pretty Log where
@@ -248,6 +257,8 @@ instance Pretty Log where
     LogSetFilesOfInterest ofInterest ->
         "Set files of interst to" <> Pretty.line
             <> indent 4 (pretty $ fmap (first fromNormalizedFilePath) ofInterest)
+    LogRestartWorkerException e ->
+        "Restart worker exception:" <+> pretty (displayException e)
 
 -- | We need to serialize writes to the database, so we send any function that
 -- needs to write to the database over the channel, where it will be picked up by
@@ -269,9 +280,9 @@ type LoaderQueue = TaskQueue (IO ())
 
 
 data ThreadQueue = ThreadQueue {
-    tIndexQueue     :: IndexQueue
-    , tRestartQueue :: RestartQueue
-    , tLoaderQueue  :: LoaderQueue
+    tIndexQueue    :: IndexQueue
+    , tRestartSlot :: RestartSlot
+    , tLoaderQueue :: LoaderQueue
 }
 
 -- Note [Semantic Tokens Cache Location]
@@ -315,7 +326,7 @@ data ShakeExtras = ShakeExtras
     -- ^ Whether to enable additional lsp messages used by the test suite for checking invariants
     ,restartShakeSession
         :: VFSModified
-        -> String
+        -> T.Text
         -> [DelayedAction ()]
         -> IO [Key]
         -> IO ()
@@ -342,8 +353,8 @@ data ShakeExtras = ShakeExtras
       -- ^ Default HLS config, only relevant if the client does not provide any Config
     , dirtyKeys :: TVar KeySet
       -- ^ Set of dirty rule keys since the last Shake run
-    , restartQueue :: RestartQueue
-      -- ^ Queue of restart actions to be run.
+    , restartSlot :: RestartSlot
+      -- ^ Restart action to be run.
     , loaderQueue :: LoaderQueue
       -- ^ Queue of loader actions to be run.
     }
@@ -675,7 +686,7 @@ shakeOpen recorder lspEnv defaultConfig idePlugins debouncer
   withHieDb threadQueue opts monitoring rules rootDir = mdo
     -- see Note [Serializing runs in separate thread]
     let indexQueue = tIndexQueue threadQueue
-        restartQueue = tRestartQueue threadQueue
+        restartSlot = tRestartSlot threadQueue
         loaderQueue = tLoaderQueue threadQueue
 
 #if MIN_VERSION_ghc(9,13,0)
@@ -692,7 +703,7 @@ shakeOpen recorder lspEnv defaultConfig idePlugins debouncer
         semanticTokensCache <- STM.newIO
         positionMapping <- STM.newIO
         knownTargetsVar <- newTVarIO $ hashed emptyKnownTargets
-        let restartShakeSession = shakeRestart recorder ideState
+        let restartShakeSession = shakeRestart ideState
         persistentKeys <- newTVarIO mempty
         indexPending <- newTVarIO HMap.empty
         indexCompleted <- newTVarIO 0
@@ -766,7 +777,7 @@ shakeSessionInit recorder IdeState{..} = do
     -- Take a snapshot of the VFS - it should be empty as we've received no notifications
     -- till now, but it can't hurt to be in sync with the `lsp` library.
     vfs <- vfsSnapshot (lspEnv shakeExtras)
-    initSession <- newSession recorder shakeExtras (VFSModified vfs) shakeDb [] "shakeSessionInit"
+    initSession <- newSession recorder shakeExtras (VFSModified vfs) shakeDb [] ["shakeSessionInit"]
     putMVar shakeSession initSession
     logWith recorder Debug LogSessionInitialised
 
@@ -804,38 +815,99 @@ delayedAction a = do
   extras <- ask
   liftIO $ shakeEnqueue extras a
 
+data PendingRestart = PendingRestart
+    { pendingRestartVFS                   :: VFSModified
+    , pendingRestartActionBetweenSessions :: IO [Key]
+    , pendingRestartReasons               :: [T.Text]
+    , pendingRestartActions               :: [DelayedActionInternal]
+    , pendingRestartDoneSignals           :: [TMVar ()]
+    }
+
+newestVFSModified :: VFSModified -> VFSModified -> VFSModified
+newestVFSModified VFSUnmodified old     = old
+newestVFSModified new@(VFSModified _) _ = new
+
+mergePendingRestart :: PendingRestart -> Maybe PendingRestart -> PendingRestart
+mergePendingRestart new Nothing = new
+mergePendingRestart new (Just old) = PendingRestart
+    { pendingRestartVFS = newestVFSModified (pendingRestartVFS new) (pendingRestartVFS old)
+    , pendingRestartActions = do
+        old' <- pendingRestartActions old
+        new' <- pendingRestartActions new
+        pure $ new' <> old'
+    , pendingRestartReasons = pendingRestartReasons new <> pendingRestartReasons old
+    , pendingRestartActionBetweenSessions = do
+        old' <- pendingRestartActionBetweenSessions old
+        new' <- pendingRestartActionBetweenSessions new
+        pure $ new' <> old'
+    , pendingRestartDoneSignals = pendingRestartDoneSignals new <> pendingRestartDoneSignals old    }
+
+data RestartSlot = RestartSlot
+    { queuedRestart :: IORef (Maybe (PendingRestart))
+    , restartSignal :: MVar ()
+    }
+
+newRestartSlot :: IO RestartSlot
+newRestartSlot = RestartSlot <$> newIORef Nothing <*> newEmptyMVar
 
 -- | Restart the current 'ShakeSession' with the given system actions.
 --   Any actions running in the current session will be aborted,
 --   but actions added via 'shakeEnqueue' will be requeued.
-shakeRestart :: Recorder (WithPriority Log) -> IdeState -> VFSModified -> String -> [DelayedAction ()] -> IO [Key] -> IO ()
-shakeRestart recorder IdeState{..} vfs reason acts ioActionBetweenShakeSession =
-    void $ awaitRunInThread (restartQueue shakeExtras) $ do
-        withMVar'
-            shakeSession
-            (\runner -> do
-                (stopTime,()) <- duration $ logErrorAfter 10 $ cancelShakeSession runner
-                keys <- ioActionBetweenShakeSession
-                -- it is every important to update the dirty keys after we enter the critical section
-                -- see Note [Housekeeping rule cache and dirty key outside of hls-graph]
-                atomically $ modifyTVar' (dirtyKeys shakeExtras) $ \x -> foldl' (flip insertKeySet) x keys
-                res <- shakeDatabaseProfile shakeDb
-                backlog <- readTVarIO $ dirtyKeys shakeExtras
-                queue <- atomicallyNamed "actionQueue - peek" $ peekInProgress $ actionQueue shakeExtras
+shakeRestart :: IdeState -> VFSModified -> T.Text -> [DelayedAction ()] -> IO [Key] -> IO ()
+shakeRestart IdeState{..} vfs reason acts ioActionBetweenShakeSession = do
+    restartDone <- newEmptyTMVarIO
+    atomicModifyIORef'_ (queuedRestart (restartSlot shakeExtras)) $ Just . mergePendingRestart PendingRestart
+        { pendingRestartVFS = vfs
+        , pendingRestartActionBetweenSessions = ioActionBetweenShakeSession
+        , pendingRestartReasons = [reason]
+        , pendingRestartActions = acts
+        , pendingRestartDoneSignals = [restartDone]
+        }
+    void $ tryPutMVar (restartSignal (restartSlot shakeExtras)) ()
+    atomically $ readTMVar restartDone
 
-                -- this log is required by tests
-                logWith recorder Debug $ LogBuildSessionRestart reason queue backlog stopTime res
-            )
-            -- It is crucial to be masked here, otherwise we can get killed
-            -- between spawning the new thread and updating shakeSession.
-            -- See https://github.com/haskell/ghcide/issues/79
-            (\() -> do
-            (,()) <$> newSession recorder shakeExtras vfs shakeDb acts reason)
-    where
-        logErrorAfter :: Seconds -> IO () -> IO ()
-        logErrorAfter seconds action = flip withAsync (const action) $ do
-            sleep seconds
-            logWith recorder Error (LogBuildSessionRestartTakingTooLong seconds)
+-- | Run a worker that asynchronously processes shake restart requests. Will
+-- only ever queue upto 1 additional restart, accumulating data while processing
+-- any restart.
+withRestartWorker :: IdeState -> IO r -> IO r
+withRestartWorker ide@IdeState{..} action =
+    withAsync (forever $
+        processPendingRestart (shakeRecorder shakeExtras) ide
+            `catch` \(e :: SomeException) ->
+                logWith (shakeRecorder shakeExtras) Error (LogRestartWorkerException e)) $
+        \_ -> action
+
+processPendingRestart :: Recorder (WithPriority Log) -> IdeState -> IO ()
+processPendingRestart recorder IdeState{..} = do
+    takeMVar (restartSignal (restartSlot shakeExtras))
+    pendingRestart <- atomicModifyIORef' (queuedRestart (restartSlot shakeExtras)) (Nothing,)
+    void $ forM pendingRestart $ \PendingRestart {..} -> do
+        flip finally (atomically $ traverse (flip tryPutTMVar ()) pendingRestartDoneSignals) $ do
+            let sessionAction runner = do
+                    (stopTime,()) <- duration $ logErrorAfter 10 $ cancelShakeSession runner
+                    keys <- pendingRestartActionBetweenSessions
+                    -- it is every important to update the dirty keys after we enter the critical section
+                    -- see Note [Housekeeping rule cache and dirty key outside of hls-graph]
+                    atomically $ modifyTVar' (dirtyKeys shakeExtras) $ \x -> foldl' (flip insertKeySet) x keys
+                    res <- shakeDatabaseProfile shakeDb
+                    backlog <- readTVarIO $ dirtyKeys shakeExtras
+                    queue <- atomicallyNamed "actionQueue - peek" $ peekInProgress $ actionQueue shakeExtras
+
+                    -- this log is required by tests
+                    logWith recorder Debug $ LogBuildSessionRestart pendingRestartReasons queue backlog stopTime res
+
+            withMVar' shakeSession sessionAction $ \() ->
+                -- It is crucial to be masked here, otherwise we can get killed
+                -- between spawning the new thread and updating shakeSession.
+                -- See https://github.com/haskell/ghcide/issues/79
+                (,()) <$> newSession recorder shakeExtras pendingRestartVFS shakeDb pendingRestartActions pendingRestartReasons
+    pure ()
+  where
+    logErrorAfter :: Seconds -> IO () -> IO ()
+    logErrorAfter seconds action = flip withAsync (const action) $ do
+        sleep seconds
+        logWith recorder Error (LogBuildSessionRestartTakingTooLong seconds)
+
 
 -- | Enqueue an action in the existing 'ShakeSession'.
 --   Returns a computation to block until the action is run, propagating exceptions.
@@ -869,9 +941,9 @@ newSession
     -> VFSModified
     -> ShakeDatabase
     -> [DelayedActionInternal]
-    -> String
+    -> [T.Text]
     -> IO ShakeSession
-newSession recorder extras@ShakeExtras{..} vfsMod shakeDb acts reason = do
+newSession recorder extras@ShakeExtras{..} vfsMod shakeDb acts reasons = do
 
     -- Take a new VFS snapshot
     case vfsMod of
@@ -902,7 +974,7 @@ newSession recorder extras@ShakeExtras{..} vfsMod shakeDb acts reason = do
         -- The inferred type signature doesn't work in ghc >= 9.0.1
         workRun :: (forall b. IO b -> IO b) -> IO (IO ())
         workRun restore = withSpan "Shake session" $ \otSpan -> do
-          setTag otSpan "reason" (fromString reason)
+          setTag otSpan "reason" (T.encodeUtf8 (T.intercalate ", " reasons))
           setTag otSpan "queue" (fromString $ unlines $ map actionName reenqueued)
           whenJust allPendingKeys $ \kk -> setTag otSpan "keys" (BS8.pack $ unlines $ map show $ toListKeySet kk)
           let keysActs = pumpActionThread otSpan : map (run otSpan) (reenqueued ++ acts)

--- a/ghcide/src/Development/IDE/Core/WorkerThread.hs
+++ b/ghcide/src/Development/IDE/Core/WorkerThread.hs
@@ -30,7 +30,7 @@ import           Control.Concurrent.Strict (newBarrier, signalBarrier,
                                             waitBarrier)
 import           Control.Exception.Safe    (SomeException, finally, throwIO,
                                             try)
-import           Control.Monad.Cont        (ContT (ContT))
+import           Control.Monad.Cont        (ContT (..))
 import           Data.Maybe                (isNothing)
 import qualified Data.Text                 as T
 import           Ide.Logger
@@ -80,14 +80,19 @@ withWorkerQueue = withWorkerTasks workerTaskQueue
 -- | Similar to @withWorkerQueue@, but facilitates squashing actions using some
 -- @Semigroup@ semantics.
 withWorkerRef
-  :: Semigroup a
-  => Recorder (WithPriority LogWorkerThread)
+  :: (a -> a -> a)
+  -> Recorder (WithPriority LogWorkerThread)
   -> T.Text
   -> (a -> IO ())
   -> ContT () IO (WorkerTasks STM a)
-withWorkerRef = withWorkerTasks workerTaskRef
+withWorkerRef combine = withWorkerTasks (workerTaskRef combine)
 
-withWorkerTasks :: WorkerTasks' STM t a -> Recorder (WithPriority LogWorkerThread) -> T.Text -> (a -> IO ()) -> ContT () IO (WorkerTasks STM a)
+withWorkerTasks
+  :: WorkerTasks' STM t a
+  -> Recorder (WithPriority LogWorkerThread)
+  -> T.Text
+  -> (a -> IO ())
+  -> ContT () IO (WorkerTasks STM a)
 withWorkerTasks WorkerTasks'{..} recorder title workerAction = ContT $ \mainAction -> do
   q <- atomically newWorkerTasks'
   -- Use a TMVar as a stop flag to coordinate graceful shutdown.
@@ -186,14 +191,14 @@ tryReadTaskQueue (TaskQueue q) = tryReadTQueue q
 -- @Semigroup@ semantics.
 newtype TaskRef a = TaskRef (TVar (Maybe a))
 
-workerTaskRef :: Semigroup a => WorkerTasks' STM TaskRef a
-workerTaskRef = WorkerTasks'
-  { newWorkerTasks' = TaskRef <$> newTVar mempty
+workerTaskRef :: (a -> a -> a) -> WorkerTasks' STM TaskRef a
+workerTaskRef combine = WorkerTasks'
+  { newWorkerTasks' = TaskRef <$> newTVar Nothing
   , addWorkerTask' = \(TaskRef t) a -> do
       workerTask <- readTVar t
       case workerTask of
         Nothing -> writeTVar t (Just a)
-        Just wt -> writeTVar t (Just (wt <> a))
+        Just wt -> writeTVar t (Just (combine wt a))
   , nullWorkerTasks' = \(TaskRef t) -> do
       workerTask <- readTVar t
       pure $ isNothing workerTask

--- a/ghcide/src/Development/IDE/Core/WorkerThread.hs
+++ b/ghcide/src/Development/IDE/Core/WorkerThread.hs
@@ -8,12 +8,19 @@ see Note [Serializing runs in separate thread]
 -}
 module Development.IDE.Core.WorkerThread
   ( LogWorkerThread (..),
+    withWorkerTasks,
     withWorkerQueue,
-    awaitRunInThread,
+    readWorkerTask,
+    awaitWorkerTask,
     TaskQueue,
     isEmptyTaskQueue,
     writeTaskQueue,
-    withWorkerQueueSimple
+    withWorkerQueueSimple,
+    workerTaskQueue,
+    TaskRef,
+    withWorkerRef,
+    workerTaskRef,
+    WorkerTasks (..),
   )
 where
 
@@ -24,6 +31,7 @@ import           Control.Concurrent.Strict (newBarrier, signalBarrier,
 import           Control.Exception.Safe    (SomeException, finally, throwIO,
                                             try)
 import           Control.Monad.Cont        (ContT (ContT))
+import           Data.Maybe                (isNothing)
 import qualified Data.Text                 as T
 import           Ide.Logger
 
@@ -51,24 +59,35 @@ Like the db writes, session loading in session loader, shake session restarts.
 Originally we used various ways to implement this, but it was hard to maintain and error prone.
 Moreover, we can not stop these threads uniformly when we are shutting down the server.
 -}
-data TaskQueue a = TaskQueue (TQueue a)
-
-data ExitOrTask t = Exit | Task t
-
-newTaskQueueIO :: IO (TaskQueue a)
-newTaskQueueIO = TaskQueue <$> newTQueueIO
 
 -- | 'withWorkerQueueSimple' is a simplified version of 'withWorkerQueue'
 -- for the common case where the worker function is just 'id'.
-withWorkerQueueSimple :: Recorder (WithPriority LogWorkerThread) -> T.Text -> ContT () IO (TaskQueue (IO ()))
+withWorkerQueueSimple :: Recorder (WithPriority LogWorkerThread) -> T.Text -> ContT () IO (WorkerTasks STM (IO ()))
 withWorkerQueueSimple recorder title = withWorkerQueue recorder title id
+
+data ExitOrTask t = Exit | Task t
 
 -- | 'withWorkerQueue' creates a new 'TQueue', and launches a worker
 -- thread which polls the queue for requests and runs the given worker
 -- function on them.
-withWorkerQueue :: Recorder (WithPriority LogWorkerThread) -> T.Text -> (t -> IO ()) -> ContT () IO (TaskQueue t)
-withWorkerQueue recorder title workerAction = ContT $ \mainAction -> do
-  q <- newTaskQueueIO
+withWorkerQueue
+  :: Recorder (WithPriority LogWorkerThread)
+  -> T.Text
+  -> (a -> IO ())
+  -> ContT () IO (WorkerTasks STM a)
+withWorkerQueue = withWorkerTasks workerTaskQueue
+
+withWorkerRef
+  :: Semigroup a
+  => Recorder (WithPriority LogWorkerThread)
+  -> T.Text
+  -> (a -> IO ())
+  -> ContT () IO (WorkerTasks STM a)
+withWorkerRef = withWorkerTasks workerTaskRef
+
+withWorkerTasks :: WorkerTasks' STM t a -> Recorder (WithPriority LogWorkerThread) -> T.Text -> (a -> IO ()) -> ContT () IO (WorkerTasks STM a)
+withWorkerTasks WorkerTasks'{..} recorder title workerAction = ContT $ \mainAction -> do
+  q <- atomically newWorkerTasks'
   -- Use a TMVar as a stop flag to coordinate graceful shutdown.
   -- The worker thread checks this flag before dequeuing each job; if set, it exits immediately,
   -- ensuring that no new work is started after shutdown is requested.
@@ -78,7 +97,7 @@ withWorkerQueue recorder title workerAction = ContT $ \mainAction -> do
   -- the thread exits immediately and never checks the TMVar; in such cases, the stop flag is redundant.
   b <- newEmptyTMVarIO
   withAsync (writerThread q b) $ \_ -> do
-    mainAction q
+    mainAction (WorkerTasks (addWorkerTask' q) (nullWorkerTasks' q) (tryReadWorkerTask' q))
     -- if we want to debug the exact location the worker swallows an async exception, we can
     -- temporarily comment out the `finally` clause.
         `finally` atomically (putTMVar b ())
@@ -89,7 +108,7 @@ withWorkerQueue recorder title workerAction = ContT $ \mainAction -> do
       -- See above: check stop flag before dequeuing, exit if set, otherwise run next job.
       do
         task <- atomically $ do
-          task <- tryReadTaskQueue q
+          task <- tryReadWorkerTask' q
           isEm <- isEmptyTMVar b
           case (isEm, task) of
             (False, _)   -> return Exit -- stop flag set, exit
@@ -98,25 +117,59 @@ withWorkerQueue recorder title workerAction = ContT $ \mainAction -> do
         case task of
           Exit -> return ()
           Task t -> do
-                logWith recorder Debug $ LogSingleWorkStarting title
-                workerAction t
-                logWith recorder Debug $ LogSingleWorkEnded title
-                writerThread q b
+            logWith recorder Debug $ LogSingleWorkStarting title
+            workerAction t
+            logWith recorder Debug $ LogSingleWorkEnded title
+            writerThread q b
 
+readWorkerTask :: WorkerTasks STM a -> STM a
+readWorkerTask WorkerTasks {..} = do
+  task <- tryReadWorkerTask
+  case task of
+    Nothing -> retry
+    Just t  -> pure t
 
--- | 'awaitRunInThread' queues up an 'IO' action to be run by a worker thread,
+-- | 'awaitWorkerTask' queues up an 'IO' action to be run by a worker thread,
 -- and then blocks until the result is computed. If the action throws an
 -- non-async exception, it is rethrown in the calling thread.
-awaitRunInThread :: TaskQueue (IO ()) -> IO result -> IO result
-awaitRunInThread (TaskQueue q) act = do
+awaitWorkerTask :: WorkerTasks STM (IO ()) -> IO r -> IO r
+awaitWorkerTask WorkerTasks {..} act = do
   -- Take an action from TQueue, run it and
   -- use barrier to wait for the result
   barrier <- newBarrier
-  atomically $ writeTQueue q (try act >>= signalBarrier barrier)
+  atomically $ addWorkerTask (try act >>= signalBarrier barrier)
   resultOrException <- waitBarrier barrier
   case resultOrException of
     Left e  -> throwIO (e :: SomeException)
     Right r -> return r
+
+-- | Creating a class that'll only live in this module doesn't have much value.
+-- Create a simple struct instead describing the interface of worker tasks.
+data WorkerTasks' m t a = WorkerTasks'
+  { newWorkerTasks'    :: m (t a)
+  , addWorkerTask'     :: t a -> a -> m ()
+  , nullWorkerTasks'   :: t a -> m Bool
+  , tryReadWorkerTask' :: t a -> m (Maybe a)
+  }
+
+-- | Creating a class that'll only live in this module doesn't have much value.
+-- Create a simple struct instead describing the interface of worker tasks.
+data WorkerTasks m a = WorkerTasks
+  { addWorkerTask     :: a -> m ()
+  , nullWorkerTasks   :: m Bool
+  , tryReadWorkerTask :: m (Maybe a)
+  }
+
+-- | Datatype for the queue of jobs mentioned in Note [Serializing runs in separate thread].
+data TaskQueue a = TaskQueue (TQueue a)
+
+workerTaskQueue :: WorkerTasks' STM TaskQueue a
+workerTaskQueue = WorkerTasks'
+  { newWorkerTasks' = TaskQueue <$> newTQueue
+  , addWorkerTask' = writeTaskQueue
+  , nullWorkerTasks' = isEmptyTaskQueue
+  , tryReadWorkerTask' = tryReadTaskQueue
+  }
 
 writeTaskQueue :: TaskQueue a -> a -> STM ()
 writeTaskQueue (TaskQueue q) = writeTQueue q
@@ -126,3 +179,24 @@ isEmptyTaskQueue (TaskQueue q) = isEmptyTQueue q
 
 tryReadTaskQueue :: TaskQueue a -> STM (Maybe a)
 tryReadTaskQueue (TaskQueue q) = tryReadTQueue q
+
+-- | Similar to @TaskQueue@, but facilitates squashing actions using some
+-- @Semigroup@ semantics.
+newtype TaskRef a = TaskRef (TVar (Maybe a))
+
+workerTaskRef :: Semigroup a => WorkerTasks' STM TaskRef a
+workerTaskRef = WorkerTasks'
+  { newWorkerTasks' = TaskRef <$> newTVar mempty
+  , addWorkerTask' = \(TaskRef t) a -> do
+      workerTask <- readTVar t
+      case workerTask of
+        Nothing -> writeTVar t (Just a)
+        Just wt -> writeTVar t (Just (wt <> a))
+  , nullWorkerTasks' = \(TaskRef t) -> do
+      workerTask <- readTVar t
+      pure $ isNothing workerTask
+  , tryReadWorkerTask' = \(TaskRef t) -> do
+      workerTask <- readTVar t
+      writeTVar t Nothing
+      pure workerTask
+  }

--- a/ghcide/src/Development/IDE/Core/WorkerThread.hs
+++ b/ghcide/src/Development/IDE/Core/WorkerThread.hs
@@ -77,6 +77,8 @@ withWorkerQueue
   -> ContT () IO (WorkerTasks STM a)
 withWorkerQueue = withWorkerTasks workerTaskQueue
 
+-- | Similar to @withWorkerQueue@, but facilitates squashing actions using some
+-- @Semigroup@ semantics.
 withWorkerRef
   :: Semigroup a
   => Recorder (WithPriority LogWorkerThread)

--- a/ghcide/src/Development/IDE/Core/WorkerThread.hs
+++ b/ghcide/src/Development/IDE/Core/WorkerThread.hs
@@ -8,18 +8,11 @@ see Note [Serializing runs in separate thread]
 -}
 module Development.IDE.Core.WorkerThread
   ( LogWorkerThread (..),
-    withWorkerTasks,
     withWorkerQueue,
-    readWorkerTask,
-    awaitWorkerTask,
     TaskQueue,
-    isEmptyTaskQueue,
-    writeTaskQueue,
     withWorkerQueueSimple,
-    workerTaskQueue,
     TaskRef,
     withWorkerRef,
-    workerTaskRef,
     WorkerTasks (..),
   )
 where
@@ -128,27 +121,6 @@ withWorkerTasks WorkerTasks'{..} recorder title workerAction = ContT $ \mainActi
             workerAction t
             logWith recorder Debug $ LogSingleWorkEnded title
             writerThread q b
-
-readWorkerTask :: WorkerTasks STM a -> STM a
-readWorkerTask WorkerTasks {..} = do
-  task <- tryReadWorkerTask
-  case task of
-    Nothing -> retry
-    Just t  -> pure t
-
--- | 'awaitWorkerTask' queues up an 'IO' action to be run by a worker thread,
--- and then blocks until the result is computed. If the action throws an
--- non-async exception, it is rethrown in the calling thread.
-awaitWorkerTask :: WorkerTasks STM (IO ()) -> IO r -> IO r
-awaitWorkerTask WorkerTasks {..} act = do
-  -- Take an action from TQueue, run it and
-  -- use barrier to wait for the result
-  barrier <- newBarrier
-  atomically $ addWorkerTask (try act >>= signalBarrier barrier)
-  resultOrException <- waitBarrier barrier
-  case resultOrException of
-    Left e  -> throwIO (e :: SomeException)
-    Right r -> return r
 
 -- | Creating a class that'll only live in this module doesn't have much value.
 -- Create a simple struct instead describing the interface of worker tasks.

--- a/ghcide/src/Development/IDE/GHC/Compat/Core.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Core.hs
@@ -263,6 +263,9 @@ module Development.IDE.GHC.Compat.Core (
     TargetId(..),
     mkSimpleTarget,
     -- * GHCi
+    Interp,
+    hscInterpMaybe,
+    withHscInterp,
     initObjLinker,
     loadDLL,
     InteractiveImport(..),
@@ -442,6 +445,7 @@ import           GHC.Parser.Header           hiding (getImports)
 import           GHC.Rename.Fixity           (lookupFixityRn)
 import           GHC.Rename.Names
 import           GHC.Rename.Splice
+import           GHC.Runtime.Interpreter     (Interp)
 import qualified GHC.Runtime.Interpreter     as GHCi
 import           GHC.Tc.Instance.Family
 import           GHC.Tc.Module
@@ -688,6 +692,11 @@ mapConPatDetail :: (HsConPatDetails p -> Maybe (HsConPatDetails p)) -> Pat p -> 
 mapConPatDetail f pat@(ConPat _ _ args) = (\args' -> pat { pat_args = args'}) <$> f args
 mapConPatDetail _ _ = Nothing
 
+hscInterpMaybe :: HscEnv -> Maybe Interp
+hscInterpMaybe = hsc_interp
+
+withHscInterp :: Maybe Interp -> HscEnv -> HscEnv
+withHscInterp interp env = env { hsc_interp = interp }
 
 initObjLinker :: HscEnv -> IO ()
 initObjLinker env =

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -328,23 +328,46 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
                     exceptionInHandler e
                     k $ TResponseError (InR ErrorCodes_InternalError) (T.pack $ show e) Nothing
     _ <- flip forkFinally loggedTeardown $ do
-      -- Need to be careful about when the shutdown occurs, it needs to be shut
-      -- down after the session loader and restarting threads, and before the
-      -- hiedb connections are closed.
-      let shutdownSession = tryReadMVar ideMVar >>= traverse_ shutdown
-      runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc shutdownSession $ \withHieDb' threadQueue' -> do
-        ide <- ctxGetIdeState lifecycleCtx env root withHieDb' threadQueue'
-        putMVar ideMVar ide
-        -- Keep this after putMVar ideMVar ide; otherwise shutdown during
-        -- initialization could leave handleInit blocked indefinitely on readMVar.
-        untilReactorStopSignal $ forever $ do
-          msg <- readChan $ ctxClientMsgChan lifecycleCtx
-          -- We dispatch notifications synchronously and requests asynchronously
-          -- This is to ensure that all file edits and config changes are applied before a request is handled
-          case msg of
-            ReactorNotification act  -> handle exceptionInHandler act
-            ReactorRequest _id act k -> void $ async $ checkCancelled _id act k
-      logWith recorder Info LogReactorThreadStopped
+        -- Need to be careful about when the shutdown occurs, it needs to be shut
+        -- down after the session loader and restarting threads, and before the
+        -- hiedb connections are closed.
+        let shutdownSession = tryReadMVar ideMVar >>= traverse_ shutdown
+
+        -- Ensure that any request waits for all notifications that preceded
+        -- it in the channel to complete, so file edits and config changes
+        -- are applied before a request is handled. Notifications and requests
+        -- are each concurrent within their own kind.
+        --
+        -- Implemented using a list of MVars, one per in-flight notification.
+        -- Requests snapshot this list at dequeue time and wait on all of them.
+        -- Completed MVars are pruned when new notifications are added.
+        notificationLocks <- newTVarIO ([] :: [TMVar ()])
+        let
+          consumeChannel = do
+            msg <- readChan $ ctxClientMsgChan lifecycleCtx
+            case msg of
+              ReactorNotification act -> do
+                done <- newEmptyTMVarIO
+                atomically $ do
+                  old <- readTVar notificationLocks
+                  pruned <- filterM (\m -> isNothing <$> tryReadTMVar m) old
+                  writeTVar notificationLocks (done : pruned)
+                void $ async $
+                  handle exceptionInHandler act
+                    `finally` atomically (putTMVar done ())
+              ReactorRequest _id act k -> do
+                currentNotifications <- readTVarIO notificationLocks
+                void $ async $ do
+                  void $ atomically (traverse readTMVar currentNotifications)
+                  checkCancelled _id act k
+
+        runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc shutdownSession $ \withHieDb' threadQueue' -> do
+          ide <- ctxGetIdeState lifecycleCtx env root withHieDb' threadQueue'
+          putMVar ideMVar ide
+          -- Keep this after putMVar ideMVar ide; otherwise shutdown during
+          -- initialization could leave handleInit blocked indefinitely on readMVar.
+          untilReactorStopSignal $ forever consumeChannel
+        logWith recorder Info LogReactorThreadStopped
 
     ide <- readMVar ideMVar
     registerIdeConfiguration (shakeExtras ide) initConfig

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -363,14 +363,15 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
 
         runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc shutdownSession $ \withHieDb' threadQueue' -> do
           ide <- ctxGetIdeState lifecycleCtx env root withHieDb' threadQueue'
+          registerIdeConfiguration (shakeExtras ide) initConfig
           putMVar ideMVar ide
           -- Keep this after putMVar ideMVar ide; otherwise shutdown during
           -- initialization could leave handleInit blocked indefinitely on readMVar.
-          untilReactorStopSignal $ forever consumeChannel
+          withRestartWorker ide $ do
+            untilReactorStopSignal $ forever consumeChannel
         logWith recorder Info LogReactorThreadStopped
 
     ide <- readMVar ideMVar
-    registerIdeConfiguration (shakeExtras ide) initConfig
     pure $ Right (env,ide)
 
 
@@ -384,7 +385,7 @@ runWithWorkerThreads recorder dbLoc shutdownSession f = evalContT $ do
   -- being cleaned up, otherwise shake could be referencing dead connections.
   -- This is passed in via the callsites.
   ContT $ \action -> action () `finally` shutdownSession
-  sessionRestartTQueue <- withWorkerQueueSimple (cmapWithPrio Session.LogSessionWorkerThread recorder) "RestartTQueue"
+  sessionRestartTQueue <- liftIO $ newRestartSlot
   sessionLoaderTQueue <- withWorkerQueueSimple (cmapWithPrio Session.LogSessionWorkerThread recorder) "SessionLoaderTQueue"
   liftIO $ f hiedb (ThreadQueue threadQueue sessionRestartTQueue sessionLoaderTQueue)
 

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -343,7 +343,7 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
         -- Completed MVars are pruned when new notifications are added.
         notificationLocks <- newTVarIO ([] :: [TMVar ()])
         let
-          consumeChannel = do
+          consumeChannel threadQueue = do
             msg <- readChan $ ctxClientMsgChan lifecycleCtx
             case msg of
               ReactorNotification act -> do
@@ -352,9 +352,21 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
                   old <- readTVar notificationLocks
                   pruned <- filterM (\m -> isNothing <$> tryReadTMVar m) old
                   writeTVar notificationLocks (done : pruned)
-                void $ async $
-                  handle exceptionInHandler act
-                    `finally` atomically (putTMVar done ())
+                let
+                  slot = tRestartSlot threadQueue
+                  -- After the notification handler returns, check whether
+                  -- a shake restart was triggered.
+                  --
+                  -- If so, wait for it to complete before signaling 'done'
+                  -- so that subsequent requests see the updated VFS /
+                  -- session.
+                  restartDone = do
+                    barrier <- atomically $ readTVar (lastRestartBarrier slot)
+                    async $ atomically $ do
+                      readTMVar barrier
+                      putTMVar done ()
+
+                finally (handle exceptionInHandler act) restartDone
               ReactorRequest _id act k -> do
                 currentNotifications <- readTVarIO notificationLocks
                 void $ async $ do
@@ -365,14 +377,12 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
           ide <- ctxGetIdeState lifecycleCtx env root withHieDb' threadQueue'
           registerIdeConfiguration (shakeExtras ide) initConfig
           putMVar ideMVar ide
-          -- Keep this after putMVar ideMVar ide; otherwise shutdown during
-          -- initialization could leave handleInit blocked indefinitely on readMVar.
-          withRestartWorker ide $ do
-            untilReactorStopSignal $ forever consumeChannel
-        logWith recorder Info LogReactorThreadStopped
+
+          withRestartWorker ide $ untilReactorStopSignal $ forever (consumeChannel threadQueue')
+          logWith recorder Info LogReactorThreadStopped
 
     ide <- readMVar ideMVar
-    pure $ Right (env,ide)
+    pure $ Right (env, ide)
 
 
 -- | runWithWorkerThreads

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -373,12 +373,12 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
                   void $ atomically (traverse readTMVar currentNotifications)
                   checkCancelled _id act k
 
-        runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc shutdownSession $ \withHieDb' threadQueue' -> do
+        runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc shutdownSession ideMVar $ \withHieDb' threadQueue' -> do
           ide <- ctxGetIdeState lifecycleCtx env root withHieDb' threadQueue'
           registerIdeConfiguration (shakeExtras ide) initConfig
           putMVar ideMVar ide
 
-          withRestartWorker ide $ untilReactorStopSignal $ forever (consumeChannel threadQueue')
+          untilReactorStopSignal $ forever (consumeChannel threadQueue')
           logWith recorder Info LogReactorThreadStopped
 
     ide <- readMVar ideMVar
@@ -388,8 +388,14 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
 -- | runWithWorkerThreads
 -- create several threads to run the session, db and session loader
 -- see Note [Serializing runs in separate thread]
-runWithWorkerThreads :: Recorder (WithPriority Session.Log) -> FilePath -> IO () -> (WithHieDb -> ThreadQueue -> IO ()) -> IO ()
-runWithWorkerThreads recorder dbLoc shutdownSession f = evalContT $ do
+runWithWorkerThreads
+    :: Recorder (WithPriority Session.Log)
+    -> FilePath
+    -> IO ()
+    -> MVar IdeState
+    -> (WithHieDb -> ThreadQueue -> IO ())
+    -> IO ()
+runWithWorkerThreads recorder dbLoc shutdownSession ideMVar f = evalContT $ do
   (WithHieDbShield hiedb, threadQueue) <- runWithDb recorder dbLoc
   -- The shake session needs to be shut down prior to the hiedb connections
   -- being cleaned up, otherwise shake could be referencing dead connections.
@@ -397,6 +403,7 @@ runWithWorkerThreads recorder dbLoc shutdownSession f = evalContT $ do
   ContT $ \action -> action () `finally` shutdownSession
   sessionRestartTQueue <- liftIO $ newRestartSlot
   sessionLoaderTQueue <- withWorkerQueueSimple (cmapWithPrio Session.LogSessionWorkerThread recorder) "SessionLoaderTQueue"
+  ContT $ \action -> withRestartWorker ideMVar $ action ()
   liftIO $ f hiedb (ThreadQueue threadQueue sessionRestartTQueue sessionLoaderTQueue)
 
 -- | Runs the action until it ends or until the given MVar is put.

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -400,11 +400,13 @@ runWithWorkerThreads recorder dbLoc shutdownSession ideMVar f = evalContT $ do
   -- The shake session needs to be shut down prior to the hiedb connections
   -- being cleaned up, otherwise shake could be referencing dead connections.
   -- This is passed in via the callsites.
+  let workerRecorder = cmapWithPrio Session.LogSessionWorkerThread recorder
+  let shakeRecorder = cmapWithPrio Session.LogShake recorder
+  sessionRestartTQueue <- withWorkerRef workerRecorder "sessionRestartTQueue" (processPendingRestart shakeRecorder ideMVar)
   ContT $ \action -> action () `finally` shutdownSession
-  sessionRestartTQueue <- liftIO $ newRestartSlot
-  sessionLoaderTQueue <- withWorkerQueueSimple (cmapWithPrio Session.LogSessionWorkerThread recorder) "SessionLoaderTQueue"
-  ContT $ \action -> withRestartWorker ideMVar $ action ()
-  liftIO $ f hiedb (ThreadQueue threadQueue sessionRestartTQueue sessionLoaderTQueue)
+  sessionLoaderTQueue <- withWorkerQueueSimple workerRecorder "SessionLoaderTQueue"
+  restartSlot <- liftIO $ newRestartSlot sessionRestartTQueue
+  liftIO $ f hiedb (ThreadQueue threadQueue restartSlot sessionLoaderTQueue)
 
 -- | Runs the action until it ends or until the given MVar is put.
 --   It is important, that the thread that puts the 'MVar' is not dropped before it puts the 'MVar' i.e. it should

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -328,58 +328,58 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
                     exceptionInHandler e
                     k $ TResponseError (InR ErrorCodes_InternalError) (T.pack $ show e) Nothing
     _ <- flip forkFinally loggedTeardown $ do
-        -- Need to be careful about when the shutdown occurs, it needs to be shut
-        -- down after the session loader and restarting threads, and before the
-        -- hiedb connections are closed.
-        let shutdownSession = tryReadMVar ideMVar >>= traverse_ shutdown
+      -- Need to be careful about when the shutdown occurs, it needs to be shut
+      -- down after the session loader and restarting threads, and before the
+      -- hiedb connections are closed.
+      let shutdownSession = tryReadMVar ideMVar >>= traverse_ shutdown
 
-        -- Ensure that any request waits for all notifications that preceded
-        -- it in the channel to complete, so file edits and config changes
-        -- are applied before a request is handled. Notifications and requests
-        -- are each concurrent within their own kind.
-        --
-        -- Implemented using a list of MVars, one per in-flight notification.
-        -- Requests snapshot this list at dequeue time and wait on all of them.
-        -- Completed MVars are pruned when new notifications are added.
-        notificationLocks <- newTVarIO ([] :: [TMVar ()])
-        let
-          consumeChannel threadQueue = do
-            msg <- readChan $ ctxClientMsgChan lifecycleCtx
-            case msg of
-              ReactorNotification act -> do
-                done <- newEmptyTMVarIO
-                atomically $ do
-                  old <- readTVar notificationLocks
-                  pruned <- filterM (\m -> isNothing <$> tryReadTMVar m) old
-                  writeTVar notificationLocks (done : pruned)
-                let
-                  slot = tRestartSlot threadQueue
-                  -- After the notification handler returns, check whether
-                  -- a shake restart was triggered.
-                  --
-                  -- If so, wait for it to complete before signaling 'done'
-                  -- so that subsequent requests see the updated VFS /
-                  -- session.
-                  restartDone = do
-                    barrier <- atomically $ readTVar (lastRestartBarrier slot)
-                    async $ atomically $ do
-                      readTMVar barrier
-                      putTMVar done ()
+      -- Ensure that any request waits for all notifications that preceded
+      -- it in the channel to complete, so file edits and config changes
+      -- are applied before a request is handled. Notifications and requests
+      -- are each concurrent within their own kind.
+      --
+      -- Implemented using a list of MVars, one per in-flight notification.
+      -- Requests snapshot this list at dequeue time and wait on all of them.
+      -- Completed MVars are pruned when new notifications are added.
+      notificationLocks <- newTVarIO ([] :: [TMVar ()])
+      let
+        consumeChannel threadQueue = do
+          msg <- readChan $ ctxClientMsgChan lifecycleCtx
+          case msg of
+            ReactorNotification act -> do
+              done <- newEmptyTMVarIO
+              atomically $ do
+                old <- readTVar notificationLocks
+                pruned <- filterM (\m -> isNothing <$> tryReadTMVar m) old
+                writeTVar notificationLocks (done : pruned)
+              let
+                slot = tRestartSlot threadQueue
+                -- After the notification handler returns, check whether
+                -- a shake restart was triggered.
+                --
+                -- If so, wait for it to complete before signaling 'done'
+                -- so that subsequent requests see the updated VFS /
+                -- session.
+                restartDone = do
+                  barrier <- atomically $ readTVar (lastRestartBarrier slot)
+                  async $ atomically $ do
+                    readTMVar barrier
+                    putTMVar done ()
 
-                finally (handle exceptionInHandler act) restartDone
-              ReactorRequest _id act k -> do
-                currentNotifications <- readTVarIO notificationLocks
-                void $ async $ do
-                  void $ atomically (traverse readTMVar currentNotifications)
-                  checkCancelled _id act k
+              finally (handle exceptionInHandler act) restartDone
+            ReactorRequest _id act k -> do
+              currentNotifications <- readTVarIO notificationLocks
+              void $ async $ do
+                void $ atomically (traverse readTMVar currentNotifications)
+                checkCancelled _id act k
 
-        runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc shutdownSession ideMVar $ \withHieDb' threadQueue' -> do
-          ide <- ctxGetIdeState lifecycleCtx env root withHieDb' threadQueue'
-          registerIdeConfiguration (shakeExtras ide) initConfig
-          putMVar ideMVar ide
+      runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc shutdownSession ideMVar $ \withHieDb' threadQueue' -> do
+        ide <- ctxGetIdeState lifecycleCtx env root withHieDb' threadQueue'
+        registerIdeConfiguration (shakeExtras ide) initConfig
+        putMVar ideMVar ide
 
-          untilReactorStopSignal $ forever (consumeChannel threadQueue')
-          logWith recorder Info LogReactorThreadStopped
+        untilReactorStopSignal $ forever (consumeChannel threadQueue')
+        logWith recorder Info LogReactorThreadStopped
 
     ide <- readMVar ideMVar
     pure $ Right (env, ide)

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -402,7 +402,7 @@ runWithWorkerThreads recorder dbLoc shutdownSession ideMVar f = evalContT $ do
   -- This is passed in via the callsites.
   let workerRecorder = cmapWithPrio Session.LogSessionWorkerThread recorder
   let shakeRecorder = cmapWithPrio Session.LogShake recorder
-  sessionRestartTQueue <- withWorkerRef workerRecorder "sessionRestartTQueue" (processPendingRestart shakeRecorder ideMVar)
+  sessionRestartTQueue <- withWorkerRef succeedPendingRestart workerRecorder "sessionRestartTQueue" (processPendingRestart shakeRecorder ideMVar)
   ContT $ \action -> action () `finally` shutdownSession
   sessionLoaderTQueue <- withWorkerQueueSimple workerRecorder "SessionLoaderTQueue"
   restartSlot <- liftIO $ newRestartSlot sessionRestartTQueue

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -94,7 +94,7 @@ descriptor recorder plId = (defaultPluginDescriptor plId desc) { pluginNotificat
         \ide vfs _ (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> liftIO $ do
           whenUriFile _uri $ \file -> do
               let msg = "Closed text document: " <> getUri _uri
-              setSomethingModified (VFSModified vfs) ide (Text.unpack msg) $ do
+              setSomethingModified (VFSModified vfs) ide msg $ do
                 scheduleGarbageCollection ide
                 deleteFileOfInterest ide file
               logWith recorder Debug $ LogClosedTextDocument _uri
@@ -113,8 +113,8 @@ descriptor recorder plId = (defaultPluginDescriptor plId desc) { pluginNotificat
                 , not $ HM.member nfp filesOfInterest
                 ]
         unless (null fileEvents') $ do
-            let msg = show fileEvents'
-            logWith recorder Debug $ LogWatchedFileEvents (Text.pack msg)
+            let msg = Text.pack (show fileEvents')
+            logWith recorder Debug $ LogWatchedFileEvents msg
             setSomethingModified (VFSModified vfs) ide msg $ do
                 ks1 <- resetFileStore ide fileEvents'
                 ks2 <- modifyFileExists ide fileEvents'

--- a/ghcide/src/Development/IDE/LSP/Notifications.hs
+++ b/ghcide/src/Development/IDE/LSP/Notifications.hs
@@ -102,23 +102,27 @@ descriptor recorder plId = (defaultPluginDescriptor plId desc) { pluginNotificat
   , mkPluginNotificationHandler LSP.SMethod_WorkspaceDidChangeWatchedFiles $
       \ide vfs _ (DidChangeWatchedFilesParams fileEvents) -> liftIO $ do
         -- See Note [File existence cache and LSP file watchers] which explains why we get these notifications and
-        -- what we do with them
-        -- filter out files of interest, since we already know all about those
-        -- filter also uris that do not map to filenames, since we cannot handle them
-        filesOfInterest <- getFilesOfInterest ide
-        let fileEvents' =
+        -- what we do with them.
+        -- Filter URIs that don't map to filenames here; the FOI filter must run inside the
+        -- IO action body (on the restart worker) so that mutations from preceding
+        -- didOpen/didClose IO actions are observed consistently.
+        let rawEvents =
                 [ (nfp, event) | (FileEvent uri event) <- fileEvents
                 , Just fp <- [uriToFilePath uri]
                 , let nfp = toNormalizedFilePath fp
-                , not $ HM.member nfp filesOfInterest
                 ]
-        unless (null fileEvents') $ do
-            let msg = Text.pack (show fileEvents')
-            logWith recorder Debug $ LogWatchedFileEvents msg
+        unless (null rawEvents) $ do
+            let msg = Text.pack (show rawEvents)
             setSomethingModified (VFSModified vfs) ide msg $ do
-                ks1 <- resetFileStore ide fileEvents'
-                ks2 <- modifyFileExists ide fileEvents'
-                return (ks1 <> ks2)
+                filesOfInterest <- getFilesOfInterest ide
+                let fileEvents' = filter (not . (`HM.member` filesOfInterest) . fst) rawEvents
+                logWith recorder Debug $ LogWatchedFileEvents msg
+                if null fileEvents'
+                  then pure []
+                  else do
+                    ks1 <- resetFileStore ide fileEvents'
+                    ks2 <- modifyFileExists ide fileEvents'
+                    return (ks1 <> ks2)
 
   , mkPluginNotificationHandler LSP.SMethod_WorkspaceDidChangeWorkspaceFolders $
       \ide _ _ (DidChangeWorkspaceFoldersParams events) -> liftIO $ do

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -53,7 +53,8 @@ import qualified Development.IDE.Core.Service             as Service
 import           Development.IDE.Core.Shake               (IdeState (shakeExtras),
                                                            ThreadQueue (tLoaderQueue),
                                                            shakeSessionInit,
-                                                           uses)
+                                                           uses,
+                                                           withRestartWorker)
 import qualified Development.IDE.Core.Shake               as Shake
 import           Development.IDE.Graph                    (action)
 import           Development.IDE.LSP.LanguageServer       (runLanguageServer,
@@ -407,22 +408,23 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
                         , optModifyDynFlags = optModifyDynFlags def_options <> pluginModifyDynflags plugins
                         }
             ide <- initialise (cmapWithPrio LogService recorder) argsDefaultHlsConfig argsHlsPlugins rules Nothing debouncer ideOptions hiedb threadQueue mempty dir
-            shakeSessionInit (cmapWithPrio LogShake recorder) ide
-            registerIdeConfiguration (shakeExtras ide) $ IdeConfiguration mempty (hashed Nothing)
+            withRestartWorker ide $ do
+                shakeSessionInit (cmapWithPrio LogShake recorder) ide
+                registerIdeConfiguration (shakeExtras ide) $ IdeConfiguration mempty (hashed Nothing)
 
-            putStrLn "\nStep 4/4: Type checking the files"
-            setFilesOfInterest ide $ HashMap.fromList $ map ((,OnDisk) . toNormalizedFilePath') absoluteFiles
-            results <- runAction "User TypeCheck" ide $ uses TypeCheck (map toNormalizedFilePath' absoluteFiles)
-            _results <- runAction "GetHie" ide $ uses GetHieAst (map toNormalizedFilePath' absoluteFiles)
-            _results <- runAction "GenerateCore" ide $ uses GenerateCore (map toNormalizedFilePath' absoluteFiles)
-            let (worked, failed) = partition fst $ zip (map isJust results) absoluteFiles
-            when (failed /= []) $
-                putStr $ unlines $ "Files that failed:" : map ((++) " * " . snd) failed
+                putStrLn "\nStep 4/4: Type checking the files"
+                setFilesOfInterest ide $ HashMap.fromList $ map ((,OnDisk) . toNormalizedFilePath') absoluteFiles
+                results <- runAction "User TypeCheck" ide $ uses TypeCheck (map toNormalizedFilePath' absoluteFiles)
+                _results <- runAction "GetHie" ide $ uses GetHieAst (map toNormalizedFilePath' absoluteFiles)
+                _results <- runAction "GenerateCore" ide $ uses GenerateCore (map toNormalizedFilePath' absoluteFiles)
+                let (worked, failed) = partition fst $ zip (map isJust results) absoluteFiles
+                when (failed /= []) $
+                    putStr $ unlines $ "Files that failed:" : map ((++) " * " . snd) failed
 
-            let nfiles xs = let n' = length xs in if n' == 1 then "1 file" else show n' ++ " files"
-            putStrLn $ "\nCompleted (" ++ nfiles worked ++ " worked, " ++ nfiles failed ++ " failed)"
+                let nfiles xs = let n' = length xs in if n' == 1 then "1 file" else show n' ++ " files"
+                putStrLn $ "\nCompleted (" ++ nfiles worked ++ " worked, " ++ nfiles failed ++ " failed)"
 
-            unless (null failed) (exitWith $ ExitFailure (length failed))
+                unless (null failed) (exitWith $ ExitFailure (length failed))
         Db opts cmd -> do
             let root = argsProjectRoot
             dbLoc <- getHieDbLoc root
@@ -445,9 +447,10 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
                     , optModifyDynFlags = optModifyDynFlags def_options <> pluginModifyDynflags plugins
                     }
             ide <- initialise (cmapWithPrio LogService recorder) argsDefaultHlsConfig argsHlsPlugins rules Nothing debouncer ideOptions hiedb threadQueue mempty root
-            shakeSessionInit (cmapWithPrio LogShake recorder) ide
-            registerIdeConfiguration (shakeExtras ide) $ IdeConfiguration mempty (hashed Nothing)
-            c ide
+            withRestartWorker ide $ do
+                shakeSessionInit (cmapWithPrio LogShake recorder) ide
+                registerIdeConfiguration (shakeExtras ide) $ IdeConfiguration mempty (hashed Nothing)
+                c ide
 
 -- | List the haskell files given some paths
 --

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -53,8 +53,7 @@ import qualified Development.IDE.Core.Service             as Service
 import           Development.IDE.Core.Shake               (IdeState (shakeExtras),
                                                            ThreadQueue (tLoaderQueue),
                                                            shakeSessionInit,
-                                                           uses,
-                                                           withRestartWorker)
+                                                           uses)
 import qualified Development.IDE.Core.Shake               as Shake
 import           Development.IDE.Graph                    (action)
 import           Development.IDE.LSP.LanguageServer       (runLanguageServer,
@@ -379,7 +378,8 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
         Check argFiles -> do
           let dir = argsProjectRoot
           dbLoc <- getHieDbLoc dir
-          runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc mempty $ \hiedb threadQueue -> do
+          ideMVar <- newEmptyMVar
+          runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc mempty ideMVar $ \hiedb threadQueue -> do
             -- GHC produces messages with UTF8 in them, so make sure the terminal doesn't error
             hSetEncoding stdout utf8
             hSetEncoding stderr utf8
@@ -408,23 +408,23 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
                         , optModifyDynFlags = optModifyDynFlags def_options <> pluginModifyDynflags plugins
                         }
             ide <- initialise (cmapWithPrio LogService recorder) argsDefaultHlsConfig argsHlsPlugins rules Nothing debouncer ideOptions hiedb threadQueue mempty dir
-            withRestartWorker ide $ do
-                shakeSessionInit (cmapWithPrio LogShake recorder) ide
-                registerIdeConfiguration (shakeExtras ide) $ IdeConfiguration mempty (hashed Nothing)
+            putMVar ideMVar ide
+            shakeSessionInit (cmapWithPrio LogShake recorder) ide
+            registerIdeConfiguration (shakeExtras ide) $ IdeConfiguration mempty (hashed Nothing)
 
-                putStrLn "\nStep 4/4: Type checking the files"
-                setFilesOfInterest ide $ HashMap.fromList $ map ((,OnDisk) . toNormalizedFilePath') absoluteFiles
-                results <- runAction "User TypeCheck" ide $ uses TypeCheck (map toNormalizedFilePath' absoluteFiles)
-                _results <- runAction "GetHie" ide $ uses GetHieAst (map toNormalizedFilePath' absoluteFiles)
-                _results <- runAction "GenerateCore" ide $ uses GenerateCore (map toNormalizedFilePath' absoluteFiles)
-                let (worked, failed) = partition fst $ zip (map isJust results) absoluteFiles
-                when (failed /= []) $
-                    putStr $ unlines $ "Files that failed:" : map ((++) " * " . snd) failed
+            putStrLn "\nStep 4/4: Type checking the files"
+            setFilesOfInterest ide $ HashMap.fromList $ map ((,OnDisk) . toNormalizedFilePath') absoluteFiles
+            results <- runAction "User TypeCheck" ide $ uses TypeCheck (map toNormalizedFilePath' absoluteFiles)
+            _results <- runAction "GetHie" ide $ uses GetHieAst (map toNormalizedFilePath' absoluteFiles)
+            _results <- runAction "GenerateCore" ide $ uses GenerateCore (map toNormalizedFilePath' absoluteFiles)
+            let (worked, failed) = partition fst $ zip (map isJust results) absoluteFiles
+            when (failed /= []) $
+                putStr $ unlines $ "Files that failed:" : map ((++) " * " . snd) failed
 
-                let nfiles xs = let n' = length xs in if n' == 1 then "1 file" else show n' ++ " files"
-                putStrLn $ "\nCompleted (" ++ nfiles worked ++ " worked, " ++ nfiles failed ++ " failed)"
+            let nfiles xs = let n' = length xs in if n' == 1 then "1 file" else show n' ++ " files"
+            putStrLn $ "\nCompleted (" ++ nfiles worked ++ " worked, " ++ nfiles failed ++ " failed)"
 
-                unless (null failed) (exitWith $ ExitFailure (length failed))
+            unless (null failed) (exitWith $ ExitFailure (length failed))
         Db opts cmd -> do
             let root = argsProjectRoot
             dbLoc <- getHieDbLoc root
@@ -438,7 +438,8 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
         Custom (IdeCommand c) -> do
           let root = argsProjectRoot
           dbLoc <- getHieDbLoc root
-          runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc mempty $ \hiedb threadQueue -> do
+          ideMVar <- newEmptyMVar
+          runWithWorkerThreads (cmapWithPrio LogSession recorder) dbLoc mempty ideMVar $ \hiedb threadQueue -> do
             sessionLoader <- loadSessionWithOptions (cmapWithPrio LogSession recorder) argsSessionLoadingOptions "." (tLoaderQueue threadQueue)
             let def_options = argsIdeOptions argsDefaultHlsConfig sessionLoader
                 ideOptions = def_options
@@ -447,10 +448,10 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
                     , optModifyDynFlags = optModifyDynFlags def_options <> pluginModifyDynflags plugins
                     }
             ide <- initialise (cmapWithPrio LogService recorder) argsDefaultHlsConfig argsHlsPlugins rules Nothing debouncer ideOptions hiedb threadQueue mempty root
-            withRestartWorker ide $ do
-                shakeSessionInit (cmapWithPrio LogShake recorder) ide
-                registerIdeConfiguration (shakeExtras ide) $ IdeConfiguration mempty (hashed Nothing)
-                c ide
+            putMVar ideMVar ide
+            shakeSessionInit (cmapWithPrio LogShake recorder) ide
+            registerIdeConfiguration (shakeExtras ide) $ IdeConfiguration mempty (hashed Nothing)
+            c ide
 
 -- | List the haskell files given some paths
 --

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -2034,6 +2034,7 @@ test-suite ghcide-tests
     , extra
     , filepath
     , ghcide
+    , hls-graph
     , hls-plugin-api
     , lens
     , list-t
@@ -2101,6 +2102,7 @@ test-suite ghcide-tests
     ResolveTests
     RootUriTests
     SafeTests
+    ShakeRestartTests
     SymlinkTests
     THTests
     UnitTests

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal.hs
@@ -180,7 +180,7 @@ Then we restart the shake session, so that changes to our virtual files are actu
 -}
 restartCabalShakeSession :: ShakeExtras -> VFS.VFS -> NormalizedFilePath -> String -> IO [Key] -> IO ()
 restartCabalShakeSession shakeExtras vfs file actionMsg actionBetweenSession = do
-  restartShakeSession shakeExtras (VFSModified vfs) (fromNormalizedFilePath file ++ " " ++ actionMsg) [] $ do
+  restartShakeSession shakeExtras (VFSModified vfs) (T.pack (List.intercalate " " [fromNormalizedFilePath file, actionMsg])) [] $ do
     keys <- actionBetweenSession
     return (toKey GetModificationTime file:keys)
 
@@ -189,7 +189,7 @@ restartCabalShakeSession shakeExtras vfs file actionMsg actionBetweenSession = d
 -- rule to get re-run if the file changes on disk.
 restartCabalShakeSessionPhysical :: ShakeExtras -> VFS.VFS -> NormalizedFilePath -> String -> IO [Key] -> IO ()
 restartCabalShakeSessionPhysical shakeExtras vfs file actionMsg actionBetweenSession = do
-  restartShakeSession shakeExtras (VFSModified vfs) (fromNormalizedFilePath file ++ " " ++ actionMsg) [] $ do
+  restartShakeSession shakeExtras (VFSModified vfs) (T.pack (List.intercalate " " [fromNormalizedFilePath file, actionMsg])) [] $ do
     keys <- actionBetweenSession
     return (toKey GetModificationTime file:toKey GetPhysicalModificationTime file:keys)
 

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -44,7 +44,7 @@ import qualified Data.Text.Utf16.Rope.Mixed                   as Rope
 import           Development.IDE.Core.FileStore               (getUriContents, setSomethingModified)
 import           Development.IDE.Core.Rules                   (IdeState,
                                                                runAction)
-import           Development.IDE.Core.Shake                   (use_, uses_, VFSModified (VFSUnmodified), useWithSeparateFingerprintRule_)
+import           Development.IDE.Core.Shake                   (use_, uses_, VFSModified (VFSUnmodified), useWithSeparateFingerprintRule_, waitForLastRestart)
 import           Development.IDE.GHC.Compat                   hiding (typeKind,
                                                                unitState)
 import           Development.IDE.GHC.Compat.Util              (OverridingBool (..))
@@ -217,16 +217,17 @@ runEvalCmd recorder plId st mtoken EvalParams{..} =
             let nfp = toNormalizedFilePath' fp
             mdlText <- moduleText st _uri
 
+            let modifyForEvaluate adjust = do
+                  setSomethingModified VFSUnmodified st "Eval" $ do
+                    _ <- adjust st nfp
+                    return [toKey IsEvaluating nfp]
             -- enable codegen for the module which we need to evaluate.
             final_hscEnv <- liftIO $ bracket_
-              (setSomethingModified VFSUnmodified st "Eval" $ do
-                queueForEvaluation st nfp
-                return [toKey IsEvaluating nfp]
-                )
-              (setSomethingModified VFSUnmodified st "Eval" $ do
-                unqueueForEvaluation st nfp
-                return [toKey IsEvaluating nfp]
-                )
+              -- Without the restart wait, @NeedsCompilation@ is stale in the
+              -- old session and @GetLinkable@ errors.
+              -- See Note [Notification vs request restart ordering]
+              (modifyForEvaluate queueForEvaluation >> waitForLastRestart st)
+              (modifyForEvaluate unqueueForEvaluation)
               (initialiseSessionForEval (needsQuickCheck tests) st nfp)
 
             evalCfg <- liftIO $ runAction "eval: config" st $ getEvalConfig plId

--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -227,7 +227,7 @@ runEvalCmd recorder plId st mtoken EvalParams{..} =
               -- old session and @GetLinkable@ errors.
               -- See Note [Notification vs request restart ordering]
               (modifyForEvaluate queueForEvaluation >> waitForLastRestart st)
-              (modifyForEvaluate unqueueForEvaluation)
+              (modifyForEvaluate unqueueForEvaluation >> waitForLastRestart st)
               (initialiseSessionForEval (needsQuickCheck tests) st nfp)
 
             evalCfg <- liftIO $ runAction "eval: config" st $ getEvalConfig plId


### PR DESCRIPTION
Would close #4725.

Implements the ideas from https://github.com/haskell/haskell-language-server/issues/4725#issuecomment-4148881908. Makes the following changes:

1. Processes notifications asynchronously keeping with the logic that notifications preceding any request, also finish before that request is processed. But does so asynchronously.
2. The above opens up the possibility that there could be multiple shake restarts in-flight because multiple notifications arriving in quick succession. Instead of storing these restarts in a queue, accumulate all restart changes in a single slot, to be processed at once.