### PR TITLE
Prepare release 2.14.0.0

### DIFF
--- a/.github/generate-ci/gen_ci.hs
+++ b/.github/generate-ci/gen_ci.hs
@@ -67,6 +67,7 @@ data GHC
   | GHC984
   | GHC9103
   | GHC9122
+  | GHC9124
   | GHC9141
   deriving (Show, Eq, Ord, Enum, Bounded)
 
@@ -75,6 +76,7 @@ ghcVersion GHC967  = "9.6.7"
 ghcVersion GHC984  = "9.8.4"
 ghcVersion GHC9103 = "9.10.3"
 ghcVersion GHC9122 = "9.12.2"
+ghcVersion GHC9124 = "9.12.4"
 ghcVersion GHC9141 = "9.14.1"
 
 ghcVersionIdent :: GHC -> String

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
     - build-aarch64-linux-ubuntu2204-984
     - build-aarch64-linux-ubuntu2204-9103
     - build-aarch64-linux-ubuntu2204-9122
+    - build-aarch64-linux-ubuntu2204-9124
     - build-aarch64-linux-ubuntu2204-9141
     runs-on:
     - self-hosted
@@ -50,6 +51,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-aarch64-linux-ubuntu2204-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-aarch64-linux-ubuntu2204-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -92,6 +98,7 @@ jobs:
     - build-aarch64-mac-984
     - build-aarch64-mac-9103
     - build-aarch64-mac-9122
+    - build-aarch64-mac-9124
     - build-aarch64-mac-9141
     runs-on:
     - self-hosted
@@ -119,6 +126,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-aarch64-mac-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-aarch64-mac-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -167,6 +179,7 @@ jobs:
     - build-x86_64-linux-deb10-984
     - build-x86_64-linux-deb10-9103
     - build-x86_64-linux-deb10-9122
+    - build-x86_64-linux-deb10-9124
     - build-x86_64-linux-deb10-9141
     runs-on:
     - self-hosted
@@ -194,6 +207,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-deb10-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-deb10-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -231,6 +249,7 @@ jobs:
     - build-x86_64-linux-deb11-984
     - build-x86_64-linux-deb11-9103
     - build-x86_64-linux-deb11-9122
+    - build-x86_64-linux-deb11-9124
     - build-x86_64-linux-deb11-9141
     runs-on:
     - self-hosted
@@ -258,6 +277,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-deb11-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-deb11-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -295,6 +319,7 @@ jobs:
     - build-x86_64-linux-deb12-984
     - build-x86_64-linux-deb12-9103
     - build-x86_64-linux-deb12-9122
+    - build-x86_64-linux-deb12-9124
     - build-x86_64-linux-deb12-9141
     runs-on:
     - self-hosted
@@ -322,6 +347,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-deb12-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-deb12-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -359,6 +389,7 @@ jobs:
     - build-x86_64-linux-deb13-984
     - build-x86_64-linux-deb13-9103
     - build-x86_64-linux-deb13-9122
+    - build-x86_64-linux-deb13-9124
     - build-x86_64-linux-deb13-9141
     runs-on:
     - self-hosted
@@ -386,6 +417,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-deb13-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-deb13-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -423,6 +459,7 @@ jobs:
     - build-x86_64-linux-fedora33-984
     - build-x86_64-linux-fedora33-9103
     - build-x86_64-linux-fedora33-9122
+    - build-x86_64-linux-fedora33-9124
     - build-x86_64-linux-fedora33-9141
     runs-on:
     - self-hosted
@@ -450,6 +487,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-fedora33-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-fedora33-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -487,6 +529,7 @@ jobs:
     - build-x86_64-linux-fedora40-984
     - build-x86_64-linux-fedora40-9103
     - build-x86_64-linux-fedora40-9122
+    - build-x86_64-linux-fedora40-9124
     - build-x86_64-linux-fedora40-9141
     runs-on:
     - self-hosted
@@ -514,6 +557,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-fedora40-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-fedora40-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -551,6 +599,7 @@ jobs:
     - build-x86_64-linux-mint202-984
     - build-x86_64-linux-mint202-9103
     - build-x86_64-linux-mint202-9122
+    - build-x86_64-linux-mint202-9124
     - build-x86_64-linux-mint202-9141
     runs-on:
     - self-hosted
@@ -578,6 +627,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-mint202-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-mint202-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -615,6 +669,7 @@ jobs:
     - build-x86_64-linux-mint213-984
     - build-x86_64-linux-mint213-9103
     - build-x86_64-linux-mint213-9122
+    - build-x86_64-linux-mint213-9124
     - build-x86_64-linux-mint213-9141
     runs-on:
     - self-hosted
@@ -642,6 +697,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-mint213-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-mint213-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -679,6 +739,7 @@ jobs:
     - build-x86_64-linux-mint222-984
     - build-x86_64-linux-mint222-9103
     - build-x86_64-linux-mint222-9122
+    - build-x86_64-linux-mint222-9124
     - build-x86_64-linux-mint222-9141
     runs-on:
     - self-hosted
@@ -706,6 +767,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-mint222-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-mint222-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -743,6 +809,7 @@ jobs:
     - build-x86_64-linux-ubuntu2004-984
     - build-x86_64-linux-ubuntu2004-9103
     - build-x86_64-linux-ubuntu2004-9122
+    - build-x86_64-linux-ubuntu2004-9124
     - build-x86_64-linux-ubuntu2004-9141
     runs-on:
     - self-hosted
@@ -770,6 +837,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-ubuntu2004-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-ubuntu2004-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -807,6 +879,7 @@ jobs:
     - build-x86_64-linux-ubuntu2204-984
     - build-x86_64-linux-ubuntu2204-9103
     - build-x86_64-linux-ubuntu2204-9122
+    - build-x86_64-linux-ubuntu2204-9124
     - build-x86_64-linux-ubuntu2204-9141
     runs-on:
     - self-hosted
@@ -834,6 +907,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-ubuntu2204-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-ubuntu2204-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -871,6 +949,7 @@ jobs:
     - build-x86_64-linux-ubuntu2404-984
     - build-x86_64-linux-ubuntu2404-9103
     - build-x86_64-linux-ubuntu2404-9122
+    - build-x86_64-linux-ubuntu2404-9124
     - build-x86_64-linux-ubuntu2404-9141
     runs-on:
     - self-hosted
@@ -898,6 +977,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-ubuntu2404-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-ubuntu2404-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -935,6 +1019,7 @@ jobs:
     - build-x86_64-linux-unknown-984
     - build-x86_64-linux-unknown-9103
     - build-x86_64-linux-unknown-9122
+    - build-x86_64-linux-unknown-9124
     - build-x86_64-linux-unknown-9141
     runs-on:
     - self-hosted
@@ -962,6 +1047,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-linux-unknown-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-linux-unknown-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -999,6 +1089,7 @@ jobs:
     - build-x86_64-mac-984
     - build-x86_64-mac-9103
     - build-x86_64-mac-9122
+    - build-x86_64-mac-9124
     - build-x86_64-mac-9141
     runs-on:
     - macOS-15-intel
