### PR TITLE
Show built keys by rule in `ghcide-bench` summary

### DIFF
--- a/ghcide-bench/src/Experiments.hs
+++ b/ghcide-bench/src/Experiments.hs
@@ -549,7 +549,7 @@ runBenchmarksFun dir allBenchmarks = do
             showMs $ firstResponse+firstResponseDelayed,
             -- Exclude first response as it has a lot of setup time included
             -- Assume that number of requests = number of modules * number of samples
-            showMs ((userWaits - firstResponse)/((fromIntegral samples - 1)*modules)),
+            showMs ((userWaits - firstResponse) / ((fromIntegral samples - 1) * modules)),
             showMs runExperiment,
             show rulesBuilt,
             show rulesChanged,
@@ -573,7 +573,7 @@ runBenchmarksFun dir allBenchmarks = do
             showDuration runSetup',
             showDuration userWaits,
             showDuration delayedWork,
-            showDuration firstResponse,
+            showDuration (firstResponse + firstResponseDelayed),
             showDuration ((userWaits - firstResponse)/((fromIntegral samples - 1)*modules)),
             showDuration runExperiment,
             show rulesBuilt,

--- a/ghcide-bench/src/Experiments.hs
+++ b/ghcide-bench/src/Experiments.hs
@@ -501,6 +501,7 @@ runBenchmarksFun dir allBenchmarks = do
           Language.LSP.Test.lspConfig = lspConfig,
           messageTimeout = timeoutLsp ?config
         }
+      modules = fromIntegral $ length $ exampleModules $ example ?config
   results <- forM benchmarks $ \b@Bench{name} ->  do
     let p = (proc (ghcide ?config) (allArgs name dir))
                 { std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe }
@@ -556,7 +557,6 @@ runBenchmarksFun dir allBenchmarks = do
           ]
           | (Bench {name, samples}, BenchRun {..}) <- results,
             let runSetup' = if runSetup < 0.01 then 0 else runSetup
-                modules = fromIntegral $ length $ exampleModules $ example ?config
         ]
       csv = unlines $ map (intercalate ", ") (headers : rows)
   writeFile (outputCSV ?config) csv
@@ -574,6 +574,7 @@ runBenchmarksFun dir allBenchmarks = do
             showDuration userWaits,
             showDuration delayedWork,
             showDuration firstResponse,
+            showDuration ((userWaits - firstResponse)/((fromIntegral samples - 1)*modules)),
             showDuration runExperiment,
             show rulesBuilt,
             show rulesChanged,

--- a/ghcide-bench/src/Experiments.hs
+++ b/ghcide-bench/src/Experiments.hs
@@ -40,10 +40,13 @@ import qualified Data.ByteString                    as BS
 import qualified Data.ByteString.Lazy               as BSL
 import           Data.Either                        (fromRight)
 import           Data.List
+import           Data.List.Extra                    (groupSort)
 import           Data.Maybe
+import           Data.Ord                           (Down (..))
 import           Data.Proxy
 import           Data.Text                          (Text)
 import qualified Data.Text                          as T
+import qualified Data.Text.IO                       as TIO
 import           Data.Version
 import           Development.IDE.Plugin.Test
 import           Development.IDE.Test.Diagnostic
@@ -504,7 +507,6 @@ runBenchmarksFun dir allBenchmarks = do
           Language.LSP.Test.lspConfig = lspConfig,
           messageTimeout = timeoutLsp ?config
         }
-      modules = fromIntegral $ length $ exampleModules $ example ?config
   results <- forM benchmarks $ \b@Bench{name} ->  do
     let p = (proc (ghcide ?config) (allArgs name dir))
                 { std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe }
@@ -519,75 +521,15 @@ runBenchmarksFun dir allBenchmarks = do
                         runSessionWithHandles' (Just pH) inH outH conf lspTestCaps dir sess
     (b,) <$> runBench run b
 
-  -- output raw data as CSV
-  let headers =
-        [ "name"
-        , "success"
-        , "samples"
-        , "startup"
-        , "setup"
-        , "userT"
-        , "delayedT"
-        , "1stBuildT"
-        , "avgPerRespT"
-        , "totalT"
-        , "rulesBuilt"
-        , "rulesChanged"
-        , "rulesVisited"
-        , "rulesTotal"
-        , "ruleEdges"
-        , "ghcRebuilds"
-        ]
-      rows =
-        [ [ name,
-            show success,
-            show samples,
-            showMs startup,
-            showMs runSetup',
-            showMs userWaits,
-            showMs delayedWork,
-            showMs $ firstResponse+firstResponseDelayed,
-            -- Exclude first response as it has a lot of setup time included
-            -- Assume that number of requests = number of modules * number of samples
-            showMs ((userWaits - firstResponse) / ((fromIntegral samples - 1) * modules)),
-            showMs runExperiment,
-            show rulesBuilt,
-            show rulesChanged,
-            show rulesVisited,
-            show rulesTotal,
-            show edgesTotal,
-            show rebuildsTotal
-          ]
-          | (Bench {name, samples}, BenchRun {..}) <- results,
-            let runSetup' = if runSetup < 0.01 then 0 else runSetup
-        ]
-      csv = unlines $ map (intercalate ", ") (headers : rows)
-  writeFile (outputCSV ?config) csv
+  let headers = map fst summaryColumns
+      summaryRow showTime b r = [ renderCell showTime (cell b r) | (_, cell) <- summaryColumns ]
+      csv = T.unlines $ map (T.intercalate ", ")
+              (headers : [ summaryRow showMs b r | (b, r) <- results ])
+  TIO.writeFile (outputCSV ?config) csv
 
