### PR TITLE
Remove @santiweight from CODEOWNERS for hls-refactor-plugin

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,7 +32,7 @@
 /plugins/hls-overloaded-record-dot-plugin @joyfulmantis
 /plugins/hls-pragmas-plugin @eddiemundo
 /plugins/hls-qualify-imported-names-plugin @eddiemundo
-/plugins/hls-refactor-plugin @santiweight
+/plugins/hls-refactor-plugin
 /plugins/hls-rename-plugin
 /plugins/hls-semantic-tokens-plugin @soulomoon
 /plugins/hls-signature-help-plugin @jian-lin


### PR DESCRIPTION
Heya guys - been too many years since i reviewed code and i'm now mostly not in the haskell community. I could be swayed to just reviewing hlr-refactor-plugin code, but would need to lose notifications for other PRs, as the emails are too noisy and i can't keep track.

let me know what i can do here.