### PR TITLE
Fix stale completions after changing an import alias

### DIFF
--- a/ghcide-test/exe/CompletionTests.hs
+++ b/ghcide-test/exe/CompletionTests.hs
@@ -513,7 +513,37 @@ projectCompletionTests =
         compls <- getCompletions doc (Position 2 12)
         let item = head compls
         liftIO $ do
-          item ^. L.label @?= "anidentifier"
+          item ^. L.label @?= "anidentifier",
+      testSessionEmptyWithCradle "refresh completions after changing an import alias"
+                  "cradle: {direct: {arguments: [\"-Wmissing-signatures\", \"A\", \"B\"]}}" $ do
+        _ <- createDoc "A.hs" "haskell" $ T.unlines
+            [ "module A (anidentifier) where"
+            , "anidentifier = ()"
+            ]
+        _ <- waitForDiagnostics
+        doc <- createDoc "B.hs" "haskell" $ T.unlines
+            [ "module B where"
+            , "import A as CM"
+            , "before = CM."
+            ]
+        _ <- waitForDiagnostics
+        before <- getCompletions doc (Position 2 12)
+
+        changeDoc doc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $ T.unlines
+            [ "module B where"
+            , "import A as C"
+            , "after = C."
+            , "stale = CM."
+            ]]
+        void $ waitForTypecheck doc
+        after <- getCompletions doc (Position 2 10)
+        stale <- getCompletions doc (Position 3 11)
+
+        liftIO $ do
+          listToMaybe (map (^. L.label) before) @?= Just "anidentifier"
+          listToMaybe (map (^. L.label) after) @?= Just "anidentifier"
+          assertBool "the old alias is still treated as an active import alias" $
+            listToMaybe (map (^. L.label) stale) /= Just "anidentifier"
     ]
 
 completionDocTests :: [TestTree]

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -1215,7 +1215,8 @@ getModSummaryFromImports env fp mContents = do
 
         msrImports = implicit_imports ++ imps
 
-        rn_pkg_qual = renameRawPkgQual (hsc_unit_env ppEnv)
+        unitEnv = hsc_unit_env ppEnv
+        rn_pkg_qual = renameRawPkgQual unitEnv
         rn_imps = fmap (\(pk, lmn@(L _ mn)) -> (rn_pkg_qual mn pk, lmn))
 #if MIN_VERSION_ghc(9,13,0)
         -- In GHC 9.13+, ms_srcimps is just [Located ModuleName] and ms_textual_imps includes ImportLevel
@@ -1276,33 +1277,30 @@ getModSummaryFromImports env fp mContents = do
                 , ms_textual_imps = textualImports
                 }
 
-    msrFingerprint <- liftIO $ computeFingerprint opts msrModSummary
+    msrFingerprint <- liftIO $ computeFingerprint opts unitEnv msrImports msrModSummary
     msrHscEnv <- liftIO $ Loader.initializePlugins (hscSetFlags (ms_hspp_opts msrModSummary) ppEnv)
     pure ModSummaryResult{..}
     where
-        -- Compute a fingerprint from the contents of `ModSummary`,
+        -- Compute a fingerprint from the `msrImports` and the contents of `ModSummary`,
         -- eliding the timestamps, the preprocessed source and other non relevant fields
-        computeFingerprint opts ModSummary{..} = do
+        computeFingerprint opts unitEnv msrImports ModSummary{..} = do
             fingerPrintImports <- fingerprintFromPut $ do
                   put $ Util.uniq $ moduleNameFS $ moduleName ms_mod
-#if MIN_VERSION_ghc(9,13,0)
-                  -- In GHC 9.13+, ms_srcimps is [Located ModuleName] and ms_textual_imps is [(ImportLevel, PkgQual, Located ModuleName)]
-                  forM_ ms_srcimps $ \m -> do
-                    put $ Util.uniq $ moduleNameFS $ unLoc m
-                  forM_ ms_textual_imps $ \(_lvl, mb_p, m) -> do
-                    put $ Util.uniq $ moduleNameFS $ unLoc m
-                    case mb_p of
-                      G.NoPkgQual    -> pure ()
-                      G.ThisPkg uid  -> put $ getKey $ getUnique uid
-                      G.OtherPkg uid -> put $ getKey $ getUnique uid
-#else
-                  forM_ (ms_srcimps ++ ms_textual_imps) $ \(mb_p, m) -> do
-                    put $ Util.uniq $ moduleNameFS $ unLoc m
-                    case mb_p of
-                      G.NoPkgQual    -> pure ()
-                      G.ThisPkg uid  -> put $ getKey $ getUnique uid
-                      G.OtherPkg uid -> put $ getKey $ getUnique uid
-#endif
+
+                  forM_ msrImports $ \(L _ decl) -> do
+                      let modName = unLoc $ ideclName decl
+                          pkgQual = renameRawPkgQual unitEnv modName (ideclPkgQual decl)
+
+                      put $ Util.uniq $ moduleNameFS modName
+                      put $ ideclSource decl == IsBoot
+
+                      case pkgQual of
+                          G.NoPkgQual    -> pure ()
+                          G.ThisPkg uid  -> put $ getKey $ getUnique uid
+                          G.OtherPkg uid -> put $ getKey $ getUnique uid
+
+                      put $ Util.uniq . moduleNameFS . unLoc <$> ideclAs decl
+
             pure $! Util.fingerprintFingerprints $
                     [ Util.fingerprintString fp
                     , fingerPrintImports


### PR DESCRIPTION
## Description

Refresh qualified completions when an import alias is changed without restarting HLS.

Previously, changing:

```haskell
import A as CM
```

to:
```haskell
import A as C
```

could leave non-local completions associated with the old CM qualifier. As a result, completions for C did not prioritize the members imported from A.

## Root cause

`GetModSummaryWithoutTimestamps` used `msrFingerprint` as its early-cutoff fingerprint. That fingerprint represents dependency-relevant module information, such as imported
module and package names, but does not include full import declarations.

Changing only an import alias therefore left the fingerprint unchanged, preventing downstream `NonLocalCompletions` from being recomputed.

## Changes

- Add `computeImportsFingerprint` for full parsed import declarations, including aliases and import lists.
- Combine the imports fingerprint with `msrFingerprint` in the `GetModSummaryWithoutTimestamps` early cutoff.
- Add a regression test that changes an alias from CM to C in an open document, and verify that the new alias receives the imported module completions and the previous alias is no longer treated as active.

## Testing

Ran the completion and completion-resolve test selection:
```
cabal test ghcide-tests \
  --test-option=-p \
  --test-option='/completion/' \
  --test-option=--hide-progress
```
All 49 selected tests passed.