### PR TITLE
Change `rangesOverlap` to honor the fact that `Range`s are inclusive to the left but exclusive to the right

### DIFF
--- a/ghcide/src/Development/IDE/Core/PluginUtils.hs
+++ b/ghcide/src/Development/IDE/Core/PluginUtils.hs
@@ -56,7 +56,7 @@ import           Development.IDE.Types.Location       (NormalizedFilePath)
 import qualified Development.IDE.Types.Location       as Location
 import qualified Ide.Logger                           as Logger
 import           Ide.Plugin.Error
-import           Ide.PluginUtils                      (rangesOverlap)
+import           Ide.PluginUtils                      (asPosition, rangesOverlap)
 import           Ide.Types
 import qualified Language.LSP.Protocol.Lens           as LSP
 import           Language.LSP.Protocol.Message        (SMethod (..))
@@ -215,10 +215,22 @@ activeDiagnosticsInRangeMT ide nfp range = do
         case mDiags of
             Nothing -> pure Nothing
             Just fileDiags -> do
-                pure $ Just $ filter diagRangeOverlaps fileDiags
+                pure $ Just $ filter (diagRangeOverlaps range) fileDiags
     where
-        diagRangeOverlaps = \fileDiag ->
-            rangesOverlap range (fileDiag ^. fdLspDiagnosticL . LSP.range)
+        -- The rationale of how to decide whether a 'Range' overlap with the
+        -- 'Range' of a diagnostic is explained at
+        -- https://github.com/haskell/haskell-language-server/pull/5047
+        diagRangeOverlaps range fileDiag
+          | Just c <- asPosition range
+            -- The client sent us the cursor position, so we check if it
+            -- overlaps with the **closed** 'Range' of the diagnostic.
+            = LSP.positionInRange c diagRange || c == diagEnd
+          | otherwise
+            -- The client sent us a selection 'Range', so we check if it
+            -- overlaps with the 'Range' of the diagnostic.
+            = rangesOverlap range diagRange
+          where
+            diagRange@(LSP.Range _ diagEnd) = fileDiag ^. fdLspDiagnosticL . LSP.range
 
 -- | Just like 'activeDiagnosticsInRangeMT'. See the docs of 'activeDiagnosticsInRangeMT' for details.
 activeDiagnosticsInRange :: MonadIO m => Shake.ShakeExtras -> NormalizedFilePath -> LSP.Range -> m [FileDiagnostic]

--- a/hls-plugin-api/src/Ide/PluginUtils.hs
+++ b/hls-plugin-api/src/Ide/PluginUtils.hs
@@ -29,6 +29,7 @@ module Ide.PluginUtils
     installSigUsr1Handler,
     subRange,
     rangesOverlap,
+    asPosition,
     positionInRange,
     usePropertyLsp,
     -- * Escape
@@ -279,8 +280,11 @@ subRange :: Range -> Range -> Bool
 subRange = isSubrangeOf
 
 
--- | Check whether the two 'Range's overlap in any way.
+-- | Check whether the two 'Range's overlap in any way, taking into account
+-- that, as per the LSP spec, 'Range's are right-open half-open intervals.
 --
+-- >>> rangesOverlap (mkRange 1 0 1 2) (mkRange 1 4 1 6)
+-- False
 -- >>> rangesOverlap (mkRange 1 0 1 4) (mkRange 1 2 1 5)
 -- True
 -- >>> rangesOverlap (mkRange 1 2 1 5) (mkRange 1 0 1 4)
@@ -289,9 +293,22 @@ subRange = isSubrangeOf
 -- True
 -- >>> rangesOverlap (mkRange 1 2 1 4) (mkRange 1 0 1 6)
 -- True
+-- >>> rangesOverlap (mkRange 1 2 1 4) (mkRange 1 4 1 6)
+-- False
 rangesOverlap :: Range -> Range -> Bool
 rangesOverlap r1 r2 =
-  r1 ^. L.start <= r2 ^. L.end && r2 ^. L.start <= r1 ^. L.end
+  r1 ^. L.start < r2 ^. L.end && r2 ^. L.start < r1 ^. L.end
+
+-- | As per the LSP spec, the client's requests come with a 'Range', not a
+-- 'Position'. This function attempts to interpret a zero-length 'Range'
+-- as position.
+--
+-- In practice, it's useful for distinguishing whether the client sent
+-- us a cursor position or a selection.
+asPosition :: Range -> Maybe Position
+asPosition (Range b e)
+  | b == e = Just b
+  | otherwise = Nothing
 
 -- ---------------------------------------------------------------------
 

