### PR TITLE
cross-module renames

### DIFF
--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -20,7 +20,8 @@ import           Data.Generics
 import           Data.Hashable
 import           Data.HashSet                          (HashSet)
 import qualified Data.HashSet                          as HS
-import           Data.List.NonEmpty                    (NonEmpty ((:|)), groupAllWith)
+import           Data.List.NonEmpty                    (NonEmpty ((:|)),
+                                                        groupAllWith)
 import qualified Data.Map                              as M
 import           Data.Maybe
 import           Data.Mod.Word

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -226,7 +226,7 @@ refsAtName state nfp name = do
         Nothing -> pure []
         Just mod -> liftIO $ mapMaybe rowToLoc <$> withHieDb (\hieDb ->
             -- See Note [Generated references]
-            filter (\(refRow HieDb.:. _) -> refIsGenerated refRow) <$>
+            filter (\(refRow HieDb.:. _) -> not $ refIsGenerated refRow) <$>
             findReferences
                 hieDb
                 True

--- a/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
+++ b/plugins/hls-rename-plugin/src/Ide/Plugin/Rename.hs
@@ -20,8 +20,7 @@ import           Data.Generics
 import           Data.Hashable
 import           Data.HashSet                          (HashSet)
 import qualified Data.HashSet                          as HS
-import           Data.List.NonEmpty                    (NonEmpty ((:|)),
-                                                        groupWith)
+import           Data.List.NonEmpty                    (NonEmpty ((:|)), groupAllWith)
 import qualified Data.Map                              as M
 import           Data.Maybe
 import           Data.Mod.Word
@@ -285,8 +284,8 @@ removeGenerated HAR{..} =
     -- is generated from HieASTs containing GeneratedInfo
     sourceOnlyRefMap = generateReferencesMap $ getAsts sourceOnlyAsts
 
-collectWith :: (Hashable a, Eq b) => (a -> b) -> HashSet a -> [(b, HashSet a)]
-collectWith f = map (\(a :| as) -> (f a, HS.fromList (a:as))) . groupWith f . HS.toList
+collectWith :: (Hashable a, Ord b) => (a -> b) -> HashSet a -> [(b, HashSet a)]
+collectWith f = map (\(a :| as) -> (f a, HS.fromList (a:as))) . groupAllWith f . HS.toList
 
 -- | A variant 'getNamesAtPoint' that does not expect a 'PositionMapping'
 getNamesAtPoint' :: HieASTs a -> Position -> [Name]

--- a/plugins/hls-rename-plugin/test/Main.hs
+++ b/plugins/hls-rename-plugin/test/Main.hs
@@ -9,14 +9,14 @@ import           Data.Aeson                  (KeyValue ((.=)))
 import           Data.Functor                (void)
 import qualified Data.Map                    as M
 import           Data.Text                   (Text, pack)
+import qualified Data.Text.IO                as TIO
+import           Development.IDE.Test        (referenceReady)
 import           Ide.Plugin.Config
 import qualified Ide.Plugin.Rename           as Rename
 import qualified Language.LSP.Protocol.Lens  as L
 import           Language.LSP.Protocol.Types (Null (Null))
 import           System.FilePath
 import           Test.Hls
-import           Development.IDE.Test (referenceReady)
-import qualified Data.Text.IO                as TIO
 
 main :: IO ()
 main = defaultTestRunner tests

--- a/plugins/hls-rename-plugin/test/Main.hs
+++ b/plugins/hls-rename-plugin/test/Main.hs
@@ -15,6 +15,8 @@ import qualified Language.LSP.Protocol.Lens  as L
 import           Language.LSP.Protocol.Types (Null (Null))
 import           System.FilePath
 import           Test.Hls
+import           Development.IDE.Test (referenceReady)
+import qualified Data.Text.IO                as TIO
 
 main :: IO ()
 main = defaultTestRunner tests
@@ -27,6 +29,7 @@ tests = testGroup "Rename"
     [ prepareRenameTests
     , renameTests
     , moduleNameTests
+    , crossModuleTests
     ]
 
 prepareRenameTests :: TestTree
@@ -164,6 +167,24 @@ renameTests = testGroup "Identifier"
         -- Make sure renaming succeeds
         rename doc (Position 3 0) "foo'"
     ]
