### PR TITLE
ghcide-2.14 requires extra >= 1.8

### DIFF
--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -63,7 +63,7 @@ library
     , edit-distance
     , enummapset
     , exceptions
-    , extra                        >=1.7.14
+    , extra                        >=1.8
     , filepath
     , fingertree
     , focus                        >=1.0.3.2


### PR DESCRIPTION
Due to using `guardedA`, which was introduced in extra-1.8.

----

I think a hackage revision would be good too to avoid, with extra-1.7:

```
[51 of 82] Compiling Development.IDE.Session ( session-loader/Development/IDE/Session.hs, dist/build/Development/IDE/Session.o, dist/build/Development/IDE/Session.dyn_o )

session-loader/Development/IDE/Session.hs:707:6: error: [GHC-88464]
    Variable not in scope:
      guardedA
        :: ((a0, DependencyInfo) -> IO Bool)
           -> (IdeResult HscEnvEq, DependencyInfo)
           -> IO (Maybe (IdeResult HscEnvEq, DependencyInfo))
    |
707 |     (guardedA (checkDependencyInfo . snd))
    |      ^^^^^^^^
```