### PR TITLE
Fix invalid non-singleton constraint suggestion edits

### DIFF
--- a/ghcide/src/Development/IDE/GHC/Compat/Error.hs
+++ b/ghcide/src/Development/IDE/GHC/Compat/Error.hs
@@ -41,9 +41,11 @@ module Development.IDE.GHC.Compat.Error (
   _MismatchMessage,
   _TypeEqMismatchActual,
   _TypeEqMismatchExpected,
+  _CouldNotDeducePred,
   ) where
 
 import           Control.Lens
+import qualified Data.List.NonEmpty         as NE
 import           Development.IDE.GHC.Compat (Type)
 import           GHC.Driver.Errors.Types
 import           GHC.HsToCore.Errors.Types
@@ -127,6 +129,16 @@ _MismatchMessage :: Traversal' TcSolverReportMsg MismatchMsg
 _MismatchMessage focus (Mismatch msg t a c) = (\msg' -> Mismatch msg' t a c) <$> focus msg
 _MismatchMessage focus (CannotUnifyVariable msg a) = flip CannotUnifyVariable a <$> focus msg
 _MismatchMessage _ report = pure report
+
+-- | Focus the missing constraint predicate for a @"Could not deduce ..."@ or
+-- @"No instance for ..."@ error.
+_CouldNotDeducePred :: Fold TcSolverReportMsg Type
+_CouldNotDeducePred = folding $ \report -> case report of
+  CannotResolveInstance{cannotResolve_item = i} -> Just (errorItemPred i)
+  UnboundImplicitParams items -> Just (errorItemPred (NE.head items))
+  _ -> case report ^? _MismatchMessage of
+    Just CouldNotDeduce{cnd_wanted = w} -> Just (errorItemPred (NE.head w))
+    _                                   -> Nothing
 
 -- | Focus 'teq_mismatch_expected' from 'TypeEqMismatch'.
 _TypeEqMismatchExpected :: Traversal' MismatchMsg Type

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -50,8 +50,11 @@ import           Development.IDE.Core.Shake                        hiding (Log)
 import           Development.IDE.GHC.Compat                        hiding
                                                                    (ImplicitPrelude)
 import           Development.IDE.GHC.Compat.Error                  (TcRnMessage (..),
+                                                                    _CouldNotDeducePred,
                                                                     _TcRnMessage,
-                                                                    msgEnvelopeErrorL)
+                                                                    _TcRnSolverReport,
+                                                                    msgEnvelopeErrorL,
+                                                                    reportContentL)
 import           Development.IDE.GHC.Compat.Util
 import           Development.IDE.GHC.Error
 import           Development.IDE.GHC.ExactPrint
@@ -1264,9 +1267,9 @@ suggestAddRecordFieldImport exportsMap df ps fileContents Diagnostic {..}
                _                                  -> Nothing
 
 -- | Suggests a constraint for a declaration for which a constraint is missing.
-suggestConstraint :: DynFlags -> ParsedSource -> Diagnostic -> [(T.Text, Rewrite)]
-suggestConstraint df ps diag@Diagnostic {..}
-  | Just missingConstraint <- findMissingConstraint _message
+suggestConstraint :: DynFlags -> ParsedSource -> FileDiagnostic -> [(T.Text, Rewrite)]
+suggestConstraint df ps fd
+  | Just missingConstraint <- structuredMissingConstraint
   = let
 #if MIN_VERSION_ghc(9,9,0)
         parsedSource = ps
@@ -1279,22 +1282,13 @@ suggestConstraint df ps diag@Diagnostic {..}
      in codeAction diag missingConstraint
   | otherwise = []
     where
-      findMissingConstraint :: T.Text -> Maybe T.Text
-      findMissingConstraint t =
-        let -- The regex below can be tested at:
-            --   https://regex101.com/r/dfSivJ/1
-            regex = "(No instance for|Could not deduce):? (\\((.+)\\)|‘(.+)’|.+) arising from" -- a use of / a do statement
+      diag@Diagnostic{..} = fdLspDiagnostic fd
 
