### PR TITLE
Restrict batch session loads to files owned by the same cradle

### DIFF
--- a/ghcide-test/data/cross-cradle/a/A.hs
+++ b/ghcide-test/data/cross-cradle/a/A.hs
@@ -1,0 +1,3 @@
+module A(foo) where
+foo :: Int
+foo = 1

--- a/ghcide-test/data/cross-cradle/a/a.cabal
+++ b/ghcide-test/data/cross-cradle/a/a.cabal
@@ -1,0 +1,9 @@
+name: a
+version: 1.0.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  build-depends: base
+  exposed-modules: A
+  hs-source-dirs: .

--- a/ghcide-test/data/cross-cradle/cabal.project
+++ b/ghcide-test/data/cross-cradle/cabal.project
@@ -1,0 +1,1 @@
+packages: a

--- a/ghcide-test/data/cross-cradle/hie.yaml
+++ b/ghcide-test/data/cross-cradle/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/ghcide-test/data/cross-cradle/standalone/Standalone.hs
+++ b/ghcide-test/data/cross-cradle/standalone/Standalone.hs
@@ -1,0 +1,3 @@
+module Standalone where
+bar :: Int
+bar = 2

--- a/ghcide-test/data/cross-cradle/standalone/hie.yaml
+++ b/ghcide-test/data/cross-cradle/standalone/hie.yaml
@@ -1,0 +1,5 @@
+# Files in this directory are not part of any cabal component; they are owned
+# by their own direct cradle, distinct from the cabal cradle at the root.
+cradle:
+  direct:
+    arguments: []

--- a/ghcide-test/exe/CradleTests.hs
+++ b/ghcide-test/exe/CradleTests.hs
@@ -51,6 +51,7 @@ tests = testGroup "cradle"
     ,testGroup "ignore-fatal" [ignoreFatalWarning]
     ,testGroup "loading" [loadCradleOnlyonce, retryFailedCradle]
     ,testGroup "regression.batch" batchLoadRegressionTests
+    ,testGroup "cross-cradle" [crossCradleBatchIsolationTest]
     ,testGroup "multi"   (multiTests "multi")
     ,testGroup "multi-unit" (multiTests "multi-unit")
     ,testGroup "sub-directory"   [simpleSubDirectoryTest]
@@ -395,6 +396,23 @@ regressionNoStaleOutcomesOnRestart dir = do
   changeDoc bdoc
     [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $ bSource <> "\n"]
   assertTypeCheckSuccess bdoc "B should not keep stale failure after cradle restart"
+
+-- | Files loaded by one cradle must not be handed to another cradle's
+-- multi-component load. Here @standalone/Standalone.hs@ is owned by a direct
+-- cradle; once it is loaded, opening @a/A.hs@ (owned by the root cabal cradle)
+-- used to batch the standalone file into @cabal repl@, which cannot map it to
+-- any component and fails wholesale, poisoning the load of A.
+crossCradleBatchIsolationTest :: TestTree
+crossCradleBatchIsolationTest =
+  testCase "direct-cradle-file-does-not-poison-cabal-load" $
+    runWithExtraFilesMultiComponent "cross-cradle" $ \dir -> do
+      let standalonePath = dir </> "standalone/Standalone.hs"
+          aPath = dir </> "a/A.hs"
+      sdoc <- openDoc standalonePath "haskell"
+      assertTypeCheckSuccess sdoc "standalone file (direct cradle) should typecheck"
+      adoc <- openDoc aPath "haskell"
+      assertTypeCheckSuccess adoc
+        "cabal-cradle file should typecheck after a direct-cradle file was loaded"
 
 -- Like simpleMultiTest but open the files in component 'a' in a separate session
 simpleMultiDefTest :: FilePath -> TestTree

--- a/ghcide-test/exe/CradleTests.hs
+++ b/ghcide-test/exe/CradleTests.hs
@@ -235,6 +235,23 @@ runRegressionMultiOpenBThenAThenC dir = do
     checkDefs locs (pure [fooL])
     expectNoMoreDiagnostics 0.5
 
