### PR TITLE
Drop historic cabal flag overrides in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -26,20 +26,12 @@ package *
   ghc-options: -haddock
 
 constraints:
-  -- C++ is hard to distribute, especially on older GHCs
-  -- See https://github.com/haskell/haskell-language-server/issues/3822
-  text -simdutf,
   ghc-check -ghc-check-use-package-abis,
   ghc-lib-parser-ex -auto,
   -- This is only present in some versions, and it's on by default since
   -- 0.14.5.0, but there are some versions we allow that need this
   -- setting
   stylish-haskell +ghc-lib,
-  -- Centos 7 comes with an old gcc version that doesn't know about
-  -- the flag '-fopen-simd', which blocked the release 2.2.0.0.
-  -- We want to be able to benefit from the performance optimisations
-  -- in the future, thus: TODO: remove this flag.
-  bitvec -simd,
   monad-control >=1.0.3,
 
 


### PR DESCRIPTION
Closes #5061.

* `text -simdutf` was necessary on GHC 9.0 and 9.2, outside of our supported GHC set.
* `bitvec -simd` was necessary for Centos 7, which we've stopped supporting since the 2.11.0.0 release.

