### PR TITLE
Add `Unexport ...` to `hls-export-plugin`

### DIFF
--- a/plugins/hls-export-plugin/README.md
+++ b/plugins/hls-export-plugin/README.md
@@ -3,6 +3,7 @@
 The export plugin provides code actions for working with a module's export list. It provides code actions for:
 
 - Export `...`: on top-level declaration symbols.
+- Unexport `...`: on exported top-level declaration symbols.
 
 Actions are only offered when the module has an explicit export list.
 

--- a/plugins/hls-export-plugin/src/Ide/Plugin/Export.hs
+++ b/plugins/hls-export-plugin/src/Ide/Plugin/Export.hs
@@ -2,6 +2,7 @@
 
 module Ide.Plugin.Export (descriptor) where
 
+import           Control.Applicative              ((<|>))
 import           Control.Concurrent.STM           (atomically)
 import           Control.Lens
 import           Control.Monad.IO.Class           (liftIO)
@@ -59,6 +60,7 @@ quickCodeActionHandlers state _plId (CodeActionParams _ _ doc range _) = do
         [ ca
         | Just (verb, title, edits) <-
             [ addAction msrc under ps
+            , removeAction msrc under ps
             ]
         , let fixes = [ d | d <- unusedDiags, locateUnderCursor (d ^. L.range . L.start) ps == Just under ]
               ca = mkAction (verb <> " `" <> title <> "`")
@@ -86,4 +88,15 @@ addAction msrc under ps = case under of
     | otherwise ->
         ("Export", T.pack (printRdrName t) <> "(" <> T.pack (printRdrName c) <> ")",)
           <$> addConstructorExport msrc t c ps
+  Header -> Nothing
+
+removeAction :: Maybe Rope -> UnderCursor -> ParsedSource -> Maybe (Text, Text, [TextEdit])
+removeAction msrc under ps = case under of
+  Decl _ n -> ("Unexport", T.pack (printRdrName n),) <$> removeExport msrc ps n
+  -- A bare uppercase entry denotes the type, so when the constructor shares the
+  -- type's name, skip the standalone-removal fallback.
+  Constructor t c ->
+    ("Unexport", T.pack (printRdrName c),) <$>
+      (removeConstructorExport msrc t c ps
+        <|> if rdrNameFS c == rdrNameFS t then Nothing else removeExport msrc ps c)
   Header -> Nothing

--- a/plugins/hls-export-plugin/src/Ide/Plugin/Export/ExactPrint.hs
+++ b/plugins/hls-export-plugin/src/Ide/Plugin/Export/ExactPrint.hs
@@ -7,7 +7,9 @@ module Ide.Plugin.Export.ExactPrint
   ( LExportList
   , mkExportIE
   , appendIE
+  , removeMatchingIE
   , addCtorUnderParent
+  , removeCtorUnderParent
   , printExportList
   , printIE
   , freshCtorEntry
@@ -15,6 +17,7 @@ module Ide.Plugin.Export.ExactPrint
 
 import           Control.Lens                              (_last, over)
 import           Data.Bifunctor                            (first)
+import           Data.List                                 (mapAccumL)
 import           Data.List.NonEmpty                        (NonEmpty (..))
 import           Data.Text                                 (Text)
 import qualified Data.Text                                 as T
@@ -40,6 +43,7 @@ import           GHC                                       (DeltaPos (..),
 
 import           Language.Haskell.GHC.ExactPrint           (addComma,
                                                             exactPrint,
+                                                            getEntryDP,
                                                             setEntryDP)
 
 #if MIN_VERSION_ghc(9,11,0)
@@ -222,6 +226,26 @@ separatorComma :: [LIE GhcPs] -> Maybe TrailingAnn
 separatorComma items =
   listToMaybe [c | L ann _ <- items, c <- trailingAnns ann, isCommaAnn c]
 
+-- | Drop the first element matching @p@. A removed head hands its entry delta
+-- to the next element so the list keeps its start, and the new last element
+-- loses its separator comma.
+-- - @Nothing@ if nothing matches
+-- - @Just []@ if the sole element was removed.
+removeListItem
+  :: (LocatedAn AnnListItem a -> Bool)
+  -> [LocatedAn AnnListItem a]
+  -> Maybe [LocatedAn AnnListItem a]
+removeListItem p items = case break p items of
+  (_, [])               -> Nothing
+  (pre, removed : post) ->
+    let survivors = case (pre, post) of
+          ([], next : rest) -> setEntryDP next (getEntryDP removed) : rest
+          _                 -> pre ++ post
+     in Just (over _last (first removeTrailingCommaAnn) survivors)
+
+removeMatchingIE :: (IE GhcPs -> Bool) -> LExportList -> Maybe LExportList
+removeMatchingIE p (L l items) = L l <$> removeListItem (p . unLoc) items
+
 -- | 'Nothing' iff @ctor@ is already exported (via @T(..)@ or @T(...,ctor,...)@).
 addCtorUnderParent ::
   -- | parent
@@ -250,12 +274,48 @@ addCtorChildren ctor = overThingWithChildren $ \cs ->
       newChild = setEntryDP (mkIEName ctor) (SameLine (if hasSibling then 1 else 0))
    in (if hasSibling then map (first ensureTrailingComma) cs else cs) ++ [newChild]
 
+-- | Remove @ctor@ from the export entries listing it under @parent@, or
+-- 'Nothing' if none does. Removing the last child downgrades @T(ctor)@ to @T@.
+removeCtorUnderParent ::
+  -- | parent
+  RdrName ->
+  -- | ctor
+  RdrName ->
+  LExportList ->
+  Maybe LExportList
+removeCtorUnderParent parent ctor (L l items)
+  | edited    = Just (L l items')
+  | otherwise = Nothing
+  where
+    (edited, items') = mapAccumL dropCtor False items
+    parentFS = rdrNameFS parent
+    ctorFS = rdrNameFS ctor
+    isCtor = (== ctorFS) . lieWrappedNameFS
+
+    dropCtor changed item@(L itemLoc ie)
+      | parentNameIs parentFS ie
+      , Just children <- ieThingWithChildren ie
+      , Just kept <- removeListItem isCtor children
+      = (True, L itemLoc (rebuild ie kept))
+      | otherwise = (changed, item)
+
+    -- An empty child list means ctor was the only child, so collapse T(ctor)
+    -- to a bare T.
+    rebuild ie []   = downgradeToAbs ie
+    rebuild ie kept = overThingWithChildren (const kept) ie
+
+    -- Reuse the head so type/operator wrapping survives, e.g. `type (:<)(C)`
+    -- becomes `type (:<)`.
+    downgradeToAbs ie = case ieThingWithHead ie of
+      Just n  -> unLoc (mkTypeAbsIE' (setEntryDP n (SameLine 0)))
+      Nothing -> ie
+
 printExportList :: LExportList -> Text
 printExportList l = T.pack (exactPrint (setEntryDP l (SameLine 0)))
 
--- | Exactprint a single item, without the surrounding list layout. The
--- trailing separator comma counts as layout: dropping it keeps a spliced item
--- from carrying a stray comma into text that already supplies its own.
+-- | Exactprint a single item, without the surrounding list layout. Dropping
+-- the trailing comma keeps a spliced item from carrying it into text that
+-- already supplies its own.
 printIE :: LIE GhcPs -> Text
 printIE item = T.pack (exactPrint (setEntryDP (first removeTrailingCommaAnn item) (SameLine 0)))
 

--- a/plugins/hls-export-plugin/src/Ide/Plugin/Export/Exports.hs
+++ b/plugins/hls-export-plugin/src/Ide/Plugin/Export/Exports.hs
@@ -3,6 +3,8 @@ module Ide.Plugin.Export.Exports
   , isExported
   , addExport
   , addConstructorExport
+  , removeExport
+  , removeConstructorExport
   ) where
 
 import           Data.Maybe                         (isJust)
@@ -56,11 +58,27 @@ addConstructorExport msrc parent ctor ps =
     (\txt -> [insertAfterOpen full txt]) <$> freshCtorEntry parent ctor (unLoc exports)
 
 -- | Splice @itemTxt@ in right after the opening paren with a trailing comma,
--- @( <itemTxt>, <existing> )@. Valid in every CPP branch: a first item needs no
--- leading separator and a trailing comma is always legal.
+-- @( <itemTxt>, <existing> )@.
 insertAfterOpen :: Range -> Text -> TextEdit
 insertAfterOpen (Range (Position sl sc) _) itemTxt =
   TextEdit (Range pos pos) (" " <> itemTxt <> ",")
   where
     -- `sc` is the column of `(`, so insert just past it.
     pos = Position sl (sc + 1)
+
+-- | Reprinting would drop the directives the parser stripped, so unexport is
+-- declined when the export list holds a directive.
+removeExport :: Maybe Rope -> ParsedSource -> RdrName -> Maybe [TextEdit]
+removeExport msrc ps name =
+  withExportList msrc ps (removeMatchingIE matches) declineUnderCpp
+  where
+    matches = parentNameIs (rdrNameFS name)
+
+removeConstructorExport :: Maybe Rope -> RdrName -> RdrName -> ParsedSource -> Maybe [TextEdit]
+removeConstructorExport msrc parent ctor ps =
+  withExportList msrc ps (removeCtorUnderParent parent ctor) declineUnderCpp
+
+-- | An 'onCpp' handler that declines: the edit has no safe surgical form, so it
+-- is offered only when the list reprints cleanly.
+declineUnderCpp :: Range -> LExportList -> Maybe [TextEdit]
+declineUnderCpp _ _ = Nothing

--- a/plugins/hls-export-plugin/src/Ide/Plugin/Export/Utils.hs
+++ b/plugins/hls-export-plugin/src/Ide/Plugin/Export/Utils.hs
@@ -35,6 +35,15 @@ ieThingWithChildren (IEThingWith _ _ _ cs)   = Just cs
 #endif
 ieThingWithChildren _                        = Nothing
 
+-- | The head name of an @IEThingWith@, e.g. @T@ in @T(C1, C2)@.
+ieThingWithHead :: IE GhcPs -> Maybe (LIEWrappedName GhcPs)
+#if MIN_VERSION_ghc(9,9,0)
+ieThingWithHead (IEThingWith _ n _ _ _) = Just n
+#else
+ieThingWithHead (IEThingWith _ n _ _)   = Just n
+#endif
+ieThingWithHead _                       = Nothing
+
 ieWrappedRdrName :: IEWrappedName GhcPs -> RdrName
 ieWrappedRdrName = \case
   IEName _ (L _ rdr)    -> rdr

--- a/plugins/hls-export-plugin/test/Main.hs
+++ b/plugins/hls-export-plugin/test/Main.hs
@@ -37,18 +37,31 @@ runExportWith extra hsFile act =
             waitForKickDone
             act doc
 
-executeExportAction :: TextDocumentIdentifier -> Range -> Session ()
-executeExportAction doc range = do
-    actions <- rights . map toEither <$> getCodeActions doc range
-    case filter (\ca -> "Export `" `T.isPrefixOf` (ca ^. L.title)) actions of
-        (ca:_) -> executeCodeAction ca
-        []     -> liftIO $ assertFailure "Export `...` action not offered"
+codeActionTitles :: TextDocumentIdentifier -> Range -> Session [T.Text]
+codeActionTitles doc range =
+    sort . map (^. L.title) . rights . map toEither
+        <$> getCodeActions doc range
 
-noExportOffered :: TextDocumentIdentifier -> Range -> Session ()
-noExportOffered doc range = do
-    titles <- sort . map (^. L.title) . rights . map toEither <$> getCodeActions doc range
-    liftIO $ not (any ("Export `" `T.isPrefixOf`) titles)
-        @? ("Did not expect an Export action; saw: " <> show titles)
+executeByPrefix :: T.Text -> TextDocumentIdentifier -> Range -> Session ()
+executeByPrefix prefix doc range = do
+    actions <- rights . map toEither <$> getCodeActions doc range
+    case filter (\ca -> prefix `T.isPrefixOf` (ca ^. L.title)) actions of
+        (ca:_) -> executeCodeAction ca
+        []     -> liftIO $ assertFailure (T.unpack prefix <> "...` action not offered")
+
+executeExportAction, executeRemoveAction :: TextDocumentIdentifier -> Range -> Session ()
+executeExportAction = executeByPrefix "Export `"
+executeRemoveAction = executeByPrefix "Unexport `"
+
+noActionWithPrefix :: T.Text -> TextDocumentIdentifier -> Range -> Session ()
+noActionWithPrefix prefix doc range = do
+    titles <- codeActionTitles doc range
+    liftIO $ not (any (prefix `T.isPrefixOf`) titles)
+        @? ("Did not expect " <> T.unpack prefix <> " action, saw: " <> show titles)
+
+noExportOffered, noRemoveOffered :: TextDocumentIdentifier -> Range -> Session ()
+noExportOffered = noActionWithPrefix "Export `"
+noRemoveOffered = noActionWithPrefix "Unexport `"
 
 -- | Fail unless some variant is an infix of the text. The message dumps it.
 assertAnyInfix :: T.Text -> [T.Text] -> Assertion
@@ -93,14 +106,17 @@ wellFormedExportList txt = not (any (`T.isInfixOf` compact) ["(,", ",,"])
   where
     compact = T.filter (not . isSpace) (T.unlines (exportListRegion txt))
 
--- | Run the export action, assert the result is well-formed, return its text.
-exportAndCheck :: TextDocumentIdentifier -> Range -> Session T.Text
-exportAndCheck doc pos = do
-    executeExportAction doc pos
+-- | Run an action at the position, check the export list is well formed, return the new text.
+runAndCheck :: (TextDocumentIdentifier -> Range -> Session ()) -> TextDocumentIdentifier -> Range -> Session T.Text
+runAndCheck act doc pos = do
+    act doc pos
     txt <- documentContents doc
     liftIO $ wellFormedExportList txt
         @? ("malformed export list, got:\n" <> T.unpack txt)
     pure txt
+
+exportAndCheck :: TextDocumentIdentifier -> Range -> Session T.Text
+exportAndCheck = runAndCheck executeExportAction
 
 -- | Crudely re-run CPP for the macro EXAMPLE_FLAG over already-edited text,
 -- keeping the branch the given definedness selects. Single level, just enough
@@ -138,24 +154,38 @@ assertFlaggedBlockKept :: T.Text -> T.Text -> Assertion
 assertFlaggedBlockKept name txt =
     assertContainsAll txt flagBlock >> assertExportedUnconditionally name txt
 
--- | Export the binding at the position and assert the result contains one of
--- the @expected@ variants.
-addCase :: TestName -> FilePath -> UInt -> UInt -> [T.Text] -> TestTree
-addCase name file l c expected = testCase name $ runExport file $ \doc -> do
-    executeExportAction doc (rangeAt l c)
+-- | Run @exec@ at the position, assert the resulting export list is well-formed,
+-- then assert the document contains one of the @expected@ variants.
+execCase :: (TextDocumentIdentifier -> Range -> Session ())
+         -> TestName -> FilePath -> UInt -> UInt -> [T.Text] -> TestTree
+execCase exec name file l c expected = testCase name $ runExport file $ \doc -> do
+    _ <- runAndCheck exec doc (rangeAt l c)
     containsAfter doc expected
 
--- | Assert no export action is offered at the position.
-noCase :: TestName -> FilePath -> UInt -> UInt -> TestTree
-noCase name file l c = testCase name $ runExport file $ \doc ->
-    noExportOffered doc (rangeAt l c)
+addCase, removeCase :: TestName -> FilePath -> UInt -> UInt -> [T.Text] -> TestTree
+addCase    = execCase executeExportAction
+removeCase = execCase executeRemoveAction
 
--- | Export the binding at the position, assert the list is well-formed, then
--- run @check@ over the resulting document text.
-exportCase :: TestName -> FilePath -> UInt -> UInt -> (T.Text -> Assertion) -> TestTree
-exportCase name file l c check = testCase name $ runExport file $ \doc -> do
-    txt <- exportAndCheck doc (rangeAt l c)
+-- | Assert the export or unexport action is not offered at the position.
+absentCase :: (TextDocumentIdentifier -> Range -> Session ())
+           -> TestName -> FilePath -> UInt -> UInt -> TestTree
+absentCase absent name file l c = testCase name $ runExport file $ \doc ->
+    absent doc (rangeAt l c)
+
+noCase, noRemoveCase :: TestName -> FilePath -> UInt -> UInt -> TestTree
+noCase       = absentCase noExportOffered
+noRemoveCase = absentCase noRemoveOffered
+
+-- | Run @act@ at the position, assert the list is well-formed, then run @check@
+-- over the resulting document text.
+checkCase :: (TextDocumentIdentifier -> Range -> Session T.Text)
+          -> TestName -> FilePath -> UInt -> UInt -> (T.Text -> Assertion) -> TestTree
+checkCase act name file l c check = testCase name $ runExport file $ \doc -> do
+    txt <- act doc (rangeAt l c)
     liftIO (check txt)
+
+exportCase :: TestName -> FilePath -> UInt -> UInt -> (T.Text -> Assertion) -> TestTree
+exportCase = checkCase exportAndCheck
 
 main :: IO ()
 main = defaultTestRunner $ testGroup "Export"
@@ -317,5 +347,108 @@ main = defaultTestRunner $ testGroup "Export"
                             @? "Export action should carry the unused-binding diagnostic"
                 []     -> liftIO $ assertFailure $
                             "Export `unused` not offered; saw: " <> show (map (^. L.title) actions)
+        ]
+
+    , testGroup "Remove: value bindings"
+        [ removeCase "remove first value (foo)" "RemoveExport.hs" 3 0
+            ["module RemoveExport (Bar, Baz (Baz1))"]
+
+        , noRemoveCase "no remove action when value not in export list" "AddExport.hs" 6 0  -- `bar` not exported
+
+        , removeCase "unexporting the sole export empties the list to ()" "SoleExport.hs" 3 0  -- on `only`, the only export
+            ["module SoleExport () where"]
+
+        , removeCase "remove first item of a multi-line list keeps own-line layout" "RemoveFirstMultiline.hs" 6 0  -- on `foo`, the first export
+            ["( bar\n  , baz\n  ) where"]
+
+        , testCase "remove first item drops its comment, keeps the others'" $ runExport "RemoveItemComment.hs" $ \doc -> do
+            executeRemoveAction doc (rangeAt 6 0)  -- on `foo`, the first export
+            txt <- documentContents doc
+            liftIO $ do
+                assertContainsAll txt ["bar -- the bar", "baz -- the baz"]
+                not ("the foo" `T.isInfixOf` txt) @? ("foo's comment survived:\n" <> T.unpack txt)
+
+        , testCase "remove middle item drops its comment, keeps the others'" $ runExport "RemoveItemComment.hs" $ \doc -> do
+            executeRemoveAction doc (rangeAt 9 0)  -- on `bar`, the middle export
+            txt <- documentContents doc
+            liftIO $ do
+                assertContainsAll txt ["foo -- the foo", "baz -- the baz"]
+                not ("the bar" `T.isInfixOf` txt) @? ("bar's comment survived:\n" <> T.unpack txt)
+        ]
+
+    , testGroup "Remove: type declarations"
+        [ removeCase "remove bare type (middle item)" "RemoveExport.hs" 5 5  -- on `Bar`
+            ["module RemoveExport (foo, Baz (Baz1))"]
+        , removeCase "remove IEThingWith type removes whole entry" "RemoveCtor.hs" 2 5  -- on `Foo` type
+            ["module RemoveCtor (Bar (..), Baz1)"]
+        , removeCase "remove IEThingAll type removes whole entry" "RemoveCtor.hs" 3 5  -- on `Bar` type with (..)
+            ["module RemoveCtor (Foo (Foo1, Foo2), Baz1)"]
+        ]
+
+    , testGroup "Remove: constructors"
+        [ removeCase "remove sole constructor downgrades to bare type" "RemoveExport.hs" 6 11  -- on `Baz1` in Baz(Baz1)
+            ["module RemoveExport (foo, Bar, Baz)"]
+        , removeCase "remove first constructor of T(C1, C2) yields T (C2)" "RemoveCtor.hs" 2 11  -- on `Foo1` in Foo(Foo1, Foo2)
+            ["Foo (Foo2)", "Foo(Foo2)"]
+        , removeCase "remove second constructor of T(C1, C2) yields T (C1)" "RemoveCtor.hs" 2 18  -- on `Foo2` in Foo(Foo1, Foo2)
+            ["Foo (Foo1)", "Foo(Foo1)"]
+        , removeCase "remove standalone-exported constructor" "RemoveCtor.hs" 4 11  -- on `Baz1` standalone
+            ["module RemoveCtor (Foo (Foo1, Foo2), Bar (..))"]
+        , noRemoveCase "constructor under IEThingAll suppresses remove action" "RemoveCtor.hs" 3 11  -- on `Bar1`, only Bar(..) in list
+        , noRemoveCase "constructor not in export list suppresses remove action" "RemoveCtor.hs" 2 25  -- on `Foo3`, not in any entry
+
+        -- `data Bar = Bar`: unexporting the constructor leaves the abstract type
+        -- exported, so unexport must skip the standalone-removal fallback.
+        , noRemoveCase "constructor sharing its type's name does not unexport the type" "RemoveCtorNameClash.hs" 5 11  -- on the constructor `Bar`
+
+        , removeCase "unexporting the type still works when a constructor shares its name" "RemoveCtorNameClash.hs" 5 5  -- on the type `Bar`
+            ["module RemoveCtorNameClash (foo)"]
+        , removeCase "downgrading an operator type keeps the type keyword" "RemoveCtorOp.hs" 4 15  -- on `Op`, the sole constructor of (:+:)
+            ["(type (:+:)) where", "(type (:+:) ) where"]
+
+        , testCase "removing a child preserves the survivors' multiline layout" $ runExport "RemoveCtorMultiline.hs" $ \doc -> do
+            executeRemoveAction doc (rangeAt 8 18)  -- on `Foo2` in the data decl, the middle child
+            txt <- documentContents doc
+            let region = exportListRegion txt
+            liftIO $ do
+                -- Survivors keep their layout: head not flushed to `(`, Foo3 on its own line.
+                assertContainsAll txt ["( Foo1\n", "        , Foo3\n"]
+                not (any ("Foo2" `T.isInfixOf`) region) @? ("Foo2 still exported:\n" <> T.unpack txt)
+
+        , testCase "removing a middle child keeps the surviving siblings' comments" $ runExport "RemoveCtorComment.hs" $ \doc -> do
+            executeRemoveAction doc (rangeAt 8 18)  -- on `Foo2` in the data decl
+            txt <- documentContents doc
+            liftIO $ do
+                assertContainsAll txt ["Foo1 -- first", "Foo3 -- third"]
+                -- The removed child takes its own trailing comment with it.
+                not ("second" `T.isInfixOf` txt) @? ("Foo2's comment lingered:\n" <> T.unpack txt)
+
+        , testCase "removing the head child keeps the new head's own comment" $ runExport "RemoveCtorComment.hs" $ \doc -> do
+            executeRemoveAction doc (rangeAt 8 11)  -- on `Foo1` in the data decl
+            txt <- documentContents doc
+            liftIO $ do
+                -- Foo2 slides into Foo1's slot keeping its own `-- second`,
+                -- and Foo1's `-- first` is deleted along with Foo1.
+                assertContainsAll txt ["Foo2 -- second", "Foo3 -- third"]
+                not ("first" `T.isInfixOf` txt) @? ("Foo1's comment survived:\n" <> T.unpack txt)
+        ]
+
+    , testGroup "Remove: type classes"
+        [ removeCase "remove class exported as T(..)" "RemoveClass.hs" 2 6  -- on `Foo`
+            ["module RemoveClass (Bar, Baz (baz1))"]
+        , removeCase "remove class exported as bare T" "RemoveClass.hs" 5 6  -- on `Bar`
+            ["module RemoveClass (Foo (..), Baz (baz1))"]
+        , removeCase "remove class exported as T(method)" "RemoveClass.hs" 8 6  -- on `Baz`
+            ["module RemoveClass (Foo (..), Bar)"]
+        , noRemoveCase "no remove action when class not in export list" "RemoveClass.hs" 12 6  -- on `Qux`, not exported
+        , noRemoveCase "no remove action on class method" "RemoveClass.hs" 9 2  -- on `baz1` inside `class Baz a where`
+        ]
+
+    , testGroup "Remove: negative cases"
+        [ noRemoveCase "no remove action on implicit module" "Implicit.hs" 3 0
+        , noRemoveCase "no remove action when cursor on RHS" "RemoveExport.hs" 3 6  -- on the `1` of `foo = 1`
+        -- A reprint would erase the directives the parser stripped, so removal is
+        -- declined whenever the export list holds a CPP directive.
+        , noRemoveCase "no remove action under a CPP export list" "CppExportTail.hs" 9 0  -- on `foo`, exported beside an #ifdef block
         ]
     ]

--- a/plugins/hls-export-plugin/test/Main.hs
+++ b/plugins/hls-export-plugin/test/Main.hs
@@ -189,152 +189,154 @@ exportCase = checkCase exportAndCheck
 
 main :: IO ()
 main = defaultTestRunner $ testGroup "Export"
-    [ testGroup "Add: value bindings"
-        [ addCase "add value to export list" "AddExport.hs" 6 0
-            ["module AddExport (foo, Bar, bar)"]
-        , noCase "no action when value already exported" "AddExport.hs" 3 0  -- on `foo`
-        , addCase "append follows a multi-line leading-comma list" "AddExportMultiline.hs" 11 0  -- on `baz`
-            ["  , baz\n  ) where"]
-        ]
+    [ testGroup "Add"
+        [ testGroup "value bindings"
+            [ addCase "add value to export list" "AddExport.hs" 6 0
+                ["module AddExport (foo, Bar, bar)"]
+            , noCase "no action when value already exported" "AddExport.hs" 3 0  -- on `foo`
+            , addCase "append follows a multi-line leading-comma list" "AddExportMultiline.hs" 11 0  -- on `baz`
+                ["  , baz\n  ) where"]
+            ]
 
-    , testGroup "Add: type declarations"
-        [ addCase "add bare type as T(..)" "AddExport.hs" 9 5  -- on `Baz` type name
-            ["Baz(..)", "Baz (..)"]
-        ]
+        , testGroup "type declarations"
+            [ addCase "add bare type as T(..)" "AddExport.hs" 9 5  -- on `Baz` type name
+                ["Baz(..)", "Baz (..)"]
+            ]
 
-    , testGroup "Add: constructors"
-        [ addCase "constructor with no parent entry appends T (C)" "AddExport.hs" 9 12  -- on `Baz1`, no Baz entry yet
-            ["Baz (Baz1)", "Baz(Baz1)"]
-        , addCase "constructor under bare-type parent promotes to T(C)" "AddCtor.hs" 3 11  -- on `Bar1`, Bar is IEThingAbs
-            ["Bar (Bar1)", "Bar(Bar1)"]
-        , addCase "constructor merges into existing IEThingWith parent" "AddCtor.hs" 2 18  -- on `Foo2`, Foo has [Foo1]
-            ["Foo (Foo1, Foo2)", "Foo(Foo1, Foo2)"]
-        , noCase "constructor already in IEThingWith children suppresses action" "AddCtor.hs" 2 11  -- on `Foo1`, already child of Foo(Foo1)
-        , noCase "constructor under IEThingAll T(..) suppresses action" "AddCtor.hs" 4 11  -- on `Baz1`, Baz(..) covers it
-        , noCase "constructor exported standalone suppresses action" "AddCtor.hs" 5 11  -- on `Qux1`, Qux1 standalone in list
-        ]
+        , testGroup "constructors"
+            [ addCase "constructor with no parent entry appends T (C)" "AddExport.hs" 9 12  -- on `Baz1`, no Baz entry yet
+                ["Baz (Baz1)", "Baz(Baz1)"]
+            , addCase "constructor under bare-type parent promotes to T(C)" "AddCtor.hs" 3 11  -- on `Bar1`, Bar is IEThingAbs
+                ["Bar (Bar1)", "Bar(Bar1)"]
+            , addCase "constructor merges into existing IEThingWith parent" "AddCtor.hs" 2 18  -- on `Foo2`, Foo has [Foo1]
+                ["Foo (Foo1, Foo2)", "Foo(Foo1, Foo2)"]
+            , noCase "constructor already in IEThingWith children suppresses action" "AddCtor.hs" 2 11  -- on `Foo1`, already child of Foo(Foo1)
+            , noCase "constructor under IEThingAll T(..) suppresses action" "AddCtor.hs" 4 11  -- on `Baz1`, Baz(..) covers it
+            , noCase "constructor exported standalone suppresses action" "AddCtor.hs" 5 11  -- on `Qux1`, Qux1 standalone in list
+            ]
 
-    , testGroup "Add: type classes"
-        [ addCase "add class as T(..)" "AddClass.hs" 8 6  -- on `Baz` class name
-            ["module AddClass (Foo (..), Bar, Baz (..))"]
-        , noCase "no add action when class exported as T(..)" "AddClass.hs" 2 6  -- on `Foo`, exported as Foo (..)
-        , noCase "no add action when class exported as bare T" "AddClass.hs" 5 6  -- on `Bar`, exported as bare
-        , noCase "no add action on class method" "AddClass.hs" 9 2  -- on `baz1` inside `class Baz a where`
-        ]
+        , testGroup "type classes"
+            [ addCase "add class as T(..)" "AddClass.hs" 8 6  -- on `Baz` class name
+                ["module AddClass (Foo (..), Bar, Baz (..))"]
+            , noCase "no add action when class exported as T(..)" "AddClass.hs" 2 6  -- on `Foo`, exported as Foo (..)
+            , noCase "no add action when class exported as bare T" "AddClass.hs" 5 6  -- on `Bar`, exported as bare
+            , noCase "no add action on class method" "AddClass.hs" 9 2  -- on `baz1` inside `class Baz a where`
+            ]
 
-    , testGroup "Add: layout variants"
-        [ addCase "add to an empty export list" "AddExportEmpty.hs" 2 0  -- on `foo`
-            ["module AddExportEmpty (foo) where"]
-        , addCase "append after a trailing comma" "AddExportTrailingComma.hs" 7 0  -- on `bar`
-            ["( foo, bar"]
-        , addCase "preserve a haddock comment between items" "AddExportComment.hs" 16 0  -- on `quux`
-            ["  -- * For testing\n  , baz\n  , quux\n  ) where"]
-        ]
+        , testGroup "layout variants"
+            [ addCase "add to an empty export list" "AddExportEmpty.hs" 2 0  -- on `foo`
+                ["module AddExportEmpty (foo) where"]
+            , addCase "append after a trailing comma" "AddExportTrailingComma.hs" 7 0  -- on `bar`
+                ["( foo, bar"]
+            , addCase "preserve a haddock comment between items" "AddExportComment.hs" 16 0  -- on `quux`
+                ["  -- * For testing\n  , baz\n  , quux\n  ) where"]
+            ]
 
-    , testGroup "Add: declaration kinds"
-        [ addCase "function operator is parenthesized" "AddExportKinds.hs" 8 1  -- on `(<|)`
-            ["(placeholder, (<|))"]
-        , addCase "infix function exports bare name" "AddExportKinds.hs" 11 3  -- on `f`
-            ["(placeholder, f)"]
-        , addCase "newtype exports as T(..)" "AddExportKinds.hs" 13 8  -- on `NT`
-            ["placeholder, NT(..)", "placeholder, NT (..)"]
-        , addCase "type synonym exports bare" "AddExportKinds.hs" 15 5  -- on `Syn`
-            ["(placeholder, Syn)"]
-        , addCase "type family exports bare" "AddExportKinds.hs" 17 12  -- on `TF`
-            ["(placeholder, TF)"]
-        , addCase "pattern synonym gets a pattern prefix" "AddExportKinds.hs" 20 9  -- on `Pat`
-            ["(placeholder, pattern Pat)"]
-        , addCase "data operator gets type keyword and (..)" "AddExportKinds.hs" 22 7  -- on `(:<)`
-            ["placeholder, type (:<)(..)", "placeholder, type (:<) (..)"]
-        ]
+        , testGroup "declaration kinds"
+            [ addCase "function operator is parenthesized" "AddExportKinds.hs" 8 1  -- on `(<|)`
+                ["(placeholder, (<|))"]
+            , addCase "infix function exports bare name" "AddExportKinds.hs" 11 3  -- on `f`
+                ["(placeholder, f)"]
+            , addCase "newtype exports as T(..)" "AddExportKinds.hs" 13 8  -- on `NT`
+                ["placeholder, NT(..)", "placeholder, NT (..)"]
+            , addCase "type synonym exports bare" "AddExportKinds.hs" 15 5  -- on `Syn`
+                ["(placeholder, Syn)"]
+            , addCase "type family exports bare" "AddExportKinds.hs" 17 12  -- on `TF`
+                ["(placeholder, TF)"]
+            , addCase "pattern synonym gets a pattern prefix" "AddExportKinds.hs" 20 9  -- on `Pat`
+                ["(placeholder, pattern Pat)"]
+            , addCase "data operator gets type keyword and (..)" "AddExportKinds.hs" 22 7  -- on `(:<)`
+                ["placeholder, type (:<)(..)", "placeholder, type (:<) (..)"]
+            ]
 
-    , testGroup "Add: type-level operators"
-        [ addCase "type synonym operator has no type keyword" "AddExportTypeOps.hs" 8 7  -- on `(:<>)`
-            ["(placeholder, (:<>))"]
-        , addCase "type family operator gets type keyword" "AddExportTypeOps.hs" 10 14  -- on `(:+:)`
-            ["(placeholder, type (:+:))"]
-        , addCase "typeclass operator gets type keyword and (..)" "AddExportTypeOps.hs" 12 8  -- on `(:*:)`
-            ["placeholder, type (:*:)(..)", "placeholder, type (:*:) (..)"]
-        , addCase "newtype operator gets type keyword and (..)" "AddExportTypeOps.hs" 14 10  -- on `(:->)`
-            ["placeholder, type (:->)(..)", "placeholder, type (:->) (..)"]
-        , addCase "pattern synonym operator is parenthesized" "AddExportTypeOps.hs" 16 11  -- on `(:++)`
-            ["(placeholder, pattern (:++))"]
-        ]
+        , testGroup "type-level operators"
+            [ addCase "type synonym operator has no type keyword" "AddExportTypeOps.hs" 8 7  -- on `(:<>)`
+                ["(placeholder, (:<>))"]
+            , addCase "type family operator gets type keyword" "AddExportTypeOps.hs" 10 14  -- on `(:+:)`
+                ["(placeholder, type (:+:))"]
+            , addCase "typeclass operator gets type keyword and (..)" "AddExportTypeOps.hs" 12 8  -- on `(:*:)`
+                ["placeholder, type (:*:)(..)", "placeholder, type (:*:) (..)"]
+            , addCase "newtype operator gets type keyword and (..)" "AddExportTypeOps.hs" 14 10  -- on `(:->)`
+                ["placeholder, type (:->)(..)", "placeholder, type (:->) (..)"]
+            , addCase "pattern synonym operator is parenthesized" "AddExportTypeOps.hs" 16 11  -- on `(:++)`
+                ["(placeholder, pattern (:++))"]
+            ]
 
-    , testGroup "Add: negative cases"
-        [ noCase "no action on implicit module" "Implicit.hs" 3 0
-        , noCase "no action when cursor on RHS" "AddExport.hs" 6 6  -- col 6 is on the `2` of `bar = 2`
-        , noCase "no action on a where-bound name" "AddExportNegatives.hs" 7 8  -- on `whereBound`
-        , noCase "no action on a record field" "AddExportNegatives.hs" 9 18  -- on `recField`
-        ]
+        , testGroup "negative cases"
+            [ noCase "no action on implicit module" "Implicit.hs" 3 0
+            , noCase "no action when cursor on RHS" "AddExport.hs" 6 6  -- col 6 is on the `2` of `bar = 2`
+            , noCase "no action on a where-bound name" "AddExportNegatives.hs" 7 8  -- on `whereBound`
+            , noCase "no action on a record field" "AddExportNegatives.hs" 9 18  -- on `recField`
+            ]
 
-    , testGroup "Add: CPP in the export list"
-        -- EXAMPLE_FLAG is never defined in the test project, so #ifdef branches
-        -- are inactive and #ifndef branches are active. The edit must preserve
-        -- every directive verbatim and place the new export outside any branch.
-        [ exportCase "preserves a trailing #ifdef block" "CppExportTail.hs" 15 0  -- on `baz`
-            (assertFlaggedBlockKept "baz")
+        , testGroup "CPP in the export list"
+            -- EXAMPLE_FLAG is never defined in the test project, so #ifdef branches
+            -- are inactive and #ifndef branches are active. The edit must preserve
+            -- every directive verbatim and place the new export outside any branch.
+            [ exportCase "preserves a trailing #ifdef block" "CppExportTail.hs" 15 0  -- on `baz`
+                (assertFlaggedBlockKept "baz")
 
-        , exportCase "preserves a leading #ifndef block" "CppExportHead.hs" 12 0 $ \txt -> do  -- on `bar`
-            -- the whole guarded block survives verbatim, not just stray substrings
-            assertContainsAll txt ["#ifndef EXAMPLE_FLAG\n    foo\n#endif"]
-            assertExportedUnconditionally "bar" txt
+            , exportCase "preserves a leading #ifndef block" "CppExportHead.hs" 12 0 $ \txt -> do  -- on `bar`
+                -- the whole guarded block survives verbatim, not just stray substrings
+                assertContainsAll txt ["#ifndef EXAMPLE_FLAG\n    foo\n#endif"]
+                assertExportedUnconditionally "bar" txt
 
-        , exportCase "preserves both #if/#else branches" "CppExportElse.hs" 20 0 $ \txt -> do  -- on `extra`
-            assertContainsAll txt
-                ["#ifdef EXAMPLE_FLAG", ", windows", "#else", ", posix", "#endif"]
-            assertExportedUnconditionally "extra" txt
-
-        , testCase "preserves an #include directive" $ runExportWith ["CppExportInclude.h"] "CppExportInclude.hs" $ \doc -> do
-            txt <- exportAndCheck doc (rangeAt 13 0)  -- on `extra`
-            liftIO $ do
-                assertContainsAll txt ["#include \"CppExportInclude.h\"", "( extra, foo"]
+            , exportCase "preserves both #if/#else branches" "CppExportElse.hs" 20 0 $ \txt -> do  -- on `extra`
+                assertContainsAll txt
+                    ["#ifdef EXAMPLE_FLAG", ", windows", "#else", ", posix", "#endif"]
                 assertExportedUnconditionally "extra" txt
 
-        , exportCase "appends a new T(C) beside a CPP block" "CppCtorAppend.hs" 11 11 $ \txt -> do  -- on `Baz1`, no Baz entry yet
-            assertFlaggedBlockKept "Baz1" txt
-            txt `assertAnyInfix` ["Baz (Baz1)", "Baz(Baz1)"]
+            , testCase "preserves an #include directive" $ runExportWith ["CppExportInclude.h"] "CppExportInclude.hs" $ \doc -> do
+                txt <- exportAndCheck doc (rangeAt 13 0)  -- on `extra`
+                liftIO $ do
+                    assertContainsAll txt ["#include \"CppExportInclude.h\"", "( extra, foo"]
+                    assertExportedUnconditionally "extra" txt
 
-        , exportCase "adds a separate entry beside an IEThingWith parent" "CppCtorExtend.hs" 8 18 $ \txt -> do  -- on `Foo2`, Foo has [Foo1]
-            assertFlaggedBlockKept "Foo2" txt
-            assertContainsAll txt ["Foo(Foo1)"]
-            txt `assertAnyInfix` ["Foo (Foo2)", "Foo(Foo2)"]
+            , exportCase "appends a new T(C) beside a CPP block" "CppCtorAppend.hs" 11 11 $ \txt -> do  -- on `Baz1`, no Baz entry yet
+                assertFlaggedBlockKept "Baz1" txt
+                txt `assertAnyInfix` ["Baz (Baz1)", "Baz(Baz1)"]
 
-        , exportCase "adds a separate entry without a double comma" "CppCtorMid.hs" 9 18 $ \txt -> do  -- on `Foo2`, Foo(Foo1) precedes `, bar`
-            assertContainsAll txt (flagBlock <> [", bar", "Foo(Foo1)"])
-            txt `assertAnyInfix` ["Foo (Foo2)", "Foo(Foo2)"]
+            , exportCase "adds a separate entry beside an IEThingWith parent" "CppCtorExtend.hs" 8 18 $ \txt -> do  -- on `Foo2`, Foo has [Foo1]
+                assertFlaggedBlockKept "Foo2" txt
+                assertContainsAll txt ["Foo(Foo1)"]
+                txt `assertAnyInfix` ["Foo (Foo2)", "Foo(Foo2)"]
 
-        , exportCase "adds a separate entry beside a bare-type parent" "CppCtorUpgrade.hs" 8 11 $ \txt -> do  -- on `Bar1`, Bar is IEThingAbs
-            assertFlaggedBlockKept "Bar1" txt
-            txt `assertAnyInfix` ["Bar (Bar1)", "Bar(Bar1)"]
+            , exportCase "adds a separate entry without a double comma" "CppCtorMid.hs" 9 18 $ \txt -> do  -- on `Foo2`, Foo(Foo1) precedes `, bar`
+                assertContainsAll txt (flagBlock <> [", bar", "Foo(Foo1)"])
+                txt `assertAnyInfix` ["Foo (Foo2)", "Foo(Foo2)"]
 
-        , exportCase "exports an operator beside a CPP block" "CppExportKinds.hs" 12 1  -- on `(<|)`
-            (assertFlaggedBlockKept "(<|)")
+            , exportCase "adds a separate entry beside a bare-type parent" "CppCtorUpgrade.hs" 8 11 $ \txt -> do  -- on `Bar1`, Bar is IEThingAbs
+                assertFlaggedBlockKept "Bar1" txt
+                txt `assertAnyInfix` ["Bar (Bar1)", "Bar(Bar1)"]
 
-        , exportCase "exports a pattern synonym beside a CPP block" "CppExportKinds.hs" 16 8  -- on `Zero`
-            (assertFlaggedBlockKept "pattern Zero")
+            , exportCase "exports an operator beside a CPP block" "CppExportKinds.hs" 12 1  -- on `(<|)`
+                (assertFlaggedBlockKept "(<|)")
 
-        , exportCase "adds a separate entry beside a directive inside a constructor list" "CppCtorIntra.hs" 9 24 $ \txt -> do  -- on `Foo2`
-            -- the #ifdef sits inside Foo(...), where an in-place merge would erase it
-            assertContainsAll txt ["#ifdef EXAMPLE_FLAG\n      , Bar\n#endif", "Foo(Foo1"]
-            txt `assertAnyInfix` ["Foo (Foo2)", "Foo(Foo2)"]
+            , exportCase "exports a pattern synonym beside a CPP block" "CppExportKinds.hs" 16 8  -- on `Zero`
+                (assertFlaggedBlockKept "pattern Zero")
 
-        , exportCase "front-inserts even when the close paren shares a line" "CppExportParenShared.hs" 18 0 $ \txt -> do  -- on `baz`
-            assertContainsAll txt (flagBlock <> [", bar )"])
-            assertExportedUnconditionally "baz" txt
+            , exportCase "adds a separate entry beside a directive inside a constructor list" "CppCtorIntra.hs" 9 24 $ \txt -> do  -- on `Foo2`
+                -- the #ifdef sits inside Foo(...), where an in-place merge would erase it
+                assertContainsAll txt ["#ifdef EXAMPLE_FLAG\n      , Bar\n#endif", "Foo(Foo1"]
+                txt `assertAnyInfix` ["Foo (Foo2)", "Foo(Foo2)"]
 
-        , exportCase "no double comma when the last item already has a trailing comma" "CppExportTrailingComma.hs" 15 0 $ \txt -> do  -- on `baz`
-            -- a doubled `,,` would be caught by exportAndCheck's well-formedness check
-            assertContainsAll txt ["#ifdef EXAMPLE_FLAG", "flagged,", "#endif"]
-            assertExportedUnconditionally "baz" txt
+            , exportCase "front-inserts even when the close paren shares a line" "CppExportParenShared.hs" 18 0 $ \txt -> do  -- on `baz`
+                assertContainsAll txt (flagBlock <> [", bar )"])
+                assertExportedUnconditionally "baz" txt
 
-        , exportCase "edit stays valid in the unparsed CPP branch" "CppExportOtherBranch.hs" 12 0 $ \txt -> do  -- on `bar`, the only item is in the other branch
-            -- the single item lives under #ifndef, so it is the whole parsed list.
-            -- The front-insert plus trailing comma stays valid when the flag flips
-            -- and that item disappears.
-            let otherBranch = preprocessExampleFlag True txt
-            wellFormedExportList otherBranch
-                @? ("edit breaks the EXAMPLE_FLAG-defined configuration:\n" <> T.unpack otherBranch)
+            , exportCase "no double comma when the last item already has a trailing comma" "CppExportTrailingComma.hs" 15 0 $ \txt -> do  -- on `baz`
+                -- a doubled `,,` would be caught by exportAndCheck's well-formedness check
+                assertContainsAll txt ["#ifdef EXAMPLE_FLAG", "flagged,", "#endif"]
+                assertExportedUnconditionally "baz" txt
+
+            , exportCase "edit stays valid in the unparsed CPP branch" "CppExportOtherBranch.hs" 12 0 $ \txt -> do  -- on `bar`, the only item is in the other branch
+                -- the single item lives under #ifndef, so it is the whole parsed list.
+                -- The front-insert plus trailing comma stays valid when the flag flips
+                -- and that item disappears.
+                let otherBranch = preprocessExampleFlag True txt
+                wellFormedExportList otherBranch
+                    @? ("edit breaks the EXAMPLE_FLAG-defined configuration:\n" <> T.unpack otherBranch)
+            ]
         ]
 
     , testGroup "Export fixes the unused-binding warning"
@@ -349,106 +351,108 @@ main = defaultTestRunner $ testGroup "Export"
                             "Export `unused` not offered; saw: " <> show (map (^. L.title) actions)
         ]
 
-    , testGroup "Remove: value bindings"
-        [ removeCase "remove first value (foo)" "RemoveExport.hs" 3 0
-            ["module RemoveExport (Bar, Baz (Baz1))"]
+    , testGroup "Remove"
+        [ testGroup "value bindings"
+            [ removeCase "remove first value (foo)" "RemoveExport.hs" 3 0
+                ["module RemoveExport (Bar, Baz (Baz1))"]
 
-        , noRemoveCase "no remove action when value not in export list" "AddExport.hs" 6 0  -- `bar` not exported
+            , noRemoveCase "no remove action when value not in export list" "AddExport.hs" 6 0  -- `bar` not exported
 
-        , removeCase "unexporting the sole export empties the list to ()" "SoleExport.hs" 3 0  -- on `only`, the only export
-            ["module SoleExport () where"]
+            , removeCase "unexporting the sole export empties the list to ()" "SoleExport.hs" 3 0  -- on `only`, the only export
+                ["module SoleExport () where"]
 
-        , removeCase "remove first item of a multi-line list keeps own-line layout" "RemoveFirstMultiline.hs" 6 0  -- on `foo`, the first export
-            ["( bar\n  , baz\n  ) where"]
+            , removeCase "remove first item of a multi-line list keeps own-line layout" "RemoveFirstMultiline.hs" 6 0  -- on `foo`, the first export
+                ["( bar\n  , baz\n  ) where"]
 
-        , testCase "remove first item drops its comment, keeps the others'" $ runExport "RemoveItemComment.hs" $ \doc -> do
-            executeRemoveAction doc (rangeAt 6 0)  -- on `foo`, the first export
-            txt <- documentContents doc
-            liftIO $ do
-                assertContainsAll txt ["bar -- the bar", "baz -- the baz"]
-                not ("the foo" `T.isInfixOf` txt) @? ("foo's comment survived:\n" <> T.unpack txt)
+            , testCase "remove first item drops its comment, keeps the others'" $ runExport "RemoveItemComment.hs" $ \doc -> do
+                executeRemoveAction doc (rangeAt 6 0)  -- on `foo`, the first export
+                txt <- documentContents doc
+                liftIO $ do
+                    assertContainsAll txt ["bar -- the bar", "baz -- the baz"]
+                    not ("the foo" `T.isInfixOf` txt) @? ("foo's comment survived:\n" <> T.unpack txt)
 
-        , testCase "remove middle item drops its comment, keeps the others'" $ runExport "RemoveItemComment.hs" $ \doc -> do
-            executeRemoveAction doc (rangeAt 9 0)  -- on `bar`, the middle export
-            txt <- documentContents doc
-            liftIO $ do
-                assertContainsAll txt ["foo -- the foo", "baz -- the baz"]
-                not ("the bar" `T.isInfixOf` txt) @? ("bar's comment survived:\n" <> T.unpack txt)
-        ]
+            , testCase "remove middle item drops its comment, keeps the others'" $ runExport "RemoveItemComment.hs" $ \doc -> do
+                executeRemoveAction doc (rangeAt 9 0)  -- on `bar`, the middle export
+                txt <- documentContents doc
+                liftIO $ do
+                    assertContainsAll txt ["foo -- the foo", "baz -- the baz"]
+                    not ("the bar" `T.isInfixOf` txt) @? ("bar's comment survived:\n" <> T.unpack txt)
+            ]
 
-    , testGroup "Remove: type declarations"
-        [ removeCase "remove bare type (middle item)" "RemoveExport.hs" 5 5  -- on `Bar`
-            ["module RemoveExport (foo, Baz (Baz1))"]
-        , removeCase "remove IEThingWith type removes whole entry" "RemoveCtor.hs" 2 5  -- on `Foo` type
-            ["module RemoveCtor (Bar (..), Baz1)"]
-        , removeCase "remove IEThingAll type removes whole entry" "RemoveCtor.hs" 3 5  -- on `Bar` type with (..)
-            ["module RemoveCtor (Foo (Foo1, Foo2), Baz1)"]
-        ]
+        , testGroup "type declarations"
+            [ removeCase "remove bare type (middle item)" "RemoveExport.hs" 5 5  -- on `Bar`
+                ["module RemoveExport (foo, Baz (Baz1))"]
+            , removeCase "remove IEThingWith type removes whole entry" "RemoveCtor.hs" 2 5  -- on `Foo` type
+                ["module RemoveCtor (Bar (..), Baz1)"]
+            , removeCase "remove IEThingAll type removes whole entry" "RemoveCtor.hs" 3 5  -- on `Bar` type with (..)
+                ["module RemoveCtor (Foo (Foo1, Foo2), Baz1)"]
+            ]
 
-    , testGroup "Remove: constructors"
-        [ removeCase "remove sole constructor downgrades to bare type" "RemoveExport.hs" 6 11  -- on `Baz1` in Baz(Baz1)
-            ["module RemoveExport (foo, Bar, Baz)"]
-        , removeCase "remove first constructor of T(C1, C2) yields T (C2)" "RemoveCtor.hs" 2 11  -- on `Foo1` in Foo(Foo1, Foo2)
-            ["Foo (Foo2)", "Foo(Foo2)"]
-        , removeCase "remove second constructor of T(C1, C2) yields T (C1)" "RemoveCtor.hs" 2 18  -- on `Foo2` in Foo(Foo1, Foo2)
-            ["Foo (Foo1)", "Foo(Foo1)"]
-        , removeCase "remove standalone-exported constructor" "RemoveCtor.hs" 4 11  -- on `Baz1` standalone
-            ["module RemoveCtor (Foo (Foo1, Foo2), Bar (..))"]
-        , noRemoveCase "constructor under IEThingAll suppresses remove action" "RemoveCtor.hs" 3 11  -- on `Bar1`, only Bar(..) in list
-        , noRemoveCase "constructor not in export list suppresses remove action" "RemoveCtor.hs" 2 25  -- on `Foo3`, not in any entry
+        , testGroup "constructors"
+            [ removeCase "remove sole constructor downgrades to bare type" "RemoveExport.hs" 6 11  -- on `Baz1` in Baz(Baz1)
+                ["module RemoveExport (foo, Bar, Baz)"]
+            , removeCase "remove first constructor of T(C1, C2) yields T (C2)" "RemoveCtor.hs" 2 11  -- on `Foo1` in Foo(Foo1, Foo2)
+                ["Foo (Foo2)", "Foo(Foo2)"]
+            , removeCase "remove second constructor of T(C1, C2) yields T (C1)" "RemoveCtor.hs" 2 18  -- on `Foo2` in Foo(Foo1, Foo2)
+                ["Foo (Foo1)", "Foo(Foo1)"]
+            , removeCase "remove standalone-exported constructor" "RemoveCtor.hs" 4 11  -- on `Baz1` standalone
+                ["module RemoveCtor (Foo (Foo1, Foo2), Bar (..))"]
+            , noRemoveCase "constructor under IEThingAll suppresses remove action" "RemoveCtor.hs" 3 11  -- on `Bar1`, only Bar(..) in list
+            , noRemoveCase "constructor not in export list suppresses remove action" "RemoveCtor.hs" 2 25  -- on `Foo3`, not in any entry
 
-        -- `data Bar = Bar`: unexporting the constructor leaves the abstract type
-        -- exported, so unexport must skip the standalone-removal fallback.
-        , noRemoveCase "constructor sharing its type's name does not unexport the type" "RemoveCtorNameClash.hs" 5 11  -- on the constructor `Bar`
+            -- `data Bar = Bar`: unexporting the constructor leaves the abstract type
+            -- exported, so unexport must skip the standalone-removal fallback.
+            , noRemoveCase "constructor sharing its type's name does not unexport the type" "RemoveCtorNameClash.hs" 5 11  -- on the constructor `Bar`
 
-        , removeCase "unexporting the type still works when a constructor shares its name" "RemoveCtorNameClash.hs" 5 5  -- on the type `Bar`
-            ["module RemoveCtorNameClash (foo)"]
-        , removeCase "downgrading an operator type keeps the type keyword" "RemoveCtorOp.hs" 4 15  -- on `Op`, the sole constructor of (:+:)
-            ["(type (:+:)) where", "(type (:+:) ) where"]
+            , removeCase "unexporting the type still works when a constructor shares its name" "RemoveCtorNameClash.hs" 5 5  -- on the type `Bar`
+                ["module RemoveCtorNameClash (foo)"]
+            , removeCase "downgrading an operator type keeps the type keyword" "RemoveCtorOp.hs" 4 15  -- on `Op`, the sole constructor of (:+:)
+                ["(type (:+:)) where", "(type (:+:) ) where"]
 
-        , testCase "removing a child preserves the survivors' multiline layout" $ runExport "RemoveCtorMultiline.hs" $ \doc -> do
-            executeRemoveAction doc (rangeAt 8 18)  -- on `Foo2` in the data decl, the middle child
-            txt <- documentContents doc
-            let region = exportListRegion txt
-            liftIO $ do
-                -- Survivors keep their layout: head not flushed to `(`, Foo3 on its own line.
-                assertContainsAll txt ["( Foo1\n", "        , Foo3\n"]
-                not (any ("Foo2" `T.isInfixOf`) region) @? ("Foo2 still exported:\n" <> T.unpack txt)
+            , testCase "removing a child preserves the survivors' multiline layout" $ runExport "RemoveCtorMultiline.hs" $ \doc -> do
+                executeRemoveAction doc (rangeAt 8 18)  -- on `Foo2` in the data decl, the middle child
+                txt <- documentContents doc
+                let region = exportListRegion txt
+                liftIO $ do
+                    -- Survivors keep their layout: head not flushed to `(`, Foo3 on its own line.
+                    assertContainsAll txt ["( Foo1\n", "        , Foo3\n"]
+                    not (any ("Foo2" `T.isInfixOf`) region) @? ("Foo2 still exported:\n" <> T.unpack txt)
 
-        , testCase "removing a middle child keeps the surviving siblings' comments" $ runExport "RemoveCtorComment.hs" $ \doc -> do
-            executeRemoveAction doc (rangeAt 8 18)  -- on `Foo2` in the data decl
-            txt <- documentContents doc
-            liftIO $ do
-                assertContainsAll txt ["Foo1 -- first", "Foo3 -- third"]
-                -- The removed child takes its own trailing comment with it.
-                not ("second" `T.isInfixOf` txt) @? ("Foo2's comment lingered:\n" <> T.unpack txt)
+            , testCase "removing a middle child keeps the surviving siblings' comments" $ runExport "RemoveCtorComment.hs" $ \doc -> do
+                executeRemoveAction doc (rangeAt 8 18)  -- on `Foo2` in the data decl
+                txt <- documentContents doc
+                liftIO $ do
+                    assertContainsAll txt ["Foo1 -- first", "Foo3 -- third"]
+                    -- The removed child takes its own trailing comment with it.
+                    not ("second" `T.isInfixOf` txt) @? ("Foo2's comment lingered:\n" <> T.unpack txt)
 
-        , testCase "removing the head child keeps the new head's own comment" $ runExport "RemoveCtorComment.hs" $ \doc -> do
-            executeRemoveAction doc (rangeAt 8 11)  -- on `Foo1` in the data decl
-            txt <- documentContents doc
-            liftIO $ do
-                -- Foo2 slides into Foo1's slot keeping its own `-- second`,
-                -- and Foo1's `-- first` is deleted along with Foo1.
-                assertContainsAll txt ["Foo2 -- second", "Foo3 -- third"]
-                not ("first" `T.isInfixOf` txt) @? ("Foo1's comment survived:\n" <> T.unpack txt)
-        ]
+            , testCase "removing the head child keeps the new head's own comment" $ runExport "RemoveCtorComment.hs" $ \doc -> do
+                executeRemoveAction doc (rangeAt 8 11)  -- on `Foo1` in the data decl
+                txt <- documentContents doc
+                liftIO $ do
+                    -- Foo2 slides into Foo1's slot keeping its own `-- second`,
+                    -- and Foo1's `-- first` is deleted along with Foo1.
+                    assertContainsAll txt ["Foo2 -- second", "Foo3 -- third"]
+                    not ("first" `T.isInfixOf` txt) @? ("Foo1's comment survived:\n" <> T.unpack txt)
+            ]
 
-    , testGroup "Remove: type classes"
-        [ removeCase "remove class exported as T(..)" "RemoveClass.hs" 2 6  -- on `Foo`
-            ["module RemoveClass (Bar, Baz (baz1))"]
-        , removeCase "remove class exported as bare T" "RemoveClass.hs" 5 6  -- on `Bar`
-            ["module RemoveClass (Foo (..), Baz (baz1))"]
-        , removeCase "remove class exported as T(method)" "RemoveClass.hs" 8 6  -- on `Baz`
-            ["module RemoveClass (Foo (..), Bar)"]
-        , noRemoveCase "no remove action when class not in export list" "RemoveClass.hs" 12 6  -- on `Qux`, not exported
-        , noRemoveCase "no remove action on class method" "RemoveClass.hs" 9 2  -- on `baz1` inside `class Baz a where`
-        ]
+        , testGroup "type classes"
+            [ removeCase "remove class exported as T(..)" "RemoveClass.hs" 2 6  -- on `Foo`
+                ["module RemoveClass (Bar, Baz (baz1))"]
+            , removeCase "remove class exported as bare T" "RemoveClass.hs" 5 6  -- on `Bar`
+                ["module RemoveClass (Foo (..), Baz (baz1))"]
+            , removeCase "remove class exported as T(method)" "RemoveClass.hs" 8 6  -- on `Baz`
+                ["module RemoveClass (Foo (..), Bar)"]
+            , noRemoveCase "no remove action when class not in export list" "RemoveClass.hs" 12 6  -- on `Qux`, not exported
+            , noRemoveCase "no remove action on class method" "RemoveClass.hs" 9 2  -- on `baz1` inside `class Baz a where`
+            ]
 
-    , testGroup "Remove: negative cases"
-        [ noRemoveCase "no remove action on implicit module" "Implicit.hs" 3 0
-        , noRemoveCase "no remove action when cursor on RHS" "RemoveExport.hs" 3 6  -- on the `1` of `foo = 1`
-        -- A reprint would erase the directives the parser stripped, so removal is
-        -- declined whenever the export list holds a CPP directive.
-        , noRemoveCase "no remove action under a CPP export list" "CppExportTail.hs" 9 0  -- on `foo`, exported beside an #ifdef block
+        , testGroup "negative cases"
+            [ noRemoveCase "no remove action on implicit module" "Implicit.hs" 3 0
+            , noRemoveCase "no remove action when cursor on RHS" "RemoveExport.hs" 3 6  -- on the `1` of `foo = 1`
+            -- A reprint would erase the directives the parser stripped, so removal is
+            -- declined whenever the export list holds a CPP directive.
+            , noRemoveCase "no remove action under a CPP export list" "CppExportTail.hs" 9 0  -- on `foo`, exported beside an #ifdef block
+            ]
         ]
     ]

--- a/plugins/hls-export-plugin/test/testdata/RemoveClass.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveClass.hs
@@ -1,0 +1,14 @@
+module RemoveClass (Foo (..), Bar, Baz (baz1)) where
+
+class Foo a where
+  foo1 :: a -> Int
+
+class Bar a where
+  bar1 :: a -> Int
+
+class Baz a where
+  baz1 :: a -> Int
+  baz2 :: a -> Int
+
+class Qux a where
+  qux1 :: a -> Int

--- a/plugins/hls-export-plugin/test/testdata/RemoveCtor.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveCtor.hs
@@ -1,0 +1,5 @@
+module RemoveCtor (Foo (Foo1, Foo2), Bar (..), Baz1) where
+
+data Foo = Foo1 | Foo2 | Foo3
+data Bar = Bar1 | Bar2
+data Baz = Baz1 | Baz2

--- a/plugins/hls-export-plugin/test/testdata/RemoveCtorComment.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveCtorComment.hs
@@ -1,0 +1,9 @@
+module RemoveCtorComment
+    ( Foo
+        ( Foo1 -- first
+        , Foo2 -- second
+        , Foo3 -- third
+        )
+    ) where
+
+data Foo = Foo1 | Foo2 | Foo3

--- a/plugins/hls-export-plugin/test/testdata/RemoveCtorMultiline.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveCtorMultiline.hs
@@ -1,0 +1,9 @@
+module RemoveCtorMultiline
+    ( Foo
+        ( Foo1
+        , Foo2
+        , Foo3
+        )
+    ) where
+
+data Foo = Foo1 | Foo2 | Foo3

--- a/plugins/hls-export-plugin/test/testdata/RemoveCtorNameClash.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveCtorNameClash.hs
@@ -1,0 +1,6 @@
+module RemoveCtorNameClash (foo, Bar) where
+
+foo :: Int
+foo = 1
+
+data Bar = Bar

--- a/plugins/hls-export-plugin/test/testdata/RemoveCtorOp.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveCtorOp.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE TypeOperators      #-}
+module RemoveCtorOp (type (:+:) (Op)) where
+
+data a :+: b = Op

--- a/plugins/hls-export-plugin/test/testdata/RemoveExport.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveExport.hs
@@ -1,0 +1,7 @@
+module RemoveExport (foo, Bar, Baz (Baz1)) where
+
+foo :: Int
+foo = 1
+
+data Bar = Bar
+data Baz = Baz1 | Baz2

--- a/plugins/hls-export-plugin/test/testdata/RemoveFirstMultiline.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveFirstMultiline.hs
@@ -1,0 +1,14 @@
+module RemoveFirstMultiline
+  ( foo
+  , bar
+  , baz
+  ) where
+
+foo :: Int
+foo = 1
+
+bar :: Int
+bar = 2
+
+baz :: Int
+baz = 3

--- a/plugins/hls-export-plugin/test/testdata/RemoveItemComment.hs
+++ b/plugins/hls-export-plugin/test/testdata/RemoveItemComment.hs
@@ -1,0 +1,14 @@
+module RemoveItemComment
+  ( foo -- the foo
+  , bar -- the bar
+  , baz -- the baz
+  ) where
+
+foo :: Int
+foo = 1
+
+bar :: Int
+bar = 2
+
+baz :: Int
+baz = 3

--- a/plugins/hls-export-plugin/test/testdata/SoleExport.hs
+++ b/plugins/hls-export-plugin/test/testdata/SoleExport.hs
@@ -1,0 +1,4 @@
+module SoleExport (only) where
+
+only :: Int
+only = 1


### PR DESCRIPTION
Allow unexporting symbols using approximately the same machinery as the `Export ...` action.

- Currently omits the action when CPP is present. 
    This is a bit more finicky than adding exports, so I've not tackled this.
- Uses ghc-exactprint to reprint the export list.