### PR TITLE
Use defaultTestRunner in ghcide-test

### DIFF
--- a/ghcide-test/exe/Main.hs
+++ b/ghcide-test/exe/Main.hs
@@ -33,6 +33,7 @@ module Main (main) where
 import qualified HieDbRetry
 import           Test.Tasty
 import           Test.Tasty.Ingredients.Rerun
+import           Test.Hls (defaultTestRunner)
 
 import           AsyncTests
 import           BootTests
@@ -71,7 +72,7 @@ import           WatchedFileTests
 main :: IO ()
 main = do
   -- We mess with env vars so run single-threaded.
-  defaultMainWithRerun $ testGroup "ghcide"
+  defaultTestRunner $ testGroup "ghcide"
     [ OpenCloseTest.tests
     , InitializeResponseTests.tests
     , CompletionTests.tests


### PR DESCRIPTION
We found with @fendor that this test does not support flags like `--lsp-timeout`.