### PR TITLE
Set FileCache hook before typechecking

### DIFF
--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -702,8 +702,15 @@ typeCheckRuleDefinition hsc pm fp = do
            { getLinkables = unliftIO unlift . uses_ GetLinkable
            , getModuleGraph = unliftIO unlift $ useWithSeparateFingerprintRule_ GetModuleGraphTransDepsFingerprints GetModuleGraph fp
            }
+  -- This 'setFileCacheHook' is neccessary to work correctly
+  -- with ghc plugins.
+  -- In particular, with plugins we load objects, and in doing so we consult the fileCacheHook to record the hash of the object.
+  --
+  -- See issue https://github.com/haskell/haskell-language-server/issues/4675 for details
+  -- and https://github.com/ucsd-progsys/lh-plugin-demo for a reproducer.
+  hsc_env <- setFileCacheHook hsc
   addUsageDependencies $ liftIO $
-    typecheckModule defer hsc dets pm
+    typecheckModule defer hsc_env dets pm
   where
     addUsageDependencies :: Action (a, Maybe TcModuleResult) -> Action (a, Maybe TcModuleResult)
     addUsageDependencies a = do


### PR DESCRIPTION
Fixes #4675

It is currently unclear why we need this, but I tried it on `lh-plugin-demo`, and it fixed the issue, so we will most likely fix it like this for now.