### PR TITLE
Prepare release 2.15.0.0

### DIFF
--- a/.github/generate-ci/gen_ci.hs
+++ b/.github/generate-ci/gen_ci.hs
@@ -175,6 +175,7 @@ envVars arch os = object $
          AArch64 -> "ARM64")
      , "ADD_CABAL_ARGS" .= str (case (os,arch) of
         (Linux _, Amd64) -> "--enable-split-sections"
+        (Windows, _)     -> "--max-backjumps 10000"
         _                -> "")
      , "ARTIFACT" .= artifactName arch os
      ]

--- a/.github/scripts/bindist.sh
+++ b/.github/scripts/bindist.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -euxo pipefail
 
 . .github/scripts/env.sh
 . .github/scripts/common.sh

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -euxo pipefail
 
 . .github/scripts/env.sh
 . .github/scripts/common.sh

--- a/.github/scripts/entrypoint.sh
+++ b/.github/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -exo pipefail
 
 bash -c "$INSTALL curl bash git tree $TOOLS"
 

--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -108,7 +108,14 @@ case "${TARBALL_EXT}" in
         hls_bin=$(ls "$CI_PROJECT_DIR/out/${TARBALL_PREFIX}"-*-"${ARTIFACT}.tar.xz")
         hls_ver_=${hls_bin#*haskell-language-server-}
         hls_ver=${hls_ver_%-"${ARTIFACT}"*}
-        ghcup install hls -u "file://${hls_bin}" "${hls_ver}" --force
+
+        # use a clean isolated directory to install the tarball into.
+        hls_root="$CI_PROJECT_DIR/hls-bindist-test"
+        rm -rf "$hls_root"
+        ghcup install hls -u "file://${hls_bin}" "${hls_ver}" --isolate "$hls_root"
+
+        # PATH is the only place the wrapper looks for the per-GHC binaries.
+        export PATH="${hls_root}/bin:$PATH"
 
         # cleanup from previous dirty runs
         rm -rf "$HOME"/.local/lib/haskell-language-server-* || true
@@ -116,27 +123,24 @@ case "${TARBALL_EXT}" in
         # print rpaths and libdirs
         case "$(uname -s)" in
             "Darwin"|"darwin")
-                otool -l "$(ghcup whereis basedir)/hls/${hls_ver}/lib/haskell-language-server-${hls_ver}/bin/"haskell-language-server-*
+                otool -l "$hls_root"/lib/haskell-language-server-*/bin/haskell-language-server-*
                 ;;
             "FreeBSD")
-                readelf -Ws "$(ghcup whereis basedir)/hls/${hls_ver}/lib/haskell-language-server-${hls_ver}/bin/"haskell-language-server-*
+                readelf -Ws "$hls_root"/lib/haskell-language-server-*/bin/haskell-language-server-*
                 ;;
             *)
-                objdump -x "$(ghcup whereis basedir)/hls/${hls_ver}/lib/haskell-language-server-${hls_ver}/bin/"haskell-language-server-*
+                objdump -x "$hls_root"/lib/haskell-language-server-*/bin/haskell-language-server-*
                 ;;
         esac
-        tree "$(ghcup whereis basedir)/hls/${hls_ver}/lib/haskell-language-server-${hls_ver}/bin/"
-        tree "$GHCUP_BIN"
+        tree "$hls_root"
 
         enter_test_package
         create_cradle
         create_cabal_project
-        test_all_hls "$(ghcup whereis bindir)"
+        test_all_hls "${hls_root}/bin"
 
         ;;
     *)
         fail "Unknown TARBALL_EXT: ${TARBALL_EXT}"
         ;;
 esac
-
-

--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -3,7 +3,7 @@
 # Test installing HLS bindist and then run
 # every HLS-GHC version on a test module.
 
-set -eux
+set -euxo pipefail
 
 . .github/scripts/env.sh
 . .github/scripts/common.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1147,7 +1147,7 @@ jobs:
         retention-days: 2
   bindist-x86_64-windows:
     env:
-      ADD_CABAL_ARGS: ''
+      ADD_CABAL_ARGS: --max-backjumps 10000
       ARCH: '64'
       ARTIFACT: x86_64-mingw64
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -4208,7 +4208,7 @@ jobs:
         retention-days: 2
   build-x86_64-windows-9103:
     env:
-      ADD_CABAL_ARGS: ''
+      ADD_CABAL_ARGS: --max-backjumps 10000
       ARCH: '64'
       ARTIFACT: x86_64-mingw64
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -4241,7 +4241,7 @@ jobs:
         retention-days: 2
   build-x86_64-windows-9122:
     env:
-      ADD_CABAL_ARGS: ''
+      ADD_CABAL_ARGS: --max-backjumps 10000
       ARCH: '64'
       ARTIFACT: x86_64-mingw64
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -4274,7 +4274,7 @@ jobs:
         retention-days: 2
   build-x86_64-windows-9124:
     env:
-      ADD_CABAL_ARGS: ''
+      ADD_CABAL_ARGS: --max-backjumps 10000
       ARCH: '64'
       ARTIFACT: x86_64-mingw64
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -4307,7 +4307,7 @@ jobs:
         retention-days: 2
   build-x86_64-windows-9141:
     env:
-      ADD_CABAL_ARGS: ''
+      ADD_CABAL_ARGS: --max-backjumps 10000
       ARCH: '64'
       ARTIFACT: x86_64-mingw64
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -4340,7 +4340,7 @@ jobs:
         retention-days: 2
   build-x86_64-windows-967:
     env:
-      ADD_CABAL_ARGS: ''
+      ADD_CABAL_ARGS: --max-backjumps 10000
       ARCH: '64'
       ARTIFACT: x86_64-mingw64
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -4373,7 +4373,7 @@ jobs:
         retention-days: 2
   build-x86_64-windows-984:
     env:
-      ADD_CABAL_ARGS: ''
+      ADD_CABAL_ARGS: --max-backjumps 10000
       ARCH: '64'
       ARTIFACT: x86_64-mingw64
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -5010,7 +5010,7 @@ jobs:
       shell: sh
   test-x86_64-windows:
     env:
-      ADD_CABAL_ARGS: ''
+      ADD_CABAL_ARGS: --max-backjumps 10000
       ARCH: '64'
       ARTIFACT: x86_64-mingw64
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,158 @@
 # Changelog for haskell-language-server
 
