### PR TITLE
Use pretty printing context when expanding records

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Outputable.hs
@@ -100,8 +100,6 @@ printSDocQualifiedUnsafe unqual doc =
     sty  = mkUserStyle unqual AllTheWay
     doc' = pprWithUnitState emptyUnitState doc
 
-
-
 formatErrorWithQual :: DynFlags -> MsgEnvelope DecoratedSDoc -> String
 formatErrorWithQual dflags e =
   showSDoc dflags (pprNoLocMsgEnvelope e)

--- a/ghcide/src/Development/IDE/GHC/Util.hs
+++ b/ghcide/src/Development/IDE/GHC/Util.hs
@@ -28,6 +28,7 @@ module Development.IDE.GHC.Util(
     disableWarningsAsErrors,
     printOutputable,
     printOutputableOneLine,
+    printOutputableQualified,
     getExtensions,
     getExtensionsSet,
     stripOccNamePrefix,
@@ -270,6 +271,10 @@ printOutputable = printOutputable' printWithoutUniques
 
 printOutputableOneLine :: Outputable a => a -> T.Text
 printOutputableOneLine = printOutputable' printWithoutUniquesOneLine
+
+printOutputableQualified :: Outputable a => PrintUnqualified -> a -> T.Text
+printOutputableQualified ctx =
+    printOutputable' (printSDocQualifiedUnsafe ctx . ppr)
 
 printOutputable' :: Outputable a => (a -> String) -> a -> T.Text
 printOutputable' print =

--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -38,8 +38,8 @@ import           Development.IDE                      (IdeState,
                                                        Recorder (..), Rules,
                                                        WithPriority (..),
                                                        defineNoDiagnostics,
-                                                       getDefinition, hsep,
-                                                       printName,
+                                                       getDefinition, hscEnv,
+                                                       hsep, printName,
                                                        realSrcSpanToRange,
                                                        shakeExtras,
                                                        srcSpanToLocation,
@@ -48,8 +48,7 @@ import           Development.IDE.Core.PluginUtils
 import           Development.IDE.Core.PositionMapping (PositionMapping,
                                                        toCurrentPosition,
                                                        toCurrentRange)
-import           Development.IDE.Core.RuleTypes       (TcModuleResult (..),
-                                                       TypeCheck (..))
+import           Development.IDE.Core.RuleTypes
 import qualified Development.IDE.Core.Shake           as Shake
 import           Development.IDE.GHC.Compat           (FieldLabel (flSelector),
                                                        FieldOcc (FieldOcc),
@@ -71,9 +70,13 @@ import           Development.IDE.GHC.Compat           (FieldLabel (flSelector),
                                                        Var (varName),
                                                        XXExprGhcTc (..),
                                                        conLikeFieldLabels,
-                                                       isGenerated, nameSrcSpan,
+                                                       isGenerated,
+                                                       mkPrintUnqualifiedDefault,
+                                                       nameSrcSpan,
                                                        pprNameUnqualified,
-                                                       recDotDot, unLoc)
+                                                       printSDocQualifiedUnsafe,
+                                                       recDotDot, tcg_rdr_env,
+                                                       unLoc)
 import           Development.IDE.GHC.Compat.Core      (Extension (NamedFieldPuns),
                                                        HsExpr (RecordCon, rcon_flds),
                                                        HsRecField, LHsExpr,
@@ -95,6 +98,8 @@ import           Development.IDE.Spans.Pragmas        (NextPragmaInfo (..),
                                                        insertNewPragma)
 import           GHC.Generics                         (Generic)
 import           GHC.Iface.Ext.Types                  (Identifier)
+import           GHC.Utils.Outputable                 (NamePprCtx,
+                                                       Outputable (..))
 import           Ide.Logger                           (Priority (..),
                                                        cmapWithPrio, logWith,
                                                        (<+>))
@@ -207,12 +212,19 @@ codeActionResolveProvider :: ResolveFunction IdeState Int 'Method_CodeActionReso
 codeActionResolveProvider ideState pId ca uri uid = do
   nfp <- getNormalizedFilePathE uri
   pragma <- getFirstPragma pId ideState nfp
-  CRR {crCodeActionResolve, nameMap, enabledExtensions} <- runActionE "ExplicitFields.CollectRecords" ideState $ useE CollectRecords nfp
+  (CRR {crCodeActionResolve, nameMap, enabledExtensions}, pprCtx) <- runActionE "ExplicitFields.CodeAction" ideState $ do
+    cr <- useE CollectRecords nfp
+    typechecked <- useE TypeCheck nfp
+    hscEnvEq <- useE GhcSession nfp
+    let reader = tcg_rdr_env (tmrTypechecked typechecked)
+        pprCtx = mkPrintUnqualifiedDefault (hscEnv hscEnvEq) reader
+    pure (cr, pprCtx)
+
   -- If we are unable to find the unique id in our IntMap of records, it means
   -- that this resolve is stale.
   record <- handleMaybe PluginStaleResolve $ IntMap.lookup uid crCodeActionResolve
   -- We should never fail to render
-  rendered <- handleMaybe (PluginInternalError "Failed to render") $ renderRecordInfoAsTextEdit nameMap record
+  rendered <- handleMaybe (PluginInternalError "Failed to render") $ renderRecordInfoAsTextEdit nameMap pprCtx record
   let shouldInsertNamedFieldPuns (RecordInfoApp _ _) = False
       shouldInsertNamedFieldPuns _                   = True
       whenMaybe True x  = x
@@ -230,7 +242,11 @@ inlayHintDotdotProvider _ state pId InlayHintParams {_textDocument = TextDocumen
   pragma <- getFirstPragma pId state nfp
   runIdeActionE "ExplicitFields.CollectRecords" (shakeExtras state) $ do
     (crr@CRR {crCodeActions, crCodeActionResolve}, pm) <- useWithStaleFastE CollectRecords nfp
-    let -- Get all records with dotdot in current nfp
+    (typechecked, _) <- useWithStaleFastE TypeCheck nfp
+    (hscEnvEq, _) <- useWithStaleFastE GhcSession nfp
+    let reader = tcg_rdr_env (tmrTypechecked typechecked)
+        pprCtx = mkPrintUnqualifiedDefault (hscEnv hscEnvEq) reader
+        -- Get all records with dotdot in current nfp
         records = [ record
                   | Just range <- [toCurrentRange pm visibleRange]
                   , uid <- RangeMap.elementsInRange range crCodeActions
@@ -240,12 +256,12 @@ inlayHintDotdotProvider _ state pId InlayHintParams {_textDocument = TextDocumen
                     | record <- records
                     , pos <- maybeToList $ fmap _start $ recordInfoToDotDotRange record ]
     defnLocsList <- lift $ sequence locations
-    pure $ InL $ mapMaybe (mkInlayHint crr pragma pm) defnLocsList
+    pure $ InL $ mapMaybe (mkInlayHint crr pragma pprCtx pm) defnLocsList
    where
-     mkInlayHint :: CollectRecordsResult -> NextPragmaInfo -> PositionMapping -> (Maybe [(Location, Identifier)], RecordInfo) -> Maybe InlayHint
-     mkInlayHint CRR {enabledExtensions, nameMap} pragma pm (defnLocs, record) =
+     mkInlayHint :: CollectRecordsResult -> NextPragmaInfo -> NamePprCtx -> PositionMapping -> (Maybe [(Location, Identifier)], RecordInfo) -> Maybe InlayHint
+     mkInlayHint CRR {enabledExtensions, nameMap} pragma pprCtx pm (defnLocs, record) =
        let range = recordInfoToDotDotRange record
-           textEdits = maybeToList (renderRecordInfoAsTextEdit nameMap record)
+           textEdits = maybeToList (renderRecordInfoAsTextEdit nameMap pprCtx record)
                     <> maybeToList (pragmaEdit enabledExtensions pragma)
            names = renderRecordInfoAsDotdotLabelName record
        in do
@@ -280,30 +296,34 @@ inlayHintPosRecProvider _ state _pId InlayHintParams {_textDocument = TextDocume
   nfp <- getNormalizedFilePathE uri
   runIdeActionE "ExplicitFields.CollectRecords" (shakeExtras state) $ do
     (CRR {crCodeActions, nameMap, crCodeActionResolve}, pm) <- useWithStaleFastE CollectRecords nfp
-    let records = [ record
+    (typechecked, _) <- useWithStaleFastE TypeCheck nfp
+    (hscEnvEq, _) <- useWithStaleFastE GhcSession nfp
+    let reader = tcg_rdr_env (tmrTypechecked typechecked)
+        pprCtx = mkPrintUnqualifiedDefault (hscEnv hscEnvEq) reader
+        records = [ record
                   | Just range <- [toCurrentRange pm visibleRange]
                   , uid <- RangeMap.elementsInRange range crCodeActions
                   , Just record <- [IntMap.lookup uid crCodeActionResolve] ]
-    pure $ InL (concatMap (mkInlayHints nameMap pm) records)
+    pure $ InL (concatMap (mkInlayHints nameMap pprCtx pm) records)
    where
-     mkInlayHints :: UniqFM Name [Name] -> PositionMapping -> RecordInfo -> [InlayHint]
-     mkInlayHints nameMap pm record@(RecordInfoApp _ (RecordAppExpr sat _ fla)) =
+     mkInlayHints :: UniqFM Name [Name] -> NamePprCtx -> PositionMapping -> RecordInfo -> [InlayHint]
+     mkInlayHints nameMap pprCtx pm record@(RecordInfoApp _ (RecordAppExpr sat _ fla)) =
        -- Only create inlay hints for fully saturated constructors
        case sat of
-         Saturated -> let textEdits = renderRecordInfoAsTextEdit nameMap record
-                      in mapMaybe (mkInlayHint textEdits pm) fla
+         Saturated -> let textEdits = renderRecordInfoAsTextEdit nameMap pprCtx record
+                      in mapMaybe (mkInlayHint textEdits pprCtx pm) fla
          Unsaturated -> []
-     mkInlayHints _ _ _ = []
+     mkInlayHints _ _ _ _ = []
 
-     mkInlayHint :: Maybe TextEdit -> PositionMapping -> (Located FieldLabel, HsExpr GhcTc) -> Maybe InlayHint
-     mkInlayHint te pm (label, _) =
+     mkInlayHint :: Maybe TextEdit -> NamePprCtx -> PositionMapping -> (Located FieldLabel, HsExpr GhcTc) -> Maybe InlayHint
+     mkInlayHint te pprCtx pm (label, _) =
        let (name, loc) = ((flSelector . unLoc) &&& (srcSpanToLocation . getLoc)) label
            fieldDefLoc = srcSpanToLocation (nameSrcSpan name)
        in do
          (Location _ recRange) <- loc
          currentStart <- toCurrentPosition pm (_start recRange)
          pure InlayHint { _position = currentStart
-                        , _label = InR $ pure (mkInlayHintLabelPart name fieldDefLoc)
+                        , _label = InR $ pure (mkInlayHintLabelPart pprCtx name fieldDefLoc)
                         , _kind = Nothing -- neither a type nor a parameter
                         , _textEdits = Just (maybeToList te) -- same as CodeAction
                         , _tooltip = Just $ InL (mkTitle [] RecordTraditionalSyntaxConversion) -- same as CodeAction
@@ -312,7 +332,7 @@ inlayHintPosRecProvider _ state _pId InlayHintParams {_textDocument = TextDocume
                         , _data_ = Nothing
                         }
 
-     mkInlayHintLabelPart name loc = InlayHintLabelPart (printFieldName (pprNameUnqualified name) <> "=") Nothing loc Nothing
+     mkInlayHintLabelPart pprCtx name loc = InlayHintLabelPart (printFieldName pprCtx (pprNameUnqualified name) <> "=") Nothing loc Nothing
 
 mkTitle :: [Extension] -> RecordConversionType -> Text
 mkTitle exts = \case
@@ -445,10 +465,10 @@ data RecordInfo
   deriving (Generic)
 
 instance Pretty RecordInfo where
-  pretty (RecordInfoPat ss p) = pretty (printFieldName ss) <> ":" <+> pretty (printOutputable p)
-  pretty (RecordInfoCon ss e) = pretty (printFieldName ss) <> ":" <+> pretty (printOutputable e)
-  pretty (RecordInfoApp ss (RecordAppExpr _ _ fla))
-    = pretty (printFieldName ss) <> ":" <+> hsep (map (pretty . printOutputable) fla)
+  pretty (RecordInfoPat _ p) = pretty (printOutputable p)
+  pretty (RecordInfoCon _ e) = pretty (printOutputable e)
+  pretty (RecordInfoApp _ (RecordAppExpr _ _ fla))
+    = hsep (map (pretty . printOutputable) fla)
 
 recordInfoToRange :: RecordInfo -> Range
 recordInfoToRange (RecordInfoPat ss _) = realSrcSpanToRange ss
@@ -460,10 +480,10 @@ recordInfoToDotDotRange (RecordInfoPat _ (ConPat _ _ (RecCon flds))) = srcSpanTo
 recordInfoToDotDotRange (RecordInfoCon _ (RecordCon _ _ flds)) = srcSpanToRange . getLoc =<< rec_dotdot flds
 recordInfoToDotDotRange _ = Nothing
 
-renderRecordInfoAsTextEdit :: UniqFM Name [Name] -> RecordInfo -> Maybe TextEdit
-renderRecordInfoAsTextEdit names (RecordInfoPat ss pat) = TextEdit (realSrcSpanToRange ss) <$> showRecordPat names pat
-renderRecordInfoAsTextEdit _ (RecordInfoCon ss expr) = TextEdit (realSrcSpanToRange ss) <$> showRecordCon expr
-renderRecordInfoAsTextEdit _ (RecordInfoApp ss appExpr) = TextEdit (realSrcSpanToRange ss) <$> showRecordApp appExpr
+renderRecordInfoAsTextEdit :: UniqFM Name [Name] -> NamePprCtx -> RecordInfo -> Maybe TextEdit
+renderRecordInfoAsTextEdit names pprCtx (RecordInfoPat ss pat) = TextEdit (realSrcSpanToRange ss) <$> showRecordPat names pprCtx pat
+renderRecordInfoAsTextEdit _ pprCtx (RecordInfoCon ss expr) = TextEdit (realSrcSpanToRange ss) <$> showRecordCon pprCtx expr
+renderRecordInfoAsTextEdit _ pprCtx (RecordInfoApp ss appExpr) = TextEdit (realSrcSpanToRange ss) <$> showRecordApp pprCtx appExpr
 
 renderRecordInfoAsDotdotLabelName :: RecordInfo -> Maybe [Name]
 renderRecordInfoAsDotdotLabelName (RecordInfoPat _ pat)  = showRecordPatFlds pat
@@ -553,9 +573,8 @@ processRecordFlds flds = flds { rec_dotdot = Nothing , rec_flds = puns' }
     -- explained above).
     puns' = map (mapLoc (\fld -> fld { hfbPun = True })) puns
 
-
-showRecordPat :: Outputable (Pat GhcTc) => UniqFM Name [Name] -> Pat GhcTc -> Maybe Text
-showRecordPat names = fmap printFieldName . mapConPatDetail (\case
+showRecordPat :: Outputable (Pat GhcTc) => UniqFM Name [Name] -> NamePprCtx -> Pat GhcTc -> Maybe Text
+showRecordPat names pprCtx = fmap (printFieldName pprCtx) . mapConPatDetail (\case
   RecCon flds -> Just $ RecCon (preprocessRecordPat names flds)
   _           -> Nothing)
 
@@ -576,11 +595,11 @@ showRecordPatFlds (ConPat _ _ args) = do
     getFieldName = getOccName . unLoc . hfbLHS . unLoc
 showRecordPatFlds _ = Nothing
 
-showRecordCon :: Outputable (HsExpr (GhcPass c)) => HsExpr (GhcPass c) -> Maybe Text
-showRecordCon expr@(RecordCon _ _ flds) =
-  Just $ printOutputable $
+showRecordCon :: Outputable (HsExpr (GhcPass c)) => NamePprCtx -> HsExpr (GhcPass c) -> Maybe Text
+showRecordCon pprCtx expr@(RecordCon _ _ flds) =
+  Just $ formatOutputable pprCtx $
     expr { rcon_flds = preprocessRecordCon flds }
-showRecordCon _ = Nothing
+showRecordCon _ _ = Nothing
 
 showRecordConFlds :: p ~ GhcTc => HsExpr p -> Maybe [Name]
 showRecordConFlds (RecordCon _ _ flds) =
@@ -591,12 +610,15 @@ showRecordConFlds (RecordCon _ _ flds) =
     getFieldName = getVarName . unLoc . hfbRHS . unLoc
 showRecordConFlds _ = Nothing
 
-showRecordApp :: RecordAppExpr -> Maybe Text
-showRecordApp (RecordAppExpr _ recConstr fla)
-  = Just $ printOutputable recConstr <>  " { "
+showRecordApp :: NamePprCtx -> RecordAppExpr -> Maybe Text
+showRecordApp pprCtx (RecordAppExpr _ recConstr fla)
+  = Just $ formatOutputable pprCtx recConstr <>  " { "
          <> T.intercalate ", " (showFieldWithArg <$> fla)
          <> " }"
-  where showFieldWithArg (field, arg) = printFieldName field <> " = " <> printOutputable arg
+  where showFieldWithArg (field, arg) = printFieldName pprCtx field <> " = " <> formatOutputable pprCtx arg
+
+formatOutputable :: Outputable a => NamePprCtx -> a -> Text
+formatOutputable pprCtx a = T.pack $ printSDocQualifiedUnsafe pprCtx (ppr a)
 
 collectRecords :: GenericQ [RecordInfo]
 collectRecords = everythingBut (<>) (([], False) `mkQ` ignoreGenerated `extQ` getRecPatterns `extQ` getRecCons)
@@ -689,6 +711,5 @@ getRecPatterns conPat@(conPatDetails . unLoc -> Just (RecCon flds))
       [ RecordInfoPat realSpan' (unLoc pat) | RealSrcSpan realSpan' _ <- [ getLoc pat ]]
 getRecPatterns _ = ([], False)
 
-printFieldName :: Outputable a => a -> Text
-printFieldName = stripOccNamePrefix . printOutputable
-
+printFieldName :: Outputable a => NamePprCtx -> a -> Text
+printFieldName pprCtx = stripOccNamePrefix . formatOutputable pprCtx

--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -182,7 +182,7 @@ getConversionType = \case
 codeActionProvider :: PluginMethodHandler IdeState 'Method_TextDocumentCodeAction
 codeActionProvider ideState _ (CodeActionParams _ _ docId range _) = do
   nfp <- getNormalizedFilePathE (docId ^. L.uri)
-  CRR {crCodeActions, crCodeActionResolve, enabledExtensions} <- runActionE "ExplicitFields.CollectRecords" ideState $ useE CollectRecords nfp
+  CRR {crCodeActions, crCodeActionResolve, enabledExtensions} <- runActionE "ExplicitFields.CodeAction" ideState $ useE CollectRecords nfp
   -- All we need to build a code action is the list of extensions, and a int to
   -- allow us to resolve it later.
   let recordsWithUid = [ (RecordConversion uid conversionType, record)
@@ -212,7 +212,7 @@ codeActionResolveProvider :: ResolveFunction IdeState Int 'Method_CodeActionReso
 codeActionResolveProvider ideState pId ca uri uid = do
   nfp <- getNormalizedFilePathE uri
   pragma <- getFirstPragma pId ideState nfp
-  (CRR {crCodeActionResolve, nameMap, enabledExtensions}, pprCtx) <- runActionE "ExplicitFields.CodeAction" ideState $ do
+  (CRR {crCodeActionResolve, nameMap, enabledExtensions}, pprCtx) <- runActionE "ExplicitFields.CodeActionResolve" ideState $ do
     cr <- useE CollectRecords nfp
     typechecked <- useE TypeCheck nfp
     hscEnvEq <- useE GhcSession nfp
@@ -240,7 +240,7 @@ inlayHintDotdotProvider :: Recorder (WithPriority Log) -> PluginMethodHandler Id
 inlayHintDotdotProvider _ state pId InlayHintParams {_textDocument = TextDocumentIdentifier uri, _range = visibleRange} = do
   nfp <- getNormalizedFilePathE uri
   pragma <- getFirstPragma pId state nfp
-  runIdeActionE "ExplicitFields.CollectRecords" (shakeExtras state) $ do
+  runIdeActionE "ExplicitFields.InlayHintDotDot" (shakeExtras state) $ do
     (crr@CRR {crCodeActions, crCodeActionResolve}, pm) <- useWithStaleFastE CollectRecords nfp
     (typechecked, _) <- useWithStaleFastE TypeCheck nfp
     (hscEnvEq, _) <- useWithStaleFastE GhcSession nfp
@@ -294,7 +294,7 @@ inlayHintDotdotProvider _ state pId InlayHintParams {_textDocument = TextDocumen
 inlayHintPosRecProvider :: Recorder (WithPriority Log) -> PluginMethodHandler IdeState 'Method_TextDocumentInlayHint
 inlayHintPosRecProvider _ state _pId InlayHintParams {_textDocument = TextDocumentIdentifier uri, _range = visibleRange} = do
   nfp <- getNormalizedFilePathE uri
-  runIdeActionE "ExplicitFields.CollectRecords" (shakeExtras state) $ do
+  runIdeActionE "ExplicitFields.InlayHintPosRec" (shakeExtras state) $ do
     (CRR {crCodeActions, nameMap, crCodeActionResolve}, pm) <- useWithStaleFastE CollectRecords nfp
     (typechecked, _) <- useWithStaleFastE TypeCheck nfp
     (hscEnvEq, _) <- useWithStaleFastE GhcSession nfp
@@ -465,10 +465,12 @@ data RecordInfo
   deriving (Generic)
 
 instance Pretty RecordInfo where
-  pretty (RecordInfoPat _ p) = pretty (printOutputable p)
-  pretty (RecordInfoCon _ e) = pretty (printOutputable e)
-  pretty (RecordInfoApp _ (RecordAppExpr _ _ fla))
-    = hsep (map (pretty . printOutputable) fla)
+  pretty rec = case rec of
+    (RecordInfoPat ss p) -> formatSrcSpan ss <+> pretty (printOutputable p)
+    (RecordInfoCon ss e) -> formatSrcSpan ss <+> pretty (printOutputable e)
+    (RecordInfoApp ss (RecordAppExpr _ _ fla)) -> formatSrcSpan ss <+> hsep (map (pretty . printOutputable) fla)
+   where
+    formatSrcSpan ss = pretty (stripOccNamePrefix (printOutputable ss)) <> ":"
 
 recordInfoToRange :: RecordInfo -> Range
 recordInfoToRange (RecordInfoPat ss _) = realSrcSpanToRange ss

--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -40,6 +40,7 @@ import           Development.IDE                      (IdeState,
                                                        defineNoDiagnostics,
                                                        getDefinition, hscEnv,
                                                        hsep, printName,
+                                                       printOutputableQualified,
                                                        realSrcSpanToRange,
                                                        shakeExtras,
                                                        srcSpanToLocation,
@@ -74,7 +75,6 @@ import           Development.IDE.GHC.Compat           (FieldLabel (flSelector),
                                                        mkPrintUnqualifiedDefault,
                                                        nameSrcSpan,
                                                        pprNameUnqualified,
-                                                       printSDocQualifiedUnsafe,
                                                        recDotDot, tcg_rdr_env,
                                                        unLoc)
 import           Development.IDE.GHC.Compat.Core      (Extension (NamedFieldPuns),
@@ -98,8 +98,7 @@ import           Development.IDE.Spans.Pragmas        (NextPragmaInfo (..),
                                                        insertNewPragma)
 import           GHC.Generics                         (Generic)
 import           GHC.Iface.Ext.Types                  (Identifier)
-import           GHC.Utils.Outputable                 (NamePprCtx,
-                                                       Outputable (..))
+import           GHC.Utils.Outputable                 (NamePprCtx)
 import           Ide.Logger                           (Priority (..),
                                                        cmapWithPrio, logWith,
                                                        (<+>))
@@ -599,7 +598,7 @@ showRecordPatFlds _ = Nothing
 
 showRecordCon :: Outputable (HsExpr (GhcPass c)) => NamePprCtx -> HsExpr (GhcPass c) -> Maybe Text
 showRecordCon pprCtx expr@(RecordCon _ _ flds) =
-  Just $ formatOutputable pprCtx $
+  Just $ printOutputableQualified pprCtx $
     expr { rcon_flds = preprocessRecordCon flds }
 showRecordCon _ _ = Nothing
 
@@ -614,13 +613,10 @@ showRecordConFlds _ = Nothing
 
 showRecordApp :: NamePprCtx -> RecordAppExpr -> Maybe Text
 showRecordApp pprCtx (RecordAppExpr _ recConstr fla)
-  = Just $ formatOutputable pprCtx recConstr <>  " { "
+  = Just $ printOutputableQualified pprCtx recConstr <>  " { "
          <> T.intercalate ", " (showFieldWithArg <$> fla)
          <> " }"
-  where showFieldWithArg (field, arg) = printFieldName pprCtx field <> " = " <> formatOutputable pprCtx arg
-
-formatOutputable :: Outputable a => NamePprCtx -> a -> Text
-formatOutputable pprCtx a = T.pack $ printSDocQualifiedUnsafe pprCtx (ppr a)
+  where showFieldWithArg (field, arg) = printFieldName pprCtx field <> " = " <> printOutputableQualified pprCtx arg
 
 collectRecords :: GenericQ [RecordInfo]
 collectRecords = everythingBut (<>) (([], False) `mkQ` ignoreGenerated `extQ` getRecPatterns `extQ` getRecCons)
@@ -714,4 +710,4 @@ getRecPatterns conPat@(conPatDetails . unLoc -> Just (RecCon flds))
 getRecPatterns _ = ([], False)
 
 printFieldName :: Outputable a => NamePprCtx -> a -> Text
-printFieldName pprCtx = stripOccNamePrefix . formatOutputable pprCtx
+printFieldName pprCtx = stripOccNamePrefix . printOutputableQualified pprCtx

--- a/plugins/hls-explicit-record-fields-plugin/test/Main.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/Main.hs
@@ -38,6 +38,7 @@ test = testGroup "explicit-fields"
     , mkTestNoAction "Prefix" "Prefix" 10 11 10 28
     , mkTestNoAction "PartiallyAppliedCon" "PartiallyAppliedCon" 7 8 7 12
     , mkConversionTest "PolymorphicRecordConstruction" "PolymorphicRecordConstruction" 15 5 15 15
+    , mkConversionTest "QualifiedPositionalConstruction" "QualifiedPositionalConstruction" 9 10 9 15
     , mkConversionTest "CursorAwarePositional" "CursorPositional" 15 26 15 34
     , mkExpansionTest "CursorAwareRecords" "CursorRecords" 9 40 9 40
     ]

--- a/plugins/hls-explicit-record-fields-plugin/test/Main.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/Main.hs
@@ -41,6 +41,7 @@ test = testGroup "explicit-fields"
     , mkConversionTest "QualifiedPositionalConstruction" "QualifiedPositionalConstruction" 9 10 9 15
     , mkConversionTest "CursorAwarePositional" "CursorPositional" 15 26 15 34
     , mkExpansionTest "CursorAwareRecords" "CursorRecords" 9 40 9 40
+    , mkConversionTest "UnicodeStrings" "UnicodeStrings" 10 12 10 17
     ]
   , testGroup "inlay hints"
     [ mkInlayHintsTest "Construction" Nothing 16 $ \ih -> do
@@ -291,6 +292,24 @@ test = testGroup "explicit-fields"
           , defInlayHint { _position = Position 15 15
                          , _label = InR [ baz ]
                          , _textEdits = Just [ mkLineTextEdit "MyRec { foo = a, bar = b, baz = c }" 15 5 16 ]
+                         , _tooltip = Just $ InL "Convert to traditional record syntax"
+                         , _paddingLeft = Nothing
+                         }
+          ]
+    , mkInlayHintsTest "UnicodeStrings" Nothing 10 $ \ih -> do
+        let mkLabelPart' = mkLabelPartOffsetLengthSub1 "UnicodeStrings"
+        name  <- mkLabelPart' 5 4 "αβγa="
+        count <- mkLabelPart' 6 4 "count="
+        (@?=) ih
+          [ defInlayHint { _position = Position 10 18
+                         , _label = InR [ name ]
+                         , _textEdits = Just [ mkLineTextEdit "MyRec { αβγa = \"αβγ\", count = 42 }" 10 12 26 ]
+                         , _tooltip = Just $ InL "Convert to traditional record syntax"
+                         , _paddingLeft = Nothing
+                         }
+          , defInlayHint { _position = Position 10 24
+                         , _label = InR [ count ]
+                         , _textEdits = Just [ mkLineTextEdit "MyRec { αβγa = \"αβγ\", count = 42 }" 10 12 26 ]
                          , _tooltip = Just $ InL "Convert to traditional record syntax"
                          , _paddingLeft = Nothing
                          }

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/QualifiedPositionalConstruction.expected.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/QualifiedPositionalConstruction.expected.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE Haskell2010 #-}
+
+module QualifiedPositionalConstruction where
+
+import qualified Data.Foldable as Foldable
+
+data Foo = Foo { bar :: [Int] }
+
+foo :: Foo
+foo = Foo { bar = (Foldable.toList [1, 2, 3]) }

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/QualifiedPositionalConstruction.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/QualifiedPositionalConstruction.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE Haskell2010 #-}
+
+module QualifiedPositionalConstruction where
+
+import qualified Data.Foldable as Foldable
+
+data Foo = Foo { bar :: [Int] }
+
+foo :: Foo
+foo = Foo (Foldable.toList [1, 2, 3])

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/UnicodeStrings.expected.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/UnicodeStrings.expected.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE Haskell2010 #-}
+
+module UnicodeStrings where
+
+data MyRec = MyRec
+  { αβγa  :: String
+  , count :: Int
+  }
+
+convertMe :: MyRec
+convertMe = MyRec { αβγa = "αβγ", count = 42 }

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/UnicodeStrings.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/UnicodeStrings.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE Haskell2010 #-}
+
+module UnicodeStrings where
+
+data MyRec = MyRec
+  { αβγa  :: String
+  , count :: Int
+  }
+
+convertMe :: MyRec
+convertMe = MyRec "αβγ" 42


### PR DESCRIPTION
Closes #4903.

There were some existing helpers for determining whether to print qualified/unqualified, use those when printing the expanded records. 

An alternate approach would be to get the ranges from the expressions and use those to extract the expressions from the source files. That would have the benefit that record expansions with erroneous expressions would be nicely transplanted, but I think that would also require detaching `CollectRecords` from type checking, so I didn't pursue.