### PR TITLE
Update cabal-version to 3.14

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.4
+cabal-version:      3.14
 category:           Development
 name:               haskell-language-server
 version:            2.14.0.0
@@ -15,9 +15,10 @@ license:            Apache-2.0
 license-file:       LICENSE
 build-type:         Simple
 tested-with:        GHC == {9.14.1, 9.12.2, 9.10.3, 9.8.4, 9.6.7}
-extra-source-files:
+extra-doc-files:
   README.md
   ChangeLog.md
+extra-files:
   test/testdata/**/*.project
   test/testdata/**/*.cabal
   test/testdata/**/*.yaml


### PR DESCRIPTION
Attempt at updating `cabal-version` to 3.14.

The real motivation is to have the `extra-files` stanza in which to move most files currently listed under `extra-source-files`; doing so would improve the developer experience by preventing `cabal run`/`build` from rebuilding the project when only `*/testdata/*` files are changed.