### PR TITLE
Ormolu & Fourmolu on GHC 9.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,11 +174,11 @@ jobs:
         name: Test hls-stylish-haskell-plugin
         run: cabal test ${CABAL_ARGS} hls-stylish-haskell-plugin-tests || cabal test ${CABAL_ARGS} hls-stylish-haskell-plugin-tests
 
-      - if: matrix.test && matrix.ghc != '9.14'
+      - if: matrix.test
         name: Test hls-ormolu-plugin
         run: cabal test ${CABAL_ARGS} hls-ormolu-plugin-tests || cabal test ${CABAL_ARGS} hls-ormolu-plugin-tests
 
-      - if: matrix.test && matrix.ghc != '9.14'
+      - if: matrix.test
         name: Test hls-fourmolu-plugin
         run: cabal test ${CABAL_ARGS} hls-fourmolu-plugin-tests || cabal test ${CABAL_ARGS} hls-fourmolu-plugin-tests
 

--- a/cabal.project
+++ b/cabal.project
@@ -6,7 +6,7 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-index-state: 2026-04-16T00:00:00Z
+index-state: 2026-07-11T00:00:00Z
 
 tests: True
 test-show-details: direct

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1374,15 +1374,13 @@ flag fourmolu
   manual:      True
 
 common fourmolu
-  -- fourmolu depends on ghc-lib-parser which doesn't support GHC 9.14
-  if flag(fourmolu) && !impl(ghc >= 9.14)
+  if flag(fourmolu)
     build-depends: haskell-language-server:hls-fourmolu-plugin
     cpp-options: -Dhls_fourmolu
 
 library hls-fourmolu-plugin
   import:           defaults, pedantic, warnings
-  -- fourmolu depends on ghc-lib-parser which doesn't support GHC 9.14
-  if !flag(fourmolu) || impl(ghc >= 9.14)
+  if !flag(fourmolu)
     buildable: False
   exposed-modules:  Ide.Plugin.Fourmolu
   hs-source-dirs:   plugins/hls-fourmolu-plugin/src
@@ -1402,8 +1400,7 @@ library hls-fourmolu-plugin
 
 test-suite hls-fourmolu-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  -- fourmolu depends on ghc-lib-parser which doesn't support GHC 9.14
-  if !flag(fourmolu) || impl(ghc >= 9.14)
+  if !flag(fourmolu)
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-fourmolu-plugin/test
@@ -1435,15 +1432,13 @@ flag ormolu
   manual:      True
 
 common ormolu
-  -- ormolu depends on ghc-lib-parser which doesn't support GHC 9.14
-  if flag(ormolu) && !impl(ghc >= 9.14)
+  if flag(ormolu)
     build-depends: haskell-language-server:hls-ormolu-plugin
     cpp-options: -Dhls_ormolu
 
 library hls-ormolu-plugin
   import:           defaults, pedantic, warnings
-  -- ormolu depends on ghc-lib-parser which doesn't support GHC 9.14
-  if !flag(ormolu) || impl(ghc >= 9.14)
+  if !flag(ormolu)
     buildable: False
   exposed-modules:  Ide.Plugin.Ormolu
   hs-source-dirs:   plugins/hls-ormolu-plugin/src
@@ -1463,8 +1458,7 @@ library hls-ormolu-plugin
 
 test-suite hls-ormolu-plugin-tests
   import:           defaults, pedantic, test-defaults, warnings
-  -- ormolu depends on ghc-lib-parser which doesn't support GHC 9.14
-  if !flag(ormolu) || impl(ghc >= 9.14)
+  if !flag(ormolu)
     buildable: False
   type:             exitcode-stdio-1.0
   hs-source-dirs:   plugins/hls-ormolu-plugin/test

--- a/test/testdata/schema/ghc914/default-config.golden.json
+++ b/test/testdata/schema/ghc914/default-config.golden.json
@@ -58,6 +58,12 @@
         "export": {
             "globalOn": true
         },