+
+crossModuleTests :: TestTree
+crossModuleTests =
+    testGroup
+        "CrossModule"
+        [ testCase "Term used in two modules" $ runRenameSession "" $ do
+            defDoc <- openDoc "CrossModuleDefinition.hs" "haskell"
+            useDoc <- openDoc "CrossModuleUsage.hs" "haskell"
+            void $ skipManyTill anyMessage $ referenceReady (((==) "CrossModuleUsage.hs") . takeFileName)
+            rename defDoc (Position 3 0) "succInt"
+            assertGolden "CrossModuleDefinition" defDoc
+            assertGolden "CrossModuleUsage" useDoc
+        ]
+  where
+    assertGolden path doc = do
+        actual <- documentContents doc
+        expected <- liftIO $ TIO.readFile (testDataDir </> path <.> "expected" <.> "hs")
+        liftIO $ assertEqual path expected actual
 
 moduleNameTests :: TestTree
 moduleNameTests =

--- a/plugins/hls-rename-plugin/test/testdata/CrossModuleDefinition.expected.hs
+++ b/plugins/hls-rename-plugin/test/testdata/CrossModuleDefinition.expected.hs
@@ -1,0 +1,4 @@
+module CrossModuleDefinition (succInt) where
+
+succInt :: Int -> Int
+succInt x = x + 1

--- a/plugins/hls-rename-plugin/test/testdata/CrossModuleDefinition.hs
+++ b/plugins/hls-rename-plugin/test/testdata/CrossModuleDefinition.hs
@@ -1,0 +1,4 @@
+module CrossModuleDefinition (increment) where
+
+increment :: Int -> Int
+increment x = x + 1

--- a/plugins/hls-rename-plugin/test/testdata/CrossModuleUsage.expected.hs
+++ b/plugins/hls-rename-plugin/test/testdata/CrossModuleUsage.expected.hs
@@ -1,0 +1,6 @@
+module CrossModuleUse (incrementUsage) where
+
+import CrossModuleDefinition (succInt)
+
+incrementUsage :: Int -> Int
+incrementUsage x = succInt x

--- a/plugins/hls-rename-plugin/test/testdata/CrossModuleUsage.expected.hs
+++ b/plugins/hls-rename-plugin/test/testdata/CrossModuleUsage.expected.hs
@@ -4,3 +4,9 @@ import CrossModuleDefinition (succInt)
 
 incrementUsage :: Int -> Int
 incrementUsage x = succInt x
+
+incrementUsage2 :: Int -> Int
+incrementUsage2 = succInt . succInt
+
+incrementUsage3 :: Int -> Int
+incrementUsage3 x = succInt (succInt (succInt x))

--- a/plugins/hls-rename-plugin/test/testdata/CrossModuleUsage.hs
+++ b/plugins/hls-rename-plugin/test/testdata/CrossModuleUsage.hs
@@ -1,0 +1,6 @@
+module CrossModuleUse (incrementUsage) where
+
+import CrossModuleDefinition (increment)
+
+incrementUsage :: Int -> Int
+incrementUsage x = increment x

--- a/plugins/hls-rename-plugin/test/testdata/CrossModuleUsage.hs
+++ b/plugins/hls-rename-plugin/test/testdata/CrossModuleUsage.hs
@@ -4,3 +4,9 @@ import CrossModuleDefinition (increment)
 
 incrementUsage :: Int -> Int
 incrementUsage x = increment x
+
+incrementUsage2 :: Int -> Int
+incrementUsage2 = increment . increment
+
+incrementUsage3 :: Int -> Int
+incrementUsage3 x = increment (increment (increment x))

--- a/plugins/hls-rename-plugin/test/testdata/hie.yaml
+++ b/plugins/hls-rename-plugin/test/testdata/hie.yaml
@@ -1,6 +1,8 @@
 cradle:
   direct:
     arguments:
+      - "CrossModuleDefinition"
+      - "CrossModuleUsage"
       - "DataConstructor"
       - "ExportedFunction"
       - "FieldPuns"


### PR DESCRIPTION
Fixes #4816, partially

This PR could hopefully serve as a stopgap until #4845 is merged.
Additionally it fixes an edge-case where there are multiple rename terms in the same line,
but still suffers from the existing global vs local term rename problems that the other PR fixes.

