### PR TITLE
Support symbolic record fields when converting to record syntax

### DIFF
--- a/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
+++ b/plugins/hls-explicit-record-fields-plugin/src/Ide/Plugin/ExplicitFields.hs
@@ -71,9 +71,9 @@ import           Development.IDE.GHC.Compat           (FieldLabel (flSelector),
                                                        Var (varName),
                                                        XXExprGhcTc (..),
                                                        conLikeFieldLabels,
-                                                       isGenerated,
+                                                       isGenerated, isSymOcc,
                                                        mkPrintUnqualifiedDefault,
-                                                       nameSrcSpan,
+                                                       nameOccName, nameSrcSpan,
                                                        pprNameUnqualified,
                                                        recDotDot, tcg_rdr_env,
                                                        unLoc)
@@ -331,7 +331,9 @@ inlayHintPosRecProvider _ state _pId InlayHintParams {_textDocument = TextDocume
                         , _data_ = Nothing
                         }
 
-     mkInlayHintLabelPart pprCtx name loc = InlayHintLabelPart (printFieldName pprCtx (pprNameUnqualified name) <> "=") Nothing loc Nothing
+     mkInlayHintLabelPart pprCtx name loc = InlayHintLabelPart (wrappedIfSymOcc rendered name <> "=") Nothing loc Nothing
+       where
+         rendered = printFieldName pprCtx (pprNameUnqualified name)
 
 mkTitle :: [Extension] -> RecordConversionType -> Text
 mkTitle exts = \case
@@ -616,7 +618,9 @@ showRecordApp pprCtx (RecordAppExpr _ recConstr fla)
   = Just $ printOutputableQualified pprCtx recConstr <>  " { "
          <> T.intercalate ", " (showFieldWithArg <$> fla)
          <> " }"
-  where showFieldWithArg (field, arg) = printFieldName pprCtx field <> " = " <> printOutputableQualified pprCtx arg
+  where
+    showFieldWithArg (flSelector . unLoc -> name, arg) =
+          wrappedIfSymOcc (printFieldName pprCtx (pprNameUnqualified name)) name <> " = " <> printOutputableQualified pprCtx arg
 
 collectRecords :: GenericQ [RecordInfo]
 collectRecords = everythingBut (<>) (([], False) `mkQ` ignoreGenerated `extQ` getRecPatterns `extQ` getRecCons)
@@ -711,3 +715,7 @@ getRecPatterns _ = ([], False)
 
 printFieldName :: Outputable a => NamePprCtx -> a -> Text
 printFieldName pprCtx = stripOccNamePrefix . printOutputableQualified pprCtx
+
+wrappedIfSymOcc :: Text -> Name -> Text
+wrappedIfSymOcc rendered name | isSymOcc (nameOccName name) = "(" <> rendered <> ")"
+                              | otherwise                   = rendered

--- a/plugins/hls-explicit-record-fields-plugin/test/Main.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/Main.hs
@@ -29,7 +29,7 @@ test = testGroup "explicit-fields"
     , mkExpansionTest "WithExplicitBind" "WithExplicitBind" 12 10 12 32
     , mkExpansionTest "Mixed" "Mixed" 14 10 14 37
     , mkExpansionTest "Construction" "Construction" 16 5 16 15
-    , mkConversionTest "PositionalConstruction" "PositionalConstruction" 15 5 15 15
+    , mkConversionTest "PositionalConstruction" "PositionalConstruction" 17 5 17 15
     , mkExpansionTest "HsExpanded1" "HsExpanded1" 17 10 17 20
     , mkExpansionTest "HsExpanded2" "HsExpanded2" 23 10 23 22
     , mkTestNoAction "ExplicitBinds" "ExplicitBinds" 11 10 11 52
@@ -79,27 +79,34 @@ test = testGroup "explicit-fields"
                         , _paddingLeft = Just True
                         }]
 
