### PR TITLE
Unload linkables if any transitive dependency changes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -52,6 +52,11 @@ allow-newer:
   cabal-install-parsers:Cabal-syntax,
 
 
+-- See https://gitlab.haskell.org/ghc/ghc/-/work_items/26609
+-- https://github.com/digital-asset/ghc-lib/issues/620
+if impl(ghc >= 9.10) && impl(ghc < 9.11)
+  constraints: ghc-lib-parser ^>=9.10
+
 if impl(ghc >= 9.13)
   allow-newer:
     cabal-install-parsers:base,

--- a/ghcide-test/data/THUnload/A.hs
+++ b/ghcide-test/data/THUnload/A.hs
@@ -1,0 +1,4 @@
+module A where
+
+a :: Int
+a = 1

--- a/ghcide-test/data/THUnload/B.hs
+++ b/ghcide-test/data/THUnload/B.hs
@@ -1,0 +1,6 @@
+module B where
+
+import A
+
+b :: Int
+b = a

--- a/ghcide-test/data/THUnload/C.hs
+++ b/ghcide-test/data/THUnload/C.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+module C where
+
+import B
+import Language.Haskell.TH
+
+c :: Int
+c = $(reportWarning ("b is " ++ show b) >> [| b |])

--- a/ghcide-test/data/THUnload/hie.yaml
+++ b/ghcide-test/data/THUnload/hie.yaml
@@ -1,0 +1,1 @@
+cradle: {direct: {arguments: ["-Wmissing-signatures", "-package template-haskell", "A", "B", "C"]}}

--- a/ghcide-test/data/THUnloadDeep/A1.hs
+++ b/ghcide-test/data/THUnloadDeep/A1.hs
@@ -1,0 +1,4 @@
+module A1 where
+
+a1 :: Int
+a1 = 1

--- a/ghcide-test/data/THUnloadDeep/A2.hs
+++ b/ghcide-test/data/THUnloadDeep/A2.hs
@@ -1,0 +1,6 @@
+module A2 where
+
+import A1
+
+a2 :: Int
+a2 = a1

--- a/ghcide-test/data/THUnloadDeep/A3.hs
+++ b/ghcide-test/data/THUnloadDeep/A3.hs
@@ -1,0 +1,6 @@
+module A3 where
+
+import A2
+
+a3 :: Int
+a3 = a2

--- a/ghcide-test/data/THUnloadDeep/A4.hs
+++ b/ghcide-test/data/THUnloadDeep/A4.hs
@@ -1,0 +1,6 @@
+module A4 where
+
+import A3
+
+a4 :: Int
+a4 = a3

--- a/ghcide-test/data/THUnloadDeep/A5.hs
+++ b/ghcide-test/data/THUnloadDeep/A5.hs
@@ -1,0 +1,6 @@
+module A5 where
+
+import A4
+
+a5 :: Int
+a5 = a4

--- a/ghcide-test/data/THUnloadDeep/A6.hs
+++ b/ghcide-test/data/THUnloadDeep/A6.hs
@@ -1,0 +1,6 @@
+module A6 where
+
+import A5
+
+a6 :: Int
+a6 = a5

--- a/ghcide-test/data/THUnloadDeep/C.hs
+++ b/ghcide-test/data/THUnloadDeep/C.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+module C where
+
+import A6
+import Language.Haskell.TH
+
+c :: Int
+c = $(reportWarning ("a6 is " ++ show a6) >> [| a6 |])

--- a/ghcide-test/data/THUnloadDeep/hie.yaml
+++ b/ghcide-test/data/THUnloadDeep/hie.yaml
@@ -1,0 +1,1 @@
+cradle: {direct: {arguments: ["-Wmissing-signatures", "-package template-haskell", "A1", "A2", "A3", "A4", "A5", "A6", "C"]}}

--- a/ghcide-test/exe/THTests.hs
+++ b/ghcide-test/exe/THTests.hs
@@ -72,6 +72,8 @@ tests =
     -- Regression test for https://github.com/haskell/haskell-language-server/issues/891
     , thLinkingTest False
     , thLinkingTest True