@@ -1024,6 +1115,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-mac-9122
+        path: ./
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-mac-9124
         path: ./
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -1065,6 +1161,7 @@ jobs:
     - build-x86_64-windows-984
     - build-x86_64-windows-9103
     - build-x86_64-windows-9122
+    - build-x86_64-windows-9124
     - build-x86_64-windows-9141
     runs-on:
     - windows-latest
@@ -1090,6 +1187,11 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: artifacts-build-x86_64-windows-9122
+        path: ./out
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: artifacts-build-x86_64-windows-9124
         path: ./out
     - name: Download artifacts
       uses: actions/download-artifact@v7
@@ -1189,6 +1291,43 @@ jobs:
         if-no-files-found: error
         name: artifacts-build-aarch64-linux-ubuntu2204-9122
         path: out-aarch64-linux-ubuntu2204-9.12.2.tar
+        retention-days: 2
+  build-aarch64-linux-ubuntu2204-9124:
+    env:
+      ADD_CABAL_ARGS: ''
+      ARCH: ARM64
+      ARTIFACT: aarch64-linux-ubuntu2204
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-aarch64-linux-ubuntu2204-9124 (Build binaries)
+    runs-on:
+    - ubuntu-22.04-arm
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - env:
+        GHC_VERSION: 9.12.4
+      name: Build aarch64-linux binaries
+      uses: docker://hasufell/arm64v8-ubuntu-haskell:focal
+      with:
+        args: bash .github/scripts/build.sh
+    - env:
+        GHC_VERSION: 9.12.4
+      name: Tar aarch64-linux binaries
+      uses: docker://hasufell/arm64v8-ubuntu-haskell:focal
+      with:
+        args: bash .github/scripts/tar.sh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-aarch64-linux-ubuntu2204-9124
+        path: out-aarch64-linux-ubuntu2204-9.12.4.tar
         retention-days: 2
   build-aarch64-linux-ubuntu2204-9141:
     env:
@@ -1377,6 +1516,44 @@ jobs:
         name: artifacts-build-aarch64-mac-9122
         path: out-aarch64-apple-darwin-9.12.2.tar
         retention-days: 2
+  build-aarch64-mac-9124:
+    env:
+      ADD_CABAL_ARGS: ''
+      ARCH: ARM64
+      ARTIFACT: aarch64-apple-darwin
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      HOMEBREW_CHANGE_ARCH_TO_ARM: '1'
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-aarch64-mac-9124 (Build binaries)
+    runs-on:
+    - self-hosted
+    - macOS
+    - ARM64
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - env:
+        GHC_VERSION: 9.12.4
+      name: Run build
+      run: |
+        bash .github/scripts/brew.sh git coreutils autoconf automake tree
+        export PATH="$HOME/.brew/bin:$HOME/.brew/sbin:$PATH"
+        export LD=ld
+        bash .github/scripts/build.sh
+        tar cf out-${ARTIFACT}-${GHC_VERSION}.tar out/ store/
+      shell: sh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-aarch64-mac-9124
+        path: out-aarch64-apple-darwin-9.12.4.tar
+        retention-days: 2
   build-aarch64-mac-9141:
     env:
       ADD_CABAL_ARGS: ''
@@ -1551,6 +1728,36 @@ jobs:
         name: artifacts-build-x86_64-linux-deb10-9122
         path: out-x86_64-linux-deb10-9.12.2.tar
         retention-days: 2
+  build-x86_64-linux-deb10-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-deb10
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-deb10-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-deb10
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-deb10-9124
+        path: out-x86_64-linux-deb10-9.12.4.tar
+        retention-days: 2
   build-x86_64-linux-deb10-9141:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -1700,6 +1907,36 @@ jobs:
         if-no-files-found: error
         name: artifacts-build-x86_64-linux-deb11-9122
         path: out-x86_64-linux-deb11-9.12.2.tar
+        retention-days: 2
+  build-x86_64-linux-deb11-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-deb11
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-deb11-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-deb11
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-deb11-9124
+        path: out-x86_64-linux-deb11-9.12.4.tar
         retention-days: 2
   build-x86_64-linux-deb11-9141:
     env:
@@ -1851,6 +2088,36 @@ jobs:
         name: artifacts-build-x86_64-linux-deb12-9122
         path: out-x86_64-linux-deb12-9.12.2.tar
         retention-days: 2
+  build-x86_64-linux-deb12-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-deb12
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-deb12-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-deb12
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-deb12-9124
+        path: out-x86_64-linux-deb12-9.12.4.tar
+        retention-days: 2
   build-x86_64-linux-deb12-9141:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2000,6 +2267,36 @@ jobs:
         if-no-files-found: error
         name: artifacts-build-x86_64-linux-deb13-9122
         path: out-x86_64-linux-deb13-9.12.2.tar
+        retention-days: 2
+  build-x86_64-linux-deb13-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-deb13
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-deb13-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-deb13
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-deb13-9124
+        path: out-x86_64-linux-deb13-9.12.4.tar
         retention-days: 2
   build-x86_64-linux-deb13-9141:
     env:
@@ -2151,6 +2448,36 @@ jobs:
         name: artifacts-build-x86_64-linux-fedora33-9122
         path: out-x86_64-linux-fedora33-9.12.2.tar
         retention-days: 2
+  build-x86_64-linux-fedora33-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-fedora33
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-fedora33-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-fedora33
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-fedora33-9124
+        path: out-x86_64-linux-fedora33-9.12.4.tar
+        retention-days: 2
   build-x86_64-linux-fedora33-9141:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2300,6 +2627,36 @@ jobs:
         if-no-files-found: error
         name: artifacts-build-x86_64-linux-fedora40-9122
         path: out-x86_64-linux-fedora40-9.12.2.tar
+        retention-days: 2
+  build-x86_64-linux-fedora40-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-fedora40
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-fedora40-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-fedora40
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-fedora40-9124
+        path: out-x86_64-linux-fedora40-9.12.4.tar
         retention-days: 2
   build-x86_64-linux-fedora40-9141:
     env:
@@ -2451,6 +2808,36 @@ jobs:
         name: artifacts-build-x86_64-linux-mint202-9122
         path: out-x86_64-linux-mint202-9.12.2.tar
         retention-days: 2
+  build-x86_64-linux-mint202-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-mint202
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-mint202-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-mint202
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-mint202-9124
+        path: out-x86_64-linux-mint202-9.12.4.tar
+        retention-days: 2
   build-x86_64-linux-mint202-9141:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2600,6 +2987,36 @@ jobs:
         if-no-files-found: error
         name: artifacts-build-x86_64-linux-mint213-9122
         path: out-x86_64-linux-mint213-9.12.2.tar
+        retention-days: 2
+  build-x86_64-linux-mint213-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-mint213
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-mint213-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-mint213
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-mint213-9124
+        path: out-x86_64-linux-mint213-9.12.4.tar
         retention-days: 2
   build-x86_64-linux-mint213-9141:
     env:
@@ -2751,6 +3168,36 @@ jobs:
         name: artifacts-build-x86_64-linux-mint222-9122
         path: out-x86_64-linux-mint222-9.12.2.tar
         retention-days: 2