--- a/plugins/hls-refactor-plugin/test/Main.hs
+++ b/plugins/hls-refactor-plugin/test/Main.hs
@@ -1290,7 +1290,7 @@ extendImportTests = testGroup "extend import actions"
                     , "b :: A"
                     , "b = 0"
                     ])
-            (Range (Position 2 5) (Position 2 5))
+            (Range (Position 2 5) (Position 2 6))
             ["Add A to the import list of ModuleA"]
             (T.unlines
                     [ "module ModuleB where"
@@ -2958,7 +2958,7 @@ fillTypedHoleTests = let
               ]
       doc <- createDoc "Test.hs" "haskell" $ mkDoc "_"
       _ <- waitForDiagnostics
-      actions <- getCodeActions doc (Range (Position 2 13) (Position 2 14))
+      actions <- getCodeActions doc (Range (Position 2 12) (Position 2 13))
       chosen <- pickActionWithTitle "Replace _ with (<$>)" actions
       executeCodeAction chosen
       modifiedCode <- documentContents doc
@@ -2971,7 +2971,7 @@ fillTypedHoleTests = let
               ]
       doc <- createDoc "Test.hs" "haskell" $ mkDoc "`_`"
       _ <- waitForDiagnostics
-      actions <- getCodeActions doc (Range (Position 2 16) (Position 2 19))
+      actions <- getCodeActions doc (Range (Position 2 18) (Position 2 19))
       chosen <- pickActionWithTitle "Replace _ with (<$>)" actions
       executeCodeAction chosen
       modifiedCode <- documentContents doc


### PR DESCRIPTION
I brainstormed what follows, and therefore the intended solution, with @MangoIV


### The setting

Consider this code
```haskell
    foo = bar + baz
```
and imagine that there's two adjacent diagnostics on it¹:
```haskell
--  vvvvvv <---------- diagnostic 1
    foo = bar + baz
--        ^^^^^^^^^ <- diagnostic 2
```
As per the LSP spec, the `Range`s of these diagnostics are (`l` is the 0-based line number):
```haskell
Range (Position l  4) (Position l 10)
Range (Position l 10) (Position l 19)
```
Since all happens on line `l`, I'll use the mathematical notation for right-open intervals:
```none
r1 = [ 4, 10)
r2 = [10, 19)
```
Now imagine the following two scenarî.

### Scenario 1 - the cursor is between the diagnostics

***The cursor***, intended as the thin vertical bar that most GUI-based editors (as opposed to, say, Vim) show, ***is between the `b` of `bar` and the space before it***², and the only way the client can hope to tell this to the server is to send the range `[4, 4)`, which is precisely what VSCode does, for instance.

In this case, the cursor is in a pefectly symmetrical position with respect to the two diagnostics, so there's absolutely no reason to consider it overlapping with only one diagnostic or only with the other.

We either claim it's overlapping with both, or we claim it's overlapping with none.

For that, the inherently asymmetrical interpretation of `Range`s as half-open comes short, and needs changing:

  1. if we wanted the cursor to overlap with neither diagnostic, we'd have to consider their `Range`s to be open on both sides,

  2. if we wanted the cursor to overlap with both diagnostics, we'd have to consider their `Range`s to be losed on both sides.

### Scenario 2 - the second diagnostic is selected

***The user has selected the second diagnostic***, in which case the client sends HLS the range `[10, 19)`, verified on VSCode.

In this case, I think it's only reasonable that we provide interaction with that diagnostic, and not with the other one.

For that, the interpretation of `Range`s as half-open comes handy, because adjacent half-open ranges have no overlap.

### The solution

The solution supports both scenarî, and for the first one, I decided to allow interaction with both diagnostics, as opposed to neither.


---

¹ I'm not aware of how to make HLS generate such diagnostics, but that's irrelevant, as adjacent diagnostics are not forbidden by the LSP spec.

² This is what the LSP spec refers to as "insert cursor", which is probably reminiscent of Vim's insert mode as opposed to normal mode?

---

Fixes #5049.
