### PR TITLE
docs: updated moved nvim-lspconfig page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -287,7 +287,7 @@ Plugins that streamline the setup of `haskell-language-server` using Neovim's bu
 
 * [haskell-tools.nvim](https://github.com/MrcJkb/haskell-tools.nvim): A plugin with a focus on Haskell tooling, including `haskell-language-server`.
 * [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig): A collection of quickstart configs for various LSP servers.
-  - Includes a basic [`hls` configuration](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#hls).
+  - Includes a basic [`hls` configuration](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#hls).
 
 Neovim is also compatible with the [Vim plugins](#vim).
 


### PR DESCRIPTION
Hi,

The nvim-lspconfig page pointed to was moved, so I am pointing it to the correct path for hls there.

Thanks,
Mohammed

---

PS: [Internal Notes](https://codeberg.org/deltatraced/deltatraced/src/commit/eafa13f6a500b1af264f6528533b90f945a7058b/lan/2026/main/task/001%20Install%20a%20new%20Gentoo%20system/task/010%20Update%20moved%20documentation%20to%20haskell%20docs%20for%20neovim%20hls%20lsp.md)