-    , mkInlayHintsTest "PositionalConstruction" Nothing 15 $ \ih -> do
+    , mkInlayHintsTest "PositionalConstruction" Nothing 17 $ \ih -> do
         let mkLabelPart' = mkLabelPartOffsetLengthSub1 "PositionalConstruction"
         foo <- mkLabelPart' 5 4 "foo="
         bar <- mkLabelPart' 6 4 "bar="
         baz <- mkLabelPart' 7 4 "baz="
+        sym <- mkLabelPart' 8 4 "(><)="
         (@?=) ih
-          [ defInlayHint { _position = Position 15 11
+          [ defInlayHint { _position = Position 17 11
                          , _label = InR [ foo ]
-                         , _textEdits = Just [ mkLineTextEdit "MyRec { foo = a, bar = b, baz = c }" 15 5 16 ]
+                         , _textEdits = Just [ mkLineTextEdit "MyRec { foo = a, bar = b, baz = c, (><) = d }" 17 5 18 ]
                          , _tooltip = Just $ InL "Convert to traditional record syntax"
                          , _paddingLeft = Nothing
                          }
-          , defInlayHint { _position = Position 15 13
+          , defInlayHint { _position = Position 17 13
                          , _label = InR [ bar ]
-                         , _textEdits = Just [ mkLineTextEdit "MyRec { foo = a, bar = b, baz = c }" 15 5 16 ]
+                         , _textEdits = Just [ mkLineTextEdit "MyRec { foo = a, bar = b, baz = c, (><) = d }" 17 5 18 ]
                          , _tooltip = Just $ InL "Convert to traditional record syntax"
                          , _paddingLeft = Nothing
                          }
-          , defInlayHint { _position = Position 15 15
+          , defInlayHint { _position = Position 17 15
                          , _label = InR [ baz ]
-                         , _textEdits = Just [ mkLineTextEdit "MyRec { foo = a, bar = b, baz = c }" 15 5 16 ]
+                         , _textEdits = Just [ mkLineTextEdit "MyRec { foo = a, bar = b, baz = c, (><) = d }" 17 5 18 ]
+                         , _tooltip = Just $ InL "Convert to traditional record syntax"
+                         , _paddingLeft = Nothing
+                         }
+          , defInlayHint { _position = Position 17 17
+                         , _label = InR [ sym ]
+                         , _textEdits = Just [ mkLineTextEdit "MyRec { foo = a, bar = b, baz = c, (><) = d }" 17 5 18 ]
                          , _tooltip = Just $ InL "Convert to traditional record syntax"
                          , _paddingLeft = Nothing
                          }

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/PositionalConstruction.expected.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/PositionalConstruction.expected.hs
@@ -6,6 +6,7 @@ data MyRec = MyRec
   { foo :: Int
   , bar :: Int
   , baz :: Char
+  , (><) :: Int
   }
 
 convertMe :: () -> MyRec
@@ -13,4 +14,5 @@ convertMe _ =
   let a = 3
       b = 5
       c = 'a'
-  in MyRec { foo = a, bar = b, baz = c }
+      d = 8
+  in MyRec { foo = a, bar = b, baz = c, (><) = d }

--- a/plugins/hls-explicit-record-fields-plugin/test/testdata/PositionalConstruction.hs
+++ b/plugins/hls-explicit-record-fields-plugin/test/testdata/PositionalConstruction.hs
@@ -6,6 +6,7 @@ data MyRec = MyRec
   { foo :: Int
   , bar :: Int
   , baz :: Char
+  , (><) :: Int
   }
 
 convertMe :: () -> MyRec
@@ -13,4 +14,5 @@ convertMe _ =
   let a = 3
       b = 5
       c = 'a'
-  in MyRec a b c
+      d = 8
+  in MyRec a b c d


### PR DESCRIPTION
Closes #4975 

If the field name consists of symbolic characters, add surrounding parentheses before rendering inlay hint or field with argument when converting to record syntax.

Extended relevant test case to feature a record field made up of symbolic characters.