### PR TITLE
Remove unused test-logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ stack*.yaml.lock
 shake.yaml.lock
 
 .vscode
-/test-logs/*.log
 
 # ignore hie.yaml's for testdata
 test/testdata/**/hie.yaml

--- a/test-logs/README.md
+++ b/test-logs/README.md
@@ -1,1 +1,0 @@
-## When the tests run, the logs get put here.


### PR DESCRIPTION
Noticed this directory and couldn't find any references to it. Inspecting logs can be done using [environment variables](https://github.com/haskell/haskell-language-server/blob/master/hls-test-utils/src/Test/Hls/TestEnv.hs).