### PR TITLE
Docs: update Kakoune configuration instructions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -491,15 +491,30 @@ dotspacemacs-configuration-layers
 
 ### [Kakoune](https://github.com/mawww/kakoune)
 
-1. Grab a copy of [kak-lsp](https://github.com/ul/kak-lsp), and follow the setup instructions.
-2. Point your `kak-lsp.toml` to `haskell-language-server-wrapper`.
+1. Grab a copy of [kak-lsp](https://github.com/kakoune-lsp/kakoune-lsp), and add the following to your `kakrc`:
 
-```toml
-[language.haskell]
-filetypes = ["haskell"]
-roots = ["Setup.hs", "stack.yaml", "*.cabal"]
-command = "haskell-language-server-wrapper"
-args = ["--lsp"]
+```kak
+evaluate-commands %sh{kak-lsp}
+lsp-enable
+```
+
+2. The LSP should start automatically when editing any Haskell file. To override the default settings, you may add the following to your `kakrc` at any point after the previous snippet:
+
+```kak
+remove-hooks global lsp-filetype-haskell
+hook -group lsp-filetype-haskell global BufSetOption filetype=haskell %{
+    set-option buffer lsp_servers %{
+        [haskell-language-server]
+        root_globs = ["hie.yaml", "cabal.project", "Setup.hs", "stack.yaml", "*.cabal"]
+        command = "haskell-language-server-wrapper"
+        args = ["--lsp"]
+        settings_section = "_"
+        [haskell-language-server.settings._]
+        # See https://haskell-language-server.readthedocs.io/en/latest/configuration.html
+        # example:
+        # haskell.formattingProvider = "ormolu"
+    }
+}
 ```
 
 ### [Helix](https://github.com/helix-editor/helix)


### PR DESCRIPTION
`kak-lsp` no longer uses `kak-lsp.toml`, instead, all configuration is done inside the Kakoune configuration via the buffer-scoped `lsp_servers` option. The included snippet is taken from `kak-lsp`'s default settings.