+  build-x86_64-linux-mint222-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-mint222
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-mint222-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-mint222
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-mint222-9124
+        path: out-x86_64-linux-mint222-9.12.4.tar
+        retention-days: 2
   build-x86_64-linux-mint222-9141:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -2900,6 +3347,36 @@ jobs:
         if-no-files-found: error
         name: artifacts-build-x86_64-linux-ubuntu2004-9122
         path: out-x86_64-linux-ubuntu2004-9.12.2.tar
+        retention-days: 2
+  build-x86_64-linux-ubuntu2004-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-ubuntu2004
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-ubuntu2004-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-ubuntu2004
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-ubuntu2004-9124
+        path: out-x86_64-linux-ubuntu2004-9.12.4.tar
         retention-days: 2
   build-x86_64-linux-ubuntu2004-9141:
     env:
@@ -3051,6 +3528,36 @@ jobs:
         name: artifacts-build-x86_64-linux-ubuntu2204-9122
         path: out-x86_64-linux-ubuntu2204-9.12.2.tar
         retention-days: 2
+  build-x86_64-linux-ubuntu2204-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-ubuntu2204
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-ubuntu2204-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-ubuntu2204
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-ubuntu2204-9124
+        path: out-x86_64-linux-ubuntu2204-9.12.4.tar
+        retention-days: 2
   build-x86_64-linux-ubuntu2204-9141:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -3201,6 +3708,36 @@ jobs:
         name: artifacts-build-x86_64-linux-ubuntu2404-9122
         path: out-x86_64-linux-ubuntu2404-9.12.2.tar
         retention-days: 2
+  build-x86_64-linux-ubuntu2404-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-ubuntu2404
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-ubuntu2404-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-ubuntu2404
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-ubuntu2404-9124
+        path: out-x86_64-linux-ubuntu2404-9.12.4.tar
+        retention-days: 2
   build-x86_64-linux-ubuntu2404-9141:
     env:
       ADD_CABAL_ARGS: --enable-split-sections
@@ -3350,6 +3887,36 @@ jobs:
         if-no-files-found: error
         name: artifacts-build-x86_64-linux-unknown-9122
         path: out-x86_64-linux-unknown-9.12.2.tar
+        retention-days: 2
+  build-x86_64-linux-unknown-9124:
+    env:
+      ADD_CABAL_ARGS: --enable-split-sections
+      ARCH: '64'
+      ARTIFACT: x86_64-linux-unknown
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DEBIAN_FRONTEND: noninteractive
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-linux-unknown-9124 (Build binaries)
+    runs-on:
+    - ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build 9.12.4
+      uses: ./.github/actions/bindist-actions/action-unknown
+      with:
+        stage: BUILD
+        version: 9.12.4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-linux-unknown-9124
+        path: out-x86_64-linux-unknown-9.12.4.tar
         retention-days: 2
   build-x86_64-linux-unknown-9141:
     env:
@@ -3506,6 +4073,39 @@ jobs:
         if-no-files-found: error
         name: artifacts-build-x86_64-mac-9122
         path: out-x86_64-apple-darwin-9.12.2.tar
+        retention-days: 2
+  build-x86_64-mac-9124:
+    env:
+      ADD_CABAL_ARGS: ''
+      ARCH: '64'
+      ARTIFACT: x86_64-apple-darwin
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: tar.xz
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-mac-9124 (Build binaries)
+    runs-on:
+    - macOS-15-intel
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - env:
+        GHC_VERSION: 9.12.4
+      name: Run build
+      run: |
+        brew install coreutils tree
+        bash .github/scripts/build.sh
+        tar cf out-${ARTIFACT}-${GHC_VERSION}.tar out/ store/
+      shell: sh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-mac-9124
+        path: out-x86_64-apple-darwin-9.12.4.tar
         retention-days: 2
   build-x86_64-mac-9141:
     env:
@@ -3670,6 +4270,39 @@ jobs:
       with:
         if-no-files-found: error
         name: artifacts-build-x86_64-windows-9122
