### PR TITLE
Fix accidentally deleting the installed GHC in CI

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -128,17 +128,24 @@ runs:
       run: rm -f cabal.project.freeze
       shell: bash
 
-    # Make sure to clear all unneeded `ghcup`` caches.
+    # Make sure to clear all unneeded `ghcup` caches.
     # At some point, we were running out of disk space, see issue
     # https://github.com/haskell/haskell-language-server/issues/4386 for details.
     #
     # Using "printf" debugging (`du -sh *` and `df -h /`) and binary searching,
     # we figured out that `ghcup` caches are taking up a sizable portion of the
     # disk space.
-    # Thus, we remove anything we don't need, especially caches and temporary files.
-    # For got measure, we also make sure no other tooling versions are
+    #
+    # Thus, we remove anything we don't need, especially caches and temporary
+    # files. For good measure, we also make sure no other tooling versions are
     # installed besides the ones we explicitly want.
     - name: "Remove ghcup caches"
       if: runner.os == 'Linux'
-      run: ghcup gc --ghc-old --share-dir --hls-no-ghc --cache --tmpdirs --unset
+      # haskell-actions/setup installs the GHC but does not `ghcup set` it, so
+      # ghcup considers the active compiler "unset". Mark it set first, otherwise
+      # `--ghc-old --unset` garbage-collects the active GHC and the following
+      # cabal steps fail with "ghc could not be found".
+      run: |
+        ghcup set ghc "$(ghc --numeric-version)"
+        ghcup gc --ghc-old --share-dir --hls-no-ghc --cache --tmpdirs --unset
       shell: bash


### PR DESCRIPTION
CI currently fails on the linux setups, when GCing caches it accidentally uninstalled the active GHC version. 