### PR TITLE
bugfix(ghc optimization option): set optimization level to 0 to eval properly

### DIFF
--- a/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
+++ b/plugins/hls-eval-plugin/src/Ide/Plugin/Eval/Handlers.hs
@@ -81,6 +81,7 @@ import qualified Development.IDE.GHC.Compat.Core              as Compat (Interac
 import qualified Development.IDE.GHC.Compat.Core              as SrcLoc (unLoc)
 import           Development.IDE.Types.HscEnvEq               (HscEnvEq (hscEnv))
 import qualified GHC.LanguageExtensions.Type                  as LangExt (Extension (..))
+import           Development.IDE.Session.Ghc                  (disableOptimisation)
 
 import           Data.List.Extra                              (unsnoc)
 import           Development.IDE.Core.PluginUtils
@@ -303,6 +304,7 @@ initialiseSessionForEval needs_quickcheck st nfp = do
                    . flip xopt_unset  LangExt.MonomorphismRestriction
                    . flip gopt_set    Opt_ImplicitImportQualified
                    . flip gopt_unset  Opt_DiagnosticsShowCaret
+                   . disableOptimisation
                    . setBackend ghciBackend
                    $ (ms_hspp_opts ms) {
                         useColor = Never

--- a/plugins/hls-eval-plugin/test/Main.hs
+++ b/plugins/hls-eval-plugin/test/Main.hs
@@ -215,6 +215,7 @@ tests =
         Right keys <- getLastBuildKeys
         let ifaceKeys = filter ("GetModIface" `T.isPrefixOf`) keys
         liftIO $ ifaceKeys @?= []
+    , goldenWithEval "Works with OPTIONS_GHC -O1" "TGHCOptionO1" "hs"
   ]
   where
     knownBrokenInWindowsBeforeGHC912 msg =

--- a/plugins/hls-eval-plugin/test/testdata/TGHCOptionO1.expected.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TGHCOptionO1.expected.hs
@@ -1,0 +1,6 @@
+{-# OPTIONS_GHC -O1 #-}
+
+module TGHCOptionO1 where
+
+-- >>> 0.7
+-- 0.7

--- a/plugins/hls-eval-plugin/test/testdata/TGHCOptionO1.hs
+++ b/plugins/hls-eval-plugin/test/testdata/TGHCOptionO1.hs
@@ -1,0 +1,5 @@
+{-# OPTIONS_GHC -O1 #-}
+
+module TGHCOptionO1 where
+
+-- >>> 0.7


### PR DESCRIPTION
I couldn't fully understand what was root cause, but setting `updOptLevel 0` dynamic flag is fixed the problem with ghc optimization level

Fixes #4968 