+        "fourmolu": {
+            "config": {
+                "external": false,
+                "path": "fourmolu"
+            }
+        },
         "gadt": {
             "globalOn": true
         },
@@ -98,6 +104,11 @@
         "notes": {
             "completionOn": true,
             "hoverOn": true
+        },
+        "ormolu": {
+            "config": {
+                "external": false
+            }
         },
         "overloaded-record-dot": {
             "globalOn": true

--- a/test/testdata/schema/ghc914/markdown-reference.md
+++ b/test/testdata/schema/ghc914/markdown-reference.md
@@ -20,6 +20,11 @@
 | --- | --- | --- | --- |
 | `mode` | Control how type lenses are shown | `Always` | <ul> <li><code>Always</code></li> <li><code>Exported</code></li> <li><code>Diagnostics</code></li> </ul> |
 
+## ormolu
+| Property | Description | Default | Allowed values |
+| --- | --- | --- | --- |
+| `external` | Call out to an external "ormolu" executable, rather than using the bundled library | `False` |  &nbsp;  |
+
 ## rename
 | Property | Description | Default | Allowed values |
 | --- | --- | --- | --- |
@@ -41,6 +46,12 @@
 | `recordFieldToken` | LSP semantic token type to use for record fields | `SemanticTokenTypes_Property` | <ul> <li><code>SemanticTokenTypes_Namespace</code></li> <li><code>SemanticTokenTypes_Type</code></li> <li><code>SemanticTokenTypes_Class</code></li> <li><code>SemanticTokenTypes_Enum</code></li> <li><code>SemanticTokenTypes_Interface</code></li> <li><code>SemanticTokenTypes_Struct</code></li> <li><code>SemanticTokenTypes_TypeParameter</code></li> <li><code>SemanticTokenTypes_Parameter</code></li> <li><code>SemanticTokenTypes_Variable</code></li> <li><code>SemanticTokenTypes_Property</code></li> <li><code>SemanticTokenTypes_EnumMember</code></li> <li><code>SemanticTokenTypes_Event</code></li> <li><code>SemanticTokenTypes_Function</code></li> <li><code>SemanticTokenTypes_Method</code></li> <li><code>SemanticTokenTypes_Macro</code></li> <li><code>SemanticTokenTypes_Keyword</code></li> <li><code>SemanticTokenTypes_Modifier</code></li> <li><code>SemanticTokenTypes_Comment</code></li> <li><code>SemanticTokenTypes_String</code></li> <li><code>SemanticTokenTypes_Number</code></li> <li><code>SemanticTokenTypes_Regexp</code></li> <li><code>SemanticTokenTypes_Operator</code></li> <li><code>SemanticTokenTypes_Decorator</code></li> </ul> |
 | `operatorToken` | LSP semantic token type to use for operators | `SemanticTokenTypes_Operator` | <ul> <li><code>SemanticTokenTypes_Namespace</code></li> <li><code>SemanticTokenTypes_Type</code></li> <li><code>SemanticTokenTypes_Class</code></li> <li><code>SemanticTokenTypes_Enum</code></li> <li><code>SemanticTokenTypes_Interface</code></li> <li><code>SemanticTokenTypes_Struct</code></li> <li><code>SemanticTokenTypes_TypeParameter</code></li> <li><code>SemanticTokenTypes_Parameter</code></li> <li><code>SemanticTokenTypes_Variable</code></li> <li><code>SemanticTokenTypes_Property</code></li> <li><code>SemanticTokenTypes_EnumMember</code></li> <li><code>SemanticTokenTypes_Event</code></li> <li><code>SemanticTokenTypes_Function</code></li> <li><code>SemanticTokenTypes_Method</code></li> <li><code>SemanticTokenTypes_Macro</code></li> <li><code>SemanticTokenTypes_Keyword</code></li> <li><code>SemanticTokenTypes_Modifier</code></li> <li><code>SemanticTokenTypes_Comment</code></li> <li><code>SemanticTokenTypes_String</code></li> <li><code>SemanticTokenTypes_Number</code></li> <li><code>SemanticTokenTypes_Regexp</code></li> <li><code>SemanticTokenTypes_Operator</code></li> <li><code>SemanticTokenTypes_Decorator</code></li> </ul> |
 | `moduleToken` | LSP semantic token type to use for modules | `SemanticTokenTypes_Namespace` | <ul> <li><code>SemanticTokenTypes_Namespace</code></li> <li><code>SemanticTokenTypes_Type</code></li> <li><code>SemanticTokenTypes_Class</code></li> <li><code>SemanticTokenTypes_Enum</code></li> <li><code>SemanticTokenTypes_Interface</code></li> <li><code>SemanticTokenTypes_Struct</code></li> <li><code>SemanticTokenTypes_TypeParameter</code></li> <li><code>SemanticTokenTypes_Parameter</code></li> <li><code>SemanticTokenTypes_Variable</code></li> <li><code>SemanticTokenTypes_Property</code></li> <li><code>SemanticTokenTypes_EnumMember</code></li> <li><code>SemanticTokenTypes_Event</code></li> <li><code>SemanticTokenTypes_Function</code></li> <li><code>SemanticTokenTypes_Method</code></li> <li><code>SemanticTokenTypes_Macro</code></li> <li><code>SemanticTokenTypes_Keyword</code></li> <li><code>SemanticTokenTypes_Modifier</code></li> <li><code>SemanticTokenTypes_Comment</code></li> <li><code>SemanticTokenTypes_String</code></li> <li><code>SemanticTokenTypes_Number</code></li> <li><code>SemanticTokenTypes_Regexp</code></li> <li><code>SemanticTokenTypes_Operator</code></li> <li><code>SemanticTokenTypes_Decorator</code></li> </ul> |
+
+## fourmolu
+| Property | Description | Default | Allowed values |
+| --- | --- | --- | --- |
+| `external` | Call out to an external "fourmolu" executable, rather than using the bundled library. | `False` |  &nbsp;  |
+| `path` | Set path to executable (for "external" mode). | `"fourmolu"` |  &nbsp;  |
 
 ## cabal-gild
 | Property | Description | Default | Allowed values |

--- a/test/testdata/schema/ghc914/vscode-extension-schema.golden.json
+++ b/test/testdata/schema/ghc914/vscode-extension-schema.golden.json
@@ -125,6 +125,18 @@
         "scope": "resource",
         "type": "boolean"
     },
+    "haskell.plugin.fourmolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"fourmolu\" executable, rather than using the bundled library.",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.fourmolu.config.path": {
+        "default": "fourmolu",
+        "markdownDescription": "Set path to executable (for \"external\" mode).",
+        "scope": "resource",
+        "type": "string"
+    },
     "haskell.plugin.gadt.globalOn": {
         "default": true,
         "description": "Enables gadt plugin",
@@ -234,6 +246,12 @@
     "haskell.plugin.notes.hoverOn": {
         "default": true,
         "description": "Enables notes hover",
+        "scope": "resource",
+        "type": "boolean"
+    },
+    "haskell.plugin.ormolu.config.external": {
+        "default": false,
+        "markdownDescription": "Call out to an external \"ormolu\" executable, rather than using the bundled library",
         "scope": "resource",
         "type": "boolean"
     },


### PR DESCRIPTION
Ormolu & Fourmolu on GHC 9.14

- Bump cabal index state to 2026-07-11
- Remove build restrictions for Ormolu on GHC 9.14 and above
- Remove build restrictions for Fourmolu on GHC 9.14 and above

| cabal test | Result |
| - | - |
| hls-ormolu-plugin-tests | PASS |
| hls-fourmolu-plugin-tests | PASS |

Closes #4836.
