### PR TITLE
Fix Signature Help inside `do` Notation in GHC >= 9.10

### DIFF
--- a/plugins/hls-signature-help-plugin/src/Ide/Plugin/SignatureHelp.hs
+++ b/plugins/hls-signature-help-plugin/src/Ide/Plugin/SignatureHelp.hs
@@ -4,6 +4,7 @@
 
 module Ide.Plugin.SignatureHelp (descriptor) where
 
+import           Control.Applicative
 import           Control.Arrow                        ((>>>))
 import           Control.Monad.Trans.Except           (ExceptT (ExceptT))
 import           Data.Bifunctor                       (bimap)
@@ -49,6 +50,7 @@ import           GHC.Iface.Ext.Types                  (ContextInfo (Use),
                                                        HieAST (nodeChildren, nodeSpan),
                                                        HieASTs (getAsts),
                                                        IdentifierDetails (identInfo, identType),
+                                                       NodeInfo (nodeIdentifiers),
                                                        nodeType)
 import           GHC.Iface.Ext.Utils                  (smallestContainingSatisfying)
 import           GHC.Types.Name.Env                   (lookupNameEnv)
@@ -295,7 +297,10 @@ getNodeNameAndTypes hieKind hieAst =
         case extractName identifier of
           Nothing -> Nothing
           Just name ->
-            let mTypeOfName = identType identifierDetails
+            let mTypeOfName = identType identifierDetails <|> do
+                                nodeInfo <- generatedNodeInfo hieAst
+                                details <- M.lookup identifier (nodeIdentifiers nodeInfo)
+                                identType details
                 -- types from the source NodeInfo
                 typesOfNode = case sourceNodeInfo hieAst of
                   Nothing       -> []

