### PR TITLE
Improve error messages in HLS

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,10 +1,14 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main(main) where
 
 import           Control.Exception             (displayException)
+#if MIN_VERSION_base(4,20,0)
+import qualified Control.Exception.Backtrace   as Backtrace
+#endif
 import           Control.Monad.IO.Class        (liftIO)
 import           Data.Bifunctor                (first)
 import           Data.Function                 ((&))
@@ -45,6 +49,9 @@ instance Pretty Log where
 
 main :: IO ()
 main = do
+#if MIN_VERSION_base(4,20,0)
+    Backtrace.setBacktraceMechanismState Backtrace.IPEBacktrace True
+#endif
     stderrRecorder <- makeDefaultStderrRecorder Nothing
     -- plugin cli commands use stderr logger for now unless we change the args
     -- parser to get logging arguments first or do more complicated things

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ImplicitParams        #-}
 {-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE RecursiveDo           #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE ImplicitParams        #-}
 
 -- | A Shake implementation of the compiler service.
 --
@@ -229,10 +229,7 @@ instance Pretty Log where
         , "Took:" <+> pretty (showDuration seconds) ]
     LogBuildSessionFinish e -> case e of
       Nothing -> "Finished build session"
-      Just e -> vcat
-        [ "Finished build session"
-        , pretty (displayException e)
-        ]
+      Just e -> "Finished build session:" <+> prettyBuildSessionFinishException e
     LogDiagsDiffButNoLspEnv fileDiagnostics ->
       "updateFileDiagnostics published different from new diagnostics - file diagnostics:"
       <+> pretty (showDiagnosticsColored fileDiagnostics)
@@ -1357,6 +1354,13 @@ displayExcContext (SomeException _exc) =
 #else
     Just $ displayException (SomeException _exc)
 #endif
+
+prettyBuildSessionFinishException :: SomeException -> Doc ann
+prettyBuildSessionFinishException exc = case fromException exc of
+  Nothing -> case displayExcContext exc of
+    Nothing  -> pretty (displayException exc)
+    Just ctx -> pretty ctx
+  Just AsyncCancelled -> viaShow AsyncCancelled -- We don't want to see the stack trace for a cancelled build session
 
 -- Note [Housekeeping rule cache and dirty key outside of hls-graph]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ghcide/src/Development/IDE/Core/Shake.hs
+++ b/ghcide/src/Development/IDE/Core/Shake.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE RecursiveDo           #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ImplicitParams        #-}
 
 -- | A Shake implementation of the compiler service.
 --
@@ -86,6 +87,9 @@ import           Control.Concurrent.STM.Stats           (atomicallyNamed)
 import           Control.Concurrent.Strict
 import           Control.DeepSeq
 import           Control.Exception.Extra                hiding (bracket_)
+#if MIN_VERSION_ghc(9,10,0)
+import           Control.Exception.Context              (displayExceptionContext)
+#endif
 import           Control.Lens                           ((%~), (&), (?~))
 import           Control.Monad.Extra
 import           Control.Monad.IO.Class
@@ -108,8 +112,8 @@ import           Data.Hashable
 import qualified Data.HashMap.Strict                    as HMap
 import           Data.HashSet                           (HashSet)
 import qualified Data.HashSet                           as HSet
-import           Data.List.Extra                        (foldl', partition,
-                                                         takeEnd)
+import qualified Data.List                              as List
+import           Data.List.Extra                        (partition, takeEnd)
 import qualified Data.Map.Strict                        as Map
 import           Data.Maybe
 import qualified Data.SortedList                        as SL
@@ -820,7 +824,7 @@ shakeRestart recorder IdeState{..} vfs reason acts ioActionBetweenShakeSession =
                 keys <- ioActionBetweenShakeSession
                 -- it is every important to update the dirty keys after we enter the critical section
                 -- see Note [Housekeeping rule cache and dirty key outside of hls-graph]
-                atomically $ modifyTVar' (dirtyKeys shakeExtras) $ \x -> foldl' (flip insertKeySet) x keys
+                atomically $ modifyTVar' (dirtyKeys shakeExtras) $ \x -> List.foldl' (flip insertKeySet) x keys
                 res <- shakeDatabaseProfile shakeDb
                 backlog <- readTVarIO $ dirtyKeys shakeExtras
                 queue <- atomicallyNamed "actionQueue - peek" $ peekInProgress $ actionQueue shakeExtras
@@ -1285,7 +1289,7 @@ defineEarlyCutoff' doDiagnostics cmp key file mbOld mode action = do
                 (mbBs, (diags, mbRes)) <- actionCatch
                     (do v <- action staleV; liftIO $ evaluate $ force v) $
                     \(e :: SomeException) -> do