+-- | Several files across different components of the same cradle are all
+-- pending before the first load starts. Ensure they are submitted in the same
+-- batch.
+runRegressionInitialOpenSingleBatchLoad :: FilePath -> Session ()
+runRegressionInitialOpenSingleBatchLoad dir = do
+    let aPath = dir </> "a/A.hs"
+        bPath = dir </> "b/B.hs"
+        cPath = dir </> "c/C.hs"
+    adoc <- openDoc aPath "haskell"
+    bdoc <- openDoc bPath "haskell"
+    cdoc <- openDoc cPath "haskell"
+    _ <- waitForBuildQueue
+    (results, loads) <- waitForTypeChecksCountingCradleLoads [adoc, bdoc, cdoc]
+    liftIO $ do
+      assertBool "A, B and C should all typecheck" (all ideResultSuccess results)
+      assertEqual "cradle loads for the initial batch of files" 1 loads
+
 sendTestRequest :: TestRequest -> Session A.Value
 sendTestRequest req = do
   let method = SMethod_CustomMethod (Proxy @"test")
@@ -243,6 +260,27 @@ sendTestRequest req = do
   case _result of
     Left err -> liftIO (assertFailure $ "test plugin request failed: " <> show err) >> pure A.Null
     Right val -> pure val
+
+-- | Like 'waitForTypeChecksBatched', but additionally count the
+-- @ghcide/cradle/loaded@ notifications the server emits while satisfying the
+-- request, i.e. how many cradle loads it took to serve all the files.
+waitForTypeChecksCountingCradleLoads :: [TextDocumentIdentifier] -> Session ([WaitForIdeRuleResult], Int)
+waitForTypeChecksCountingCradleLoads docs = do
+  let uris = map (\TextDocumentIdentifier{_uri} -> _uri) docs
+      method = SMethod_CustomMethod (Proxy @"test")
+  reqId <- sendRequest method (A.toJSON (WaitForIdeRules "TypeCheck" uris))
+  let
+    go loads = do
+      next <- skipManyTill anyMessage $
+        (Left <$> cradleLoadedMessage) <|> (Right <$> responseForId method reqId)
+      case next of
+        Left _ -> go (loads + 1)
+        Right TResponseMessage{_result} -> case _result of
+          Left err -> liftIO $ assertFailure $ "test plugin request failed: " <> show err
+          Right val -> case A.fromJSON val of
+            A.Success res -> pure (res, loads)
+            A.Error parseErr -> liftIO $ assertFailure $ "batched typecheck parse failed: " <> parseErr
+  go 0
 
 waitForTypeChecksBatched :: [TextDocumentIdentifier] -> Session [WaitForIdeRuleResult]
 waitForTypeChecksBatched docs = do
@@ -265,6 +303,8 @@ batchLoadRegressionTests =
       runWithExtraFilesMultiComponent "multi" runRegressionMultiOpenBThenA
   , testCase "m3-open-b-then-a-then-c-batch-pending-and-success" $
       runWithExtraFilesMultiComponent "multi" runRegressionMultiOpenBThenAThenC
+  , testCase "m4-initial-multi-file-open-loads-cradle-once" $
+      runWithExtraFilesMultiComponent "multi" runRegressionInitialOpenSingleBatchLoad
   , testCase "f1-batch-pending-failure-isolates-broken-file" $
       runWithExtraFilesMultiComponent "multi" regressionBatchFailureIsolatesBrokenFile
   , testCase "f2-failed-file-keeps-failing-until-cradle-fix" $

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -539,6 +539,11 @@ insertFileMapping :: SessionState -> Maybe FilePath -> NormalizedFilePath -> STM
 insertFileMapping state hieYaml ncfp =
   STM.insert hieYaml ncfp (filesMap state)
 
+-- | Same as 'insertFileMapping', but never overwrites an existing value.
+insertFileMappingIfMissing :: SessionState -> Maybe FilePath -> NormalizedFilePath -> STM ()
+insertFileMappingIfMissing state hieYaml ncfp =
+  STM.focus (Focus.alter (<|> Just hieYaml)) ncfp (filesMap state)
+
 -- | Remove a file from the pending file set
 removeFromPending :: SessionState -> FilePath -> STM ()
 removeFromPending state file =
@@ -711,14 +716,14 @@ loadSessionWithOptions recorder SessionLoadingOptions{..} rootDir que = do
     let absolutePathsCradleDeps (eq, deps) = (eq, fmap toAbsolutePath $ Map.keys deps)
     returnWithVersion $ \file -> do
       let absFile = toAbsolutePath file
-      absolutePathsCradleDeps <$> lookupOrWaitCache recorder sessionState absFile
+      absolutePathsCradleDeps <$> lookupOrWaitCache recorder sessionState cradleLoc absFile
 
 -- | Given a file, this function will return the HscEnv and the dependencies
 -- it would look up the cache first, if the cache is not available, it would
 -- submit a request to the getOptionsLoop to get the options for the file
 -- and wait until the options are available