-  -- print a nice table
-  let rowsHuman =
-        [ [ name,
-            show success,
-            show samples,
-            showDuration startup,
-            showDuration runSetup',
-            showDuration userWaits,
-            showDuration delayedWork,
-            showDuration (firstResponse + firstResponseDelayed),
-            showDuration ((userWaits - firstResponse)/((fromIntegral samples - 1)*modules)),
-            showDuration runExperiment,
-            show rulesBuilt,
-            show rulesChanged,
-            show rulesVisited,
-            show rulesTotal,
-            show edgesTotal,
-            show rebuildsTotal
-          ]
-          | (Bench {name, samples}, BenchRun {..}) <- results,
-            let runSetup' = if runSetup < 0.01 then 0 else runSetup
-        ]
   mapM_ putStrLn $ ruleHistogram results
-  mapM_ putStrLn $ renderTable headers rowsHuman
+  mapM_ putStrLn $ renderTable headers
+      [ summaryRow (T.pack . showDuration) b r | (b, r) <- results ]
   where
     ghcideArgs dir =
         [ "--lsp",
@@ -616,8 +558,8 @@ runBenchmarksFun dir allBenchmarks = do
         & (L.textDocument . _Just . L.codeAction . _Just . L.resolveSupport . _Just) .~ (ClientCodeActionResolveOptions ["edit"])
         & (L.textDocument . _Just . L.codeAction . _Just . L.dataSupport . _Just) .~ True
 
-showMs :: Seconds -> String
-showMs = printf "%.2f"
+showMs :: Seconds -> Text
+showMs = T.pack . printf "%.2f"
 
 data BenchRun = BenchRun
   { startup              :: !Seconds,
@@ -879,6 +821,40 @@ findEndOfImports _ = Nothing
 
 --------------------------------------------------------------------------------------------
 
+-- | A summary value
+data Cell = Time Seconds | Count Int | Str Text
+
+renderCell :: (Seconds -> Text) -> Cell -> Text
+renderCell showTime (Time s) = showTime s
+renderCell _ (Count n)       = T.pack (show n)
+renderCell _ (Str s)         = s
+
+summaryColumns :: HasConfig => [(Text, Bench -> BenchRun -> Cell)]
+summaryColumns =
+    [ ("name", \Bench{name} _ -> Str (T.pack name))
+    , ("success", \_ BenchRun{success} -> Str (T.pack (show success)))
+    , ("samples", \Bench{samples} _ -> Str (T.pack (show samples)))
+    , ("startup", \_ BenchRun{startup} -> Time startup)
+    , ("setup", \_ BenchRun{runSetup} -> Time (if runSetup < 0.01 then 0 else runSetup))
+    , ("userT", \_ BenchRun{userWaits} -> Time userWaits)
+    , ("delayedT", \_ BenchRun{delayedWork} -> Time delayedWork)
+    , ("1stBuildT", \_ BenchRun{firstResponse, firstResponseDelayed} ->
+        Time (firstResponse + firstResponseDelayed))
+      -- Exclude the first response as it has a lot of setup time included.
+      -- Assume that number of requests = number of modules * number of samples
+    , ("avgPerRespT",  \Bench{samples} BenchRun{userWaits, firstResponse} ->
+        Time ((userWaits - firstResponse) / ((fromIntegral samples - 1) * modules)))
+    , ("totalT",       \_ BenchRun{runExperiment} -> Time runExperiment)
+    , ("rulesBuilt",   \_ BenchRun{rulesBuilt} -> Count rulesBuilt)
+    , ("rulesChanged", \_ BenchRun{rulesChanged} -> Count rulesChanged)
+    , ("rulesVisited", \_ BenchRun{rulesVisited} -> Count rulesVisited)
+    , ("rulesTotal",   \_ BenchRun{rulesTotal} -> Count rulesTotal)
+    , ("ruleEdges",    \_ BenchRun{edgesTotal} -> Count edgesTotal)
+    , ("ghcRebuilds",  \_ BenchRun{rebuildsTotal} -> Count rebuildsTotal)
+    ]
+  where
+    modules = fromIntegral $ length $ exampleModules $ example ?config
+
 ruleCounts :: [T.Text] -> [(T.Text, Int)]
 ruleCounts keys =
     [ (k, length g)
@@ -887,16 +863,16 @@ ruleCounts keys =
 -- | Keys built per rule, one column per benchmark.
 ruleHistogram :: [(Bench, BenchRun)] -> [String]
 ruleHistogram results =
-    renderTable ("rule" : [ name | (Bench{name}, _) <- results ])
-                (map row rules ++ [totals])
+    renderTable ("rule" : [ T.pack name | (Bench{name}, _) <- results ]) (map row rules ++ [totals])
   where
     counts = [ rulesBuiltByRule | (_, BenchRun{rulesBuiltByRule}) <- results ]
-    rules  = sortOn (\r -> (negate (total r), r)) $ nub (map fst (concat counts))
-    total r = sum [ n | c <- counts, Just n <- [lookup r c] ]
-    row r  = T.unpack r : [ maybe "0" show (lookup r c) | c <- counts ]
-    totals = "TOTAL" : [ show (sum (map snd c)) | c <- counts ]
+    rules = map fst $ sortOn (\(r, n) -> (Down n, r)) groups
+    groups = [ (r, sum ns) | (r, ns) <- groupSort (concat counts) ]
+    row r = r : [ num (fromMaybe 0 (lookup r c)) | c <- counts ]
+    totals = "TOTAL" : [ num (sum (map snd c)) | c <- counts ]
+    num = T.pack . show
 
-renderTable :: [String] -> [[String]] -> [String]
+renderTable :: [Text] -> [[Text]] -> [String]
 renderTable hdrs rows =
     tableLines $ columnHeaderTableS (map (const def) hdrs) asciiS
                                     (titlesH hdrs) [rowsG rows]

--- a/ghcide-bench/src/Experiments.hs
+++ b/ghcide-bench/src/Experiments.hs
@@ -64,6 +64,9 @@ import           System.FilePath                    ((<.>), (</>))
 import           System.IO
 import           System.Process
 import           System.Time.Extra
+import           Text.Layout.Table                  (columnHeaderTableS, def,
+                                                     rowsG, tableLines, titlesH)
+import           Text.Layout.Table.Style            (asciiS)
 import           Text.ParserCombinators.ReadP       (readP_to_S)
 import           Text.Printf
 
@@ -371,7 +374,7 @@ experiments =
                     , ">>> xs = ([minBound..maxBound] ++ [minBound..maxBound] :: [T])"
                     , ">>> nub xs"
                     , "-}"
-                    ]
+                   ]
             changeDoc doc [edit]
         )
         ( \docs -> do
@@ -562,10 +565,7 @@ runBenchmarksFun dir allBenchmarks = do
   writeFile (outputCSV ?config) csv
 
   -- print a nice table
-  let pads = map (maximum . map length) (transpose (headers : rowsHuman))
-      paddedHeaders = zipWith pad pads headers
-      outputRow = putStrLn . intercalate " | "
-      rowsHuman =
+  let rowsHuman =
         [ [ name,
             show success,
             show samples,
@@ -586,9 +586,8 @@ runBenchmarksFun dir allBenchmarks = do
           | (Bench {name, samples}, BenchRun {..}) <- results,
             let runSetup' = if runSetup < 0.01 then 0 else runSetup
         ]
-  outputRow paddedHeaders
-  outputRow $ (map . map) (const '-') paddedHeaders
-  forM_ rowsHuman $ \row -> outputRow $ zipWith pad pads row
+  mapM_ putStrLn $ ruleHistogram results
+  mapM_ putStrLn $ renderTable headers rowsHuman
   where
     ghcideArgs dir =
         [ "--lsp",
@@ -629,6 +628,7 @@ data BenchRun = BenchRun
     firstResponse        :: !Seconds,
     firstResponseDelayed :: !Seconds,
     rulesBuilt           :: !Int,
+    rulesBuiltByRule     :: ![(Text, Int)],
     rulesChanged         :: !Int,
     rulesVisited         :: !Int,
     rulesTotal           :: !Int,
@@ -638,7 +638,7 @@ data BenchRun = BenchRun
   }
 
 badRun :: BenchRun
-badRun = BenchRun 0 0 0 0 0 0 0 0 0 0 0 0 0 False
+badRun = BenchRun 0 0 0 0 0 0 0 0 [] 0 0 0 0 0 False
 
 waitForProgressStart :: Session ()
 waitForProgressStart = void $ do
@@ -706,7 +706,9 @@ runBench runSess Bench{..} = handleAny (\e -> print e >> return badRun)
           (userWaits, delayedWork, (firstResponse, firstResponseDelayed)) = fromMaybe (0,0,(0,0)) result
 
       rulesTotal <- length <$> getStoredKeys
-      rulesBuilt <- either (const 0) length <$> getBuildKeysBuilt
+      builtKeys <- fromRight [] <$> getBuildKeysBuilt
+      let rulesBuilt = length builtKeys
+          rulesBuiltByRule = ruleCounts builtKeys
       rulesChanged <- either (const 0) length <$> getBuildKeysChanged
       rulesVisited <- either (const 0) length <$> getBuildKeysVisited
       edgesTotal   <- fromRight 0 <$> getBuildEdgesCount
@@ -877,10 +879,27 @@ findEndOfImports _ = Nothing
 
 --------------------------------------------------------------------------------------------
 
-pad :: Int -> String -> String
-pad n []     = replicate n ' '
-pad 0 _      = error "pad"
-pad n (x:xx) = x : pad (n-1) xx
+ruleCounts :: [T.Text] -> [(T.Text, Int)]
+ruleCounts keys =
+    [ (k, length g)
+    | g@(k:_) <- group $ sort [ T.takeWhile (/= ';') t | t <- keys ] ]
+
+-- | Keys built per rule, one column per benchmark.
+ruleHistogram :: [(Bench, BenchRun)] -> [String]
+ruleHistogram results =
+    renderTable ("rule" : [ name | (Bench{name}, _) <- results ])
+                (map row rules ++ [totals])
+  where
+    counts = [ rulesBuiltByRule | (_, BenchRun{rulesBuiltByRule}) <- results ]
+    rules  = sortOn (\r -> (negate (total r), r)) $ nub (map fst (concat counts))
+    total r = sum [ n | c <- counts, Just n <- [lookup r c] ]
+    row r  = T.unpack r : [ maybe "0" show (lookup r c) | c <- counts ]
+    totals = "TOTAL" : [ show (sum (map snd c)) | c <- counts ]
+
+renderTable :: [String] -> [[String]] -> [String]
+renderTable hdrs rows =
+    tableLines $ columnHeaderTableS (map (const def) hdrs) asciiS
+                                    (titlesH hdrs) [rowsG rows]
 
 -- | Search for a position where:
 --     - get definition works and returns a uri other than this file

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -2251,6 +2251,7 @@ library ghcide-bench-lib
         process,
         safe-exceptions,
         shake,
+        table-layout,
         text,
         hls-test-utils,
         row-types

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,6 +29,7 @@ extra-deps:
   - lsp-2.8.0.0
   - lsp-test-0.18.0.0
   - lsp-types-2.4.0.0
+  - table-layout-1.0.0.2
   # stan dependencies not found in the stackage snapshot
   - stan-0.2.1.0
   - dir-traverse-0.2.3.0


### PR DESCRIPTION
Closes https://github.com/haskell/haskell-language-server/issues/5052.

Makes the following changes:
- Use table-layout to print the tables.
- There were some discrepencies between the csv and stdout outputs.
  - Fixes `avgPerRespT` in stdout, which was present in the csv but omitted in stdout
  - Fixes `1stBuildT` in stdout, which didn't include `firstResponseDelayed` which the csv did.
- Outputs per-rule build histogram for each benchmark. 

<details><summary>Example output of ghcide-bench tables now</summary>

```
+--------------------------------+------+
|              rule              | edit |
+--------------------------------+------+
| GenerateCore                   | 1    |
| GetFileContents                | 1    |
| GetHieAst                      | 1    |
| GetModSummary                  | 1    |
| GetModSummaryWithoutTimestamps | 1    |
| GetModificationTime            | 1    |
| GetParsedModule                | 1    |
| TypeCheck                      | 1    |
| TOTAL                          | 8    |
+--------------------------------+------+
+------+---------+---------+---------+-------+-------+----------+-----------+-------------+--------+------------+--------------+--------------+------------+-----------+-------------+
| name | success | samples | startup | setup | userT | delayedT | 1stBuildT | avgPerRespT | totalT | rulesBuilt | rulesChanged | rulesVisited | rulesTotal | ruleEdges | ghcRebuilds |
+------+---------+---------+---------+-------+-------+----------+-----------+-------------+--------+------------+--------------+--------------+------------+-----------+-------------+
| edit | True    | 50      | 0.26s   | 0.00s | 1.04s | 2.73s    | 0.03s     | 0.02s       | 3.78s  | 8          | 7            | 14           | 11550      | 118607    | 2           |
+------+---------+---------+---------+-------+-------+----------+-----------+-------------+--------+------------+--------------+--------------+------------+-----------+-------------+
```
</details>