### PR TITLE
Remove CI workaround for ghcup GH runner issue

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -23,14 +23,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Workaround runner image issue
-      if: runner.os == 'Linux'
-      # https://github.com/actions/runner-images/issues/7061
-      run: |
-        sudo mkdir -p /usr/local/.ghcup
-        sudo chown -R $USER /usr/local/.ghcup
-      shell: bash
-
     - uses: haskell-actions/setup@v2.11
       id: HaskEnvSetup
       with:


### PR DESCRIPTION
Closes: https://github.com/haskell/haskell-language-server/issues/3484

[Original issue](https://github.com/actions/runner-images/issues/7061) was resolved some time ago. 