### PR TITLE
fix(hls-eval-plugin): hardcode QckChck to eval property tests

### DIFF
--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -594,7 +594,7 @@ needsQuickCheck :: [(Section, EvalExpr)] -> Bool
 needsQuickCheck = any (isProperty . snd)
 
 hasQuickCheck :: DynFlags -> Bool
-hasQuickCheck df = hasPackage df "QuickCheck"
+hasQuickCheck df = any (hasPackage df) ["QuickCheck", "QckChck"]
 
 singleLine :: String -> [Text]
 singleLine s = [T.pack s]


### PR DESCRIPTION
Due to problem with [cabal store](https://github.com/haskell/cabal/issues/7209), currently on MacOS property test evaluation not working. And this pr fixes https://github.com/haskell/haskell-language-server/issues/5003 issue