### PR TITLE
Add build-type: Hooks to Cabal completion plugin

### DIFF
--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Data.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Data.hs
@@ -53,7 +53,7 @@ cabalKeywords =
   Map.fromList
     [ ("name:", nameCompleter),
       ("version:", noopCompleter),
-      ("build-type:", constantCompleter ["Simple", "Custom", "Configure", "Make"]),
+      ("build-type:", constantCompleter ["Simple", "Custom", "Configure", "Make", "Hooks"]),
       ("license:", weightedConstantCompleter licenseNames weightedLicenseNames),
       ("license-file:", filePathCompleter),
       ("license-files:", filePathCompleter),


### PR DESCRIPTION
As it says on the tin.