+        path: ./out/*
+        retention-days: 2
+  build-x86_64-windows-9124:
+    env:
+      ADD_CABAL_ARGS: ''
+      ARCH: '64'
+      ARTIFACT: x86_64-mingw64
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      S3_HOST: ${{ secrets.S3_HOST }}
+      TARBALL_EXT: zip
+      TZ: Asia/Singapore
+    environment: CI
+    name: build-x86_64-windows-9124 (Build binaries)
+    runs-on:
+    - windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - env:
+        GHC_VERSION: 9.12.4
+      name: Run build
+      run: |
+        $env:CHERE_INVOKING = 1
+        $env:MSYS2_PATH_TYPE = "inherit"
+        $ErrorActionPreference = "Stop"
+        C:\msys64\usr\bin\bash -lc "bash .github/scripts/build.sh"
+      shell: pwsh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: artifacts-build-x86_64-windows-9124
         path: ./out/*
         retention-days: 2
   build-x86_64-windows-9141:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,155 @@
 # Changelog for haskell-language-server
 
+## 2.14.0.0
+
+- Bindists for GHC 9.14.1
+- Bindists for GHC 9.12.4
+- Bindists for GHC 9.12.2
+- Bindists for GHC 9.10.3
+- Bindists for GHC 9.8.4
+- Bindists for GHC 9.6.7
+- Remove `hls-floskell-plugin`
+- Merge `hls-module-name-plugin` into `hls-rename-plugin`
+- Support for `ExplicitLevelImports` in GHC 9.14
+- Improved startup responsiveness via decoupled session loader
+- Improvements to ghcide
+  - Print hover types on a single line
+  - Only show linear arrows when `LinearTypes` is enabled
+  - Smart-case matching for module and filepath completions
+- Improvements to `hls-rename-plugin`
+  - Cross-module rename enabled by default
+  - `prepareRename` returns exact identifier range
+- Improvements to `hls-refactor-plugin`
+  - Don't offer 'Add Argument' for qualified names
+  - Fix spacing in constraint reduction
+  - Fix `makeDeltaAst` regression (#4731)
+- Improvements to `hls-explicit-record-fields-plugin`
+  - Cursor-aware record expansion
+  - Distinguish wildcard expansion from record syntax conversion
+  - Ignore compiler-generated match groups
+- Improvements to `hls-notes-plugin`
+  - Hover and autocompletion for note references and declarations
+  - Fix crash on single-line comments
+- Improvements to `hls-cabal-plugin`
+  - Completions in `custom-setup` stanzas
+- Improvements to `hls-fourmolu-plugin` / `hls-ormolu-plugin`
+  - Show actual parse errors from external formatters
+
+### Pull Requests
+
+- Allow skipping over non-required progress messages
+  ([#4896](https://github.com/haskell/haskell-language-server/pull/4896)) by @crtschin
+- Cleanup 9.4 leftovers, fix couple -Wunused-packages and import warnings
+  ([#4893](https://github.com/haskell/haskell-language-server/pull/4893)) by @jhrcek
+- Keep communication pipes between lsp-test and ghcide alive for the entire test
+  ([#4892](https://github.com/haskell/haskell-language-server/pull/4892)) by @crtschin
+- Cancel outstanding threads prior to closing sqlite connection
+  ([#4886](https://github.com/haskell/haskell-language-server/pull/4886)) by @crtschin
+- Bump cachix/cachix-action from 16 to 17
+  ([#4872](https://github.com/haskell/haskell-language-server/pull/4872)) by @dependabot[bot]
+- Fix cache clearing job
+  ([#4868](https://github.com/haskell/haskell-language-server/pull/4868)) by @vidit-od
+- Improve `prepareRename` responses
+  ([#4867](https://github.com/haskell/haskell-language-server/pull/4867)) by @izuzu-izuzu
+- Migrate stackage build on GHA
+  ([#4865](https://github.com/haskell/haskell-language-server/pull/4865)) by @vidit-od
+- new snapshot for stack build
+  ([#4864](https://github.com/haskell/haskell-language-server/pull/4864)) by @vidit-od
+- Pin version of extra to 1.8.1 for stack
+  ([#4863](https://github.com/haskell/haskell-language-server/pull/4863)) by @fendor
+- Only show linear arrows on data constructors with LinearTypes
+  ([#4862](https://github.com/haskell/haskell-language-server/pull/4862)) by @crtschin
+- Use 2 spaces for tab in HLS
+  ([#4860](https://github.com/haskell/haskell-language-server/pull/4860)) by @fendor
+- Produce structured error for unknown module
+  ([#4857](https://github.com/haskell/haskell-language-server/pull/4857)) by @vidit-od
+- Use Server side Diagnostics
+  ([#4856](https://github.com/haskell/haskell-language-server/pull/4856)) by @vidit-od
+- Fix: Show actual parse errors for external Fourmolu/Ormolu
+  ([#4855](https://github.com/haskell/haskell-language-server/pull/4855)) by @ijatinydv
+- Fixes redundant hash in ghcide cache path (getCacheDirsDefault)
+  ([#4854](https://github.com/haskell/haskell-language-server/pull/4854)) by @adpad-13
+- fix(refactor): do not offer 'Add Argument' for qualified names
+  ([#4852](https://github.com/haskell/haskell-language-server/pull/4852)) by @ijatinydv
+- Prefer extending import code actions
+  ([#4851](https://github.com/haskell/haskell-language-server/pull/4851)) by @vherrmann
+- Custom-setups completion in cabal files
+  ([#4848](https://github.com/haskell/haskell-language-server/pull/4848)) by @vidit-od
+- Move hls-module-name-plugin into hls-rename-plugin
+  ([#4847](https://github.com/haskell/haskell-language-server/pull/4847)) by @fendor
+- ghcide: implement level-aware module graph edges for GHC 9.14+
+  ([#4846](https://github.com/haskell/haskell-language-server/pull/4846)) by @ijatinydv
+- fix spacing issues while refactor-reduce
+  ([#4841](https://github.com/haskell/haskell-language-server/pull/4841)) by @vidit-od
+- Remove Floskell support
+  ([#4838](https://github.com/haskell/haskell-language-server/pull/4838)) by @omarjatoi
+- Ignore records in matching groups that are compiler-generated
+  ([#4837](https://github.com/haskell/haskell-language-server/pull/4837)) by @ozkutuk
+- Add tasty-options to control test execution
+  ([#4835](https://github.com/haskell/haskell-language-server/pull/4835)) by @observant2
+- Use `VirtualFileTree` in `hls-call-hierarchy-plugin-tests`
+  ([#4834](https://github.com/haskell/haskell-language-server/pull/4834)) by @fendor
+- fix notes crashing and leaking single comments notes
+  ([#4828](https://github.com/haskell/haskell-language-server/pull/4828)) by @vidit-od
+- Also add max-backjumps to caching job
+  ([#4827](https://github.com/haskell/haskell-language-server/pull/4827)) by @jhrcek
+- docs: add WSL build location note for contributors
+  ([#4824](https://github.com/haskell/haskell-language-server/pull/4824)) by @Siya-05
+- Smart Casing in modules and file paths
+  ([#4823](https://github.com/haskell/haskell-language-server/pull/4823)) by @vidit-od
+- Prune allow-newer for ghc 9.14, bump hiedb to 0.8
+  ([#4821](https://github.com/haskell/haskell-language-server/pull/4821)) by @jhrcek
+- Distinguish between wildcard expansion and traditional record syntax
+  ([#4819](https://github.com/haskell/haskell-language-server/pull/4819)) by @ozkutuk
+- Enable `crossModule` option by default
+  ([#4817](https://github.com/haskell/haskell-language-server/pull/4817)) by @Aster89
+- Re-introduce call to `makeDeltaAst` to fix #4731
+  ([#4814](https://github.com/haskell/haskell-language-server/pull/4814)) by @Aster89
+- Cursor aware record expansion
+  ([#4813](https://github.com/haskell/haskell-language-server/pull/4813)) by @vidit-od
+- Bump GHA versions
+  ([#4812](https://github.com/haskell/haskell-language-server/pull/4812)) by @fendor
+- Use macos-15-intel runners instead of arm macos-15
+  ([#4811](https://github.com/haskell/haskell-language-server/pull/4811)) by @fendor
+- Bump haskell-actions/setup from 2.8.2 to 2.10.3
+  ([#4809](https://github.com/haskell/haskell-language-server/pull/4809)) by @dependabot[bot]
+- Bump hlint action, move options to .hlint.yaml
+  ([#4808](https://github.com/haskell/haskell-language-server/pull/4808)) by @philderbeast
+- Add nix devShell for GHC 9.14
+  ([#4804](https://github.com/haskell/haskell-language-server/pull/4804)) by @jian-lin
+- Print type in one line
+  ([#4803](https://github.com/haskell/haskell-language-server/pull/4803)) by @jian-lin
+- Use Data.HashMap.lookupKey and Data.HashSet.lookupElement
+  ([#4802](https://github.com/haskell/haskell-language-server/pull/4802)) by @sjakobi
+- Mark 9.4.8 as deprecated
+  ([#4801](https://github.com/haskell/haskell-language-server/pull/4801)) by @fendor
+- Fix cache job on windows
+  ([#4800](https://github.com/haskell/haskell-language-server/pull/4800)) by @fendor
+- Fix GHC support table for 9.4.8
+  ([#4799](https://github.com/haskell/haskell-language-server/pull/4799)) by @fendor
+- More ghcup-metadata tweaks
+  ([#4798](https://github.com/haskell/haskell-language-server/pull/4798)) by @fendor
+- Bump haskell-actions/setup from 2.8.2 to 2.10.3 in /.github/actions/setup-build
+  ([#4796](https://github.com/haskell/haskell-language-server/pull/4796)) by @dependabot[bot]
+- Bump actions/cache from 3 to 5 in /.github/actions/setup-build
+  ([#4795](https://github.com/haskell/haskell-language-server/pull/4795)) by @dependabot[bot]
+- Bump actions/cache from 3 to 5
+  ([#4793](https://github.com/haskell/haskell-language-server/pull/4793)) by @dependabot[bot]
+- Improving Notes Plugin
+  ([#4791](https://github.com/haskell/haskell-language-server/pull/4791)) by @vidit-od
+- fix: git sub-repository files listing (#4788)
+  ([#4790](https://github.com/haskell/haskell-language-server/pull/4790)) by @blackheaven
+- Prepare release 2.13.0.0
+  ([#4785](https://github.com/haskell/haskell-language-server/pull/4785)) by @fendor
+- ghcide: Require unordered-containers >= 0.2.21
+  ([#4774](https://github.com/haskell/haskell-language-server/pull/4774)) by @sjakobi
+- Fix broken pipe during test and gracefully exit the server
+  ([#4701](https://github.com/haskell/haskell-language-server/pull/4701)) by @soulomoon
+- Change tracking of file types to language kinds
+  ([#4621](https://github.com/haskell/haskell-language-server/pull/4621)) by @VeryMilkyJoe
+- Decouple the session loader into reader and writer over the cache
+  ([#4445](https://github.com/haskell/haskell-language-server/pull/4445)) by @soulomoon
+
 ## 2.13.0.0
 
 - Bindists for GHC 9.14.1
@@ -7,7 +157,6 @@
 - Bindists for GHC 9.10.3
 - Bindists for GHC 9.8.4
 - Bindists for GHC 9.6.7
-- Last release supporting GHC 9.6
 
 Support for GHC 9.14.1 is preliminary, some plugins are not yet support but will
 be in the future.

--- a/GenChangelogs.hs
+++ b/GenChangelogs.hs
@@ -12,7 +12,6 @@ import           Data.List
 import           Data.Maybe
 import qualified Data.Text                as T
 import           Data.Time.Format.ISO8601
-import           Data.Time.LocalTime
 import           GitHub
 import           System.Environment
 import           System.Process
@@ -23,7 +22,7 @@ main = do
         token:tag:_ -> (github (OAuth $ BS.pack token), tag)
   prs <- githubReq $ pullRequestsForR "haskell" "haskell-language-server" stateClosed FetchAll
   lastDateStr <- last . lines <$> readProcess "git" ["show", "-s", "--format=%cI", "-1", tag] ""
-  lastDate <- zonedTimeToUTC <$> iso8601ParseM lastDateStr
+  lastDate <- iso8601ParseM lastDateStr
 
   let prsAfterLastTag = either (error . show)
                         (foldMap (\pr -> [pr | inRange pr]))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,4 +54,5 @@
   - https://github.com/haskell/ghcup-hs/blob/master/docs/install.md#supported-platforms
   - https://github.com/haskell/ghcup-metadata/blob/44c6e2b5d0fcae15abeffff03e87544edf76dd7a/ghcup-gen/Main.hs#L67
 - [ ] post release on discourse and reddit
+  - Include links to the plugin support table (https://haskell-language-server.readthedocs.io/en/2.13.0.0/support/plugin-support.html) and ghc version support table (https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html)
 - [ ] merge release PR to master or forward port relevant changes

--- a/cabal.project
+++ b/cabal.project
@@ -6,7 +6,7 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-index-state: 2026-02-24T00:00:00Z
+index-state: 2026-04-16T00:00:00Z
 
 tests: True
 test-show-details: direct

--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -18,12 +18,13 @@ Support status (see the support policy below for more details):
 | GHC version  | Last supporting HLS version                                                          | Support status |
 | ------------ | ------------------------------------------------------------------------------------ | -------------- |
 | 9.14.1       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | basic support  |
+| 9.12.4       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
 | 9.12.3       |                                                                                      | no support     |
 | 9.12.2       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
 | 9.12.1       |                                                                                      | no support     |
 | 9.10.3       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
-| 9.10.2       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
-| 9.10.1       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
+| 9.10.2       | [latest](https://github.com/haskell/haskell-language-server/releases/tag/2.11.0.0)         | deprecated     |
+| 9.10.1       | [latest](https://github.com/haskell/haskell-language-server/releases/tag/2.10.0.0)         | deprecated     |
 | 9.8.4        | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
 | 9.8.2        | [2.9.0.1](https://github.com/haskell/haskell-language-server/releases/tag/2.9.0.1)   | deprecated     |
 | 9.8.1        | [2.6.0.0](https://github.com/haskell/haskell-language-server/releases/tag/2.6.0.0)   | deprecated     |

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            2.13.0.0
+version:            2.14.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -74,10 +74,10 @@ library
     , Glob
     , haddock-library              >=1.8      && <1.12
     , hashable
-    , hie-bios                     ^>= 0.18.0
+    , hie-bios                     ^>= 0.19.0
     , hiedb                        ^>= 0.8.0.0
-    , hls-graph                    == 2.13.0.0
-    , hls-plugin-api               == 2.13.0.0
+    , hls-graph                    == 2.14.0.0
+    , hls-plugin-api               == 2.14.0.0
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5
     , lens
     , lens-aeson

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.4
 category:           Development
 name:               haskell-language-server
-version:            2.13.0.0
+version:            2.14.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -136,8 +136,8 @@ library hls-cabal-fmt-plugin
   build-depends:
     , directory
     , filepath
-    , ghcide          == 2.13.0.0
-    , hls-plugin-api  == 2.13.0.0
+    , ghcide          == 2.14.0.0
+    , hls-plugin-api  == 2.14.0.0
     , lens
     , lsp-types
     , mtl
@@ -157,8 +157,8 @@ test-suite hls-cabal-fmt-plugin-tests
     , filepath
     , haskell-language-server:hls-cabal-plugin
     , haskell-language-server:hls-cabal-fmt-plugin
-    , hls-plugin-api        == 2.13.0.0
-    , hls-test-utils        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
+    , hls-test-utils        == 2.14.0.0
 
   if flag(isolateCabalfmtTests)
     build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.12
@@ -193,8 +193,8 @@ library hls-cabal-gild-plugin
   build-depends:
     , directory
     , filepath
-    , ghcide          == 2.13.0.0
-    , hls-plugin-api  == 2.13.0.0
+    , ghcide          == 2.14.0.0
+    , hls-plugin-api  == 2.14.0.0
     , lsp-types
     , text
     , mtl
@@ -213,8 +213,8 @@ test-suite hls-cabal-gild-plugin-tests
     , filepath
     , haskell-language-server:hls-cabal-plugin
     , haskell-language-server:hls-cabal-gild-plugin
-    , hls-plugin-api        == 2.13.0.0
-    , hls-test-utils        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
+    , hls-test-utils        == 2.14.0.0
 
   if flag(isolateCabalGildTests)
     -- https://github.com/tfausak/cabal-gild/issues/89
@@ -274,10 +274,10 @@ library hls-cabal-plugin
     , directory
     , filepath
     , extra                 >=1.7.4
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , hashable
-    , hls-plugin-api        == 2.13.0.0
-    , hls-graph             == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
+    , hls-graph             == 2.14.0.0
     , lens
     , lsp                   ^>=2.8
     , lsp-types             ^>=2.4
@@ -316,7 +316,7 @@ test-suite hls-cabal-plugin-tests
     , filepath
     , ghcide
     , haskell-language-server:hls-cabal-plugin
-    , hls-test-utils    == 2.13.0.0
+    , hls-test-utils    == 2.14.0.0
     , lens
     , lsp-types
     , text
@@ -353,9 +353,9 @@ library hls-class-plugin
     , extra
     , ghc
     , ghc-exactprint  >= 1.5 && < 1.15
-    , ghcide          == 2.13.0.0
+    , ghcide          == 2.14.0.0
     , hls-graph
-    , hls-plugin-api  == 2.13.0.0
+    , hls-plugin-api  == 2.14.0.0
     , lens
     , lsp
     , mtl
@@ -376,7 +376,7 @@ test-suite hls-class-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-class-plugin
-    , hls-test-utils     == 2.13.0.0
+    , hls-test-utils     == 2.14.0.0
     , lens
     , lsp-types
     , text
@@ -411,9 +411,9 @@ library hls-call-hierarchy-plugin
     , containers
     , extra
     , ghc
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , hiedb                 ^>= 0.8.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lens
     , lsp                    >=2.8
     , sqlite-simple
@@ -434,7 +434,7 @@ test-suite hls-call-hierarchy-plugin-tests
     , extra
     , filepath
     , haskell-language-server:hls-call-hierarchy-plugin
-    , hls-test-utils        == 2.13.0.0
+    , hls-test-utils        == 2.14.0.0
     , lens
     , lsp
     , lsp-test
@@ -484,9 +484,9 @@ library hls-eval-plugin
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , hls-graph
-    , hls-plugin-api        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lens
     , lsp
     , lsp-types
@@ -517,7 +517,7 @@ test-suite hls-eval-plugin-tests
     , filepath
     , haskell-language-server:hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   == 2.13.0.0
+    , hls-test-utils   == 2.14.0.0
     , lens
     , lsp-types
     , text
@@ -547,9 +547,9 @@ library hls-explicit-imports-plugin
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , hls-graph
-    , hls-plugin-api        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lens
     , lsp
     , mtl
@@ -570,7 +570,7 @@ test-suite hls-explicit-imports-plugin-tests
     , extra
     , filepath
     , haskell-language-server:hls-explicit-imports-plugin
-    , hls-test-utils   == 2.13.0.0
+    , hls-test-utils   == 2.14.0.0
     , lens
     , lsp-types
     , text
@@ -602,10 +602,10 @@ library hls-rename-plugin
     , containers
     , filepath
     , ghc
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , hashable
     , hiedb                 ^>= 0.8.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp-types
@@ -631,7 +631,7 @@ test-suite hls-rename-plugin-tests
     , filepath
     , hls-plugin-api
     , haskell-language-server:hls-rename-plugin
-    , hls-test-utils             == 2.13.0.0
+    , hls-test-utils             == 2.14.0.0
     , lens
     , lsp-types
     , text
@@ -662,9 +662,9 @@ library hls-retrie-plugin
     , containers
     , extra
     , ghc
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , hashable
-    , hls-plugin-api        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp
@@ -693,7 +693,7 @@ test-suite hls-retrie-plugin-tests
     , filepath
     , hls-plugin-api
     , haskell-language-server:{hls-refactor-plugin, hls-retrie-plugin}
-    , hls-test-utils             == 2.13.0.0
+    , hls-test-utils             == 2.14.0.0
     , text
 
 -----------------------------
@@ -737,10 +737,10 @@ library hls-hlint-plugin
     , containers
     , deepseq
     , filepath
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , hashable
     , hlint                 >= 3.5 && < 3.11
-    , hls-plugin-api        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lens
     , mtl
     , refact
@@ -793,7 +793,7 @@ test-suite hls-hlint-plugin-tests
     , filepath
     , haskell-language-server:hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.13.0.0
+    , hls-test-utils      == 2.14.0.0
     , lens
     , lsp-types
     , text
@@ -847,7 +847,7 @@ test-suite hls-stan-plugin-tests
     , filepath
     , haskell-language-server:hls-stan-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.13.0.0
+    , hls-test-utils      == 2.14.0.0
     , lens
     , lsp-types
     , text
@@ -881,8 +881,8 @@ library hls-signature-help-plugin
   build-depends:
     , containers
     , ghc
-    , ghcide                == 2.13.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , ghcide                == 2.14.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lsp-types
     , text
     , transformers
@@ -898,7 +898,7 @@ test-suite hls-signature-help-plugin-tests
   build-depends:
     , ghcide
     , haskell-language-server:hls-signature-help-plugin
-    , hls-test-utils             == 2.13.0.0
+    , hls-test-utils             == 2.14.0.0
     , text
   default-extensions:
     DerivingStrategies
@@ -928,8 +928,8 @@ library hls-pragmas-plugin
     , aeson
     , extra
     , fuzzy
-    , ghcide                == 2.13.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , ghcide                == 2.14.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lens
     , lsp
     , text
@@ -946,7 +946,7 @@ test-suite hls-pragmas-plugin-tests
     , aeson
     , filepath
     , haskell-language-server:hls-pragmas-plugin
-    , hls-test-utils      == 2.13.0.0
+    , hls-test-utils      == 2.14.0.0
     , lens
     , lsp-types
     , text
@@ -979,8 +979,8 @@ library hls-splice-plugin
     , extra
     , foldl
     , ghc
-    , ghcide                == 2.13.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , ghcide                == 2.14.0.0
+    , hls-plugin-api        == 2.14.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp
@@ -1003,7 +1003,7 @@ test-suite hls-splice-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-splice-plugin
-    , hls-test-utils == 2.13.0.0
+    , hls-test-utils == 2.14.0.0
     , text
 
 -----------------------------
@@ -1030,10 +1030,10 @@ library hls-alternate-number-format-plugin
   build-depends:
     , containers
     , extra
-    , ghcide               == 2.13.0.0
+    , ghcide               == 2.14.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       == 2.13.0.0
+    , hls-plugin-api       == 2.14.0.0
     , lens
     , lsp                  ^>=2.8
     , mtl
@@ -1058,7 +1058,7 @@ test-suite hls-alternate-number-format-plugin-tests
     , containers
     , filepath
     , haskell-language-server:hls-alternate-number-format-plugin
-    , hls-test-utils       == 2.13.0.0
+    , hls-test-utils       == 2.14.0.0
     , regex-tdfa
     , tasty-quickcheck
     , text
@@ -1091,8 +1091,8 @@ library hls-qualify-imported-names-plugin
   build-depends:
     , containers
     , ghc
-    , ghcide                == 2.13.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , ghcide                == 2.14.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lens
     , lsp
     , text
@@ -1114,7 +1114,7 @@ test-suite hls-qualify-imported-names-plugin-tests
     , text
     , filepath
     , haskell-language-server:hls-qualify-imported-names-plugin
-    , hls-test-utils             == 2.13.0.0
+    , hls-test-utils             == 2.14.0.0
 
 -----------------------------
 -- code range plugin
@@ -1145,9 +1145,9 @@ library hls-code-range-plugin
     , deepseq
     , extra
     , ghc
-    , ghcide           == 2.13.0.0
+    , ghcide           == 2.14.0.0
     , hashable
-    , hls-plugin-api   == 2.13.0.0
+    , hls-plugin-api   == 2.14.0.0
     , lens
     , lsp
     , mtl
@@ -1169,7 +1169,7 @@ test-suite hls-code-range-plugin-tests
     , bytestring
     , filepath
     , haskell-language-server:hls-code-range-plugin
-    , hls-test-utils             == 2.13.0.0
+    , hls-test-utils             == 2.14.0.0
     , lens
     , lsp
     , lsp-test
@@ -1197,8 +1197,8 @@ library hls-change-type-signature-plugin
   exposed-modules:  Ide.Plugin.ChangeTypeSignature
   hs-source-dirs:   plugins/hls-change-type-signature-plugin/src
   build-depends:
-    , ghcide           == 2.13.0.0
-    , hls-plugin-api   == 2.13.0.0
+    , ghcide           == 2.14.0.0
+    , hls-plugin-api   == 2.14.0.0
     , lens
     , lsp-types
     , regex-tdfa
@@ -1224,7 +1224,7 @@ test-suite hls-change-type-signature-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-change-type-signature-plugin
-    , hls-test-utils       == 2.13.0.0
+    , hls-test-utils       == 2.14.0.0
     , regex-tdfa
     , text
   default-extensions:
@@ -1257,9 +1257,9 @@ library hls-gadt-plugin
     , containers
     , extra
     , ghc
-    , ghcide                 == 2.13.0.0
+    , ghcide                 == 2.14.0.0
     , ghc-exactprint
-    , hls-plugin-api         == 2.13.0.0
+    , hls-plugin-api         == 2.14.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp                    >=2.8
@@ -1279,7 +1279,7 @@ test-suite hls-gadt-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-gadt-plugin
-    , hls-test-utils              == 2.13.0.0
+    , hls-test-utils              == 2.14.0.0
     , text
 
 -----------------------------
@@ -1306,9 +1306,9 @@ library hls-explicit-fixity-plugin
     , containers
     , deepseq
     , extra
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , hashable
-    , hls-plugin-api        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lsp                   >=2.8
     , text
 
@@ -1324,7 +1324,7 @@ test-suite hls-explicit-fixity-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-explicit-fixity-plugin
-    , hls-test-utils              == 2.13.0.0
+    , hls-test-utils              == 2.14.0.0
     , text
 
 -----------------------------
@@ -1348,8 +1348,8 @@ library hls-explicit-record-fields-plugin
   exposed-modules:  Ide.Plugin.ExplicitFields
   build-depends:
     , ghc
-    , ghcide                == 2.13.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , ghcide                == 2.14.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lsp
     , lens
     , hls-graph
@@ -1375,7 +1375,7 @@ test-suite hls-explicit-record-fields-plugin-tests
     , text
     , ghcide
     , haskell-language-server:hls-explicit-record-fields-plugin
-    , hls-test-utils              == 2.13.0.0
+    , hls-test-utils              == 2.14.0.0
 
 -----------------------------
 -- overloaded record dot plugin
@@ -1421,7 +1421,7 @@ test-suite hls-overloaded-record-dot-plugin-tests
     , filepath
     , text
     , haskell-language-server:hls-overloaded-record-dot-plugin
-    , hls-test-utils              == 2.13.0.0
+    , hls-test-utils              == 2.14.0.0
 
 
 -----------------------------
@@ -1450,8 +1450,8 @@ library hls-fourmolu-plugin
     , filepath
     , fourmolu        ^>= 0.14 || ^>= 0.15 || ^>= 0.16 || ^>=0.17 || ^>=0.18 || ^>=0.19
     , ghc-boot-th
-    , ghcide          == 2.13.0.0
-    , hls-plugin-api  == 2.13.0.0
+    , ghcide          == 2.14.0.0
+    , hls-plugin-api  == 2.14.0.0
     , lens
     , lsp
     , mtl
@@ -1479,7 +1479,7 @@ test-suite hls-fourmolu-plugin-tests
     , filepath
     , haskell-language-server:hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       == 2.13.0.0
+    , hls-test-utils       == 2.14.0.0
     , lens
     , lsp-test
     , lsp-types
@@ -1511,8 +1511,8 @@ library hls-ormolu-plugin
     , extra
     , filepath
     , ghc-boot-th
-    , ghcide          == 2.13.0.0
-    , hls-plugin-api  == 2.13.0.0
+    , ghcide          == 2.14.0.0
+    , hls-plugin-api  == 2.14.0.0
     , lsp
     , mtl
     , process-extras  >= 0.7.1
@@ -1540,7 +1540,7 @@ test-suite hls-ormolu-plugin-tests
     , filepath
     , haskell-language-server:hls-ormolu-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.13.0.0
+    , hls-test-utils     == 2.14.0.0
     , lens
     , lsp-types
     , ormolu
@@ -1573,8 +1573,8 @@ library hls-stylish-haskell-plugin
     , directory
     , filepath
     , ghc-boot-th
-    , ghcide           == 2.13.0.0
-    , hls-plugin-api   == 2.13.0.0
+    , ghcide           == 2.14.0.0
+    , hls-plugin-api   == 2.14.0.0
     , lsp-types
     , mtl
     , stylish-haskell  >=0.12 && <0.16
@@ -1592,7 +1592,7 @@ test-suite hls-stylish-haskell-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-stylish-haskell-plugin
-    , hls-test-utils              == 2.13.0.0
+    , hls-test-utils              == 2.14.0.0
 
 -----------------------------
 -- refactor plugin
@@ -1644,8 +1644,8 @@ library hls-refactor-plugin
     , bytestring
     , ghc-boot
     , regex-tdfa
-    , ghcide                == 2.13.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , ghcide                == 2.14.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lsp
     , text
     , text-rope
@@ -1680,7 +1680,7 @@ test-suite hls-refactor-plugin-tests
     , filepath
     , ghcide:ghcide
     , haskell-language-server:hls-refactor-plugin
-    , hls-test-utils      == 2.13.0.0
+    , hls-test-utils      == 2.14.0.0
     , lens
     , lsp-test
     , lsp-types
@@ -1727,8 +1727,8 @@ library hls-semantic-tokens-plugin
     , text-rope
     , mtl                   >= 2.2
     , ghc
-    , ghcide                == 2.13.0.0
-    , hls-plugin-api        == 2.13.0.0
+    , ghcide                == 2.14.0.0
+    , hls-plugin-api        == 2.14.0.0
     , lens
     , lsp                    >=2.8
     , text
@@ -1737,7 +1737,7 @@ library hls-semantic-tokens-plugin
     , array
     , deepseq
     , dlist
-    , hls-graph == 2.13.0.0
+    , hls-graph == 2.14.0.0
     , template-haskell
     , data-default
     , stm
@@ -1758,10 +1758,10 @@ test-suite hls-semantic-tokens-plugin-tests
     , containers
     , data-default
     , filepath
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , haskell-language-server:hls-semantic-tokens-plugin
-    , hls-plugin-api        == 2.13.0.0
-    , hls-test-utils        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
+    , hls-test-utils        == 2.14.0.0
     , lens
     , lsp
     , lsp-test
@@ -1791,9 +1791,9 @@ library hls-notes-plugin
   hs-source-dirs:     plugins/hls-notes-plugin/src
   build-depends:
     , array
-    , ghcide == 2.13.0.0
-    , hls-graph == 2.13.0.0
-    , hls-plugin-api == 2.13.0.0
+    , ghcide == 2.14.0.0
+    , hls-graph == 2.14.0.0
+    , hls-plugin-api == 2.14.0.0
     , lens
     , lsp >=2.8
     , mtl >= 2.2
@@ -1819,7 +1819,7 @@ test-suite hls-notes-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-notes-plugin
-    , hls-test-utils == 2.13.0.0
+    , hls-test-utils == 2.14.0.0
   default-extensions: OverloadedStrings
 
 ----------------------------
@@ -1878,10 +1878,10 @@ library
     , extra
     , filepath
     , ghc
-    , ghcide                == 2.13.0.0
+    , ghcide                == 2.14.0.0
     , githash               >=0.1.6.1
     , hie-bios
-    , hls-plugin-api        == 2.13.0.0
+    , hls-plugin-api        == 2.14.0.0
     , optparse-applicative
     , optparse-simple
     , prettyprinter         >= 1.7
@@ -1984,7 +1984,7 @@ test-suite func-test
     , ghcide:ghcide
     , hashable
     , hls-plugin-api
-    , hls-test-utils == 2.13.0.0
+    , hls-test-utils == 2.14.0.0
     , lens
     , lsp-test
     , lsp-types
@@ -2026,7 +2026,7 @@ test-suite wrapper-test
 
   build-depends:
     , extra
-    , hls-test-utils              == 2.13.0.0
+    , hls-test-utils              == 2.14.0.0
     , process
 
   hs-source-dirs:     test/wrapper
@@ -2119,7 +2119,7 @@ test-suite ghcide-tests
     , text
     , text-rope
     , unordered-containers
-    , hls-test-utils == 2.13.0.0
+    , hls-test-utils == 2.14.0.0
 
   if impl(ghc <9.3)
     build-depends: ghc-typelits-knownnat

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-graph
-version:            2.13.0.0
+version:            2.14.0.0
 synopsis:           Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       2.13.0.0
+version:       2.14.0.0
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -66,7 +66,7 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             == 2.13.0.0
+    , hls-graph             == 2.14.0.0
     , lens
     , lens-aeson
     , lsp                   ^>=2.8

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       2.13.0.0
+version:       2.14.0.0
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -44,8 +44,8 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  == 2.13.0.0
-    , hls-plugin-api          == 2.13.0.0
+    , ghcide                  == 2.14.0.0
+    , hls-plugin-api          == 2.14.0.0
     , lens
     , lsp
     , lsp-test                ^>=0.18

--- a/stack-lts24.yaml
+++ b/stack-lts24.yaml
@@ -22,7 +22,7 @@ extra-deps:
   - hiedb-0.8.0.0
   - hie-compat-0.3.1.2
   - implicit-hie-0.1.4.0
-  - hie-bios-0.18.0
+  - hie-bios-0.19.0
   - hw-fingertree-0.1.2.1
   - monad-dijkstra-0.1.1.5
   - retrie-1.2.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
   - hiedb-0.8.0.0
   - hie-compat-0.3.1.2
   - implicit-hie-0.1.4.0
-  - hie-bios-0.18.0
+  - hie-bios-0.19.0
   - hw-fingertree-0.1.2.1
   - monad-dijkstra-0.1.1.5
   - retrie-1.2.3


### PR DESCRIPTION
- Fix ChangeLog.md date parsing
- bump hie-bios to 0.19.0.0

- [x] check ghcup supports new GHC releases if any
- [x] check all plugins still work if release includes code changes
- [x] set the supported GHCs in workflow file `.github/generate-ci/gen_ci.hs`
- [x] regenerate the CI via `./.github/generate-ci/generate-jobs`
- [x] bump package versions in all `*.cabal` files (same version as hls)
  - HLS uses lockstep versioning. The core packages and all plugins use the same version number, and only support exactly this version.
    - Exceptions:
      - `shake-bench` is an internal testing tool, not exposed to the outside world. Thus, no version bump required for releases.
  - For updating cabal files, the following script can be used:
    - ```sh
      ./release/update_versions.sh <OLD_VERSION> <NEW_VERSION>
      ```
    - It still requires manual verification and review
- [x] generate and update changelog
  - Generate a ChangeLog via `./GenChangelogs.hs <api-key> <tag>`
    - `<tag>` is the git tag you want to generate the ChangeLog from.
    - `<api-key>` is a github access key: https://github.com/settings/tokens
- [x] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
- [x] create release branch as `wip/<version>`
  - `git switch -c wip/<version>`
- [x] create release tag as `<version>`
  - `git tag <version>`
- [x] trigger release pipeline by pushing the tag
  - this creates a draft release
  - `git push <remote> <version>`
- [x] run `sh scripts/release/download-gh-artifacts.sh <version> <your-gpg-email>`
  - downloads artifacts to `gh-release-artifacts/haskell-language-server-<version>/`
  - also downloads FreeBSD bindist from circle CI
  - adds signatures
- [x] upload artifacts to downloads.haskell.org from `gh-release-artifacts/haskell-language-server-<version>/`
  - You require sftp access, contact wz1000, bgamari or chreekat
  - `cd gh-release-artifacts/haskell-language-server-<version>`
  - `SIGNING_KEY=... ../../release/upload.sh upload`
    - Your SIGNING_KEY can be obtained with `gpg --list-secret-keys --keyid-format=long`
  - Afterwards, the artifacts are available at: `https://downloads.haskell.org/~hls/haskell-language-server-<version>/`
  - Run `SIGNING_KEY=... ../../release/upload.sh purge_all` to remove CDN caches
- [x] create PR to [ghcup-metadata](https://github.com/haskell/ghcup-metadata)
  - [x] update `ghcup-vanilla-0.0.9.yaml`
    - can use `sh scripts/release/create-yaml-snippet.sh <version>` to generate a snippet that can be manually inserted into the yaml files
  - ~~update `hls-metadata-0.0.1.json`~~ Currently unnecessary, GHCup builds its own HLS binaries and updates that file.
    - utilize `cabal run ghcup-gen -- generate-hls-ghcs -f ghcup-0.0.7.yaml --format json --stdout` in the root of ghcup-metadata repository
  - Be sure to mark the correct latest version and add the 'recommended' tag to the latest release.
- [x] get sign-off on release
  - from wz1000, michealpj, maerwald and fendor
- [x] publish release on github
- [x] upload hackage packages
  - requires credentials
- [x] Supported tools table needs to be updated:
  - https://www.haskell.org/ghcup/install/#supported-platforms
  - https://github.com/haskell/ghcup-hs/blob/master/docs/install.md#supported-platforms
  - https://github.com/haskell/ghcup-metadata/blob/44c6e2b5d0fcae15abeffff03e87544edf76dd7a/ghcup-gen/Main.hs#L67
- [x] post release on discourse and reddit
- [x] merge release PR to master or forward port relevant changes