-lookupOrWaitCache :: Recorder (WithPriority Log) -> SessionState -> FilePath -> IO (IdeResult HscEnvEq, DependencyInfo)
-lookupOrWaitCache recorder sessionState absFile = do
+lookupOrWaitCache :: Recorder (WithPriority Log) -> SessionState -> (FilePath -> IO (Maybe FilePath)) -> FilePath -> IO (IdeResult HscEnvEq, DependencyInfo)
+lookupOrWaitCache recorder sessionState cradleLoc absFile = do
   let ncfp = toNormalizedFilePath' absFile
   cacheResult <- maybeM
     (return Nothing)
@@ -736,8 +741,14 @@ lookupOrWaitCache recorder sessionState absFile = do
     Just r -> return r
     Nothing -> do
       -- if not ok, we need to reload the session
-      atomically $ addToPending sessionState absFile
-      lookupOrWaitCache recorder sessionState absFile
+      hieYaml <- cradleLoc absFile
+      atomically $ do
+        -- Insert the mapping into filesMap so the cradle is known up-front.
+        -- This ensures we are able to batch requests belonging to the same
+        -- cradle.
+        insertFileMappingIfMissing sessionState hieYaml ncfp
+        addToPending sessionState absFile
+      lookupOrWaitCache recorder sessionState cradleLoc absFile
 
 checkInCache :: SessionState -> NormalizedFilePath -> STM (Maybe (IdeResult HscEnvEq, DependencyInfo))
 checkInCache sessionState ncfp = runMaybeT $ do

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -401,6 +401,8 @@ getHieDbLocIn base dir = do
 -- - The loader processes files from 'pendingFiles', attempting to load them in batches.
 -- - (SBL1) If a file is already in 'failedFiles', it is loaded individually (single-file mode).
 -- - (SBL2) Otherwise, the loader tries to load as many files as possible together (batch mode).
+--   Only files owned by the same cradle (the same @hie.yaml@) as the file being
+--   loaded are batched together; see 'getExtraFilesToLoad'.
 --
 -- On success:
 --   - (SBL3) All successfully loaded files are removed from 'pendingFiles' and 'failedFiles',
@@ -580,18 +582,24 @@ handleSingleFileProcessingError state hieYaml file diags extraDepFiles = liftIO 
 --
 -- If the current file is in error loading files, we fallback to single loading mode (empty set)
 -- Otherwise, we remove error files from pending files and also exclude the current file
-getExtraFilesToLoad :: SessionState -> FilePath -> IO [FilePath]
-getExtraFilesToLoad state cfp = do
-  pendingFiles <- getPendingFiles state
-  errorFiles <- readVar (failedFiles state)
-  old_files <- readVar (loadedFiles state)
+--
+-- Only files that belong to the same cradle as the current file (i.e. resolve
+-- to the same @hie.yaml@) are returned. Handing files owned by a different
+-- cradle to a multi-component load makes the build tool fail wholesale — e.g.
+-- cabal cannot map the foreign files to any component of this cradle — which
+-- poisons the load of the current file.
+getExtraFilesToLoad :: SessionState -> Maybe FilePath -> FilePath -> SessionM [FilePath]
+getExtraFilesToLoad state hieYaml cfp = do
+  pendingFiles <- liftIO $ getPendingFiles state
+  errorFiles <- liftIO $ readVar (failedFiles state)
+  old_files <- liftIO $ readVar (loadedFiles state)
   -- if the file is in error loading files, we fall back to single loading mode
-  return $
-    Set.toList $
-      if cfp `Set.member` errorFiles
-        then Set.empty
-        -- remove error files from pending files since error loading need to load one by one
-        else (Set.delete cfp $ pendingFiles `Set.difference` errorFiles) <> old_files
+  let candidates =
+        if cfp `Set.member` errorFiles
+          then Set.empty
+          -- remove error files from pending files since error loading need to load one by one
+          else (Set.delete cfp $ pendingFiles `Set.difference` errorFiles) <> old_files
+  filterM (fmap (== hieYaml) . findHieYamlForTarget (filesMap state)) (Set.toList candidates)
 
 -- | We allow users to specify a loading strategy.
 -- Check whether this config was changed since the last time we have loaded