-            match = matchRegexUnifySpaces t regex
-
-            -- For a string like:
-            --   "Could not deduce: ?a::() arising from"
-            -- The `matchRegexUnifySpaces` function returns two empty match
-            -- groups at the end of the list. It's not clear why this is the
-            -- case, so we select the last non-empty match group.
-            getCorrectGroup = last . filter (/="")
-
-        in getCorrectGroup <$> match
+      -- The missing constraint, taken from GHC's structured solver report.
+      structuredMissingConstraint =
+        printOutputable <$>
+          (fd ^? fdStructuredMessageL . _SomeStructuredMessage . msgEnvelopeErrorL
+                 . _TcRnMessage . _TcRnSolverReport . _1 . reportContentL . _CouldNotDeducePred)
 
 -- | Suggests a constraint for an instance declaration for which a constraint is missing.
 suggestInstanceConstraint :: DynFlags -> ParsedSource -> Diagnostic -> T.Text -> [(T.Text, Rewrite)]

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -104,7 +104,7 @@ import           Language.LSP.Protocol.Types                       (ApplyWorkspa
                                                                     uriToFilePath)
 import qualified Language.LSP.Protocol.Types                       as TE (TextEdit (..))
 import qualified Text.Fuzzy.Parallel                               as TFP
-import           Text.Regex.TDFA                                   ((=~), (=~~))
+import           Text.Regex.TDFA                                   ((=~~))
 
 -- See Note [Guidelines For Using CPP In GHCIDE Import Statements]
 #if MIN_VERSION_ghc(9,7,0)
