### PR TITLE
Remove `LD_LIBRARY_PATH` override in nix `devShell`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,6 @@
 
           shellHook = ''
             # @guibou: I'm not sure theses lines are needed
-            export LD_LIBRARY_PATH=${gmp}/lib:${zlib}/lib:${ncurses}/lib:${capstone}/lib
             export DYLD_LIBRARY_PATH=${gmp}/lib:${zlib}/lib:${ncurses}/lib:${capstone}/lib
             export PATH=$PATH:$HOME/.local/bin
 


### PR DESCRIPTION
I get glibc mismatch errors (`version 'GLIBC_2.42' not found`) errors with this override between the nix provided shared libraries and what my host system expects. I don't run nixos. These shared libraries are included in `buildInputs`, so should already be available to nix-provided binaries.

I didn't touch `DYLD_LIBRARY_PATH` as I don't run a mac, and I can't evaluate.