-                        pure (Nothing, ([ideErrorText file (T.pack $ show (key, file) ++ show e) | not $ isBadDependency e],Nothing))
+                        pure (Nothing, ([ideErrorText file (prettyRuleAbortedByException key file e) | not $ isBadDependency e],Nothing))
 
                 ver <- estimateFileVersionUnsafely key mbRes file
                 (bs, res) <- case mbRes of
@@ -1329,6 +1333,30 @@ defineEarlyCutoff' doDiagnostics cmp key file mbOld mode action = do
         --  * creating a dependency: If everything depends on GetModificationTime, we lose early cutoff
         --  * creating bogus "file does not exists" diagnostics
         | otherwise = useWithoutDependency (GetModificationTime_ False) fp
+
+    prettyRuleAbortedByException key file e = T.pack $ unlines $
+        [ "Rule execution aborted due to exception"
+        , ""
+        , "Rule: " <> show key
+        , "Target: " <> fromNormalizedFilePath file
+        , "Message: " <> show e
+        ] <>
+        [ unlines
+            [ "Context:"
+            , ctx
+            ]
+        | Just ctx <- [displayExcContext e]
+        ]
+
+displayExcContext :: SomeException -> Maybe String
+displayExcContext (SomeException _exc) =
+#if MIN_VERSION_ghc(9,10,0)
+    case displayExceptionContext ?exceptionContext of
+      "" -> Nothing
+      dc -> Just dc
+#else
+    Just $ displayException (SomeException _exc)
+#endif
 
 -- Note [Housekeeping rule cache and dirty key outside of hls-graph]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ghcide/src/Development/IDE/Types/HscEnvEq.hs
+++ b/ghcide/src/Development/IDE/Types/HscEnvEq.hs
@@ -12,6 +12,7 @@ import           Control.Concurrent.Async        (Async, async, waitCatch)
 import           Control.Concurrent.Strict       (modifyVar, newVar)
 import           Control.DeepSeq                 (force, rwhnf)
 import           Control.Exception               (evaluate, mask, throwIO)
+import qualified Control.Exception               as Exc
 import           Control.Monad.Extra             (eitherM, join, mapMaybeM)
 import           Data.Either                     (fromRight)
 import           Data.IORef
@@ -56,14 +57,14 @@ newHscEnvEq hscEnv' = do
 #if MIN_VERSION_ghc(9,11,0)
     let hscEnv = hscEnv'
                { hsc_FC = FinderCache
-                        { flushFinderCaches = \_ -> error "GHC should never call flushFinderCaches outside the driver"
+                        { flushFinderCaches = \_ -> throwIO $ Exc.ErrorCall "flushFinderCaches: GHC should never call flushFinderCaches outside the driver"
 #if MIN_VERSION_ghc(9,13,0)
                         , addToFinderCache  = \im val -> do
 #else
                         , addToFinderCache  = \(GWIB im _) val -> do
 #endif
                             if moduleUnit im `elem` hsc_all_home_unit_ids hscEnv'
-                            then error "tried to add home module to FC"
+                            then throwIO $ Exc.ErrorCall "addToFinderCache: tried to add home module to FC"
                             else atomicModifyIORef' mod_cache $ \c -> (extendInstalledModuleEnv c im val, ())
 #if MIN_VERSION_ghc(9,13,0)
                         , lookupFinderCache = \im -> do
@@ -71,9 +72,9 @@ newHscEnvEq hscEnv' = do
                         , lookupFinderCache = \(GWIB im _) -> do
 #endif
                             if moduleUnit im `elem` hsc_all_home_unit_ids hscEnv'
-                            then error ("tried to lookup home module from FC" ++ showSDocUnsafe (ppr (im, hsc_all_home_unit_ids hscEnv')))
+                            then throwIO $ Exc.ErrorCall ("lookupFinderCache: tried to lookup home module from FC: " ++ showSDocUnsafe (ppr (im, hsc_all_home_unit_ids hscEnv')))
                             else lookupInstalledModuleEnv <$> readIORef mod_cache <*> pure im
-                        , lookupFileCache = \fp -> error ("not used by HLS" ++ fp)
+                        , lookupFileCache = \fp -> throwIO $ Exc.ErrorCall ("lookupFileCache: Called without using setFileCacheHook for target: " ++ fp)
                         }
                 }
 


### PR DESCRIPTION
Use more lines to make exceptions more readable once they occur.

For debugging, also attach IPEBacktraces if HLS is compiled with `-finfo-table-map` on GHC >=9.10.

Turns the error:

<img width="2158" height="187" alt="image" src="https://github.com/user-attachments/assets/fc77165c-cea6-475b-ac2c-8a7e3c1d2018" />

Into 

<img width="2181" height="627" alt="image" src="https://github.com/user-attachments/assets/7f22c8bb-6e8a-4375-9698-824c854424ca" />

And with `-finfo-table-map` we get something actually useful:

<img width="2265" height="907" alt="image" src="https://github.com/user-attachments/assets/9442fb33-7d38-4327-9f75-f814d29fd4d0" />
