### PR TITLE
Add support for extra LSP options

### DIFF
--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -111,6 +111,7 @@ import           Ide.Types                                (IdeCommand (IdeComman
                                                            PluginDescriptor (PluginDescriptor, pluginCli),
                                                            PluginId (PluginId),
                                                            ipMap, pluginId)
+import qualified Language.LSP.Protocol.Types              as LSP
 import qualified Language.LSP.Server                      as LSP
 import           Numeric.Natural                          (Natural)
 import           Options.Applicative                      hiding (action)
@@ -300,7 +301,29 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
     let hlsPlugin = asGhcIdePlugin (cmapWithPrio LogPluginHLS recorder) argsHlsPlugins
         hlsCommands = allLspCmdIds' pid argsHlsPlugins
         plugins = hlsPlugin <> argsGhcidePlugin
-        options = argsLspOptions { LSP.optExecuteCommandCommands = LSP.optExecuteCommandCommands argsLspOptions <> Just hlsCommands }
+        options =
+          argsLspOptions
+            { LSP.optExecuteCommandCommands = LSP.optExecuteCommandCommands argsLspOptions <> Just hlsCommands
+            , LSP.optWorkspaceWillRenameFileOperationRegistrationOptions = fileModificationOptions
+            , LSP.optWorkspaceDidRenameFileOperationRegistrationOptions = fileModificationOptions
+            , LSP.optWorkspaceWillDeleteFileOperationRegistrationOptions = fileModificationOptions
+            , LSP.optWorkspaceDidDeleteFileOperationRegistrationOptions = fileModificationOptions
+            , LSP.optWorkspaceWillCreateFileOperationRegistrationOptions = fileModificationOptions
+            , LSP.optWorkspaceDidCreateFileOperationRegistrationOptions = fileModificationOptions
+            }
+        fileModificationOptions =
+          Just $
+            LSP.FileOperationRegistrationOptions
+              [ LSP.FileOperationFilter
+                  { _scheme = Just "file"
+                  , _pattern =
+                      LSP.FileOperationPattern
+                        { _glob = "**/*.hs"
+                        , _matches = Just LSP.FileOperationPatternKind_File
+                        , _options = Nothing
+                        }
+                  }
+              ]
         argsParseConfig = getConfigFromNotification argsHlsPlugins
         rules = do
             argsRules

--- a/hls-plugin-api/src/Ide/Types.hs
+++ b/hls-plugin-api/src/Ide/Types.hs
@@ -625,6 +625,9 @@ instance PluginMethod Request Method_WorkspaceExecuteCommand where
 instance PluginMethod Request (Method_CustomMethod m) where
   handlesRequest _ _ _ _ _ = HandlesRequest
 
+instance PluginMethod Request Method_WorkspaceWillRenameFiles where
+  handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
+
 -- Plugin Notifications
 
 instance PluginMethod Notification Method_TextDocumentDidOpen where
@@ -645,6 +648,15 @@ instance PluginMethod Notification Method_WorkspaceDidChangeWorkspaceFolders whe
 
 instance PluginMethod Notification Method_WorkspaceDidChangeConfiguration where
   -- This method has no URI parameter, thus no call to 'pluginResponsible'.
+  handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
+
+instance PluginMethod Notification Method_WorkspaceDidDeleteFiles where
+  handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
+
+instance PluginMethod Notification Method_WorkspaceDidRenameFiles where
+  handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
+
+instance PluginMethod Notification Method_WorkspaceDidCreateFiles where
   handlesRequest _ _ _ desc conf = pluginEnabledGlobally desc conf
 
 instance PluginMethod Notification Method_Initialized where
@@ -856,6 +868,8 @@ instance PluginRequestMethod Method_TextDocumentSemanticTokensFullDelta where
 instance PluginRequestMethod Method_TextDocumentInlayHint where
   combineResponses _ _ _ _ x = sconcat x
 
+instance PluginRequestMethod Method_WorkspaceWillRenameFiles where
+
 takeLefts :: [a |? b] -> [a]
 takeLefts = mapMaybe (\x -> [res | (InL res) <- Just x])
 
@@ -926,6 +940,12 @@ instance PluginNotificationMethod Method_WorkspaceDidChangeWorkspaceFolders wher
 instance PluginNotificationMethod Method_WorkspaceDidChangeConfiguration where
 
 instance PluginNotificationMethod Method_Initialized where
+
+instance PluginNotificationMethod Method_WorkspaceDidDeleteFiles where
+
+instance PluginNotificationMethod Method_WorkspaceDidCreateFiles where
+
+instance PluginNotificationMethod Method_WorkspaceDidRenameFiles where
 
 -- ---------------------------------------------------------------------
 
@@ -1257,6 +1277,9 @@ instance HasTracing CompletionItem
 instance HasTracing DocumentLink
 instance HasTracing InlayHint
 instance HasTracing WorkspaceSymbol
+instance HasTracing RenameFilesParams
+instance HasTracing DeleteFilesParams
+instance HasTracing CreateFilesParams
 -- ---------------------------------------------------------------------
 --Experimental resolve refactoring
 {-# NOINLINE pROCESS_ID #-}


### PR DESCRIPTION
Add support for new LSP file modification options that plugins
can register for.

This is part of solving issue #4951.

These options are:
* SMethod_WorkspaceDidRenameFiles,
* SMethod_WorkspaceWillRenameFiles,
* SMethod_WorkspaceDidDeleteFiles,
* SMethod_WorkspaceWillDeleteFiles,
* SMethod_WorkspaceDidCreateFiles