@@ -113,6 +113,8 @@ import           GHC.Tc.Errors.Types                               (UnusedImport
 import           GHC.Tc.Types.Constraint                           (ctLoc,
                                                                     ctOrigin)
 --import           GHC.Types.Name.Occurrence (OccName,occNameSpace)
+#else
+import           Text.Regex.TDFA                                   ((=~))
 #endif
 
 #if !MIN_VERSION_ghc(9,9,0)

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction.hs
@@ -89,6 +89,7 @@ import           Ide.Logger                                        hiding
 import           Ide.PluginUtils                                   (extendToFullLines,
                                                                     subRange)
 import           Ide.Types
+import qualified Language.LSP.Protocol.Lens                        as L
 import           Language.LSP.Protocol.Message                     (Method (..),
                                                                     SMethod (..))
 import           Language.LSP.Protocol.Types                       (ApplyWorkspaceEditParams (..),
@@ -101,7 +102,6 @@ import           Language.LSP.Protocol.Types                       (ApplyWorkspa
                                                                     ShowMessageParams (..),
                                                                     TextDocumentIdentifier (TextDocumentIdentifier),
                                                                     TextEdit (TextEdit, _range),
-                                                                    UInt,
                                                                     WorkspaceEdit (WorkspaceEdit, _changeAnnotations, _changes, _documentChanges),
                                                                     type (|?) (InL, InR),
                                                                     uriToFilePath)
@@ -376,14 +376,6 @@ findSigOfBinds range = go
 #endif
             findSigOfBind range (unLoc lHsBindLR)
     go _ = Nothing
-
-findInstanceHead :: (Outputable (HsType p), p ~ GhcPass p0) => DynFlags -> String -> [LHsDecl p] -> Maybe (LHsType p)
-findInstanceHead df instanceHead decls =
-  listToMaybe
-    [ hsib_body
-      | L _ (InstD _ (ClsInstD _ ClsInstDecl {cid_poly_ty = (unLoc -> HsSig {sig_body = hsib_body})})) <- decls,
-        showSDoc df (ppr hsib_body) == instanceHead
-    ]
 
 #if MIN_VERSION_ghc(9,9,0)
 findDeclContainingLoc :: (Foldable t, HasLoc l) => Position -> t (GenLocated l e) -> Maybe (GenLocated l e)
@@ -1267,67 +1259,39 @@ suggestAddRecordFieldImport exportsMap df ps fileContents Diagnostic {..}
                _                                  -> Nothing
 
 -- | Suggests a constraint for a declaration for which a constraint is missing.
-suggestConstraint :: DynFlags -> ParsedSource -> FileDiagnostic -> [(T.Text, Rewrite)]
-suggestConstraint df ps fd
+suggestConstraint :: ParsedSource -> FileDiagnostic -> [(T.Text, Rewrite)]
+suggestConstraint ps fd
   | Just missingConstraint <- structuredMissingConstraint
-  = let
+  =
 #if MIN_VERSION_ghc(9,9,0)
-        parsedSource = ps
+    let parsedSource = ps in
 #else
-        parsedSource = makeDeltaAst ps
+    let parsedSource = makeDeltaAst ps in
 #endif
-        codeAction = if _message =~ ("the type signature for:" :: String)
-                        then suggestFunctionConstraint df parsedSource
-                        else suggestInstanceConstraint df parsedSource
-     in codeAction diag missingConstraint
+    -- The error site sits in exactly one of the two, so at most one fires.
+       suggestFunctionConstraint parsedSource diag missingConstraint
+    ++ suggestInstanceConstraint parsedSource diag missingConstraint
   | otherwise = []
     where
-      diag@Diagnostic{..} = fdLspDiagnostic fd
+      diag = fdLspDiagnostic fd
 
       -- The missing constraint, taken from GHC's structured solver report.
       structuredMissingConstraint =
-        printOutputable <$>
-          (fd ^? fdStructuredMessageL . _SomeStructuredMessage . msgEnvelopeErrorL
-                 . _TcRnMessage . _TcRnSolverReport . _1 . reportContentL . _CouldNotDeducePred)
+        fmap printOutputable $
+          fd ^? fdStructuredMessageL
+            . _SomeStructuredMessage . msgEnvelopeErrorL . _TcRnMessage
+            . _TcRnSolverReport . _1 . reportContentL . _CouldNotDeducePred
 
 -- | Suggests a constraint for an instance declaration for which a constraint is missing.
-suggestInstanceConstraint :: DynFlags -> ParsedSource -> Diagnostic -> T.Text -> [(T.Text, Rewrite)]
-
-suggestInstanceConstraint df (L _ HsModule {hsmodDecls}) Diagnostic {..} missingConstraint
-  | Just instHead <- instanceHead
-  = [(actionTitle missingConstraint , appendConstraint (T.unpack missingConstraint) instHead)]
+suggestInstanceConstraint :: ParsedSource -> Diagnostic -> T.Text -> [(T.Text, Rewrite)]
+suggestInstanceConstraint (L _ HsModule {hsmodDecls}) diag missingConstraint
+  -- The error range is inside an instance method, so the enclosing declaration
+  -- is the instance whose context gains the constraint.
+  | Just (L _ (InstD _ (ClsInstD _ ClsInstDecl {cid_poly_ty = (unLoc -> HsSig{sig_body = sig})})))
+      <- findDeclContainingLoc (diag ^. L.range . L.start) hsmodDecls
+  = [(actionTitle missingConstraint, appendConstraint (T.unpack missingConstraint) sig)]
   | otherwise = []
     where
-      instanceHead
-        -- Suggests a constraint for an instance declaration with no existing constraints.
-        -- • No instance for (Eq a) arising from a use of ‘==’
-        --   Possible fix: add (Eq a) to the context of the instance declaration
-        -- • In the expression: x == y
-        --   In an equation for ‘==’: (Wrap x) == (Wrap y) = x == y
-        --   In the instance declaration for ‘Eq (Wrap a)’
-        | Just [instanceDeclaration] <- matchRegexUnifySpaces _message "In the instance declaration for ‘([^`]*)’"
-        , Just instHead <- findInstanceHead df (T.unpack instanceDeclaration) hsmodDecls
-        = Just instHead
-        -- Suggests a constraint for an instance declaration with one or more existing constraints.
-        -- • Could not deduce (Eq b) arising from a use of ‘==’
-        --   from the context: Eq a
-        --     bound by the instance declaration at /path/to/Main.hs:7:10-32
-        --   Possible fix: add (Eq b) to the context of the instance declaration
-        -- • In the second argument of ‘(&&)’, namely ‘x' == y'’
-        --   In the expression: x == y && x' == y'
-        --   In an equation for ‘==’:
-        --       (Pair x x') == (Pair y y') = x == y && x' == y'
-        | Just [instanceLineStr, constraintFirstCharStr]
-            <- matchRegexUnifySpaces _message "bound by the instance declaration at .+:([0-9]+):([0-9]+)"
-        , Just (L _ (InstD _ (ClsInstD _ ClsInstDecl {cid_poly_ty = (unLoc -> HsSig{sig_body = hsib_body})})))
-            <- findDeclContainingLoc (Position (readPositionNumber instanceLineStr) (readPositionNumber constraintFirstCharStr)) hsmodDecls
-        = Just hsib_body
-        | otherwise
-        = Nothing
-
-      readPositionNumber :: T.Text -> UInt
-      readPositionNumber = T.unpack >>> read @Integer >>> fromIntegral
-
       actionTitle :: T.Text -> T.Text
       actionTitle constraint = "Add `" <> constraint
         <> "` to the context of the instance declaration"
@@ -1336,9 +1300,9 @@ suggestImplicitParameter ::
   ParsedSource ->
   Diagnostic ->
   [(T.Text, Rewrite)]
-suggestImplicitParameter (L _ HsModule {hsmodDecls}) Diagnostic {_message, _range}
-  | Just [implicitT] <- matchRegexUnifySpaces _message "Unbound implicit parameter \\(([^:]+::.+)\\) arising",
-    Just (L _ (ValD _ FunBind {fun_id = L _ funId})) <- findDeclContainingLoc (_start _range) hsmodDecls,
+suggestImplicitParameter (L _ HsModule {hsmodDecls}) diag
+  | Just [implicitT] <- matchRegexUnifySpaces (diag ^. L.message) "Unbound implicit parameter \\(([^:]+::.+)\\) arising",
+    Just (L _ (ValD _ FunBind {fun_id = L _ funId})) <- findDeclContainingLoc (diag ^. L.range . L.start) hsmodDecls,
     Just (TypeSig _ _ HsWC {hswc_body = (unLoc -> HsSig {sig_body = hsib_body})})
       <- findSigOfDecl (== funId) hsmodDecls
     =
@@ -1350,35 +1314,15 @@ findTypeSignatureName :: T.Text -> Maybe T.Text
 findTypeSignatureName t = matchRegexUnifySpaces t "([^ ]+) :: " >>= listToMaybe
 
 -- | Suggests a constraint for a type signature with any number of existing constraints.
-suggestFunctionConstraint :: DynFlags -> ParsedSource -> Diagnostic -> T.Text -> [(T.Text, Rewrite)]
-
-suggestFunctionConstraint df (L _ HsModule {hsmodDecls}) Diagnostic {..} missingConstraint
--- • No instance for (Eq a) arising from a use of ‘==’
---   Possible fix:
---     add (Eq a) to the context of
---       the type signature for:
---         eq :: forall a. a -> a -> Bool
--- • In the expression: x == y
---   In an equation for ‘eq’: eq x y = x == y
-
--- • Could not deduce (Eq b) arising from a use of ‘==’
---   from the context: Eq a
---     bound by the type signature for:
---                eq :: forall a b. Eq a => Pair a b -> Pair a b -> Bool
---     at Main.hs:5:1-42
---   Possible fix:
---     add (Eq b) to the context of
---       the type signature for:
---         eq :: forall a b. Eq a => Pair a b -> Pair a b -> Bool
--- • In the second argument of ‘(&&)’, namely ‘y == y'’
---   In the expression: x == x' && y == y'
---   In an equation for ‘eq’:
---       eq (Pair x y) (Pair x' y') = x == x' && y == y'
-  | Just typeSignatureName <- findTypeSignatureName _message
-  , Just (TypeSig _ _ HsWC{hswc_body = (unLoc -> HsSig {sig_body = sig})})
-    <- findSigOfDecl ((T.unpack typeSignatureName ==) . showSDoc df . ppr) hsmodDecls
+suggestFunctionConstraint :: ParsedSource -> Diagnostic -> T.Text -> [(T.Text, Rewrite)]
+suggestFunctionConstraint (L _ HsModule {hsmodDecls}) diag missingConstraint
+  -- The error range is inside the function body, so the enclosing binding names
+  -- the signature whose context gains the constraint.
+  | Just (L _ (ValD _ FunBind {fun_id = L _ funId})) <- findDeclContainingLoc (diag ^. L.range . L.start) hsmodDecls
+  , Just (TypeSig _ _ HsWC{hswc_body = (unLoc -> HsSig {sig_body})}) <- findSigOfDecl (== funId) hsmodDecls
+  , let typeSignatureName = T.pack (printRdrName funId)
   , title <- actionTitle missingConstraint typeSignatureName
-  = [(title, appendConstraint (T.unpack missingConstraint) sig)]
+  = [(title, appendConstraint (T.unpack missingConstraint) sig_body)]
   | otherwise
   = []
     where

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/ExactPrint.hs
@@ -204,7 +204,11 @@ appendConstraint constraintT = go . traceAst "appendConstraint"
             [L _ (HsParTy EpAnn{anns=AnnParen{ap_close}} _)] -> Just ap_close
 #endif
             _ -> Nothing
-        ctxt' = over _last (first addComma) $ map dropHsParTy ctxt
+        -- Drop parens only for a lone constraint. In a multi-constraint context
+        -- an element's parens may be required.
+        ctxt' = over _last (first addComma) $ case ctxt of
+            [c] -> [dropHsParTy c]
+            _   -> ctxt
     return $ L l $ it{hst_ctxt = L l'' $ ctxt' ++ [constraint]}
   go (L _ HsForAllTy{hst_body}) = go hst_body
   go (L _ (HsParTy _ ty)) = go ty

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -3134,6 +3134,16 @@ addFunctionConstraintTests = let
     , "  return ()"
     ]
 
+  -- See https://github.com/haskell/haskell-language-server/issues/3486
+  quantifiedConstraintSourceCode :: T.Text -> T.Text
+  quantifiedConstraintSourceCode context = T.unlines
+    [ "{-# LANGUAGE QuantifiedConstraints #-}"
+    , "{-# LANGUAGE RankNTypes #-}"
+    , "module Testing where"
+    , "f :: " <> context <> " => f Int -> m Bool"
+    , "f x = return (x == x)"
+    ]
+
   in testGroup "add function constraint"
   [ checkCodeAction
     "no preexisting constraint"
@@ -3180,6 +3190,11 @@ addFunctionConstraintTests = let
     "Add `Monad m` to the context of the type signature for `f`"
     (missingMonadConstraint "")
     (missingMonadConstraint "Monad m => ")
+  , checkCodeAction
+    "preexisting parenthesized quantified constraint"
+    "Add `Monad m` to the context of the type signature for `f`"
+    (quantifiedConstraintSourceCode "((forall a. Eq (f a)), Applicative m)")
+    (quantifiedConstraintSourceCode "((forall a. Eq (f a)), Applicative m, Monad m)")
   ]
 
 checkCodeAction :: TestName -> T.Text -> T.Text -> T.Text -> TestTree


### PR DESCRIPTION
Ref: https://github.com/haskell/haskell-language-server/issues/4605
Closes: https://github.com/haskell/haskell-language-server/issues/3486

Makes the following changes
- Fixes the incorrect constraint edit in constraint lists with extra parentheses.
- Adds a lens to pull missing constraints from diagnostics.
- Use the diagnostic ranges to deduce where to add the constraints, instead of regex matching.