### PR TITLE
Simplify `activeDiagnosticsInRange` by returning `[FileDiagnostic]` instead of `Maybe [FileDiagnostic]`

### DIFF
--- a/ghcide/src/Development/IDE/Core/PluginUtils.hs
+++ b/ghcide/src/Development/IDE/Core/PluginUtils.hs
@@ -221,8 +221,8 @@ activeDiagnosticsInRangeMT ide nfp range = do
             rangesOverlap range (fileDiag ^. fdLspDiagnosticL . LSP.range)
 
 -- | Just like 'activeDiagnosticsInRangeMT'. See the docs of 'activeDiagnosticsInRangeMT' for details.
-activeDiagnosticsInRange :: MonadIO m => Shake.ShakeExtras -> NormalizedFilePath -> LSP.Range -> m (Maybe [FileDiagnostic])
-activeDiagnosticsInRange ide nfp range = runMaybeT (activeDiagnosticsInRangeMT ide nfp range)
+activeDiagnosticsInRange :: MonadIO m => Shake.ShakeExtras -> NormalizedFilePath -> LSP.Range -> m [FileDiagnostic]
+activeDiagnosticsInRange ide nfp range = concat <$> runMaybeT (activeDiagnosticsInRangeMT ide nfp range)
 
 -- Prefer server-side diagnostics if available; they are authoritative.
 injectServerDiagnostics :: IdeState -> CodeActionParams -> IO CodeActionParams
@@ -231,9 +231,7 @@ injectServerDiagnostics ide params@LSP.CodeActionParams{_textDocument=LSP.TextDo
     Nothing  -> pure []
     Just nfp -> do
       mDiags <- activeDiagnosticsInRange (shakeExtras ide) nfp _range
-      case mDiags of
-        Nothing    -> pure []
-        Just diags -> pure $ diags ^.. traverse . fdLspDiagnosticL
+      pure $ mDiags ^.. traverse . fdLspDiagnosticL
   pure $ params & LSP.context . LSP.diagnostics .~ serverDiags
 
 -- ----------------------------------------------------------------------------

--- a/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
+++ b/plugins/hls-change-type-signature-plugin/src/Ide/Plugin/ChangeTypeSignature.hs
@@ -92,11 +92,9 @@ codeActionHandler recorder plId ideState _ CodeActionParams{_textDocument, _rang
     nfp <- getNormalizedFilePathE uri
     decls <- getDecls plId ideState nfp
 
-    activeDiagnosticsInRange (shakeExtras ideState) nfp _range >>= \case
-        Nothing -> pure (InL [])
-        Just fileDiags -> do
-            actions <- lift $ mapM (generateAction recorder plId uri decls) fileDiags
-            pure (InL (catMaybes actions))
+    fileDiags <- activeDiagnosticsInRange (shakeExtras ideState) nfp _range
+    actions <- lift $ mapM (generateAction recorder plId uri decls) fileDiags
+    pure $ InL $ catMaybes actions
 
 getDecls :: MonadIO m => PluginId -> IdeState -> NormalizedFilePath -> ExceptT PluginError m [LHsDecl GhcPs]
 getDecls (PluginId changeTypeSignatureId) state =

--- a/plugins/hls-class-plugin/src/Ide/Plugin/Class/CodeAction.hs
+++ b/plugins/hls-class-plugin/src/Ide/Plugin/Class/CodeAction.hs
@@ -86,9 +86,7 @@ codeAction recorder state plId (CodeActionParams _ _ docId caRange _) = do
     verTxtDocId <- liftIO $ runAction "classplugin.codeAction.getVersionedTextDoc" state $ getVersionedTextDoc docId
     nfp <- getNormalizedFilePathE (verTxtDocId ^. L.uri)
     activeDiagnosticsInRange (shakeExtras state) nfp caRange
-        >>= \case
-        Nothing -> pure $ InL []
-        Just fileDiags -> do
+        >>= \fileDiags -> do
             actions <- join <$> mapM (mkActions nfp verTxtDocId) (methodDiags fileDiags)
             pure $ InL actions
     where

--- a/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
+++ b/plugins/hls-pragmas-plugin/src/Ide/Plugin/Pragmas.hs
@@ -94,9 +94,7 @@ mkCodeActionProvider mkSuggest state _plId
     parsedModule <- liftIO $ runAction "Pragmas.GetParsedModule" state $ getParsedModule normalizedFilePath
     let parsedModuleDynFlags = ms_hspp_opts . pm_mod_summary <$> parsedModule
         nextPragmaInfo = Pragmas.getNextPragmaInfo sessionDynFlags fileContents
-    activeDiagnosticsInRange (shakeExtras state) normalizedFilePath caRange >>= \case
-        Nothing -> pure $ LSP.InL []
-        Just fileDiags -> do
+    activeDiagnosticsInRange (shakeExtras state) normalizedFilePath caRange >>= \fileDiags -> do
             let actions = concatMap (mkSuggest parsedModuleDynFlags) fileDiags
             pure $ LSP.InL $ pragmaEditToAction uri nextPragmaInfo <$> nubOrdOn snd actions
 

--- a/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Args.hs
+++ b/plugins/hls-refactor-plugin/src/Development/IDE/Plugin/CodeAction/Args.hs
@@ -22,8 +22,7 @@ import           Data.Either                                  (fromRight,
 import           Data.Functor                                 ((<&>))
 import           Data.IORef.Extra
 import qualified Data.Map                                     as Map
-import           Data.Maybe                                   (fromMaybe,
-                                                               maybeToList)
+import           Data.Maybe                                   (fromMaybe)
 import qualified Data.Text                                    as T
 import qualified Data.Text.Utf16.Rope.Mixed                   as Rope
 import           Development.IDE                              hiding
@@ -80,7 +79,7 @@ runGhcideCodeAction state (CodeActionParams _ _ (TextDocumentIdentifier uri) _ra
         caaHar <- onceIO $ runRule GetHieAst
         caaBindings <- onceIO $ runRule GetBindings
         caaGblSigs <- onceIO $ runRule GetGlobalBindingTypeSigs
-        diags <- concat . maybeToList <$> activeDiagnosticsInRange (shakeExtras state) nfp _range
+        diags <- activeDiagnosticsInRange (shakeExtras state) nfp _range
         results <- liftIO $
             sequence
                 [


### PR DESCRIPTION
The function `activeDiagnosticsInRange` returns `MonadIO m => m (Maybe [FileDiagnostic])`, but no callers appear to make any distinction between `Just []` and `Nothing`, so we can probably just drop the `Maybe` layer alltogether? Tests will tell.