+    , thStaleBytecodeTest
+    , thStaleBytecodeDeepTest
     , testWithDummyPluginEmpty "findsTHIdentifiers" $ do
         let sourceA =
               T.unlines
@@ -267,6 +269,50 @@ thReloadingTest unboxed = testCase name $ runWithExtraFiles dir $ \dir -> do
     name = "reloading-th-test" <> if unboxed then "-unboxed" else ""
     dir | unboxed = "THUnboxed"
         | otherwise = "TH"
+
+-- | Test that a value change in a dependency without an interface change is
+-- seen by splices: the loaded bytecode of the intermediate modules must be
+-- relinked against the new leaf even though they are not recompiled.
+--
+-- The leaf and C are open; the intermediate modules are intentionally not, so
+-- they stay non-FOI and are not recompiled when the leaf changes.
+thStaleBytecodeTestFor :: String -> String -> FilePath -> T.Text -> TestTree
+thStaleBytecodeTestFor name dataDir leafFile tag = testCase name $ runWithExtraFiles dataDir $ \dir -> do
+    let aPath = dir </> leafFile
+        cPath = dir </> "C.hs"
+
+    aSource <- liftIO $ readFileUtf8 aPath -- <leaf> = 1
+    cSource <- liftIO $ readFileUtf8 cPath -- c = $(reportWarning (tag ++ show <top>) >> [| <top> |])
+
+    adoc <- createDoc aPath "haskell" aSource
+    cdoc <- createDoc cPath "haskell" cSource
+
+    expectDiagnostics [("C.hs", [(DiagnosticSeverity_Warning, (7, 5), tag <> " 1", Nothing)])]
+
+    -- Change the value of the leaf without changing its interface, so the
+    -- modules in between are not recompiled and only their loaded bytecode
+    -- can go stale
+    changeDoc adoc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $
+        T.replace "= 1" "= 2" aSource]
+    -- sentinel warning so a stale splice result fails fast instead of timing out
+    changeDoc cdoc [TextDocumentContentChangeEvent . InR . TextDocumentContentChangeWholeDocument $
+        cSource <> "foo=()"]
+
+    expectDiagnostics
+        [("C.hs", [ (DiagnosticSeverity_Warning, (7, 5), tag <> " 2", Nothing)
+                  , (DiagnosticSeverity_Warning, (8, 0), "Top-level binding", Just "GHC-38417")
+                  ])]
+
+    closeDoc adoc
+    closeDoc cdoc
+
+-- | C splices a value from B, which imports it from A. A is edited.
+thStaleBytecodeTest :: TestTree
+thStaleBytecodeTest = thStaleBytecodeTestFor "th-stale-bytecode" "THUnload" "A.hs" "b is"
+
+-- | C splices a6, whose value flows through the chain A6 <- ... <- A1. A1 is edited.
+thStaleBytecodeDeepTest :: TestTree
+thStaleBytecodeDeepTest = thStaleBytecodeTestFor "th-stale-bytecode-deep" "THUnloadDeep" "A1.hs" "a6 is"
 
 thLinkingTest :: Bool -> TestTree
 thLinkingTest unboxed = testCase name $ runWithExtraFiles dir $ \dir -> do

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -701,8 +701,8 @@ compileModule (RunSimplifier simplify) session ms tcg =
              else pure desugar
       pure (diagFromErrMsgs compilePhase (hsc_dflags session') $ getWarningMessages msgs, desugar)
 
-generateObjectCode :: HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
-generateObjectCode session summary guts = do
+generateObjectCode :: UTCTime -> HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
+generateObjectCode t session summary guts = do
     fmap (either (, Nothing) (second Just)) $
           catchSrcErrors (hsc_dflags session) "object" $ do
               let dot_o =  ml_obj_file (ms_location summary)
@@ -724,8 +724,6 @@ generateObjectCode session summary guts = do
                       case obj of
                         Nothing -> throwGhcExceptionIO $ Panic "compileFile didn't generate object code"
                         Just x -> pure x
-              -- Need time to be the modification time for recompilation checking
-              t <- liftIO $ getModificationTime dot_o_fp
 #if MIN_VERSION_ghc(9,11,0)
               let linkable = Linkable t mod (pure $ DotO dot_o_fp ModuleObject)
 #else
@@ -733,10 +731,8 @@ generateObjectCode session summary guts = do
 #endif
               pure (map snd warnings, linkable)
 
-newtype CoreFileTime = CoreFileTime UTCTime
-
-generateByteCode :: CoreFileTime -> HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
-generateByteCode (CoreFileTime time) hscEnv summary guts = do
+generateByteCode :: UTCTime -> HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
+generateByteCode time hscEnv summary guts = do
     fmap (either (, Nothing) (second Just)) $
           catchSrcErrors (hsc_dflags hscEnv) "bytecode" $ do
 
@@ -1684,8 +1680,8 @@ coreFileToLinkable :: LinkableType -> HscEnv -> ModSummary -> ModIface -> ModDet
 coreFileToLinkable linkableType session ms iface details core_file t = do
   cgi_guts <- coreFileToCgGuts session iface details core_file
   (warns, lb) <- case linkableType of
-    BCOLinkable    -> fmap (maybe emptyHomeModInfoLinkable justBytecode) <$> generateByteCode (CoreFileTime t) session ms cgi_guts
-    ObjectLinkable -> fmap (maybe emptyHomeModInfoLinkable justObjects) <$> generateObjectCode session ms cgi_guts
+    BCOLinkable    -> fmap (maybe emptyHomeModInfoLinkable justBytecode) <$> generateByteCode t session ms cgi_guts
+    ObjectLinkable -> fmap (maybe emptyHomeModInfoLinkable justObjects) <$> generateObjectCode t session ms cgi_guts
   pure (warns, Just $ HomeModInfo iface details lb) -- TODO wz1000 handle emptyHomeModInfoLinkable
 
 -- | Non-interactive, batch version of 'InteractiveEval.getDocs'.

--- a/ghcide/src/Development/IDE/Core/Compile.hs
+++ b/ghcide/src/Development/IDE/Core/Compile.hs
@@ -18,6 +18,8 @@ module Development.IDE.Core.Compile
   , mkHiFileResultNoCompile
   , generateObjectCode
   , generateByteCode
+  , LinkableFingerprint (..)
+  , mkLinkableFingerprint
   , generateHieAsts
   , writeAndIndexHieFile
   , indexHieFile
@@ -66,7 +68,9 @@ import qualified Data.Map.Strict                              as Map
 import           Data.Maybe
 import           Data.Proxy                                   (Proxy (Proxy))
 import qualified Data.Text                                    as T
-import           Data.Time                                    (UTCTime (..))
+import           Data.Time                                    (Day (ModifiedJulianDay),
+                                                               UTCTime (..),
+                                                               picosecondsToDiffTime)
 import           Data.Tuple.Extra                             (dupe)
 import           Debug.Trace
 import           Development.IDE.Core.FileStore               (resetInterfaceStore)
@@ -701,8 +705,29 @@ compileModule (RunSimplifier simplify) session ms tcg =
              else pure desugar
       pure (diagFromErrMsgs compilePhase (hsc_dflags session') $ getWarningMessages msgs, desugar)
 
-generateObjectCode :: UTCTime -> HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
-generateObjectCode t session summary guts = do
+
+-- | A horrible hack
+-- GHC identifies Linkables using their UTCTime (when they were generated)
+-- This is insufficient for our needs, we need to identify linkables by a fingerprint containing
+-- both the hash of the linkable itself as well as all of all of its dependencies
+--
+-- UTCTime has an unbounded integer
+-- We can smuggle an arbitary 128 bit fingerprint
+-- in the integer
+--
+-- This way we can ensure we only keep loaded objects (byte/native) with the correct
+-- transitive closure.
+--
+-- This is fine because GHC only uses the time for identity
+newtype LinkableFingerprint = LinkableFingerprint UTCTime
+
+mkLinkableFingerprint :: Util.Fingerprint -> LinkableFingerprint
+mkLinkableFingerprint (Util.Fingerprint a b) =
+  LinkableFingerprint $ UTCTime (ModifiedJulianDay 0) $ picosecondsToDiffTime $
+    toInteger a * 2 ^ (64 :: Int) + toInteger b
+
+generateObjectCode :: LinkableFingerprint -> HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
+generateObjectCode (LinkableFingerprint linkable_fp) session summary guts = do
     fmap (either (, Nothing) (second Just)) $
           catchSrcErrors (hsc_dflags session) "object" $ do
               let dot_o =  ml_obj_file (ms_location summary)
@@ -725,14 +750,14 @@ generateObjectCode t session summary guts = do
                         Nothing -> throwGhcExceptionIO $ Panic "compileFile didn't generate object code"
                         Just x -> pure x
 #if MIN_VERSION_ghc(9,11,0)
-              let linkable = Linkable t mod (pure $ DotO dot_o_fp ModuleObject)
+              let linkable = Linkable linkable_fp mod (pure $ DotO dot_o_fp ModuleObject)
 #else
-              let linkable = LM t mod [DotO dot_o_fp]
+              let linkable = LM linkable_fp mod [DotO dot_o_fp]
 #endif
               pure (map snd warnings, linkable)
 
-generateByteCode :: UTCTime -> HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
-generateByteCode time hscEnv summary guts = do
+generateByteCode :: LinkableFingerprint -> HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
+generateByteCode (LinkableFingerprint linkable_fp) hscEnv summary guts = do
     fmap (either (, Nothing) (second Just)) $
           catchSrcErrors (hsc_dflags hscEnv) "bytecode" $ do
 
@@ -755,9 +780,9 @@ generateByteCode time hscEnv summary guts = do
 #endif
 
 #if MIN_VERSION_ghc(9,11,0)
-              let linkable = Linkable time (ms_mod summary) (pure $ BCOs bytecode)
+              let linkable = Linkable linkable_fp (ms_mod summary) (pure $ BCOs bytecode)
 #else
-              let linkable = LM time (ms_mod summary) [BCOs bytecode sptEntries]
+              let linkable = LM linkable_fp (ms_mod summary) [BCOs bytecode sptEntries]
 #endif
 
               pure (map snd warnings, linkable)
@@ -1676,7 +1701,7 @@ coreFileToCgGuts session iface details core_file = do
 #endif
                 Nothing []
 
-coreFileToLinkable :: LinkableType -> HscEnv -> ModSummary -> ModIface -> ModDetails -> CoreFile -> UTCTime -> IO ([FileDiagnostic], Maybe HomeModInfo)
+coreFileToLinkable :: LinkableType -> HscEnv -> ModSummary -> ModIface -> ModDetails -> CoreFile -> LinkableFingerprint -> IO ([FileDiagnostic], Maybe HomeModInfo)
 coreFileToLinkable linkableType session ms iface details core_file t = do
   cgi_guts <- coreFileToCgGuts session iface details core_file
   (warns, lb) <- case linkableType of

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -104,6 +104,9 @@ data LinkableResult
   { linkableHomeMod :: !HomeModInfo
   , linkableHash    :: !ByteString
   -- ^ The hash of the core file
+  , linkableVersion :: !ByteString
+  -- ^ Fingerprint of the core file and the versions of all transitive
+  -- dependencies, identifying the code the linkable links against
   }
 
 instance Show LinkableResult where

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -93,9 +93,7 @@ import           Data.Proxy
 import qualified Data.Text                                    as T
 import qualified Data.Text.Encoding                           as T
 import qualified Data.Text.Utf16.Rope.Mixed                   as Rope
-import           Data.Time                                    (Day (ModifiedJulianDay),
-                                                               UTCTime (..),
-                                                               picosecondsToDiffTime)
+import           Data.Time                                    (UTCTime (..))
 import           Data.Tuple.Extra
 import           Data.Typeable                                (cast)
 import           Development.IDE.Core.Compile
@@ -1124,17 +1122,6 @@ usePropertyByPathAction path plId p = do
 
 -- ---------------------------------------------------------------------
 
--- | A horrible hack
--- UTCTime is an unbounded integer
--- We can smuggle an arbitary 128 bit fingerprint
--- in the integer
---
--- This is fine because GHC only uses the time for identity
-versionToUTCTime :: Fingerprint -> UTCTime
-versionToUTCTime (Fingerprint a b) =
-  UTCTime (ModifiedJulianDay 0) $ picosecondsToDiffTime $
-    toInteger a * 2 ^ (64 :: Int) + toInteger b
-
 getLinkableRule :: Recorder (WithPriority Log) -> Rules ()
 getLinkableRule recorder =
   defineEarlyCutoff (cmapWithPrio LogShake recorder) $ RuleWithOldValue $ \GetLinkable f old_value -> do
@@ -1180,7 +1167,7 @@ getLinkableRule recorder =
         -- Smuggle the hash into the UTCTime.
         --
         -- Fine because GHC only checks the UTCTime for equality
-        let vtime = versionToUTCTime version
+        let vfp@(LinkableFingerprint linkable_fp) = mkLinkableFingerprint version
         let m_old_lr = case old_value of
               Shake.Succeeded _ v -> Just v
               Shake.Stale _ _ v   -> Just v
@@ -1193,9 +1180,9 @@ getLinkableRule recorder =
             | Just old_lr <- m_old_lr
             , linkableHash old_lr == fileHash
             , Just bc <- homeModInfoByteCode (linkableHomeMod old_lr)
-            -> pure ([], Just $ HomeModInfo hirModIface hirModDetails (justBytecode $ setLinkableTime vtime bc))
+            -> pure ([], Just $ HomeModInfo hirModIface hirModDetails (justBytecode $ setLinkableTime linkable_fp bc))
           -- Bytecode needs to be regenerated from the core file
-          BCOLinkable -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core vtime
+          BCOLinkable -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core vfp
           -- Object code can be read from the disk
           ObjectLinkable -> do
             -- object file is up to date if it is newer than the core file
@@ -1211,8 +1198,8 @@ getLinkableRule recorder =
               else pure Nothing
             case mobj_time of
               Just obj_t
-                | obj_t >= core_t -> pure ([], Just $ HomeModInfo hirModIface hirModDetails (justObjects $ mkLinkable vtime (ms_mod hirModSummary) (dotO obj_file)))
-              _ -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core vtime
+                | obj_t >= core_t -> pure ([], Just $ HomeModInfo hirModIface hirModDetails (justObjects $ mkLinkable linkable_fp (ms_mod hirModSummary) (dotO obj_file)))
+              _ -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core vfp
         -- Record the linkable so we know not to unload it, and unload old versions
         whenJust ((homeModInfoByteCode =<< hmi) <|> (homeModInfoObject =<< hmi))
 #if MIN_VERSION_ghc(9,11,0)

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -1137,12 +1137,13 @@ versionToUTCTime (Fingerprint a b) =
 
 getLinkableRule :: Recorder (WithPriority Log) -> Rules ()
 getLinkableRule recorder =
-  defineEarlyCutoff (cmapWithPrio LogShake recorder) $ Rule $ \GetLinkable f -> do
+  defineEarlyCutoff (cmapWithPrio LogShake recorder) $ RuleWithOldValue $ \GetLinkable f old_value -> do
     HiFileResult{hirModSummary, hirModIface, hirModDetails, hirCoreFp} <- use_ GetModIface f
     let obj_file  = ml_obj_file (ms_location hirModSummary)
         core_file = ml_core_file (ms_location hirModSummary)
 #if MIN_VERSION_ghc(9,11,0)
         mkLinkable t mod l = Linkable t mod (pure l)
+        setLinkableTime t (Linkable _ mod l) = Linkable t mod l
         dotO o = DotO o ModuleObject
         keepLinkables t mod =
           [ mkLinkable t mod (DotA "dummy")
@@ -1150,6 +1151,7 @@ getLinkableRule recorder =
           ]
 #else
         mkLinkable t mod l = LM t mod [l]
+        setLinkableTime t (LM _ mod l) = LM t mod l
         dotO = DotO
         -- An empty part list is treated as bytecode by isObjectLinkable
         keepLinkables t mod = [mkLinkable t mod (DotA "dummy"), LM t mod []]
@@ -1179,10 +1181,19 @@ getLinkableRule recorder =
         --
         -- Fine because GHC only checks the UTCTime for equality
         let vtime = versionToUTCTime version
-        -- Can't use `GetModificationTime` rule because the core file was possibly written in this
-        -- very session, so the results aren't reliable
-        core_t <- liftIO $ getModTime core_file
+        let m_old_lr = case old_value of
+              Shake.Succeeded _ v -> Just v
+              Shake.Stale _ _ v   -> Just v
+              Shake.Failed _      -> Nothing
         (warns, hmi) <- case linkableType of
+          -- Bytecode is a function of the core file alone, so if our core file
+          -- is unchanged we can reuse the old bytecode. Only its identity
+          -- changed, and it is relinked when it is next loaded.
+          BCOLinkable
+            | Just old_lr <- m_old_lr
+            , linkableHash old_lr == fileHash
+            , Just bc <- homeModInfoByteCode (linkableHomeMod old_lr)
+            -> pure ([], Just $ HomeModInfo hirModIface hirModDetails (justBytecode $ setLinkableTime vtime bc))
           -- Bytecode needs to be regenerated from the core file
           BCOLinkable -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core vtime
           -- Object code can be read from the disk
@@ -1190,6 +1201,9 @@ getLinkableRule recorder =
             -- object file is up to date if it is newer than the core file
             -- Can't use a rule like 'GetModificationTime' or 'GetFileExists' because 'coreFileToLinkable' will write the object file, and
             -- thus bump its modification time, forcing this rule to be rerun every time.
+            -- Can't use `GetModificationTime` for the core file either, because it was
+            -- possibly written in this very session, so the results aren't reliable
+            core_t <- liftIO $ getModTime core_file
             exists <- liftIO $ doesFileExist obj_file
             mobj_time <- liftIO $
               if exists

--- a/ghcide/src/Development/IDE/Core/Rules.hs
+++ b/ghcide/src/Development/IDE/Core/Rules.hs
@@ -93,8 +93,9 @@ import           Data.Proxy
 import qualified Data.Text                                    as T
 import qualified Data.Text.Encoding                           as T
 import qualified Data.Text.Utf16.Rope.Mixed                   as Rope
-import           Data.Time                                    (UTCTime (..))
-import           Data.Time.Clock.POSIX                        (posixSecondsToUTCTime)
+import           Data.Time                                    (Day (ModifiedJulianDay),
+                                                               UTCTime (..),
+                                                               picosecondsToDiffTime)
 import           Data.Tuple.Extra
 import           Data.Typeable                                (cast)
 import           Development.IDE.Core.Compile
@@ -1123,6 +1124,17 @@ usePropertyByPathAction path plId p = do
 
 -- ---------------------------------------------------------------------
 
+-- | A horrible hack
+-- UTCTime is an unbounded integer
+-- We can smuggle an arbitary 128 bit fingerprint
+-- in the integer
+--
+-- This is fine because GHC only uses the time for identity
+versionToUTCTime :: Fingerprint -> UTCTime
+versionToUTCTime (Fingerprint a b) =
+  UTCTime (ModifiedJulianDay 0) $ picosecondsToDiffTime $
+    toInteger a * 2 ^ (64 :: Int) + toInteger b
+
 getLinkableRule :: Recorder (WithPriority Log) -> Rules ()
 getLinkableRule recorder =
   defineEarlyCutoff (cmapWithPrio LogShake recorder) $ Rule $ \GetLinkable f -> do
@@ -1149,12 +1161,30 @@ getLinkableRule recorder =
         linkableType <- getLinkableType f >>= \case
           Nothing -> error $ "called GetLinkable for a file which doesn't need compilation: " ++ show f
           Just t -> pure t
+        -- We need to depend on the linkables for all dependencies, so that
+        -- whenever a dependeny is relinked/reloaded, we unload the current linkable, because
+        -- the old version of the current linkable references the old dependency
+        --
+        -- We get transitivity via induction
+        imports <- use_ GetLocatedImports f
+        let dep_files = [ artifactFilePath loc | (_, Just loc) <- imports, not (isBootLocation loc) ]
+        dep_comps <- uses_ NeedsCompilation dep_files
+        dep_versions <- map linkableVersion <$> uses_ GetLinkable [ d | (d, Just _) <- zip dep_files dep_comps ]
+        -- We compute a hash/identity for this linkable based on its hash + hash of dependencies
+        -- transitive dependencies are included by induction
+        version <- liftIO $ fingerprintFromByteString $ BS.concat (fileHash : dep_versions)
+
+        -- GHC identifies linkables by UTCTime, we want to identify them by hash
+        -- Smuggle the hash into the UTCTime.
+        --
+        -- Fine because GHC only checks the UTCTime for equality
+        let vtime = versionToUTCTime version
         -- Can't use `GetModificationTime` rule because the core file was possibly written in this
         -- very session, so the results aren't reliable
         core_t <- liftIO $ getModTime core_file
         (warns, hmi) <- case linkableType of
           -- Bytecode needs to be regenerated from the core file
-          BCOLinkable -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core (posixSecondsToUTCTime core_t)
+          BCOLinkable -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core vtime
           -- Object code can be read from the disk
           ObjectLinkable -> do
             -- object file is up to date if it is newer than the core file
@@ -1167,8 +1197,8 @@ getLinkableRule recorder =
               else pure Nothing
             case mobj_time of
               Just obj_t
-                | obj_t >= core_t -> pure ([], Just $ HomeModInfo hirModIface hirModDetails (justObjects $ mkLinkable (posixSecondsToUTCTime obj_t) (ms_mod hirModSummary) (dotO obj_file)))
-              _ -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core (error "object doesn't have time")
+                | obj_t >= core_t -> pure ([], Just $ HomeModInfo hirModIface hirModDetails (justObjects $ mkLinkable vtime (ms_mod hirModSummary) (dotO obj_file)))
+              _ -> liftIO $ coreFileToLinkable linkableType (hscEnv session) hirModSummary hirModIface hirModDetails bin_core vtime
         -- Record the linkable so we know not to unload it, and unload old versions
         whenJust ((homeModInfoByteCode =<< hmi) <|> (homeModInfoObject =<< hmi))
 #if MIN_VERSION_ghc(9,11,0)
@@ -1195,7 +1225,8 @@ getLinkableRule recorder =
               --contents, therefore the dummies.
               unload (hscEnv session) (concatMap (\(mod', time') -> keepLinkables time' mod') $ moduleEnvToList to_keep)
               return (to_keep, ())
-        return (fileHash <$ hmi, (warns, LinkableResult <$> hmi <*> pure fileHash))
+        let versionBS = fingerprintToBS version
+        return (versionBS <$ hmi, (warns, LinkableResult <$> hmi <*> pure fileHash <*> pure versionBS))
 
 -- | For now we always use bytecode unless something uses unboxed sums and tuples along with TH
 getLinkableType :: NormalizedFilePath -> Action (Maybe LinkableType)


### PR DESCRIPTION
Take transitive dependencies into account when unloading

In 7d9ccb70be66a9118eee88505b0455174752d184 we finally stopped unloading
all bytecode on every call to GetLinkable. However, this exposed the fact
that our unloading strategy was not sound

In particular, if you have
```haskell
-- A.hs
f = 1
```

```haskell
-- B.hs
import A
g = f + 1
```

If you change A (say f=2), you must unload/reload B as well, otherwise
its bytecode/linkable will still be pointing to the old version of A
with f=1

We do this with two changes:

- GetLinkable now depends on GetLinkable for direct depdencies
  - So it is recomputed whenever a transtive dependency changes (by induction)
  - It's hash includes the hash of all its direct dependencies (transitive by induction)
- When GetLinkable is recomputed, we unload the old version of the linkable
  - Now we identify linkables by hash of the linkable + all the (transitive) dependencies,
    so we can tell GHC exactly what it needs to keep/vs what it needs to unload
  - This involves a horrid hack, see versionToUTCTime