@@ -1026,7 +1034,7 @@ loadCradleWithNotifications recorder sessionState hieYaml cfp = do
                 <> " (for " <> T.pack lfpLog <> ")"
 
   sessionPref <- asks (sessionLoading . sessionClientConfig)
-  extraToLoads <- liftIO $ getExtraFilesToLoad sessionState cfp
+  extraToLoads <- getExtraFilesToLoad sessionState hieYaml cfp
   -- Start loading the file!
   eopts <- mRunLspTCallback lspEnv (\act -> withIndefiniteProgress progMsg Nothing NotCancellable (const act)) $
     withTrace "Load cradle" $ \addTag -> do

--- a/ghcide/session-loader/Development/IDE/Session.hs
+++ b/ghcide/session-loader/Development/IDE/Session.hs
@@ -583,23 +583,26 @@ handleSingleFileProcessingError state hieYaml file diags extraDepFiles = liftIO 
 -- If the current file is in error loading files, we fallback to single loading mode (empty set)
 -- Otherwise, we remove error files from pending files and also exclude the current file
 --
--- Only files that belong to the same cradle as the current file (i.e. resolve
--- to the same @hie.yaml@) are returned. Handing files owned by a different
--- cradle to a multi-component load makes the build tool fail wholesale — e.g.
--- cabal cannot map the foreign files to any component of this cradle — which
--- poisons the load of the current file.
-getExtraFilesToLoad :: SessionState -> Maybe FilePath -> FilePath -> SessionM [FilePath]
+-- Only files already known to belong to the same cradle as the current file are
+-- returned. Handing files owned by a different cradle to a multi-component load
+-- makes the build tool fail wholesale — e.g. cabal cannot map the foreign files
+-- to any component of this cradle — which poisons the load of the current file.
+getExtraFilesToLoad :: SessionState -> Maybe FilePath -> FilePath -> IO [FilePath]
 getExtraFilesToLoad state hieYaml cfp = do
-  pendingFiles <- liftIO $ getPendingFiles state
-  errorFiles <- liftIO $ readVar (failedFiles state)
-  old_files <- liftIO $ readVar (loadedFiles state)
+  pendingFiles <- getPendingFiles state
+  errorFiles <- readVar (failedFiles state)
+  old_files <- readVar (loadedFiles state)
   -- if the file is in error loading files, we fall back to single loading mode
   let candidates =
         if cfp `Set.member` errorFiles
           then Set.empty
           -- remove error files from pending files since error loading need to load one by one
           else (Set.delete cfp $ pendingFiles `Set.difference` errorFiles) <> old_files
-  filterM (fmap (== hieYaml) . findHieYamlForTarget (filesMap state)) (Set.toList candidates)
+  filterM ownedByThisCradle (Set.toList candidates)
+  where
+    ownedByThisCradle file = do
+      owner <- atomically $ STM.lookup (toNormalizedFilePath' file) (filesMap state)
+      pure $ owner == Just hieYaml
 
 -- | We allow users to specify a loading strategy.
 -- Check whether this config was changed since the last time we have loaded
@@ -1034,7 +1037,7 @@ loadCradleWithNotifications recorder sessionState hieYaml cfp = do
                 <> " (for " <> T.pack lfpLog <> ")"
 
   sessionPref <- asks (sessionLoading . sessionClientConfig)
-  extraToLoads <- getExtraFilesToLoad sessionState hieYaml cfp
+  extraToLoads <- liftIO $ getExtraFilesToLoad sessionState hieYaml cfp
   -- Start loading the file!
   eopts <- mRunLspTCallback lspEnv (\act -> withIndefiniteProgress progMsg Nothing NotCancellable (const act)) $
     withTrace "Load cradle" $ \addTag -> do


### PR DESCRIPTION
I keep running into this issue so I've attempted to fix it. 

Essentially:

* Launch VSCode and open the haskell-language-server repo
* Open ghcide-test/data/hover/GotoHover.hs
* Wait for everything to settle
* Open ghcide/src/Development/Ide/Spans/AtPoint.hs

expect: AtPoint.hs should load without error
actual: Loading the module '/Users/simon/src/github.com/haskell/haskell-language-server/ghcide/src/Development/IDE/Spans/AtPoint.hs' failed.

It may not be listed in your .cabal file!
Perhaps you need to add `AtPoint` to other-modules or exposed-modules.
...

Please take a look and let me know if the patch is suitable.

AI disclaimer: This patch was made with assistance from Claude.

Fixes #4431