### PR TITLE
Add ghcide-test for hover on Visible Type Applications

### DIFF
--- a/ghcide-test/data/hover/GotoHover.hs
+++ b/ghcide-test/data/hover/GotoHover.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings, TemplateHaskell, TypeApplications #-}
 {- HLINT ignore -}
 module GotoHover ( module GotoHover) where
 import Data.Text (Text, pack)
@@ -68,3 +68,5 @@ hole2 = _
 -- A comment above a type defnition with a deriving clause
 data Example = Example
   deriving (Eq)
+
+typeApplication = mapM_ @[] @IO @Float print [1, 2, 3]

--- a/ghcide-test/exe/FindDefinitionAndHoverTests.hs
+++ b/ghcide-test/exe/FindDefinitionAndHoverTests.hs
@@ -190,7 +190,8 @@ tests = let
   cmtL68 = Position 67  0  ;  lackOfdEq = [ExpectHoverExcludeText ["$dEq"]]
   import310 = Position 3 10; pkgTxt = [ExpectHoverText ["Data.Text\n\ntext-"]]
   typeAppMap = Position 71 22; typeAppMapTxt = [ExpectHoverText ["mapM_ :: (Float ->"]]
-  typeAppAt = Position 71 32; typeAppAtTxt = [ExpectHoverText ["_ :: (Float"]]
+  typeAppAt2 = Position 71 28; typeAppAt2Txt = [ExpectHoverText ["-> IO ()"]]
+  typeAppAt3 = Position 71 32; typeAppAt3Txt = [ExpectHoverText ["_ :: (Float"]]
   in
   mkFindTests
   --      def    hover  look       expect
@@ -246,7 +247,8 @@ tests = let
   , test  no             yes               bbbL16     bbbType       "hover shows 'Go to' link for data constructor's type"
   , test  no             yes               aaaL11     aaaType       "hover shows 'Go to' link for binding's underlying type"
   , test  yes            yes               typeAppMap typeAppMapTxt "Type application function hover"
-  , test  yes            yes               typeAppAt  typeAppAtTxt  "Type application signature hover"
+  , test  yes            yes               typeAppAt2 typeAppAt2Txt "Type application signature hover (@IO)"
+  , test  yes            yes               typeAppAt3 typeAppAt3Txt "Type application signature hover (@Float)"
   ]
   where yes :: (TestTree -> Maybe TestTree)
         yes = Just -- test should run and pass

--- a/ghcide-test/exe/FindDefinitionAndHoverTests.hs
+++ b/ghcide-test/exe/FindDefinitionAndHoverTests.hs
@@ -189,6 +189,8 @@ tests = let
   thLocL57 = Position 59 10 ; thLoc = [ExpectHoverText ["Identity"]]
   cmtL68 = Position 67  0  ;  lackOfdEq = [ExpectHoverExcludeText ["$dEq"]]
   import310 = Position 3 10; pkgTxt = [ExpectHoverText ["Data.Text\n\ntext-"]]
+  typeAppMap = Position 71 22; typeAppMapTxt = [ExpectHoverText ["mapM_ :: (Float ->"]]
+  typeAppAt = Position 71 32; typeAppAtTxt = [ExpectHoverText ["_ :: (Float"]]
   in
   mkFindTests
   --      def    hover  look       expect
@@ -235,14 +237,16 @@ tests = let
   , testM yes            yes               imported   importedSig   "Imported symbol"
   , if isWindows then
         -- Flaky on Windows: https://github.com/haskell/haskell-language-server/issues/2997
-        testM no     yes    reexported reexportedSig "Imported symbol reexported"
+        testM no         yes               reexported reexportedSig "Imported symbol reexported"
     else
-        testM yes    yes    reexported reexportedSig "Imported symbol reexported"
-  , test  no     yes       thLocL57   thLoc         "TH Splice Hover"
-  , test yes yes import310 pkgTxt "show package name and its version"
+        testM yes        yes               reexported reexportedSig "Imported symbol reexported"
+  , test  no             yes               thLocL57   thLoc         "TH Splice Hover"
+  , test  yes            yes               import310  pkgTxt        "show package name and its version"
   , test  no             yes               kkkL30     kkkType       "hover shows 'Go to' link for class in constraint"
   , test  no             yes               bbbL16     bbbType       "hover shows 'Go to' link for data constructor's type"
   , test  no             yes               aaaL11     aaaType       "hover shows 'Go to' link for binding's underlying type"
+  , test  yes            yes               typeAppMap typeAppMapTxt "Type application function hover"
+  , test  yes            yes               typeAppAt  typeAppAtTxt  "Type application signature hover"
   ]
   where yes :: (TestTree -> Maybe TestTree)
         yes = Just -- test should run and pass


### PR DESCRIPTION
* Add a test case for #4017

```
ghcide
  get
    definition
      Type application function hover:           OK (0.54s)
      Type application signature hover (@IO):    OK (0.34s)
      Type application signature hover (@Float): OK (0.35s)
    hover
      Type application function hover:           FAIL (0.38s)
        ghcide-test/exe/Hover.hs:13:
        failed to find: `mapM_ :: (Float ->` in hover message:

        '''haskell
        mapM_ :: forall (t :: Type -> Type) (m :: Type -> Type) a b. (Foldable t, Monad m) => (a -> m b) -> t a -> m ()
        '''

        *Defined in 'GHC.Internal.Data.Foldable'* *(ghc-internal-9.1401.0)*



        Map each element of a structure to a monadic action, evaluate
         these actions from left to right, and ignore the results.  For a
         version that doesn't ignore the results see
          'Data.Traversable.mapM' .

        'mapM_'  is just like  'traverse_' , but specialised to monadic actions.

        [Documentation](https://hackage.haskell.org/package/ghc-internal-9.1401.0/docs/GHC-Internal-Data-Foldable.html#v:mapM_)

        [Source](https://hackage.haskell.org/package/ghc-internal-9.1401.0/docs/src/GHC.Internal.Data.Foldable.html#mapM_)



        Use -p '/Type application/&&/hover.Type application function hover/' to rerun this test only.
      Type application signature hover (@IO):    FAIL (0.41s)
        ghcide-test/exe/Hover.hs:13:
        failed to find: `-> IO ()` in hover message:

        Use -p '/Type application/&&/hover.Type application signature hover (@IO)/' to rerun this test only.
      Type application signature hover (@Float): OK (0.35s)
```