--- a/plugins/hls-signature-help-plugin/src/Ide/Plugin/SignatureHelp.hs
+++ b/plugins/hls-signature-help-plugin/src/Ide/Plugin/SignatureHelp.hs
@@ -29,6 +29,7 @@ import           Development.IDE.Core.PluginUtils     (runIdeActionE,
 import           Development.IDE.Core.PositionMapping (fromCurrentPosition)
 import           Development.IDE.GHC.Compat           (FastStringCompat, Name,
                                                        RealSrcSpan,
+                                                       generatedNodeInfo,
                                                        getSourceNodeIds,
                                                        isAnnotationInNodeInfo,
                                                        mkRealSrcLoc,
@@ -295,11 +296,19 @@ getNodeNameAndTypes hieKind hieAst =
           Nothing -> Nothing
           Just name ->
             let mTypeOfName = identType identifierDetails
+                -- types from the source NodeInfo
                 typesOfNode = case sourceNodeInfo hieAst of
                   Nothing       -> []
                   Just nodeInfo -> nodeType nodeInfo
+                -- fall back to generated NodeInfo when source has no types
+                typesOfGeneratedNode = case generatedNodeInfo hieAst of
+                  Nothing       -> []
+                  Just nodeInfo -> nodeType nodeInfo
                 allTypes = case mTypeOfName of
-                  Nothing -> typesOfNode
+                  Nothing ->
+                    case typesOfNode of
+                      [] -> typesOfGeneratedNode
+                      ts -> ts
                   -- (the last?) one type of 'typesOfNode' may (always?) be the same as 'typeOfName'
                   -- To avoid generating two identical signature helps, we do a filtering here
                   -- This is similar to 'dropEnd1' in Development.IDE.Spans.AtPoint.atPoint

--- a/plugins/hls-signature-help-plugin/test/Main.hs
+++ b/plugins/hls-signature-help-plugin/test/Main.hs
@@ -391,10 +391,12 @@ main =
             test :: IO ()
             test = do
               x <- pure 1
+                        ^
               print (f x 2)
                        ^ ^
           |]
-          [ Just $ SimilarSignatureHelp $ SignatureHelp [SignatureInformation "f :: Int -> Int -> Int" Nothing (Just [ParameterInformation (InR (5, 8)) Nothing, ParameterInformation (InR (12, 15)) Nothing]) (Just (InL 0))] (Just 0) (Just (InL 0)),
+          [ Just $ SimilarSignatureHelp $ SignatureHelp [SignatureInformation "pure :: forall (f :: Type -> Type) a. Applicative f => a -> f a" (Just $ InR $ MarkupContent MarkupKind_Markdown "Lift a value") (Just [ParameterInformation (InR (55,56)) Nothing]) (Just (InL 0)), SignatureInformation "pure :: Int -> IO Int" (Just $ InR $ MarkupContent MarkupKind_Markdown "Lift a value") (Just [ParameterInformation (InR (8,11)) Nothing]) (Just (InL 0)), SignatureInformation "pure :: forall a. a -> IO a" (Just $ InR $ MarkupContent MarkupKind_Markdown "Lift a value") (Just [ParameterInformation (InR (18,19)) Nothing]) (Just (InL 0))] (Just 0) (Just (InL 0)),
+            Just $ SimilarSignatureHelp $ SignatureHelp [SignatureInformation "f :: Int -> Int -> Int" Nothing (Just [ParameterInformation (InR (5, 8)) Nothing, ParameterInformation (InR (12, 15)) Nothing]) (Just (InL 0))] (Just 0) (Just (InL 0)),
             Just $ SimilarSignatureHelp $ SignatureHelp [SignatureInformation "f :: Int -> Int -> Int" Nothing (Just [ParameterInformation (InR (5, 8)) Nothing, ParameterInformation (InR (12, 15)) Nothing]) (Just (InL 1))] (Just 0) (Just (InL 1))
           ]
       ]

--- a/plugins/hls-signature-help-plugin/test/Main.hs
+++ b/plugins/hls-signature-help-plugin/test/Main.hs
@@ -381,6 +381,21 @@ main =
             Nothing,
             Nothing,
             Just $ SimilarSignatureHelp $ SignatureHelp [SignatureInformation "f :: forall a b c. a -> b -> c" Nothing (Just [ParameterInformation (InR (19, 20)) Nothing, ParameterInformation (InR (24, 25)) Nothing]) (Just (InL 0))] (Just 0) (Just (InL 0))
+          ],
+        -- Prevents https://github.com/haskell/haskell-language-server/issues/4769
+        mkTest
+          "inside do block"
+          [__i|
+            f :: Int -> Int -> Int
+            f = _
+            test :: IO ()
+            test = do
+              x <- pure 1
+              print (f x 2)
+                       ^ ^
+          |]
+          [ Just $ SimilarSignatureHelp $ SignatureHelp [SignatureInformation "f :: Int -> Int -> Int" Nothing (Just [ParameterInformation (InR (5, 8)) Nothing, ParameterInformation (InR (12, 15)) Nothing]) (Just (InL 0))] (Just 0) (Just (InL 0)),
+            Just $ SimilarSignatureHelp $ SignatureHelp [SignatureInformation "f :: Int -> Int -> Int" Nothing (Just [ParameterInformation (InR (5, 8)) Nothing, ParameterInformation (InR (12, 15)) Nothing]) (Just (InL 1))] (Just 0) (Just (InL 1))
           ]
       ]
 


### PR DESCRIPTION
Closes : #4769 

As recommended, Type information of Some nodes were stored in GHC generated nodes. 
This PR keeps the old pipeline and add a Fall back to traverse these generated nodes in case source node lack type information. 

Attached image of signature help in cases where we did not get them before;
<img width="562" height="171" alt="image" src="https://github.com/user-attachments/assets/1ddcbde7-6f9d-43d6-b469-be62f1e2732e" />

Prerequisite : 
- [x] passes all hls-signature-help-plugin tests on GHC 9.12.2 : 

<img width="786" height="101" alt="image" src="https://github.com/user-attachments/assets/dc9a375d-fadb-4852-81f9-fc48c86e9a39" />

<br>
Major Finding credits : @jian-lin 