+## 2.15.0.0
+
+### Pull Requests
+
+- Split module interface rule into interface and code outputs
+  ([#5057](https://github.com/haskell/haskell-language-server/pull/5057)) by @crtschin
+- Show built keys by rule in `ghcide-bench` summary
+  ([#5055](https://github.com/haskell/haskell-language-server/pull/5055)) by @crtschin
+- docs: updated moved nvim-lspconfig page
+  ([#5051](https://github.com/haskell/haskell-language-server/pull/5051)) by @LanHikari22
+- Delete unused `CodeAction.RuleTypes` module
+  ([#5050](https://github.com/haskell/haskell-language-server/pull/5050)) by @crtschin
+- Keep only the core file hash in `HiFileResult`
+  ([#5048](https://github.com/haskell/haskell-language-server/pull/5048)) by @crtschin
+- Change `rangesOverlap` to honor the fact that `Range`s are inclusive to the left but exclusive to the right
+  ([#5047](https://github.com/haskell/haskell-language-server/pull/5047)) by @Aster89
+- Use a unique id for each file watcher registration
+  ([#5043](https://github.com/haskell/haskell-language-server/pull/5043)) by @crtschin
+- Simplify `activeDiagnosticsInRange` by returning `[FileDiagnostic]` instead of `Maybe [FileDiagnostic]`
+  ([#5041](https://github.com/haskell/haskell-language-server/pull/5041)) by @Aster89
+- Unload linkables if any transitive dependency changes
+  ([#5035](https://github.com/haskell/haskell-language-server/pull/5035)) by @wz1000
+- Stop unloading all bytecode whenever we generate new bytecode
+  ([#5033](https://github.com/haskell/haskell-language-server/pull/5033)) by @wz1000
+- cross-module renames
+  ([#5031](https://github.com/haskell/haskell-language-server/pull/5031)) by @Esgariot
+- Set FileCache hook before typechecking
+  ([#5030](https://github.com/haskell/haskell-language-server/pull/5030)) by @fendor
+- Improve error messages in HLS
+  ([#5029](https://github.com/haskell/haskell-language-server/pull/5029)) by @fendor
+- Fix invalid non-singleton constraint suggestion edits
+  ([#5028](https://github.com/haskell/haskell-language-server/pull/5028)) by @crtschin
+- Some improvements of comments, of code, and return->pure
+  ([#5026](https://github.com/haskell/haskell-language-server/pull/5026)) by @Aster89
+- Build CI with `--jobs` and `--semaphore`
+  ([#5022](https://github.com/haskell/haskell-language-server/pull/5022)) by @crtschin
+- Bump fkirc/skip-duplicate-actions from 5.3.1 to 5.3.2
+  ([#5019](https://github.com/haskell/haskell-language-server/pull/5019)) by @dependabot[bot]
+- Isolate per-test caches via explicit args instead of `XDG_CACHE_HOME`
+  ([#5018](https://github.com/haskell/haskell-language-server/pull/5018)) by @crtschin
+- Restrict batch session loads to files owned by the same cradle
+  ([#5017](https://github.com/haskell/haskell-language-server/pull/5017)) by @simonhorlick
+- Workaround for semantic tokens on Windows with CPP
+  ([#5016](https://github.com/haskell/haskell-language-server/pull/5016)) by @Abbath
+- Case split plugin
+  ([#5014](https://github.com/haskell/haskell-language-server/pull/5014)) by @Aster89
+- Fix stale completions after changing an import alias
+  ([#5011](https://github.com/haskell/haskell-language-server/pull/5011)) by @BurningLutz
+- Ormolu & Fourmolu on GHC 9.14
+  ([#5009](https://github.com/haskell/haskell-language-server/pull/5009)) by @kafji
+- bugfix(ghc optimization option): set optimization level to 0 to eval properly
+  ([#5008](https://github.com/haskell/haskell-language-server/pull/5008)) by @abdivasiyev
+- fix(hls-eval-plugin): hardcode QckChck to eval property tests
+  ([#5007](https://github.com/haskell/haskell-language-server/pull/5007)) by @abdivasiyev
+- adding whole-project loading
+  ([#5002](https://github.com/haskell/haskell-language-server/pull/5002)) by @Saizan
+- Enable semantic tokens plugin by default
+  ([#5000](https://github.com/haskell/haskell-language-server/pull/5000)) by @soulomoon
+- Nix shell for ghc9.14
+  ([#4998](https://github.com/haskell/haskell-language-server/pull/4998)) by @dyniec
+- Docs: update Kakoune configuration instructions
+  ([#4997](https://github.com/haskell/haskell-language-server/pull/4997)) by @ficd0
+- Bump actions/checkout to v7
+  ([#4995](https://github.com/haskell/haskell-language-server/pull/4995)) by @fendor
+- Bump actions/cache from 5 to 6 in /.github/actions/setup-build
+  ([#4994](https://github.com/haskell/haskell-language-server/pull/4994)) by @dependabot[bot]
+- Bump actions/cache from 5 to 6
+  ([#4993](https://github.com/haskell/haskell-language-server/pull/4993)) by @dependabot[bot]
+- Add `Unexport ...` to `hls-export-plugin`
+  ([#4991](https://github.com/haskell/haskell-language-server/pull/4991)) by @crtschin
+- Remove @santiweight from CODEOWNERS for hls-refactor-plugin
+  ([#4984](https://github.com/haskell/haskell-language-server/pull/4984)) by @santiweight
+- Remove CI workaround for ghcup GH runner issue
+  ([#4982](https://github.com/haskell/haskell-language-server/pull/4982)) by @crtschin
+- Splice export modifications precisely when using CPP
+  ([#4981](https://github.com/haskell/haskell-language-server/pull/4981)) by @crtschin
+- Bump GHA versions
+  ([#4980](https://github.com/haskell/haskell-language-server/pull/4980)) by @fendor
+- Support fourmolu 0.20.0.0
+  ([#4979](https://github.com/haskell/haskell-language-server/pull/4979)) by @brandonchinn178
+- Support symbolic record fields when converting to record syntax
+  ([#4978](https://github.com/haskell/haskell-language-server/pull/4978)) by @olaberglund
+- Fix running `cabal test all` as a local workflow
+  ([#4974](https://github.com/haskell/haskell-language-server/pull/4974)) by @crtschin
+- Extend delete-unused-bindings to let-expression bindings
+  ([#4972](https://github.com/haskell/haskell-language-server/pull/4972)) by @olaberglund
+- Try getting rid of `withWarnings` in `~Compile.hs`
+  ([#4971](https://github.com/haskell/haskell-language-server/pull/4971)) by @Aster89
+- Remove `LD_LIBRARY_PATH` override in nix `devShell`
+  ([#4966](https://github.com/haskell/haskell-language-server/pull/4966)) by @crtschin
+- Fix: make subsumesEither commutative
+  ([#4964](https://github.com/haskell/haskell-language-server/pull/4964)) by @olaberglund
+- Remove unused test-logs directory
+  ([#4960](https://github.com/haskell/haskell-language-server/pull/4960)) by @crtschin
+- Change HLS default to prefer multi-component loading
+  ([#4959](https://github.com/haskell/haskell-language-server/pull/4959)) by @xsebek
+- Code action to delete all unused bindings
+  ([#4958](https://github.com/haskell/haskell-language-server/pull/4958)) by @olaberglund
+- nix-flake: Update inputs
+  ([#4956](https://github.com/haskell/haskell-language-server/pull/4956)) by @akshaymankar
+- Add support for extra LSP options
+  ([#4955](https://github.com/haskell/haskell-language-server/pull/4955)) by @VeryMilkyJoe
+- Use defaultTestRunner in ghcide-test
+  ([#4953](https://github.com/haskell/haskell-language-server/pull/4953)) by @xsebek
+- Create `hls-export-plugin` with `Export '...'` code action
+  ([#4952](https://github.com/haskell/haskell-language-server/pull/4952)) by @crtschin
+- use knownBuildTypes to populate completion targets
+  ([#4950](https://github.com/haskell/haskell-language-server/pull/4950)) by @olaberglund
+- Fix accidentally deleting the installed GHC in CI
+  ([#4947](https://github.com/haskell/haskell-language-server/pull/4947)) by @crtschin
+- Fix `transitiveReverseDependencies` recursion
+  ([#4946](https://github.com/haskell/haskell-language-server/pull/4946)) by @crtschin
+- Fix hls-class-plugin indentation
+  ([#4937](https://github.com/haskell/haskell-language-server/pull/4937)) by @Aster89
+- Never compute the DocMap with stale data
+  ([#4936](https://github.com/haskell/haskell-language-server/pull/4936)) by @fendor
+- Add typing burst benchmark coverage
+  ([#4934](https://github.com/haskell/haskell-language-server/pull/4934)) by @soulomoon
+- Avoid relying on `OccNames` when generating class methods
+  ([#4932](https://github.com/haskell/haskell-language-server/pull/4932)) by @crtschin
+- Fixbench
+  ([#4928](https://github.com/haskell/haskell-language-server/pull/4928)) by @soulomoon
+- ghcide-2.14 requires extra >= 1.8
+  ([#4926](https://github.com/haskell/haskell-language-server/pull/4926)) by @juhp
+- Add build-type: Hooks to Cabal completion plugin
+  ([#4920](https://github.com/haskell/haskell-language-server/pull/4920)) by @sheaf
+- Avoid logging `AsyncCancelled` stacktraces on session restart
+  ([#4919](https://github.com/haskell/haskell-language-server/pull/4919)) by @crtschin
+- Use pretty printing context when expanding records
+  ([#4917](https://github.com/haskell/haskell-language-server/pull/4917)) by @crtschin
+- Update splice plugin
+  ([#4915](https://github.com/haskell/haskell-language-server/pull/4915)) by @georgefst
+- Mark boot files to load first in `ghcSessionDepsDefinition`
+  ([#4914](https://github.com/haskell/haskell-language-server/pull/4914)) by @martijnbastiaan
+- Account for boot files in `processDependencyInformation`
+  ([#4913](https://github.com/haskell/haskell-language-server/pull/4913)) by @martijnbastiaan
+- Exclude superclass-generated names in class placeholders
+  ([#4902](https://github.com/haskell/haskell-language-server/pull/4902)) by @crtschin
+- Only check for garbage in key garbage collection test
+  ([#4900](https://github.com/haskell/haskell-language-server/pull/4900)) by @crtschin
+- Prepare release 2.14.0.0
+  ([#4897](https://github.com/haskell/haskell-language-server/pull/4897)) by @wz1000
+- Remove `hls-retrie-plugin`
+  ([#4839](https://github.com/haskell/haskell-language-server/pull/4839)) by @omarjatoi
+- Use Hackage for Documentation and Source links
+  ([#4746](https://github.com/haskell/haskell-language-server/pull/4746)) by @Saizan
+- Capture output of `eval` plugin and some girls scout changes
+  ([#4726](https://github.com/haskell/haskell-language-server/pull/4726)) by @dschrempf
+- Migrate `hls-refactor-plugin` to use structured diagnostics
+  ([#4708](https://github.com/haskell/haskell-language-server/pull/4708)) by @dyniec
+- Optimise module to filename
+  ([#4600](https://github.com/haskell/haskell-language-server/pull/4600)) by @guibou
+
 ## 2.14.0.0
 
 - Bindists for GHC 9.14.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,33 @@
 
 ## 2.15.0.0
 
+- Remove `hls-retrie-plugin`
+- Add `hls-case-split-plugin`
+- Add `hls-export-plugin`
+- Enable `hls-semantic-tokens-plugin` by default
+- Prefer multi-component loading by default
+- Replace the `sessionLoading` config with `componentsLoading`
+- Support for Ormolu and Fourmolu on GHC 9.14
+- Improvements to ghcide
+  - Point documentation and source links at Hackage
+  - Stop unloading all bytecode whenever new bytecode is generated
+  - Unload linkables when any transitive dependency changes
+- Improvements to `hls-rename-plugin`
+  - Improved limited cross-module renaming
+- Improvements to `hls-refactor-plugin`
+  - Code action to delete all unused bindings, including `let` bindings
+- Improvements to `hls-eval-plugin`
+  - Capture `stdout` and `stderr` from evaluated expressions
+- Improvements to `hls-splice-plugin`
+  - Support declaration splices
+- Optimizations
+  - Speed up dependency graph building
+  - Load core files on demand and improve freshness checking
+- Bug fixes
+  - Correct code action edits across several plugins
+  - Match GHC when resolving imports and boot files
+  - Avoid serving stale completions, documentation and diagnostics
+
 ### Pull Requests
 
 - Split module interface rule into interface and code outputs

--- a/GenChangelogs.hs
+++ b/GenChangelogs.hs
@@ -6,15 +6,22 @@ build-depends: base, bytestring, process, text, github, time >= 1.9
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
+import           Control.Applicative      ((<|>))
 import           Control.Monad
 import qualified Data.ByteString.Char8    as BS
 import           Data.List
 import           Data.Maybe
 import qualified Data.Text                as T
+import           Data.Time.Clock          (UTCTime)
 import           Data.Time.Format.ISO8601
+import           Data.Time.LocalTime      (zonedTimeToUTC)
 import           GitHub
 import           System.Environment
 import           System.Process
+
+-- %cI yields either a Z or a numeric offset, depending on the committer.
+parseUTC :: String -> Maybe UTCTime
+parseUTC s = iso8601ParseM s <|> (zonedTimeToUTC <$> iso8601ParseM s)
 
 main = do
   args <- getArgs
@@ -22,7 +29,7 @@ main = do
         token:tag:_ -> (github (OAuth $ BS.pack token), tag)
   prs <- githubReq $ pullRequestsForR "haskell" "haskell-language-server" stateClosed FetchAll
   lastDateStr <- last . lines <$> readProcess "git" ["show", "-s", "--format=%cI", "-1", tag] ""
-  lastDate <- iso8601ParseM lastDateStr
+  lastDate <- maybe (fail $ "no parse of " <> show lastDateStr) pure (parseUTC lastDateStr)
 
   let prsAfterLastTag = either (error . show)
                         (foldMap (\pr -> [pr | inRange pr]))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,9 @@
 - [ ] generate and update changelog
   - Generate a ChangeLog via `./GenChangelogs.hs <api-key> <tag>`
     - `<tag>` is the git tag you want to generate the ChangeLog from.
-    - `<api-key>` is a github access key: https://github.com/settings/tokens
+    - `<api-key>` is a github access key: https://github.com/settings/tokens.
+      the token only needs read access on public repositories in order to read
+      the issue tracker.
 - [ ] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
 - [ ] create release branch as `wip/<version>`
   - `git switch -c wip/<version>`

--- a/cabal.project
+++ b/cabal.project
@@ -6,7 +6,7 @@ packages:
          ./hls-plugin-api
          ./hls-test-utils
 
-index-state: 2026-08-07T04:49:30Z
+index-state: 2026-08-26T00:00:00Z
 
 tests: True
 test-show-details: direct

--- a/cabal.project
+++ b/cabal.project
@@ -26,20 +26,12 @@ package *
   ghc-options: -haddock
 
 constraints:
-  -- C++ is hard to distribute, especially on older GHCs
-  -- See https://github.com/haskell/haskell-language-server/issues/3822
-  text -simdutf,
   ghc-check -ghc-check-use-package-abis,
   ghc-lib-parser-ex -auto,
   -- This is only present in some versions, and it's on by default since
   -- 0.14.5.0, but there are some versions we allow that need this
   -- setting
   stylish-haskell +ghc-lib,
-  -- Centos 7 comes with an old gcc version that doesn't know about
-  -- the flag '-fopen-simd', which blocked the release 2.2.0.0.
-  -- We want to be able to benefit from the performance optimisations
-  -- in the future, thus: TODO: remove this flag.
-  bitvec -simd,
   monad-control >=1.0.3,
 
 

--- a/docs/support/ghc-version-support.md
+++ b/docs/support/ghc-version-support.md
@@ -17,7 +17,7 @@ Support status (see the support policy below for more details):
 
 | GHC version  | Last supporting HLS version                                                          | Support status |
 | ------------ | ------------------------------------------------------------------------------------ | -------------- |
-| 9.14.1       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | basic support  |
+| 9.14.1       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support  |
 | 9.12.4       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |
 | 9.12.3       |                                                                                      | no support     |
 | 9.12.2       | [latest](https://github.com/haskell/haskell-language-server/releases/latest)         | full support   |

--- a/docs/support/plugin-support.md
+++ b/docs/support/plugin-support.md
@@ -54,12 +54,12 @@ For example, a plugin to provide a formatter which has itself been abandoned has
 | `hls-signature-help-plugin`          | 2    |                          |
 | `hls-explicit-fixity-plugin`         | 2    |                          |
 | `hls-explicit-record-fields-plugin`  | 2    |                          |
-| `hls-fourmolu-plugin`                | 2    | 9.14.1                   |
+| `hls-fourmolu-plugin`                | 2    |                          |
 | `hls-gadt-plugin`                    | 2    |                          |
 | `hls-hlint-plugin`                   | 2    | 9.10 [1], 9.14.1         |
 | `hls-notes-plugin`                   | 2    |                          |
 | `hls-qualify-imported-names-plugin`  | 2    |                          |
-| `hls-ormolu-plugin`                  | 2    | 9.14.1                   |
+| `hls-ormolu-plugin`                  | 2    |                          |
 | `hls-rename-plugin`                  | 2    |                          |
 | `hls-stylish-haskell-plugin`         | 2    | 9.14.1                   |
 | `hls-overloaded-record-dot-plugin`   | 2    |                          |

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
             dest=$out/bin/gen-hls-changelogs
             mkdir -p $out/bin
             echo "#!${runtimeShell}" >> $dest
-            echo "${myGHC}/bin/runghc ${./GenChangelogs.hs}" >> $dest
+            echo '${myGHC}/bin/runghc ${./GenChangelogs.hs} "$@"' >> $dest
             chmod +x $dest
           '';
 

--- a/ghcide/ghcide.cabal
+++ b/ghcide/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      3.4
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            2.14.0.0
+version:            2.15.0.0
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors
@@ -76,8 +76,8 @@ library
     , hashable
     , hie-bios                     ^>= 0.21.0
     , hiedb                        ^>= 0.8.0.0
-    , hls-graph                    == 2.14.0.0
-    , hls-plugin-api               == 2.14.0.0
+    , hls-graph                    == 2.15.0.0
+    , hls-plugin-api               == 2.15.0.0
     , implicit-hie                 >= 0.1.4.0 && < 0.1.5
     , lens
     , lens-aeson

--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.4
 category:           Development
 name:               haskell-language-server
-version:            2.14.0.0
+version:            2.15.0.0
 synopsis:           LSP server for GHC
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -136,8 +136,8 @@ library hls-cabal-fmt-plugin
   build-depends:
     , directory
     , filepath
-    , ghcide          == 2.14.0.0
-    , hls-plugin-api  == 2.14.0.0
+    , ghcide          == 2.15.0.0
+    , hls-plugin-api  == 2.15.0.0
     , lens
     , lsp-types
     , mtl
@@ -157,8 +157,8 @@ test-suite hls-cabal-fmt-plugin-tests
     , filepath
     , haskell-language-server:hls-cabal-plugin
     , haskell-language-server:hls-cabal-fmt-plugin
-    , hls-plugin-api        == 2.14.0.0
-    , hls-test-utils        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
+    , hls-test-utils        == 2.15.0.0
 
   if flag(isolateCabalfmtTests)
     build-tool-depends: cabal-fmt:cabal-fmt ^>=0.1.12
@@ -193,8 +193,8 @@ library hls-cabal-gild-plugin
   build-depends:
     , directory
     , filepath
-    , ghcide          == 2.14.0.0
-    , hls-plugin-api  == 2.14.0.0
+    , ghcide          == 2.15.0.0
+    , hls-plugin-api  == 2.15.0.0
     , lsp-types
     , text
     , mtl
@@ -213,8 +213,8 @@ test-suite hls-cabal-gild-plugin-tests
     , filepath
     , haskell-language-server:hls-cabal-plugin
     , haskell-language-server:hls-cabal-gild-plugin
-    , hls-plugin-api        == 2.14.0.0
-    , hls-test-utils        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
+    , hls-test-utils        == 2.15.0.0
 
   if flag(isolateCabalGildTests)
     -- https://github.com/tfausak/cabal-gild/issues/89
@@ -274,10 +274,10 @@ library hls-cabal-plugin
     , directory
     , filepath
     , extra                 >=1.7.4
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , hashable
-    , hls-plugin-api        == 2.14.0.0
-    , hls-graph             == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
+    , hls-graph             == 2.15.0.0
     , lens
     , lsp                   ^>=2.8
     , lsp-types             ^>=2.4
@@ -316,7 +316,7 @@ test-suite hls-cabal-plugin-tests
     , filepath
     , ghcide
     , haskell-language-server:hls-cabal-plugin
-    , hls-test-utils    == 2.14.0.0
+    , hls-test-utils    == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -353,9 +353,9 @@ library hls-class-plugin
     , extra
     , ghc
     , ghc-exactprint  >= 1.5 && < 1.15
-    , ghcide          == 2.14.0.0
+    , ghcide          == 2.15.0.0
     , hls-graph
-    , hls-plugin-api  == 2.14.0.0
+    , hls-plugin-api  == 2.15.0.0
     , lens
     , lsp
     , text
@@ -375,7 +375,7 @@ test-suite hls-class-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-class-plugin
-    , hls-test-utils     == 2.14.0.0
+    , hls-test-utils     == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -410,9 +410,9 @@ library hls-call-hierarchy-plugin
     , containers
     , extra
     , ghc
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , hiedb                 ^>= 0.8.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lens
     , lsp                    >=2.8
     , sqlite-simple
@@ -433,7 +433,7 @@ test-suite hls-call-hierarchy-plugin-tests
     , extra
     , filepath
     , haskell-language-server:hls-call-hierarchy-plugin
-    , hls-test-utils        == 2.14.0.0
+    , hls-test-utils        == 2.15.0.0
     , lens
     , lsp
     , lsp-test
@@ -484,9 +484,9 @@ library hls-eval-plugin
     , filepath
     , ghc
     , ghc-boot-th
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , hls-graph
-    , hls-plugin-api        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lens
     , lsp                   ^>=2.8
     , lsp-types
@@ -517,7 +517,7 @@ test-suite hls-eval-plugin-tests
     , filepath
     , haskell-language-server:hls-eval-plugin
     , hls-plugin-api
-    , hls-test-utils   == 2.14.0.0
+    , hls-test-utils   == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -547,9 +547,9 @@ library hls-explicit-imports-plugin
     , containers
     , deepseq
     , ghc
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , hls-graph
-    , hls-plugin-api        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lens
     , lsp
     , mtl
@@ -570,7 +570,7 @@ test-suite hls-explicit-imports-plugin-tests
     , extra
     , filepath
     , haskell-language-server:hls-explicit-imports-plugin
-    , hls-test-utils   == 2.14.0.0
+    , hls-test-utils   == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -599,8 +599,8 @@ library hls-case-split-plugin
     , extra
     , ghc
     , haskell-language-server:hls-refactor-plugin
-    , ghcide                == 2.14.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , ghcide                == 2.15.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lens
     , lsp
     , mtl
@@ -622,7 +622,7 @@ test-suite hls-case-split-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-case-split-plugin
-    , hls-test-utils   == 2.14.0.0
+    , hls-test-utils   == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -654,10 +654,10 @@ library hls-rename-plugin
     , containers
     , filepath
     , ghc
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , hashable
     , hiedb                 ^>= 0.8.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp-types
@@ -683,7 +683,7 @@ test-suite hls-rename-plugin-tests
     , filepath
     , hls-plugin-api
     , haskell-language-server:hls-rename-plugin
-    , hls-test-utils             == 2.14.0.0
+    , hls-test-utils             == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -729,10 +729,10 @@ library hls-hlint-plugin
     , containers
     , deepseq
     , filepath
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , hashable
     , hlint                 >= 3.5 && < 3.11
-    , hls-plugin-api        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lens
     , mtl
     , refact
@@ -785,7 +785,7 @@ test-suite hls-hlint-plugin-tests
     , filepath
     , haskell-language-server:hls-hlint-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.14.0.0
+    , hls-test-utils      == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -839,7 +839,7 @@ test-suite hls-stan-plugin-tests
     , filepath
     , haskell-language-server:hls-stan-plugin
     , hls-plugin-api
-    , hls-test-utils      == 2.14.0.0
+    , hls-test-utils      == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -873,8 +873,8 @@ library hls-signature-help-plugin
   build-depends:
     , containers
     , ghc
-    , ghcide                == 2.14.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , ghcide                == 2.15.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lsp-types
     , text
     , transformers
@@ -890,7 +890,7 @@ test-suite hls-signature-help-plugin-tests
   build-depends:
     , ghcide
     , haskell-language-server:hls-signature-help-plugin
-    , hls-test-utils             == 2.14.0.0
+    , hls-test-utils             == 2.15.0.0
     , text
   default-extensions:
     DerivingStrategies
@@ -920,8 +920,8 @@ library hls-pragmas-plugin
     , aeson
     , extra
     , fuzzy
-    , ghcide                == 2.14.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , ghcide                == 2.15.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lens
     , lsp
     , text
@@ -938,7 +938,7 @@ test-suite hls-pragmas-plugin-tests
     , aeson
     , filepath
     , haskell-language-server:hls-pragmas-plugin
-    , hls-test-utils      == 2.14.0.0
+    , hls-test-utils      == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -971,8 +971,8 @@ library hls-splice-plugin
     , extra
     , foldl
     , ghc
-    , ghcide                == 2.14.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , ghcide                == 2.15.0.0
+    , hls-plugin-api        == 2.15.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp
@@ -995,7 +995,7 @@ test-suite hls-splice-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-splice-plugin
-    , hls-test-utils == 2.14.0.0
+    , hls-test-utils == 2.15.0.0
     , text
 
 -----------------------------
@@ -1022,10 +1022,10 @@ library hls-alternate-number-format-plugin
   build-depends:
     , containers
     , extra
-    , ghcide               == 2.14.0.0
+    , ghcide               == 2.15.0.0
     , ghc-boot-th
     , hls-graph
-    , hls-plugin-api       == 2.14.0.0
+    , hls-plugin-api       == 2.15.0.0
     , lens
     , lsp                  ^>=2.8
     , mtl
@@ -1050,7 +1050,7 @@ test-suite hls-alternate-number-format-plugin-tests
     , containers
     , filepath
     , haskell-language-server:hls-alternate-number-format-plugin
-    , hls-test-utils       == 2.14.0.0
+    , hls-test-utils       == 2.15.0.0
     , regex-tdfa
     , tasty-quickcheck
     , text
@@ -1083,8 +1083,8 @@ library hls-qualify-imported-names-plugin
   build-depends:
     , containers
     , ghc
-    , ghcide                == 2.14.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , ghcide                == 2.15.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lens
     , lsp
     , text
@@ -1106,7 +1106,7 @@ test-suite hls-qualify-imported-names-plugin-tests
     , text
     , filepath
     , haskell-language-server:hls-qualify-imported-names-plugin
-    , hls-test-utils             == 2.14.0.0
+    , hls-test-utils             == 2.15.0.0
 
 -----------------------------
 -- code range plugin
@@ -1137,9 +1137,9 @@ library hls-code-range-plugin
     , deepseq
     , extra
     , ghc
-    , ghcide           == 2.14.0.0
+    , ghcide           == 2.15.0.0
     , hashable
-    , hls-plugin-api   == 2.14.0.0
+    , hls-plugin-api   == 2.15.0.0
     , lens
     , lsp
     , mtl
@@ -1161,7 +1161,7 @@ test-suite hls-code-range-plugin-tests
     , bytestring
     , filepath
     , haskell-language-server:hls-code-range-plugin
-    , hls-test-utils             == 2.14.0.0
+    , hls-test-utils             == 2.15.0.0
     , lens
     , lsp
     , lsp-test
@@ -1189,8 +1189,8 @@ library hls-change-type-signature-plugin
   exposed-modules:  Ide.Plugin.ChangeTypeSignature
   hs-source-dirs:   plugins/hls-change-type-signature-plugin/src
   build-depends:
-    , ghcide           == 2.14.0.0
-    , hls-plugin-api   == 2.14.0.0
+    , ghcide           == 2.15.0.0
+    , hls-plugin-api   == 2.15.0.0
     , lens
     , lsp-types
     , regex-tdfa
@@ -1216,7 +1216,7 @@ test-suite hls-change-type-signature-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-change-type-signature-plugin
-    , hls-test-utils       == 2.14.0.0
+    , hls-test-utils       == 2.15.0.0
     , regex-tdfa
     , text
   default-extensions:
@@ -1249,9 +1249,9 @@ library hls-gadt-plugin
     , containers
     , extra
     , ghc
-    , ghcide                 == 2.14.0.0
+    , ghcide                 == 2.15.0.0
     , ghc-exactprint
-    , hls-plugin-api         == 2.14.0.0
+    , hls-plugin-api         == 2.15.0.0
     , haskell-language-server:hls-refactor-plugin
     , lens
     , lsp                    >=2.8
@@ -1271,7 +1271,7 @@ test-suite hls-gadt-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-gadt-plugin
-    , hls-test-utils              == 2.14.0.0
+    , hls-test-utils              == 2.15.0.0
     , text
 
 -----------------------------
@@ -1298,9 +1298,9 @@ library hls-explicit-fixity-plugin
     , containers
     , deepseq
     , extra
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , hashable
-    , hls-plugin-api        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lsp                   >=2.8
     , text
 
@@ -1316,7 +1316,7 @@ test-suite hls-explicit-fixity-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-explicit-fixity-plugin
-    , hls-test-utils              == 2.14.0.0
+    , hls-test-utils              == 2.15.0.0
     , text
 
 -----------------------------
@@ -1340,8 +1340,8 @@ library hls-explicit-record-fields-plugin
   exposed-modules:  Ide.Plugin.ExplicitFields
   build-depends:
     , ghc
-    , ghcide                == 2.14.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , ghcide                == 2.15.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lsp
     , lens
     , hls-graph
@@ -1367,7 +1367,7 @@ test-suite hls-explicit-record-fields-plugin-tests
     , text
     , ghcide
     , haskell-language-server:hls-explicit-record-fields-plugin
-    , hls-test-utils              == 2.14.0.0
+    , hls-test-utils              == 2.15.0.0
 
 -----------------------------
 -- overloaded record dot plugin
@@ -1413,7 +1413,7 @@ test-suite hls-overloaded-record-dot-plugin-tests
     , filepath
     , text
     , haskell-language-server:hls-overloaded-record-dot-plugin
-    , hls-test-utils              == 2.14.0.0
+    , hls-test-utils              == 2.15.0.0
 
 
 -----------------------------
@@ -1440,8 +1440,8 @@ library hls-fourmolu-plugin
     , filepath
     , fourmolu        ^>= 0.14 || ^>= 0.15 || ^>= 0.16 || ^>=0.17 || ^>=0.18 || ^>=0.19 || ^>=0.20
     , ghc-boot-th
-    , ghcide          == 2.14.0.0
-    , hls-plugin-api  == 2.14.0.0
+    , ghcide          == 2.15.0.0
+    , hls-plugin-api  == 2.15.0.0
     , lens
     , lsp             ^>= 2.8
     , mtl
@@ -1468,7 +1468,7 @@ test-suite hls-fourmolu-plugin-tests
     , filepath
     , haskell-language-server:hls-fourmolu-plugin
     , hls-plugin-api
-    , hls-test-utils       == 2.14.0.0
+    , hls-test-utils       == 2.15.0.0
     , lens
     , lsp-test
     , lsp-types
@@ -1498,8 +1498,8 @@ library hls-ormolu-plugin
     , extra
     , filepath
     , ghc-boot-th
-    , ghcide          == 2.14.0.0
-    , hls-plugin-api  == 2.14.0.0
+    , ghcide          == 2.15.0.0
+    , hls-plugin-api  == 2.15.0.0
     , lsp
     , mtl
     , process-extras  >= 0.7.1
@@ -1526,7 +1526,7 @@ test-suite hls-ormolu-plugin-tests
     , filepath
     , haskell-language-server:hls-ormolu-plugin
     , hls-plugin-api
-    , hls-test-utils     == 2.14.0.0
+    , hls-test-utils     == 2.15.0.0
     , lens
     , lsp-types
     , ormolu
@@ -1559,8 +1559,8 @@ library hls-stylish-haskell-plugin
     , directory
     , filepath
     , ghc-boot-th
-    , ghcide           == 2.14.0.0
-    , hls-plugin-api   == 2.14.0.0
+    , ghcide           == 2.15.0.0
+    , hls-plugin-api   == 2.15.0.0
     , lsp-types
     , mtl
     , stylish-haskell  >=0.12 && <0.16
@@ -1578,7 +1578,7 @@ test-suite hls-stylish-haskell-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-stylish-haskell-plugin
-    , hls-test-utils              == 2.14.0.0
+    , hls-test-utils              == 2.15.0.0
 
 -----------------------------
 -- refactor plugin
@@ -1630,9 +1630,9 @@ library hls-refactor-plugin
     , bytestring
     , ghc-boot
     , regex-tdfa
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , haskell-language-server:hls-exactprint-utils
-    , hls-plugin-api        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lsp
     , text
     , text-rope
@@ -1667,7 +1667,7 @@ test-suite hls-refactor-plugin-tests
     , filepath
     , ghcide:ghcide
     , haskell-language-server:hls-refactor-plugin
-    , hls-test-utils      == 2.14.0.0
+    , hls-test-utils      == 2.15.0.0
     , lens
     , lsp-test
     , lsp-types
@@ -1714,8 +1714,8 @@ library hls-semantic-tokens-plugin
     , text-rope
     , mtl                   >= 2.2
     , ghc
-    , ghcide                == 2.14.0.0
-    , hls-plugin-api        == 2.14.0.0
+    , ghcide                == 2.15.0.0
+    , hls-plugin-api        == 2.15.0.0
     , lens
     , lsp                    >=2.8
     , text
@@ -1724,7 +1724,7 @@ library hls-semantic-tokens-plugin
     , array
     , deepseq
     , dlist
-    , hls-graph == 2.14.0.0
+    , hls-graph == 2.15.0.0
     , template-haskell
     , data-default
     , stm
@@ -1745,10 +1745,10 @@ test-suite hls-semantic-tokens-plugin-tests
     , containers
     , data-default
     , filepath
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , haskell-language-server:hls-semantic-tokens-plugin
-    , hls-plugin-api        == 2.14.0.0
-    , hls-test-utils        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
+    , hls-test-utils        == 2.15.0.0
     , lens
     , lsp
     , lsp-test
@@ -1778,9 +1778,9 @@ library hls-notes-plugin
   hs-source-dirs:     plugins/hls-notes-plugin/src
   build-depends:
     , array
-    , ghcide == 2.14.0.0
-    , hls-graph == 2.14.0.0
-    , hls-plugin-api == 2.14.0.0
+    , ghcide == 2.15.0.0
+    , hls-graph == 2.15.0.0
+    , hls-plugin-api == 2.15.0.0
     , lens
     , lsp >=2.8
     , mtl >= 2.2
@@ -1806,7 +1806,7 @@ test-suite hls-notes-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-notes-plugin
-    , hls-test-utils == 2.14.0.0
+    , hls-test-utils == 2.15.0.0
   default-extensions: OverloadedStrings
 
 -----------------------------
@@ -1822,7 +1822,7 @@ library hls-exactprint-utils
   build-depends:
     , ghc
     , ghc-exactprint
-    , ghcide          == 2.14.0.0
+    , ghcide          == 2.15.0.0
     , lsp             >=2.8
     , text
     , text-rope
@@ -1857,9 +1857,9 @@ library hls-export-plugin
     , ghc
     , ghc-boot-th
     , ghc-exactprint
-    , ghcide          == 2.14.0.0
+    , ghcide          == 2.15.0.0
     , haskell-language-server:hls-exactprint-utils
-    , hls-plugin-api  == 2.14.0.0
+    , hls-plugin-api  == 2.15.0.0
     , lens
     , lsp >=2.8
     , stm
@@ -1880,7 +1880,7 @@ test-suite hls-export-plugin-tests
   build-depends:
     , filepath
     , haskell-language-server:hls-export-plugin
-    , hls-test-utils == 2.14.0.0
+    , hls-test-utils == 2.15.0.0
     , lens
     , lsp-types
     , text
@@ -1943,10 +1943,10 @@ library
     , extra
     , filepath
     , ghc
-    , ghcide                == 2.14.0.0
+    , ghcide                == 2.15.0.0
     , githash               >=0.1.6.1
     , hie-bios
-    , hls-plugin-api        == 2.14.0.0
+    , hls-plugin-api        == 2.15.0.0
     , optparse-applicative
     , optparse-simple
     , prettyprinter         >= 1.7
@@ -2049,7 +2049,7 @@ test-suite func-test
     , ghcide:ghcide
     , hashable
     , hls-plugin-api
-    , hls-test-utils == 2.14.0.0
+    , hls-test-utils == 2.15.0.0
     , lens
     , lsp-test
     , lsp-types
@@ -2091,7 +2091,7 @@ test-suite wrapper-test
 
   build-depends:
     , extra
-    , hls-test-utils              == 2.14.0.0
+    , hls-test-utils              == 2.15.0.0
     , process
 
   hs-source-dirs:     test/wrapper
@@ -2184,7 +2184,7 @@ test-suite ghcide-tests
     , text
     , text-rope
     , unordered-containers
-    , hls-test-utils == 2.14.0.0
+    , hls-test-utils == 2.15.0.0
 
   if impl(ghc <9.3)
     build-depends: ghc-typelits-knownnat

--- a/hls-graph/hls-graph.cabal
+++ b/hls-graph/hls-graph.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               hls-graph
-version:            2.14.0.0
+version:            2.15.0.0
 synopsis:           Haskell Language Server internal graph API
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server/tree/master/hls-graph#readme>

--- a/hls-plugin-api/hls-plugin-api.cabal
+++ b/hls-plugin-api/hls-plugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-plugin-api
-version:       2.14.0.0
+version:       2.15.0.0
 synopsis:      Haskell Language Server API for plugin communication
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -66,7 +66,7 @@ library
     , filepath
     , ghc
     , hashable
-    , hls-graph             == 2.14.0.0
+    , hls-graph             == 2.15.0.0
     , lens
     , lens-aeson
     , lsp                   ^>=2.8

--- a/hls-test-utils/hls-test-utils.cabal
+++ b/hls-test-utils/hls-test-utils.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hls-test-utils
-version:       2.14.0.0
+version:       2.15.0.0
 synopsis:      Utilities used in the tests of Haskell Language Server
 description:
   Please see the README on GitHub at <https://github.com/haskell/haskell-language-server#readme>
@@ -44,8 +44,8 @@ library
     , directory
     , extra
     , filepath
-    , ghcide                  == 2.14.0.0
-    , hls-plugin-api          == 2.14.0.0
+    , ghcide                  == 2.15.0.0
+    , hls-plugin-api          == 2.15.0.0
     , lens
     , lsp
     , lsp-test                ^>=0.18


### PR DESCRIPTION
## Release-related fixes

- Support both zoned and non-zoned timestamps in `GenChangelogs.hs`.
- Extended release instructions with which token permissions to use.
- Fix calling `GenChangelogs.hs` via nix.
- Bumped `GHC 9.14` to `full` support as fourmolu and ormolu got fixed.
- Bump `--max-backjumps` on Windows, matching the existing `setup-build` action.
- Use `--isolate` when installing via ghcup for testing bindists
- Drop historic cabal flag overrides in cabal.project

## Release checklist

This release does not cover more/different GHC versions than `2.14.0.0`, I've marked all related tasks to do with changing GHC set.

- [X] check ghcup supports new GHC releases if any
- [X] check all plugins still work if release includes code changes
- [X] set the supported GHCs in workflow file `.github/generate-ci/gen_ci.hs`
- [X] regenerate the CI via `./.github/generate-ci/generate-jobs`
- [X] bump package versions in all `*.cabal` files (same version as hls)
  - HLS uses lockstep versioning. The core packages and all plugins use the same version number, and only support exactly this version.
    - Exceptions:
      - `shake-bench` is an internal testing tool, not exposed to the outside world. Thus, no version bump required for releases.
  - For updating cabal files, the following script can be used:
    - ```sh
      ./release/update_versions.sh <OLD_VERSION> <NEW_VERSION>
      ```
    - It still requires manual verification and review
- [X] generate and update changelog
  - Generate a ChangeLog via `./GenChangelogs.hs <api-key> <tag>`
    - `<tag>` is the git tag you want to generate the ChangeLog from.
    - `<api-key>` is a github access key: https://github.com/settings/tokens
- [X] update https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status
- [X] create release branch as `wip/<version>`
  - `git switch -c wip/<version>`
- [x] create release tag as `<version>`
  - `git tag <version>`
- [x] trigger release pipeline by pushing the tag
  - this creates a draft release
  - `git push <remote> <version>`
- [x] run `sh scripts/release/download-gh-artifacts.sh <version> <your-gpg-email>`
  - downloads artifacts to `gh-release-artifacts/haskell-language-server-<version>/`
  - also downloads FreeBSD bindist from circle CI
  - adds signatures
- [x] upload artifacts to downloads.haskell.org from `gh-release-artifacts/haskell-language-server-<version>/`
  - You require sftp access, contact wz1000, bgamari or chreekat
  - `cd gh-release-artifacts/haskell-language-server-<version>`
  - `SIGNING_KEY=... ../../release/upload.sh upload`
    - Your SIGNING_KEY can be obtained with `gpg --list-secret-keys --keyid-format=long`
  - Afterwards, the artifacts are available at: `https://downloads.haskell.org/~hls/haskell-language-server-<version>/`
  - Run `SIGNING_KEY=... ../../release/upload.sh purge_all` to remove CDN caches
- [x] create PR to [ghcup-metadata](https://github.com/haskell/ghcup-metadata)
  - [x] update `ghcup-vanilla-0.0.9.yaml`
    - can use `sh scripts/release/create-yaml-snippet.sh <version>` to generate a snippet that can be manually inserted into the yaml files
  - ~~update `hls-metadata-0.0.1.json`~~ Currently unnecessary, GHCup builds its own HLS binaries and updates that file.
    - utilize `cabal run ghcup-gen -- generate-hls-ghcs -f ghcup-0.0.7.yaml --format json --stdout` in the root of ghcup-metadata repository
  - Be sure to mark the correct latest version and add the 'recommended' tag to the latest release.
- [x] get sign-off on release
  - from wz1000, michealpj, maerwald and fendor
- [ ] publish release on github
- [ ] upload hackage packages
  - requires credentials
- [x] Supported tools table needs to be updated:
  - https://www.haskell.org/ghcup/install/#supported-platforms
  - https://github.com/haskell/ghcup-hs/blob/master/docs/install.md#supported-platforms
  - https://github.com/haskell/ghcup-metadata/blob/44c6e2b5d0fcae15abeffff03e87544edf76dd7a/ghcup-gen/Main.hs#L67
- [ ] post release on discourse and reddit
  - Include links to the plugin support table (https://haskell-language-server.readthedocs.io/en/2.13.0.0/support/plugin-support.html) and ghc version support table (https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html)
- [ ] merge release PR to master or forward port relevant changes
