### PR TITLE
use knownBuildTypes to populate completion targets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,12 +83,7 @@
             ] ++ lib.optionals (!stdenv.isDarwin)
                    [ # tracy has a build problem on macos.
                      tracy
-                   ]
-              ++ lib.optionals stdenv.isDarwin
-              (with darwin.apple_sdk.frameworks; [
-                Cocoa
-                CoreServices
-              ]);
+                   ];
 
           shellHook = ''
             # @guibou: I'm not sure theses lines are needed

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Data.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Data.hs
@@ -9,6 +9,7 @@ import           Development.IDE.GHC.Compat.Core                (flagsForComplet
 import           Distribution.CabalSpecVersion                  (CabalSpecVersion (CabalSpecV2_2),
                                                                  showCabalSpecVersion)
 import           Distribution.Pretty                            (prettyShow)
+import           Distribution.Types.BuildType                   (knownBuildTypes)
 import           Ide.Plugin.Cabal.Completion.Completer.FilePath
 import           Ide.Plugin.Cabal.Completion.Completer.Module
 import           Ide.Plugin.Cabal.Completion.Completer.Paths
@@ -53,7 +54,7 @@ cabalKeywords =
   Map.fromList
     [ ("name:", nameCompleter),
       ("version:", noopCompleter),
-      ("build-type:", constantCompleter ["Simple", "Custom", "Configure", "Make", "Hooks"]),
+      ("build-type:", constantCompleter (fmap (T.pack . show) knownBuildTypes)),
       ("license:", weightedConstantCompleter licenseNames weightedLicenseNames),
       ("license-file:", filePathCompleter),
       ("license-files:", filePathCompleter),


### PR DESCRIPTION
closes #4921

Instead of hard coding the `BuildType` [constructors](https://hackage-content.haskell.org/package/Cabal-syntax-3.16.1.0/docs/Distribution-Types-BuildType.html#t:BuildType), simply `show` the `knownBuildTypes` which enumerates them.

Didn't add a `Pretty` instance because that would add an orphan instance, and I would've implemented it using `viaShow`.

The flake changes were needed to enter the dev shell (legacy sdk pattern). See [docs](https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks).