### PR TITLE
Build CI with `--jobs` and `--semaphore`

### DIFF
--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -82,7 +82,8 @@ jobs:
           cat cabal.project.local
 
       - name: Build everything with non-default flags
-        run: cabal build all
+        # --semaphore (GHC -jsem) needs GHC >= 9.8, so skip it on 9.6.
+        run: cabal build --jobs ${{ matrix.ghc != '9.6' && '--semaphore' || '' }} all
 
   flags_post_job:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,8 @@ jobs:
           os: ${{ runner.os }}
 
       - name: Build
-        run: cabal build --max-backjumps 10000 ${CABAL_ARGS} all
+        # --semaphore (GHC -jsem) needs GHC >= 9.8, so skip it on 9.6.
+        run: cabal build --max-backjumps 10000 ${CABAL_ARGS} --jobs ${{ matrix.ghc != '9.6' && '--semaphore' || '' }} all
 
       - name: Set test options
         # See https://github.com/ocharles/tasty-rerun/issues/22 for why we need


### PR DESCRIPTION
Might as well given GHA provides runners with [4 cores](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories). A very unscientific comparison shows about a ~18% speedup in build time on CI, comparing [this](https://github.com/haskell/haskell-language-server/actions/runs/29775753269/job/88464639147) with [here](https://github.com/haskell/haskell-language-server/actions/runs/29781018813/job/88482058473?pr=5022)