### PR TITLE
Put the cwd shifts in tests behind an opt-in

### DIFF
--- a/ghcide-test/exe/Config.hs
+++ b/ghcide-test/exe/Config.hs
@@ -61,7 +61,6 @@ testSessionWithPlugin fs plugin = runSessionWithTestConfig def
     { testPluginDescriptor = plugin
     , testDirLocation = Right fs
     , testConfigCaps = lspTestCaps
-    , testShiftRoot = True
     }
 
 -- * A dummy plugin for testing ghcIde
@@ -79,7 +78,6 @@ runWithDummyPlugin' fs = runSessionWithTestConfig def
     { testPluginDescriptor = dummyPlugin
     , testDirLocation = Right fs
     , testConfigCaps = lspTestCaps
-    , testShiftRoot = True
     }
 
 testWithDummyPlugin :: String -> FS.VirtualFileTree -> Session () -> TestTree

--- a/ghcide-test/exe/CradleTests.hs
+++ b/ghcide-test/exe/CradleTests.hs
@@ -434,7 +434,6 @@ runWithExtraFilesMultiComponent sesLoading dirName action = do
         { testPluginDescriptor = dummyPlugin
         , testDirLocation = Right vfs
         , testConfigCaps = lspTestCaps
-        , testShiftRoot = True
         , testDisableKick = True
         , testLspConfig = lspConfig
         }

--- a/ghcide-test/exe/DependentFileTest.hs
+++ b/ghcide-test/exe/DependentFileTest.hs
@@ -14,6 +14,7 @@ import           Language.LSP.Protocol.Types    hiding
                                                  SemanticTokensEdit (..),
                                                  mkRange)
 import           Language.LSP.Test
+import           System.FilePath                ((</>))
 import           Test.Hls
 import           Test.Hls.FileSystem
 
@@ -21,17 +22,17 @@ import           Test.Hls.FileSystem
 tests :: TestTree
 tests = testGroup "addDependentFile"
     [testGroup "file-changed" [testCase "test" $ runSessionWithTestConfig def
-        { testShiftRoot = True
-        , testDirLocation = Right (mkIdeTestFs [])
+        { testDirLocation = Right (mkIdeTestFs [])
         , testPluginDescriptor = dummyPlugin
         } test]
     ]
     where
       test :: FilePath -> Session ()
-      test _ = do
+      test sessionDir = do
         -- If the file contains B then no type error
         -- otherwise type error
-        let depFilePath = "dep-file.txt"
+        let depFilePath = sessionDir </> "dep-file.txt"
+            depFileLit = T.pack (show depFilePath)
         liftIO $ atomicFileWriteString depFilePath "A"
         let fooContent = T.unlines
               [ "{-# LANGUAGE TemplateHaskell #-}"
@@ -39,8 +40,8 @@ tests = testGroup "addDependentFile"
               , "import Language.Haskell.TH.Syntax"
               , "foo :: Int"
               , "foo = 1 + $(do"
-              , "               qAddDependentFile \"" <> T.pack depFilePath <> "\""
-              , "               f <- qRunIO (readFile \"" <> T.pack depFilePath <> "\")"
+              , "               qAddDependentFile " <> depFileLit
+              , "               f <- qRunIO (readFile " <> depFileLit <> ")"
               , "               if f == \"B\" then [| 1 |] else lift f)"
               ]
         let bazContent = T.unlines ["module Baz where", "import Foo ()"]

--- a/ghcide-test/exe/DiagnosticTests.hs
+++ b/ghcide-test/exe/DiagnosticTests.hs
@@ -231,7 +231,7 @@ tests = testGroup "diagnostics"
       diags <- waitForDiagnosticsSource "not found"
       liftIO $ assertBool ("expected ModuleA to be unresolvable, got: " <> show diags)
         (any (T.isInfixOf "ModuleA" . (^. L.message)) diags)
-  , testWithDummyPlugin "import path order determines module file"
+  , testWithDummyPlugin' "import path order determines module file"
         (mkIdeTestFs
           [ -- GHC searches import paths in order: with -isrcA -isrcB, a module
             -- present in both directories must resolve to the file in srcA.
@@ -257,13 +257,13 @@ tests = testGroup "diagnostics"
               ]
             ]
           ]
