### PR TITLE
Fix running `cabal test all` as a local workflow

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,9 @@
             gmp zlib ncurses
             # for compatibility of curl with provided gcc
             curl
+            # for running plugin tests
+            pkgs.haskellPackages.cabal-fmt
+            pkgs.haskellPackages.cabal-gild
             # Changelog tooling
             (gen-hls-changelogs hpkgs)
             # For the documentation

--- a/ghcide-bench/src/Experiments.hs
+++ b/ghcide-bench/src/Experiments.hs
@@ -396,7 +396,7 @@ examplesPath :: FilePath
 examplesPath = "bench/example"
 
 defConfig :: Config
-Success defConfig = execParserPure defaultPrefs (info configP fullDesc) []
+Success defConfig = execParserPure defaultPrefs (info configP fullDesc) ["--example-name", "examples"]
 
 quiet, verbose :: Config -> Bool
 verbose = (== All) . verbosity

--- a/hls-plugin-api/test/Ide/PluginUtilsTest.hs
+++ b/hls-plugin-api/test/Ide/PluginUtilsTest.hs
@@ -155,7 +155,7 @@ prop_rangemapListEq r xs =
 
 
 gitDiff :: FilePath -> FilePath -> [String]
-gitDiff fRef fNew = ["git", "-c", "core.fileMode=false", "diff", "-w", "--no-index", "--text", "--exit-code", fRef, fNew]
+gitDiff fRef fNew = ["git", "-c", "core.fileMode=false", "diff", "--no-ext-diff", "-w", "--no-index", "--text", "--exit-code", fRef, fNew]
 
 goldenGitDiff :: TestName -> FilePath -> IO ByteString -> TestTree
 goldenGitDiff name = goldenVsStringDiff name gitDiff


### PR DESCRIPTION
Some small fixes while trying to run `cabal test all` locally.
- Include cabal-fmt and cabal-gild in the nix devshell so the plugin tests can run. 
- Running ghcide-bench-tests failed because of a missing required flag.
- Pass `--no-ext-diff` when utilizing git diff, for the the golden tests.