### PR TITLE
Extend delete-unused-bindings to let-expression bindings

### DIFF
--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -30,6 +30,7 @@ import           Data.Char
 import qualified Data.DList                                        as DL
 import           Data.Function
 import           Data.Functor
+import qualified Data.Generics                                     as SYB
 import qualified Data.HashMap.Strict                               as Map
 import qualified Data.HashSet                                      as Set
 import           Data.List.Extra
@@ -662,7 +663,7 @@ suggestDeleteUnusedBinding
               in Just (mkSrcSpan startLoc' endLoc', False)
       findRelatedSigSpan1 _ _ = Nothing
 
-      -- for where clause
+      -- for where and let expression bindings
       findRelatedSpanForMatch
         :: PositionIndexedString
         -> String
@@ -671,7 +672,7 @@ suggestDeleteUnusedBinding
       findRelatedSpanForMatch
         indexedContent
         name
-        (L _ Match{m_grhss=GRHSs{grhssLocalBinds}}) = do
+        (L _ Match{m_grhss=GRHSs{grhssLocalBinds, grhssGRHSs}}) = do
         let emptyBag bag =
 #if MIN_VERSION_ghc(9,11,0)
                 null bag
@@ -682,9 +683,17 @@ suggestDeleteUnusedBinding
                   if emptyBag bag
                   then []
                   else concatMap (findRelatedSpanForHsBind indexedContent name lsigs) bag
-        case grhssLocalBinds of
-          (HsValBinds _ (ValBinds _ bag lsigs)) -> go bag lsigs
-          _                                     -> []
+
+            findLetBinds :: SYB.GenericQ [HsLocalBinds GhcPs]
+            findLetBinds = SYB.everything (++) ([] `SYB.mkQ` letBinds)
+              where
+                letBinds = \case
+                    HsLet _ lb _ -> [lb]
+                    _            -> []
+
+        flip concatMap (grhssLocalBinds : findLetBinds grhssGRHSs) $ \case
+                (HsValBinds _ (ValBinds _ bag lsigs)) -> go bag lsigs
+                _                                     -> []
 
       findRelatedSpanForHsBind
         :: PositionIndexedString

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -684,14 +684,14 @@ suggestDeleteUnusedBinding
                   then []
                   else concatMap (findRelatedSpanForHsBind indexedContent name lsigs) bag
 
-            findLetBinds :: SYB.GenericQ [HsLocalBinds GhcPs]
-            findLetBinds = SYB.everything (++) ([] `SYB.mkQ` letBinds)
+            findLetBinds :: SYB.GenericQ (DL.DList (HsLocalBinds GhcPs))
+            findLetBinds = SYB.everything mappend (mempty `SYB.mkQ` letBinds)
               where
                 letBinds = \case
-                    HsLet _ lb _ -> [lb]
-                    _            -> []
+                    HsLet _ lb _ -> pure lb
+                    _            -> mempty
 
-        flip concatMap (grhssLocalBinds : findLetBinds grhssGRHSs) $ \case
+        flip concatMap (grhssLocalBinds : DL.toList (findLetBinds grhssGRHSs)) $ \case
                 (HsValBinds _ (ValBinds _ bag lsigs)) -> go bag lsigs
                 _                                     -> []
 

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -687,8 +687,13 @@ suggestDeleteUnusedBinding
             findLetBinds :: SYB.GenericQ (DL.DList (HsLocalBinds GhcPs))
             findLetBinds = SYB.everything mappend (mempty `SYB.mkQ` letBinds)
               where
+                letBinds :: HsExpr GhcPs -> DL.DList (HsLocalBinds GhcPs)
                 letBinds = \case
+#if !MIN_VERSION_ghc(9,9,0)
+                    HsLet _ _ lb _ _ -> pure lb
+#else
                     HsLet _ lb _ -> pure lb
+#endif
                     _            -> mempty
 
         flip concatMap (grhssLocalBinds : DL.toList (findLetBinds grhssGRHSs)) $ \case

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -2647,6 +2647,33 @@ deleteUnusedDefinitionTests = testGroup "delete unused definition action"
       , ""
       , "some = ()"
       , "  where"
+      ],
+  testSession "delete unused local let expr bindings" $
+    testFor
+      [ "{-# OPTIONS_GHC -Wunused-binds #-}"
+      , "module A (a, b, c) where"
+      , ""
+      , "a = let b = 1 in 2"
+      , ""
+      , "b = let c = 1"
+      , "        d = 1"
+      , "    in let e = 2 in d"
+      , ""
+      , "c = if (let a = 2 in True) then 1 else 1"
+      ]
+      (3, 8)
+      4
+      "Delete all unused bindings"
+      [ "{-# OPTIONS_GHC -Wunused-binds #-}"
+      , "module A (a, b, c) where"
+      , ""
+      , "a = let in 2"
+      , ""
+      , "b = let"
+      , "        d = 1"
+      , "    in let in d"
+      , ""
+      , "c = if (let in True) then 1 else 1"
       ]
   ]
   where


### PR DESCRIPTION
This is an extension to the code action that deletes all unused bindings. It will now also delete all unused local let expression bindings.