-        ) $ do
+        ) $ \sessionDir -> do
       tdoc <- openDoc ("srcA" </> "T.hs") "haskell"
       WaitForIdeRuleResult{ideResultSuccess} <- waitForAction "TypeCheck" tdoc
       liftIO $ assertBool "T should typecheck using srcA's C" ideResultSuccess
       expectCurrentDiagnostics tdoc []
       locs <- getDefinitions tdoc (Position 1 7)
-      assertDefsFile ("srcA" </> "C.hs") locs
+      assertDefsFile (sessionDir </> "srcA" </> "C.hs") locs
   , testWithDummyPlugin' "unlistable directory hides only itself"
         (mkIdeTestFs
           [ directCradle ["-isrc", "B"]

--- a/ghcide-test/exe/FindDefinitionAndHoverTests.hs
+++ b/ghcide-test/exe/FindDefinitionAndHoverTests.hs
@@ -9,10 +9,10 @@ import           Data.Maybe
 import qualified Data.Text                  as T
 import           Development.IDE.Test       (expectDiagnostics)
 import           Hover
+import           Ide.Types
 import qualified Language.LSP.Protocol.Lens as L
 import           Language.LSP.Test
 import           System.Info.Extra          (isWindows)
-import           Ide.Types
 import           Test.Hls
 import           Test.Hls.FileSystem        (copyDir)
 
@@ -242,7 +242,6 @@ linkToTests =
         { testPluginDescriptor = dummyPlugin
         , testDirLocation = Right (mkIdeTestFs [copyDir "hover"])
         , testConfigCaps = lspTestCaps
-        , testShiftRoot = True
         , testLspConfig = lspConf
         }
     hoverCheck pos fp expects = do

--- a/ghcide-test/exe/RootUriTests.hs
+++ b/ghcide-test/exe/RootUriTests.hs
@@ -33,7 +33,6 @@ tests = testCase "use rootUri" . runTest "dirA" "dirB" $ \dir -> do
             , testDirLocation = Right $ mkIdeTestFs [copyDir "rootUri"]
             , testServerRoot = Just dir1
             , testClientRoot = Just dir2
-            , testShiftRoot = True
         }
 
 

--- a/ghcide-test/exe/WatchedFileTests.hs
+++ b/ghcide-test/exe/WatchedFileTests.hs
@@ -181,9 +181,9 @@ tests = testGroup "watched files"
           _ <- openDoc hsFile "haskell"
           expectDiagnostics [(hsFile, [(DiagnosticSeverity_Error, (2, 7), "Could not load module \8216Data.List.Split\8217", Nothing)])]
           let cabalFile = "reload.cabal"
-          cabalContent <- liftIO $ T.readFile cabalFile
+          cabalContent <- liftIO $ T.readFile (sessionDir </> cabalFile)
           let fix = T.replace "build-depends:    base" "build-depends:    base, split"
-          liftIO $ atomicFileWriteText cabalFile (fix cabalContent)
+          liftIO $ atomicFileWriteText (sessionDir </> cabalFile) (fix cabalContent)
           sendNotification SMethod_WorkspaceDidChangeWatchedFiles $ DidChangeWatchedFilesParams
             [ FileEvent (filePathToUri $ sessionDir </> cabalFile) FileChangeType_Changed ]
           expectDiagnostics [(hsFile, [])]

--- a/ghcide/session-loader/Development/IDE/Session/Ghc.hs
+++ b/ghcide/session-loader/Development/IDE/Session/Ghc.hs
@@ -262,7 +262,7 @@ setOptions haddockOpt cfp (ComponentOptions theOpts compRoot _) dflags rootDir =
     where
       initMulti unitArgFiles =
         forM unitArgFiles $ \f -> do
-          args <- liftIO $ expandResponse [f]
+          args <- liftIO $ expandResponse [rebaseResponseFile compRoot f]
           -- The reponse files may contain arguments like "+RTS",
           -- and hie-bios doesn't expand the response files of @-unit@ arguments.
           -- Thus, we need to do the stripping here.
@@ -308,6 +308,13 @@ setOptions haddockOpt cfp (ComponentOptions theOpts compRoot _) dflags rootDir =
 
 normaliseImportsPaths :: DynFlags -> DynFlags
 normaliseImportsPaths dflags = dflags { importPaths = fmap normalise (importPaths dflags)}
+
+-- | Rebase a relative response-file path onto the component root, so
+-- 'expandResponse' does not resolve it against the process CWD.
+rebaseResponseFile :: FilePath -> String -> String
+rebaseResponseFile root arg = case arg of
+  '@' : path -> '@' : toAbsolute root path
+  _          -> arg
 
 addComponentInfo ::
   MonadUnliftIO m =>

--- a/ghcide/src/Development/IDE/LSP/LanguageServer.hs
+++ b/ghcide/src/Development/IDE/LSP/LanguageServer.hs
@@ -112,6 +112,8 @@ data ServerLifecycleContext config = ServerLifecycleContext
     -- ^ Logger for recording server events and diagnostics
   , ctxDefaultRoot :: FilePath
     -- ^ Default root directory for the workspace, see Note [Root Directory]
+  , ctxDisableInitialCwdShift :: Bool
+    -- ^ Skip the init-time setCurrentDirectory, see Note [Root Directory]
   , ctxGetHieDbLoc :: FilePath -> IO FilePath
     -- ^ Function to determine the HIE database location for a given root path
   , ctxGetIdeState :: LSP.LanguageContextEnv config -> FilePath -> WithHieDb -> ThreadQueue -> IO IdeState
@@ -191,12 +193,13 @@ setupLSP ::
      forall config.
      Recorder (WithPriority Log)
   -> FilePath -- ^ root directory, see Note [Root Directory]
+  -> Bool -- ^ disable the initial setCurrentDirectory to the rootUri, see Note [Root Directory]
   -> (FilePath -> IO FilePath) -- ^ Map root paths to the location of the hiedb for the project
   -> LSP.Handlers (ServerM config)
   -> (LSP.LanguageContextEnv config -> FilePath -> WithHieDb -> ThreadQueue -> IO IdeState)
   -> MVar ()
   -> IO (Setup config (ServerM config) IdeState)
-setupLSP recorder defaultRoot getHieDbLoc userHandlers getIdeState clientMsgVar = do
+setupLSP recorder defaultRoot disableInitialCwdShift getHieDbLoc userHandlers getIdeState clientMsgVar = do
   -- Send everything over a channel, since you need to wait until after initialise before
   -- LspFuncs is available
   clientMsgChan :: Chan ReactorMessage <- newChan
@@ -254,6 +257,7 @@ setupLSP recorder defaultRoot getHieDbLoc userHandlers getIdeState clientMsgVar 
   let lifecycleCtx = ServerLifecycleContext
         { ctxRecorder = recorder
         , ctxDefaultRoot = defaultRoot
+        , ctxDisableInitialCwdShift = disableInitialCwdShift
         , ctxGetHieDbLoc = getHieDbLoc
         , ctxGetIdeState = getIdeState
         , ctxUntilReactorStopSignal = untilReactorStopSignal
@@ -285,7 +289,9 @@ handleInit lifecycleCtx env (TRequestMessage _ _ m params) = otTracedHandler "In
       untilReactorStopSignal = ctxUntilReactorStopSignal lifecycleCtx
       lifetimeConfirm = ctxConfirmReactorShutdown lifecycleCtx
     root <- case LSP.resRootPath env of
-      Just lspRoot | lspRoot /= defaultRoot -> setCurrentDirectory lspRoot >> return lspRoot
+      Just lspRoot | lspRoot /= defaultRoot -> do
+        unless (ctxDisableInitialCwdShift lifecycleCtx) $ setCurrentDirectory lspRoot
+        return lspRoot
       _ -> pure defaultRoot
     dbLoc <- ctxGetHieDbLoc lifecycleCtx root
     let initConfig = parseConfiguration params

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -206,22 +206,23 @@ commandP plugins =
 
 
 data Arguments = Arguments
-    { argsProjectRoot           :: FilePath
-    , argCommand                :: Command
-    , argsRules                 :: Rules ()
-    , argsHlsPlugins            :: IdePlugins IdeState
-    , argsGhcidePlugin          :: Plugin Config  -- ^ Deprecated
-    , argsSessionLoadingOptions :: SessionLoadingOptions
-    , argsIdeOptions            :: Config -> Action IdeGhcSession -> IdeOptions
-    , argsLspOptions            :: LSP.Options
-    , argsDefaultHlsConfig      :: Config
-    , argsGetHieDbLoc           :: FilePath -> IO FilePath -- ^ Map project roots to the location of the hiedb for the project
-    , argsDebouncer             :: IO (Debouncer NormalizedUri) -- ^ Debouncer used for diagnostics
-    , argsHandleIn              :: IO Handle
-    , argsHandleOut             :: IO Handle
-    , argsThreads               :: Maybe Natural
-    , argsMonitoring            :: IO Monitoring
-    , argsDisableKick           :: Bool -- ^ flag to disable kick used for testing
+    { argsProjectRoot            :: FilePath
+    , argCommand                 :: Command
+    , argsRules                  :: Rules ()
+    , argsHlsPlugins             :: IdePlugins IdeState
+    , argsGhcidePlugin           :: Plugin Config  -- ^ Deprecated
+    , argsSessionLoadingOptions  :: SessionLoadingOptions
+    , argsIdeOptions             :: Config -> Action IdeGhcSession -> IdeOptions
+    , argsLspOptions             :: LSP.Options
+    , argsDefaultHlsConfig       :: Config
+    , argsGetHieDbLoc            :: FilePath -> IO FilePath -- ^ Map project roots to the location of the hiedb for the project
+    , argsDebouncer              :: IO (Debouncer NormalizedUri) -- ^ Debouncer used for diagnostics
+    , argsHandleIn               :: IO Handle
+    , argsHandleOut              :: IO Handle
+    , argsThreads                :: Maybe Natural
+    , argsMonitoring             :: IO Monitoring
+    , argsDisableKick            :: Bool -- ^ flag to disable kick used for testing
+    , argsDisableInitialCwdShift :: Bool -- ^ skip the init-time setCurrentDirectory, see Note [Root Directory]
     }
 
 defaultArguments :: Recorder (WithPriority Log) -> FilePath -> IdePlugins IdeState -> Arguments
@@ -266,6 +267,7 @@ defaultArguments recorder projectRoot plugins = Arguments
                 return newStdout
         , argsMonitoring = OpenTelemetry.monitoring
         , argsDisableKick = False
+        , argsDisableInitialCwdShift = False
         }
 
 
@@ -379,7 +381,7 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
                   putMVar ideStateVar ide
                   pure ide
 
-            let setup ideStateVar = setupLSP (cmapWithPrio LogLanguageServer recorder) argsProjectRoot argsGetHieDbLoc (pluginHandlers plugins) (getIdeState ideStateVar)
+            let setup ideStateVar = setupLSP (cmapWithPrio LogLanguageServer recorder) argsProjectRoot argsDisableInitialCwdShift argsGetHieDbLoc (pluginHandlers plugins) (getIdeState ideStateVar)
                 -- See Note [Client configuration in Rules]
                 onConfigChange ideStateVar cfg = do
                   -- TODO: this is nuts, we're converting back to JSON just to get a fingerprint

--- a/hls-test-utils/src/Test/Hls.hs
+++ b/hls-test-utils/src/Test/Hls.hs
@@ -69,7 +69,8 @@ module Test.Hls
     Priority(..),
     captureKickDiagnostics,
     kick,
-    TestConfig(..)
+    TestConfig(..),
+    CwdHandling(..)
     )
 where
 
@@ -601,7 +602,7 @@ instance Default (TestConfig b) where
     testDirLocation = Right $ VirtualFileTree [] "",
     testClientRoot = Nothing,
     testServerRoot = Nothing,
-    testShiftRoot = False,
+    testCwdHandling = NoCwdShift,
     testDisableKick = False,
     testDisableDefaultPlugin = False,
     testPluginDescriptor = mempty,
@@ -725,9 +726,17 @@ keepCurrentDirectory :: IO a -> IO a
 keepCurrentDirectory = bracket getCurrentDirectory setCurrentDirectory . const
 
 {-# NOINLINE lock #-}
--- | Never run in parallel
+-- | Serialises tests that shift the global cwd. See Note [Root Directory].
 lock :: Lock
 lock = unsafePerformIO newLock
+
+-- | How a test drives the process-global current working directory. See Note [Root Directory].
+data CwdHandling
+  = HarnessCwdShift
+    -- ^ The harness shifts the cwd to the test root under 'lock', for
+    -- cwd-coupled suites like stan and hlint.
+  | NoCwdShift
+  deriving (Eq)
 
 data TestConfig b = TestConfig
   {
@@ -750,8 +759,8 @@ data TestConfig b = TestConfig
     -- Don't forget to use 'TASTY_PATTERN' to debug only a subset of tests.
     --
     -- For plugin test logs, look at the documentation of 'mkPluginTestDescriptor'.
-  , testShiftRoot            :: Bool
-    -- ^ Whether to shift the current directory to the root of the project
+  , testCwdHandling          :: CwdHandling
+    -- ^ How the test drives the process-global cwd
   , testClientRoot           :: Maybe FilePath
     -- ^ Specify the root of (the client or LSP context),
     -- if Nothing it is the same as the testDirLocation
@@ -806,8 +815,8 @@ runSessionWithTestConfig TestConfig{..} session =
     runSessionInVFS testDirLocation $ \root cacheDir -> shiftRoot root $ do
     pipeIn@(inR, inW) <- createPipe
     pipeOut@(outR, outW) <- createPipe
-    let serverRoot = fromMaybe root testServerRoot
-    let clientRoot = fromMaybe root testClientRoot
+    let serverRoot = maybe root (root </>) testServerRoot
+    let clientRoot = maybe root (root </>) testClientRoot
 
     (recorder, cb1) <- wrapClientLogger =<< hlsPluginTestRecorder
     (recorderIde, cb2) <- wrapClientLogger =<< hlsHelperTestRecorder
@@ -849,10 +858,9 @@ runSessionWithTestConfig TestConfig{..} session =
       pure result
 
     where
-        shiftRoot shiftTarget f  =
-            if testShiftRoot
-                then withLock lock $ keepCurrentDirectory $ setCurrentDirectory shiftTarget >> f
-                else f
+        shiftRoot shiftTarget f
+            | testCwdHandling == HarnessCwdShift = withLock lock $ keepCurrentDirectory $ setCurrentDirectory shiftTarget >> f
+            | otherwise                          = f
         runSessionInVFS (Left testConfigRoot) act = do
             root <- makeAbsolute testConfigRoot
             withTemporaryDataAndCacheDirectory (\_ cacheDir -> act root cacheDir)
@@ -879,6 +887,7 @@ runSessionWithTestConfig TestConfig{..} session =
                 , argsDefaultHlsConfig = testLspConfig
                 , argsProjectRoot = prjRoot
                 , argsDisableKick = testDisableKick
+                , argsDisableInitialCwdShift = True
                 -- Keep interface files and the hiedb under this test's cache
                 -- directory instead of the shared 'XDG_CACHE_HOME'.
                 , argsGetHieDbLoc = getHieDbLocIn cacheDir

--- a/hls-test-utils/src/Test/Hls/FileSystem.hs
+++ b/hls-test-utils/src/Test/Hls/FileSystem.hs
@@ -119,7 +119,9 @@ materialise rootDir' fileTree testDataDir' = do
 
       copyDir' :: FilePath -> FilePath -> IO ()
       copyDir' root dir = do
-        files <- fmap FP.normalise . lines <$> withCurrentDirectory (testDataDir </> dir) (readProcess "git" ["ls-files", "--cached", "--modified", "--others"] "")
+        -- `git -C` avoids withCurrentDirectory, which would mutate the global CWD
+        -- and race with parallel tests. See Note [Root Directory].
+        files <- fmap FP.normalise . lines <$> readProcess "git" ["-C", testDataDir </> dir, "ls-files", "--cached", "--modified", "--others"] ""
         mapM_ (createDirectoryIfMissing True . ((root </>) . takeDirectory)) files
         mapM_ (\f -> copyFile (testDataDir </> dir </> f) (root </> f)) files
         return ()

--- a/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/FilePath.hs
+++ b/plugins/hls-cabal-plugin/src/Ide/Plugin/Cabal/Completion/Completer/FilePath.hs
@@ -167,7 +167,10 @@ mkPathCompletionDir complInfo completion =
 mkFilePathCompletion :: PathCompletionInfo -> T.Text -> IO T.Text
 mkFilePathCompletion complInfo completion = do
   let combinedPath = mkPathCompletionDir complInfo completion
-  isFilePath <- doesFileExist $ T.unpack combinedPath
+  -- combinedPath is relative to the cabal file, so the existence check must
+  -- prepend the absolute working directory to avoid relying on process CWD.
+  -- See Note [Root Directory].
+  isFilePath <- doesFileExist $ workingDirectory complInfo FP.</> T.unpack combinedPath
   let completedPath = if isFilePath then applyStringNotation (isStringNotationPath complInfo) combinedPath else combinedPath
   pure completedPath
 

--- a/plugins/hls-hlint-plugin/test/Main.hs
+++ b/plugins/hls-hlint-plugin/test/Main.hs
@@ -120,7 +120,7 @@ suggestionsTests =
             { testConfigCaps = noLiteralCaps
             , testDirLocation = Left testDir
             , testPluginDescriptor = hlintPlugin
-            , testShiftRoot = True} $ const $ do
+            , testCwdHandling = HarnessCwdShift} $ const $ do
         doc <- openDoc "Base.hs" "haskell"
 
         _ <- hlintCaptureKick
@@ -350,7 +350,7 @@ runHlintSession :: FilePath -> Session a -> IO a
 runHlintSession subdir = failIfSessionTimeout .
     runSessionWithTestConfig def
       { testConfigCaps = codeActionNoResolveCaps
-      , testShiftRoot = True
+      , testCwdHandling = HarnessCwdShift
       , testDirLocation = Left (testDir </> subdir)
       , testPluginDescriptor = hlintPlugin
       }
@@ -466,7 +466,7 @@ setupGoldenHlintTest :: TestName -> FilePath -> ClientCapabilities -> (TextDocum
 setupGoldenHlintTest testName path config =
     goldenWithTestConfig def
     { testConfigCaps = config
-    , testShiftRoot = True
+    , testCwdHandling = HarnessCwdShift
     , testPluginDescriptor = hlintPlugin
     , testDirLocation = Right tree
     } testName tree path "expected" "hs"

--- a/plugins/hls-stan-plugin/test/Main.hs
+++ b/plugins/hls-stan-plugin/test/Main.hs
@@ -78,7 +78,7 @@ runStanSession subdir =
   failIfSessionTimeout
   . runSessionWithTestConfig def{
     testConfigCaps=codeActionNoResolveCaps
-    , testShiftRoot=True
+    , testCwdHandling=HarnessCwdShift
     , testPluginDescriptor=stanPlugin
     , testDirLocation=Left (testDir </> subdir)
     }

--- a/test/functional/Config.hs
+++ b/test/functional/Config.hs
@@ -71,7 +71,7 @@ genericConfigTests = testGroup "generic plugin config"
         runConfigSession subdir session = do
           failIfSessionTimeout $
             runSessionWithTestConfig def
-                { testConfigSession=def {ignoreConfigurationRequests=False}, testShiftRoot=True
+                { testConfigSession=def {ignoreConfigurationRequests=False}, testCwdHandling=HarnessCwdShift
                 , testPluginDescriptor=plugin, testDirLocation=Left ("test/testdata" </> subdir) }
                 (const session)
 


### PR DESCRIPTION
Part of https://github.com/haskell/haskell-language-server/pull/4977.

This PR makes it explicit which testsuites depend on being able to shift the current working directory, related https://github.com/haskell/haskell-language-server/issues/4234.